### PR TITLE
Added new battery_capacity_nominal switch in Home assistant - default is OFF

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Connect to your cars sensors for accurate data:
   - **car_charging_soc** - The cars current % charge level, link to a suitable sensor. Default is 0%
 
 Control how your battery behaves during car charging:
-  - **car_charging_from_battery** - When True the car can drain the home battery, Predbat will manage the correct level of battery accordingly. When False home battery discharge will be prevented when your car charges, all load from the car and home will be from the grid. The home battery can still charge from the grid/solar in either case. Only use this if Predbat knows your car charging plan, e.g. you are using Octopus Intelligent or you use the car slots in Predbat to control your car charging.
+  - **car_charging_from_battery** - When True the car can drain the home battery, Predbat will manage the correct level of battery accordingly. When False home battery discharge will be prevented when your car charges, all load from the car and home will be from the grid. This is achieved by setting the discharge rate to 0 during car charging and to the maximum otherwise, hence if you turn this switch Off you won't be able to change your discharge rate outside Predbat. The home battery can still charge from the grid/solar in either case. Only use this if Predbat knows your car charging plan, e.g. you are using Octopus Intelligent or you use the car slots in Predbat to control your car charging.
 
 ### Workarounds
 
@@ -362,6 +362,7 @@ Control how your battery behaves during car charging:
   - **inverter_clock_skew_start**, **inverter_clock_skew_end** - Skews the setting of the charge slot registers vs the predicted start time (see apps.yml)
   - **inverter_clock_skew_discharge_start**, **inverter_clock_skew_discharge_end** - Skews the setting of the discharge slot registers vs the predicted start time (see apps.yml)
   - **clock_skew** - Skews the local time that Predbat uses (from AppDaemon), will change when real-time actions happen e.g. triggering a discharge.
+  - **predbat_battery_capacity_nominal** - When enabled Predbat uses the reported battery size from the Nominal field rather than from the normal GivTCP reported size. If your battery size is reported wrongly maybe try turning this on and see if it helps.
 
 ### Triggers
 

--- a/example_dashboard.yml
+++ b/example_dashboard.yml
@@ -28,7 +28,9 @@ entities:
   - entity: switch.predbat_combine_discharge_slots
   - entity: switch.predbat_combine_mixed_rates
   - entity: switch.predbat_iboost_enable
-  - entity: switch.predbat_inverter_hybrid  
+  - entity: switch.predbat_inverter_hybrid
+  - entity: switch.predbat_battery_capacity_nominal
+  - entity: switch.predbat_car_charging_from_battery
   - entity: input_number.predbat_battery_loss
   - entity: input_number.predbat_battery_loss_discharge
   - entity: input_number.predbat_inverter_loss


### PR DESCRIPTION
Sometimes your battery capacity is reported incorrectly by GivTCP, when battery_capacity_nominal is enabled then Predbat will use the Nominal size reported in the REST API instead.

*** Please note the default is now off, this used to be on by default - if you have issues with battery size reporting please try changing this toggle!
