### PR TITLE
Added inverter_soc_reset option, for non-hybrid inverters to reset the target SOC outside the charge window

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,8 @@ If you turn this off later check that 'GivTCP Enable Charge Schedule' is turned 
 **set_soc_enable** When enable automatically set the battery SOC charge amount a defined number of minutes before charging starts
 NOTE: it maybe set more than once if things change
 
+If you have **inverter_hybrid** set to False then if **inverter_soc_reset** is set to True then the target SOC % will be reset to 100% outside a charge window. This maybe required for AOI inverter to ensure it charges from solar.
+
 **set_soc_minutes** defines how many minutes before the charge window we should program it (do not set above 30 if you are using Agile or similar)
 **set_soc_notify** enables mobile notifications about changes to the charge %
 

--- a/example_dashboard.yml
+++ b/example_dashboard.yml
@@ -29,6 +29,7 @@ entities:
   - entity: switch.predbat_combine_mixed_rates
   - entity: switch.predbat_iboost_enable
   - entity: switch.predbat_inverter_hybrid
+  - entity: switch.predbat_inverter_soc_reset
   - entity: switch.predbat_battery_capacity_nominal
   - entity: switch.predbat_car_charging_from_battery
   - entity: input_number.predbat_battery_loss


### PR DESCRIPTION
When Inverter_soc_reset is True and inverter_hybrid is False (non hybrid) the target charge % is reset to 100% outside a charge window. This seems to be needed with the AOI inverter to ensure it charges from Solar okay.