### PR TITLE
Added template configuration guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ Overview of the key configuration elements:
 - Add https://github.com/springfall2008/batpred as a custom repository of type 'AppDaemon'
 - Click on the Repo and Download the app
 
-> After an update with HACS you may need to reboot AppDaemon as it sometimes reads the config wrongly during the update
+> After an update with HACS you may need to reboot AppDaemon as it sometimes reads the config wrongly during the update (If this happens you will get a template configuration error).
 
 - Edit in HomeAssistant config/appdaemon/apps/predbat/config/apps.yml to configure
-- Note that future updates will not overwrite apps.yml, but you may need to copy settings for new features across manually
+   - You must delete the 'template: True' line in the configuration to enable Predbat once you are happy with your configuration
+   - Note that future updates will not overwrite apps.yml, but you may need to copy settings for new features across manually
 
 ### Predbat manual install
 

--- a/apps/predbat/config/apps.yaml
+++ b/apps/predbat/config/apps.yaml
@@ -11,7 +11,10 @@ pred_bat:
 
   # Timezone to work in
   timezone: Europe/London
-  
+
+  # XXX: This is a configuration template, delete this line once you edit your configuration
+  template: True
+
   # Set to auto-match with a GivEnergy serial number, but you can override the serial or the sensor names
   # if it doesn't work or if you have more than one inverter you will need to list both
   geserial: 're:sensor.givtcp_(.+)_soc_kwh'

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -4235,7 +4235,13 @@ class PredBat(hass.Hass):
             self.log("ERROR: Exception raised {}".format(e))
             self.record_status('ERROR: Exception raised {}'.format(e))
             raise e
-        
+
+        # Catch template configurations and exit        
+        if self.get_arg('template', False):
+            self.log("ERROR: You still have a template configuration, please edit apps.yaml or restart AppDeamon if you just updated with HACS")
+            self.record_status("ERROR: You still have a template configuration, please edit apps.yaml or restart AppDeamon if you just updated with HACS")
+            return
+
         if SIMULATE and SIMULATE_LENGTH:
             # run once to get data
             SIMULATE = False


### PR DESCRIPTION
The default configuration will now error out as it's a template, you must delete the 'template' line before Predbat will run. This is to catch the cases when a HACS updated doesn't read the correct configuration.