### PR TITLE
Add new rate offset feature which allows setting a offset for future unpublished energy rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The app runs every N minutes (default 5), it will automatically update its predi
 
 ## Step by step guide
 
+Note there is a step by step guide video, see the video guides section below for a link. 
+
 Please see the sections below for how to achieve each step. This is just a checklist of things:
 
 1. Make sure GivTCP is installed and running - [GivTCP install](#givtcp-install)
@@ -722,11 +724,15 @@ You could even go to something like -0.1 to say you would charge less even if it
 **rate_low_threshold** sets the threshold below average rates as the minimum to consider for a charge window, 0.8 = 80% of average rate
 If you set this too low you might not get enough charge slots. If it's too high you might get too many in the 24-hour period.
 
-**rate_low_match_export** - When enabled consider import rates that are lower than the highest export rate (minus any battery losses). 
+**rate_low_match_export** When enabled consider import rates that are lower than the highest export rate (minus any battery losses). 
 This is if you want to be really aggressive about importing just to export, default is False (recommended).
 
 **rate_high_threshold** Sets the threshold above average rates as to the minimum export rate to consider exporting for - 1.2 = 20% above average rate
 If you set this too high you might not get any export slots. If it's too low you might get too many in the 24-hour period.
+
+**metric_future_rate_offset_import** Sets an offset to apply to future import energy rates that are not yet published, best used for variable rate tariffs such as Agile import where the rates are not published until 4pm. If you set this to a positive value then Predbat will assume unpublished import rates are higher by the given amount.
+
+**metric_future_rate_offset_export** Sets an offset to apply to future export energy rates that are not yet published, best used for variable rate tariffs such as Agile export where the rates are not published until 4pm. If you set this to a negative value then Predbat will assume unpublished export rates are lower by the given amount.
 
 ### Inverter control options
 


### PR DESCRIPTION
* metric_future_rate_offset_import Sets an offset to apply to future import energy rates that are not yet published, best used for variable rate tariffs such as Agile import where the rates are not published until 4pm. If you set this to a positive value then Predbat will assume unpublished import rates are higher by the given amount.

* metric_future_rate_offset_export Sets an offset to apply to future export energy rates that are not yet published, best used for variable rate tariffs such as Agile export where the rates are not published until 4pm. If you set this to a negative value then Predbat will assume unpublished export rates are lower by the given amount.