### PR TITLE
Create dynamic-entities-yaml

### DIFF
--- a/dynamic-entities-yaml
+++ b/dynamic-entities-yaml
@@ -1,0 +1,116 @@
+type: vertical-stack
+title: Predbat 🦇
+cards:
+  - type: entity
+    entity: predbat.status
+  - type: custom:collapsable-cards
+    title: 🔀 Control
+    defaultOpen: false
+    cards:
+      - type: custom:collapsable-cards
+        title: 🔢 Input Variables
+        defaultOpen: false
+        cards:
+          - type: custom:auto-entities
+            card:
+              type: entities
+            filter:
+              include:
+                - entity_id: input_number.predbat*
+              exclude: []
+            unique: true
+            sort:
+              method: friendly_name
+              numeric: false
+      - type: custom:collapsable-cards
+        title: 🔀 Switches
+        defaultOpen: false
+        cards:
+          - type: custom:auto-entities
+            card:
+              type: entities
+            filter:
+              include:
+                - entity_id: switch.predbat*
+              exclude: []
+            unique: true
+            sort:
+              method: friendly_name
+              numeric: false
+  - type: custom:collapsable-cards
+    title: '#️⃣ Sensors'
+    defaultOpen: false
+    cards:
+      - type: custom:collapsable-cards
+        title: 💷 Cost Sensors
+        defaultOpen: false
+        cards:
+          - type: custom:auto-entities
+            card:
+              type: entities
+            filter:
+              include:
+                - entity_id: predbat.*cost*
+                - entity_id: predbat.*rate*
+                - entity_id: predbat.*metric*
+              exclude:
+                - entity_id: predbat.*start*
+                - entity_id: predbat.*end*
+                - entity_id: predbat.*duration*
+            unique: true
+            sort:
+              method: friendly_name
+              numeric: false
+      - type: custom:collapsable-cards
+        title: 🕛 Time/Duration Sensors
+        defaultOpen: false
+        cards:
+          - type: custom:auto-entities
+            card:
+              type: entities
+            filter:
+              include:
+                - entity_id: predbat.*start*
+                - entity_id: predbat.*end*
+                - entity_id: predbat.*duration*
+                - entity_id: predbat.*record*
+              exclude: []
+            unique: true
+            sort:
+              method: friendly_name
+              numeric: false
+      - type: custom:collapsable-cards
+        title: ⚡ Power Sensors
+        defaultOpen: false
+        cards:
+          - type: custom:auto-entities
+            card:
+              type: entities
+            filter:
+              include:
+                - entity_id: predbat.*soc*
+                - entity_id: predbat.*energy*
+                - entity_id: predbat.*load*
+                - entity_id: predbat.*battery*
+                - entity_id: predbat.*kw*
+                - entity_id: predbat.*power*
+              exclude: []
+            unique: true
+            sort:
+              method: friendly_name
+              numeric: false
+      - type: custom:collapsable-cards
+        title: 1️⃣ Binary Sensors
+        defaultOpen: false
+        cards:
+          - type: custom:auto-entities
+            card:
+              type: entities
+            filter:
+              include:
+                - entity_id: binary_sensor.predbat*
+              exclude: []
+            unique: true
+            sort:
+              method: friendly_name
+              numeric: false


### PR DESCRIPTION
A dynamic card which automatically categorises and populates all Predbat entities into a collapsable format. Negates the need to add/remove entities as Predbat evolves as they automagically (dis)appear.

Requires [lovelace-collapsable-cards](https://github.com/RossMcMillan92/lovelace-collapsable-cards) and [lovelace-auto-entities](https://github.com/thomasloven/lovelace-auto-entities) custom cards as well as the stock vertical stack card.

![image](https://github.com/springfall2008/batpred/assets/1013909/d368feb9-414c-45dd-a325-5193b00bf3df)
