### PR TITLE
Added in day-adjustment feature, fix bug in calculation of charge levels with discharge enabled

### DIFF
--- a/example_chart.yml
+++ b/example_chart.yml
@@ -518,3 +518,54 @@ series:
     offset: '-12h'
     show:
       in_header: raw
+###############################################
+# In day adjustment chart
+###############################################
+type: custom:apexcharts-card
+header:
+  show: true
+  title: In day adjustment
+  show_states: true
+  colorize_states: true
+graph_span: 24h
+span:
+  start: day
+  offset: '-0h'
+now:
+  show: true
+yaxis:
+  - min: 0
+series:
+  - entity: predbat.load_energy_actual
+    stroke_width: 1
+    curve: smooth
+    name: actual
+    data_generator: >
+      let res = []; for (const [key, value] of
+      Object.entries(entity.attributes.results)) { res.push([new
+      Date(key).getTime(), value]); } return res.sort((a, b) => { return a[0] -
+      b[0]  })
+    show:
+      in_header: raw
+  - entity: predbat.load_energy_predicted
+    stroke_width: 1
+    curve: smooth
+    name: predicted
+    data_generator: >
+      let res = []; for (const [key, value] of
+      Object.entries(entity.attributes.results)) { res.push([new
+      Date(key).getTime(), value]); } return res.sort((a, b) => { return a[0] -
+      b[0]  })
+    show:
+      in_header: raw
+  - entity: predbat.load_energy_adjusted
+    stroke_width: 1
+    curve: smooth
+    name: adjusted
+    data_generator: >
+      let res = []; for (const [key, value] of
+      Object.entries(entity.attributes.results)) { res.push([new
+      Date(key).getTime(), value]); } return res.sort((a, b) => { return a[0] -
+      b[0]  })
+    show:
+      in_header: raw

--- a/example_dashboard.yml
+++ b/example_dashboard.yml
@@ -36,6 +36,7 @@ entities:
   - entity: switch.predbat_balance_inverters_charge
   - entity: switch.predbat_balance_inverters_discharge
   - entity: switch.predbat_balance_inverters_crosscharge
+  - entity: switch.predbat_calculate_inday_adjustment
   - entity: input_number.predbat_balance_inverters_threshold_charge
   - entity: input_number.predbat_balance_inverters_threshold_discharge
   - entity: input_number.predbat_battery_loss
@@ -70,6 +71,7 @@ entities:
   - entity: input_number.predbat_set_soc_minutes
   - entity: input_number.predbat_set_window_minutes
   - entity: input_number.predbat_holiday_days_left
+  - entity: input_number.predbat_metric_inday_adjust_damping
   - entity: binary_sensor.predbat_car_charging_slot
   - entity: binary_sensor.predbat_export_trigger_large
   - entity: binary_sensor.predbat_export_trigger_small
@@ -143,4 +145,5 @@ entities:
   - entity: predbat.soc_kw_best_h8
   - entity: predbat.soc_kw_h0
   - entity: predbat.soc_min_kwh
+  - entity: predbat.load_inday_adjustment
 title: Predbat


### PR DESCRIPTION
* New **switch.predbat_calculate_inday_adjustment** which when enabled will adjust the in-day prediction of load to better align to your consumption so far today by applying a scale factor. The factor can be damped with **input_number.predbat_metric_inday_adjust_damping**, the factor can be see in **predbat.load_inday_adjustment** and charted with a new charge
* Fix bug in calculation of best charge % first pass where discharge off was being skipped leading to bad calculations