### PR TITLE
Update apps.yaml, clarify how days_previous_weight should be completed

### DIFF
--- a/apps/predbat/config/apps.yaml
+++ b/apps/predbat/config/apps.yaml
@@ -276,7 +276,8 @@ pred_bat:
 
   # Days previous weight can be used to control the weighting of the previous load points, the values are multiplied by their
   # weights and then divided through by the total weight. E.g. if you used 1 and 0.5 then the first value would have 2/3rd of the weight and the second 1/3rd
-  # Include one value for each days_previous value
+  # Include one value for each days_previous value, each weighting on a separate line.
+  # If any days_previous's that are not given a weighting they will assume a default weighting of 1. 
   days_previous_weight:
     - 1
   


### PR DESCRIPTION
Added clarification comments to explain that multiple days_previous_weight entries should be entered on separate lines (entering them all as a single line causes predbat to crash!), and that any previous_days are not given a weighting then they assume a default weight of 1