### PR TITLE
Changed rate selection to pick the best N windows based on calculate_max_windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ rate_high_threshold - 0                # Consider All export slots
 rate_low_threshold - 0                 # Consider All import slots
 calculate_second_pass - True           # Slower but will give a slightly better result
 set_discharge_freeze - True            # Allow Predbat to hold the current battery level rather than just discharge
-max_windows - 32                       # Consider the top 32 slots in the 48 hour period
+calculate_max_windows - 32             # Consider the top 32 slots in the 48 hour period
 forecast_plan_hours - 48               # In apps.yml set this to 48 hours to consider a full cycle plan
 ```
 
@@ -723,15 +723,15 @@ You could even go to something like -0.1 to say you would charge less even if it
 **metric_min_improvement_discharge** Sets the minimum cost improvement it's worth discharging for. A value of 0 or 1 is generally good.
 
 **rate_low_threshold** sets the threshold below average rates as the minimum to consider for a charge window, 0.8 = 80% of average rate
-If you set this too low you might not get enough charge slots. If it's too high you might get too many in the 24-hour period which makes optimisation harder. You can set this to 0 to consider all possible slots, this can be done when combined with setting max_windows to a lower number e.g. 32.
+If you set this too low you might not get enough charge slots. If it's too high you might get too many in the 24-hour period which makes optimisation harder. You can set this to 0 to consider all possible slots, this can be done when combined with setting **calculate_max_windows** to a lower number e.g. 24 or 32.
 
 **rate_low_match_export** When enabled consider import rates that are lower than the highest export rate (minus any battery losses). 
 This is if you want to be really aggressive about importing just to export, default is False (recommended).
 
 **rate_high_threshold** Sets the threshold above average rates as to the minimum export rate to consider exporting for - 1.2 = 20% above average rate
-If you set this too high you might not get any export slots. If it's too low you might get too many in the 24-hour period. You can set this to 0 to consider all possible slots, this can be done when combined with setting max_windows to a lower number e.g. 32.
+If you set this too high you might not get any export slots. If it's too low you might get too many in the 24-hour period. You can set this to 0 to consider all possible slots, this can be done when combined with setting **calculate_max_windows** to a lower number e.g. 24 or 32.
 
-- **max_windows** - Maximum number of charge and discharge windows, the default is 128 (which means all that are found). If you system has performance issues you might want to cut this down to something between 16 and 32 to only consider the highest value exports and cheapest imports.
+**calculate_max_windows** - Maximum number of charge and discharge windows, the default is 32. If you system has performance issues you might want to cut this down to something between 16 and 24 to only consider the highest value exports and cheapest imports. The maximum usable value would be 96 which is 48 hours split into 30 minute slots
 
 **metric_future_rate_offset_import** Sets an offset to apply to future import energy rates that are not yet published, best used for variable rate tariffs such as Agile import where the rates are not published until 4pm. If you set this to a positive value then Predbat will assume unpublished import rates are higher by the given amount.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Also known by some as Batpred or Batman!
 ![image](https://github.com/springfall2008/batpred/assets/48591903/e98a0720-d2cf-4b71-94ab-97fe09b3cee1)
 
 ```
-Copyright (c) Trefor Southwell August 2023 - All rights reserved
+Copyright (c) Trefor Southwell October 2023 - All rights reserved
 This software maybe used at not cost for personal use only
 No warranty is given, either expressed or implied
 ```
@@ -240,7 +240,6 @@ Basic configuration items
   - **days_previous_weight** A list of the weightings to use of the data for each of the days in days_previous.
   - **forecast_hours** - the number of hours to forecast ahead, 48 is the suggested amount.
   - **forecast_plan_hours** - the number of hours after the next charge slot to include in the plan, default 24 hours is the suggested amount (to match energy rate cycles)
-  - **max_windows** - Maximum number of charge and discharge windows, the default is 32.  Larger numbers of windows can increase runtime, but is needed if you decide to use smaller slots (e.g. 5, 10 or 15 minutes). 
   
 ### Inverter information
 The following are entity names in HA for GivTCP, assuming you only have one inverter and the entity names are standard then it will be auto discovered
@@ -495,6 +494,7 @@ set_charge_window - True           # You want to have Predbat control the charge
 best_soc_keep - 2.0                # Tweak this to control what battery level you want to keep as a backup in case you use more energy
 best_soc_min - 0.0                 # You can also set this to best_soc_keep if you don't want charging to be turned off overnight when it's not required
 rate_low_threshold - 0.8           # Consider a 20% reduction in rates or more as a low rate
+forecast_plan_hours - 24               # In apps.yml set this to 24 hours to match the repeating rates
 calculate_discharge_first - False  # You probably only want to discharge any excess as export rates are poor
 ```
 
@@ -512,7 +512,6 @@ metric_min_improvement - 0             # Charge less if it's cost neutral
 metric_min_improvement_discharge - 0   # Discharge even if cost neutral, as you often need many slots to see the improvement
 rate_high_threshold: 1.0               # For fixed export rate you need to consider all slots
 set_discharge_freeze - True            # Allow Predbat to hold the current battery level rather than just discharge
-calculate_second_pass - True           # Slower but will give a slightly better result
 predbat_metric_battery_cycle - ?       # You can set this to maybe 2-5p if you want to avoid cycling the battery too much
 ```
 
@@ -548,18 +547,16 @@ set_discharge_window - True            # Allow the tool to control the discharge
 combine_discharge_slots - False        # Split into 30 minute chunks for best optimisation
 metric_min_improvement - 0             # Charge less if it's cost neutral 
 metric_min_improvement_discharge - 0.1 # Make sure discharge only happens if it makes a profit
-max_windows - 128                      # Ensure you have enough slots
 rate_low_match_export - False          # Start with this at False but you can try it as True if you want to charge at higher rates to export even more
-rate_high_threshold - 1.0              # Consider more export slots
+rate_high_threshold - 0                # Consider All export slots
+rate_low_threshold - 0                 # Consider All import slots
 calculate_second_pass - True           # Slower but will give a slightly better result
 set_discharge_freeze - True            # Allow Predbat to hold the current battery level rather than just discharge
+max_windows - 32                       # Consider the top 32 slots in the 48 hour period
+forecast_plan_hours - 48               # In apps.yml set this to 48 hours to consider a full cycle plan
 ```
 
-If you have a fixed export rate then follow the above for variable rates but change:
-
-```
-rate_high_threshold: 1.0               # Consider all slots for export
-```
+If you have a fixed export rate then follow the above guidance
 
 ## Video Guides
 
@@ -726,13 +723,15 @@ You could even go to something like -0.1 to say you would charge less even if it
 **metric_min_improvement_discharge** Sets the minimum cost improvement it's worth discharging for. A value of 0 or 1 is generally good.
 
 **rate_low_threshold** sets the threshold below average rates as the minimum to consider for a charge window, 0.8 = 80% of average rate
-If you set this too low you might not get enough charge slots. If it's too high you might get too many in the 24-hour period.
+If you set this too low you might not get enough charge slots. If it's too high you might get too many in the 24-hour period which makes optimisation harder. You can set this to 0 to consider all possible slots, this can be done when combined with setting max_windows to a lower number e.g. 32.
 
 **rate_low_match_export** When enabled consider import rates that are lower than the highest export rate (minus any battery losses). 
 This is if you want to be really aggressive about importing just to export, default is False (recommended).
 
 **rate_high_threshold** Sets the threshold above average rates as to the minimum export rate to consider exporting for - 1.2 = 20% above average rate
-If you set this too high you might not get any export slots. If it's too low you might get too many in the 24-hour period.
+If you set this too high you might not get any export slots. If it's too low you might get too many in the 24-hour period. You can set this to 0 to consider all possible slots, this can be done when combined with setting max_windows to a lower number e.g. 32.
+
+- **max_windows** - Maximum number of charge and discharge windows, the default is 128 (which means all that are found). If you system has performance issues you might want to cut this down to something between 16 and 32 to only consider the highest value exports and cheapest imports.
 
 **metric_future_rate_offset_import** Sets an offset to apply to future import energy rates that are not yet published, best used for variable rate tariffs such as Agile import where the rates are not published until 4pm. If you set this to a positive value then Predbat will assume unpublished import rates are higher by the given amount.
 

--- a/apps/predbat/config/apps.yaml
+++ b/apps/predbat/config/apps.yaml
@@ -300,10 +300,6 @@ pred_bat:
   # tariffs like Agile
   forecast_plan_hours: 24
 
-  # Maximum number of charge and discharge windows
-  # Larger numbers of windows can increase runtime, normally 128 is more than enough for most uses
-  max_windows: 128
-  
   # Specify the devices that notifies are sent to, the default is 'notify' which goes to all
   #notify_devices: 
   #  - mobile_app_treforsiphone12_2

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -58,6 +58,7 @@ CONFIG_ITEMS = [
     {'name' : 'best_soc_max',                  'friendly_name' : 'Best SOC Max',                   'type' : 'input_number', 'min' : 0,   'max' : 30.0, 'step' : 0.10, 'unit' : 'kwh', 'icon' : 'mdi:battery-50'},
     {'name' : 'best_soc_keep',                 'friendly_name' : 'Best SOC Keep',                  'type' : 'input_number', 'min' : 0,   'max' : 30.0, 'step' : 0.10, 'unit' : 'kwh', 'icon' : 'mdi:battery-50'},
     {'name' : 'best_soc_step',                 'friendly_name' : 'Best SOC Step',                  'type' : 'input_number', 'min' : 0.1, 'max' : 1.0,  'step' : 0.05, 'unit' : 'kwh', 'icon' : 'mdi:battery-50'},
+    {'name' : 'max_windows',                   'friendly_name' : 'Max charge/discharge windows',   'type' : 'input_number', 'min' : 8,   'max' : 128,  'step' : 8,    'unit' : 'kwh', 'icon' : 'mdi:vector-arrange-above'},
     {'name' : 'metric_min_improvement',        'friendly_name' : 'Metric Min Improvement',         'type' : 'input_number', 'min' : -50, 'max' : 50.0, 'step' : 0.1,  'unit' : 'p', 'icon' : 'mdi:currency-usd'},
     {'name' : 'metric_min_improvement_discharge', 'friendly_name' : 'Metric Min Improvement Discharge',    'type' : 'input_number', 'min' : -50, 'max' : 50.0, 'step' : 0.1,  'unit' : 'p', 'icon' : 'mdi:currency-usd'},
     {'name' : 'metric_battery_cycle',          'friendly_name' : 'Metric Battery Cycle Cost',      'type' : 'input_number', 'min' : -50, 'max' : 50.0, 'step' : 0.1,  'unit' : 'p/kwh', 'icon' : 'mdi:currency-usd'},
@@ -2519,8 +2520,8 @@ class PredBat(hass.Hass):
                         # If combine is disabled, for import slots make them all N minutes so we can select some not all
                         rate_low_end = minute
                         break
-                    if find_high and (rate_low_start >= 0) and ((minute - rate_low_start) >= 60*6):
-                        # Export slot can never be bigger than 6 hours
+                    if find_high and (rate_low_start >= 0) and ((minute - rate_low_start) >= 60*4):
+                        # Export slot can never be bigger than 4 hours
                         rate_low_end = minute
                         break
                     if rate_low_start < 0:
@@ -2881,7 +2882,7 @@ class PredBat(hass.Hass):
         minute = 0
         found_rates = []
 
-        while len(found_rates) < self.max_windows:
+        while True:
             rate_low_start, rate_low_end, rate_low_average = self.find_charge_window(rates, minute, threshold_rate, find_high)
             window = {}
             window['start'] = rate_low_start
@@ -2894,19 +2895,51 @@ class PredBat(hass.Hass):
                 minute = rate_low_end
             else:
                 break
-        return found_rates
+        
+        # Sort all windows by price
+        selected_rates = []
+        total = 0
+        window_sorted, window_index, price_set, price_links = self.sort_window_by_price_combined(found_rates, [], stand_alone=True)
+        if not find_high:
+            price_set.reverse()
+        
+        # For each price set in order, take windows newest and then oldest picks
+        for loop_price in price_set:
+            these_items = price_links[loop_price]
+            take_front = not find_high
+            while these_items and total < self.max_windows:
+                if take_front:
+                    key = these_items.pop(0)
+                else:
+                    key = these_items.pop()                
+                selected_rates.append(window_index[key]['id'])
+                total += 1
+            if total >= self.max_windows:
+                break
+        selected_rates.sort()
+        final_rates = []
+        for window_id in selected_rates:
+            final_rates.append(found_rates[window_id])
+        return final_rates
 
     def set_rate_thresholds(self):
         """
         Set the high and low rate thresholds
         """
-        self.rate_threshold = self.dp2(self.rate_average * self.rate_low_threshold)
+        if self.rate_low_threshold > 0:
+            self.rate_threshold = self.dp2(self.rate_average * self.rate_low_threshold)
+        else:
+            self.rate_threshold = self.rate_min
+
         if self.rate_low_match_export:
             # When enabled the low rate could be anything up-to the export rate (less battery losses)
             self.rate_threshold = self.dp2(max(self.rate_threshold, self.rate_export_max * self.battery_loss * self.battery_loss_discharge))
 
         # Compute the export rate threshold
-        self.rate_export_threshold = self.dp2(self.rate_export_average * self.rate_high_threshold)
+        if self.rate_high_threshold > 0:
+            self.rate_export_threshold = self.rate_export_max
+        else:
+            self.rate_export_threshold = self.dp2(self.rate_export_average * self.rate_high_threshold)
 
         # Rule out exports if the import rate is already higher unless it's a variable export tariff
         if self.rate_export_max == self.rate_export_min:
@@ -3673,14 +3706,17 @@ class PredBat(hass.Hass):
         window_sorted.sort(key=self.window_sort_func_start)
         return window_sorted
 
-    def sort_window_by_price_combined(self, charge_windows, discharge_windows):
+    def sort_window_by_price_combined(self, charge_windows, discharge_windows, stand_alone=False):
+        """
+        Sort windows into price sets
+        """
         window_sort = []
         window_links = {}
         price_set = []
         price_links = {}
 
         # Add charge windows
-        if self.calculate_best_charge:
+        if self.calculate_best_charge or stand_alone:
             id = 0
             for window in charge_windows:
                 # Account for losses in average rate as it makes import higher 
@@ -3695,7 +3731,7 @@ class PredBat(hass.Hass):
                 id += 1
 
         # Add discharge windows
-        if self.calculate_best_discharge:
+        if self.calculate_best_discharge and not stand_alone:
             id = 0
             for window in discharge_windows:
                 # Account for losses in average rate as it makes export value lower 

--- a/example_dashboard.yml
+++ b/example_dashboard.yml
@@ -67,6 +67,7 @@ entities:
   - entity: input_number.predbat_pv_scaling
   - entity: input_number.predbat_rate_high_threshold
   - entity: input_number.predbat_rate_low_threshold
+  - entity: input_number.predbat_calculate_max_windows
   - entity: input_number.predbat_metric_future_rate_offset_import
   - entity: input_number.predbat_metric_future_rate_offset_export
   - entity: input_number.predbat_set_reserve_min


### PR DESCRIPTION
* New setting calculate_max_windows which defaults to 32, only the best windows are selected based on price
* Removed old max_windows from apps.yml
* Updated guidance on Agile
* Changed high and low rate threshold so that 0 is disabled
* Default maximum window size for export to 4 hours