### PR TITLE
Solis: add minutes to write_and_poll

### DIFF
--- a/apps/predbat/config/ginlong_solis.yaml
+++ b/apps/predbat/config/ginlong_solis.yaml
@@ -16,13 +16,13 @@ pred_bat:
   # however if you have two inverters only set one of them as they will both read the same.
   #
   load_today: 
-    - sensor.solis_daily_consumption
+    - sensor.solis_house_load_today
   import_today: 
-    - sensor.solis_daily_energy_imported
+    - sensor.solis_grid_import_today
   export_today: 
-    - sensor.solis_daily_energy_exported
+    - sensor.solis_grid_import_today
   pv_today:
-    - sensor.solis_daily_generation   # This is a custom sensor - documentation TBD
+    - sensor.solis_power_generation_today
   #
   # Controls/status - must by 1 per inverter
   #
@@ -31,10 +31,14 @@ pred_bat:
 
   battery_rate_max:
     - 3000
-  charge_rate: 
-    - 3000
-  discharge_rate: 
-    - 3500
+  charge_current: 
+    - number.solis_timed_charge_current
+  discharge_current: 
+    - number.solis_timed_discharge_current
+  battery_voltage:
+    - sensor.solis_battery_voltage
+
+
 
   inverter_mode: 
   - select.predbat_mode
@@ -56,37 +60,37 @@ pred_bat:
   battery_power: 
     - sensor.solis_battery_power
   pv_power: 
-    - sensor.solis_inverter_dc_power
+    - sensor.solis_pv_total_power
   load_power: 
-    - sensor.solis_total_load_power
+    - sensor.solis_total_load_power  ******
   soc_percent:
     - sensor.solis_battery_soc
   soc_max: 
     - 10
   reserve: 
-    - sensor.solis_overdischarge_soc
+    - number.solis_battery_minimum_soc
 
 
   charge_start_hour: 
-   - sensor.solis_timed_charge_start_hour
+   - number.solis_timed_charge_start_hours
   charge_start_minute: 
-   - sensor.solis_timed_charge_start_minute
+   - number.solis_timed_charge_start_minutes
   charge_end_hour: 
-   - sensor.solis_timed_charge_end_hour
+   - number.solis_timed_charge_end_hours
   charge_end_minute: 
-   - sensor.solis_timed_charge_end_minute
+   - number.solis_timed_charge_end_minutes
   charge_limit: 
-   - sensor.solis_timed_charge_current_limit
+   - number.solis_timed_charge_current_limit
   discharge_start_hour: 
-   - sensor.solis_timed_discharge_start_hour
+   - number.solis_timed_discharge_start_hours
   discharge_start_minute: 
-   - sensor.solis_timed_discharge_start_minute
+   - number.solis_timed_discharge_start_minutes
   discharge_end_hour: 
-   - sensor.solis_timed_discharge_end_hour
+   - number.solis_timed_discharge_end_hours
   discharge_end_minute: 
-   - sensor.solis_timed_discharge_end_minute
+   - number.solis_timed_discharge_end_minutes
   discharge_limit: 
-   - sensor.solis_timed_discharge_current_limit
+   - number.solis_timed_discharge_current_limit
 
 # The following are the Modbus registers on the Solis inverter that control timed charging
 # They should not need changing but are included for completeness. Defaults are loaded by predbat.
@@ -100,7 +104,11 @@ pred_bat:
   # solis_discharge_start_hour_register: 43147
   # solis_discharge_start_minute_register: 43148
   # solis_discharge_end_hour_register: 43149
-  # olis_discharge_end_minute_register: 43150
+  # solis_discharge_end_minute_register: 43150
+
+# These are the modbus slave number and hub which also should not need updating in most cases
+  solis_modbus_slave: 1
+  solis_modbus_hub: solis
 
 
 
@@ -328,4 +336,4 @@ pred_bat:
   #iboost_energy_today: 'sensor.xxxxx'
   #iboost_energy_scaling: 1.0
 
-  
+ 


### PR DESCRIPTION
Need to write minutes as well as hours to the relevant entities: hours as [:2], minutes as [3:5]. These are also "numbers" not "select" on Solis so changed to write_and_poll_value.

Solis controls on current not rate so added "(dis)charge_current" as arg and calculate from voltage.

Removed some unnecessary stuff now I am clearer how things work. 