### PR TITLE
Fixes for Solis inverters to use low power mode correctly

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -2770,9 +2770,9 @@ class Inverter:
             # If current SOC is above Target SOC, turn Grid Charging off
             self.alt_charge_discharge_enable("charge", False, grid=True, timed=False)
             self.base.log(f"Current SOC {self.soc_percent}% is greater than Target SOC {current_charge_limit}. Grid Charge disabled.")
-        elif self.soc_percent == float(current_charge_limit):                              # If SOC target is reached
-            self.alt_charge_discharge_enable("charge", True, grid=True, timed=False)      # Make sure charging is on 
-            self.set_current_from_power("charge", (0))                                    # Set charge current to zero (i.e hold SOC)
+        elif self.soc_percent == float(current_charge_limit):  # If SOC target is reached
+            self.alt_charge_discharge_enable("charge", True, grid=True, timed=False)  # Make sure charging is on
+            self.set_current_from_power("charge", (0))  # Set charge current to zero (i.e hold SOC)
             self.base.log(f"Current SOC {self.soc_percent}% is same as Target SOC {current_charge_limit}. Grid Charge enabled, Amps rate set to 0.")
         else:
             # If we drop below the target, turn grid charging back on and make sure the charge current is correct

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -896,7 +896,7 @@ INVERTER_DEF = {
         "has_charge_enable_time": False,
         "has_discharge_enable_time": False,
         "has_target_soc": False,
-        "has_reserve_soc": True,
+        "has_reserve_soc": False,
         "charge_time_format": "H M",
         "charge_time_entity_is_option": False,
         "soc_units": "%",
@@ -2765,15 +2765,21 @@ class Inverter:
         Returns:
             None
         """
-        if self.soc_percent >= float(current_charge_limit):
+        charge_power = self.base.get_arg("charge_rate", index=self.id, default=2600.0)
+        if self.soc_percent > float(current_charge_limit):
             # If current SOC is above Target SOC, turn Grid Charging off
             self.alt_charge_discharge_enable("charge", False, grid=True, timed=False)
             self.base.log(f"Current SOC {self.soc_percent}% is greater than Target SOC {current_charge_limit}. Grid Charge disabled.")
+        elif elf.soc_percent == float(current_charge_limit):                              # If SOC target is reached
+            self.alt_charge_discharge_enable("charge", True, grid=True, timed=False)      # Make sure charging is on 
+            self.set_current_from_power("charge", (0))                                    # Set charge current to zero (i.e hold SOC)
+            self.base.log(f"Current SOC {self.soc_percent}% is same as Target SOC {current_charge_limit}. Grid Charge enabled, Amps rate set to 0.")
         else:
             # If we drop below the target, turn grid charging back on and make sure the charge current is correct
             self.alt_charge_discharge_enable("charge", True, grid=True, timed=False)
             if self.inv_output_charge_control == "current":
-                self.set_current_from_power("charge", self.battery_rate_max_charge * MINUTE_WATT)
+                self.set_current_from_power("charge", charge_power)  # Write previous current setting to inverter
+                self.base.log(f"Current SOC {self.soc_percent}% is less than Target SOC {current_charge_limit}. Grid Charge enabled, amp rate written to inverter.")
             self.base.log(
                 f"Current SOC {self.soc_percent}% is less than Target SOC {current_charge_limit}. Grid charging enabled with charge current set to {self.base.get_arg('timed_charge_current', index=self.id, default=65):0.2f}"
             )

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -2770,7 +2770,7 @@ class Inverter:
             # If current SOC is above Target SOC, turn Grid Charging off
             self.alt_charge_discharge_enable("charge", False, grid=True, timed=False)
             self.base.log(f"Current SOC {self.soc_percent}% is greater than Target SOC {current_charge_limit}. Grid Charge disabled.")
-        elif elf.soc_percent == float(current_charge_limit):                              # If SOC target is reached
+        elif self.soc_percent == float(current_charge_limit):                              # If SOC target is reached
             self.alt_charge_discharge_enable("charge", True, grid=True, timed=False)      # Make sure charging is on 
             self.set_current_from_power("charge", (0))                                    # Set charge current to zero (i.e hold SOC)
             self.base.log(f"Current SOC {self.soc_percent}% is same as Target SOC {current_charge_limit}. Grid Charge enabled, Amps rate set to 0.")


### PR DESCRIPTION
When using a Solis inverter, the predbat code at time of fork sets the value of charge current to maximum when mimicing the target SOC functionality originally designed for GivEnergy inverters. This pull request modifies the code in "mimic_soc_target" to use the charge current previously calculated in 'calculate_plan' and originally set using 'adjust_charge_rate' instead of setting it to max. It also now includes a 3rd state, triggered when the target SOC matches the inverter SOC that sets the charge current to zero, which in effect disables the inverter from supplying the house load and thus holds the inverter SOC at its current value (save 75W used for running the inverter). This method is certainly preferable to continually oscillating between charging at full current and discharging to house load, which is what the previous code did, and what is believed intended via use of low power mode. 

The above modification means it is also no longer necessary to use the backup/reserve mode switch, which equally either charges at full rate or discharges to support house load. I note this was not fully working anyway as a Solis inverter will not accept a write to the backup SOC unless one is actually in backup/reserve mode.  The "has_reserve_soc" has thus been set to False for Solis inverters. There are still elements of the code that write to the backup SOC value but they don't cause errors so I've ignored them. 

The above has been tested in "Control Charge" and "Control Charge and Discharge" modes. Control SOC mode zeros the charge windows, but as the changes involve controlling the inverter via current I see no differentiation between Control SOC and Control charge in low power modes. Should this pull request be accepted I think that the documentation for Solis inverters should mention that "Control SOC" mode should not be used.  I however admit I may not understand what Control SOC mode does or is intended for. 

I don't think the code should affect any other inverter other than Solis because the mimic_target_soc function only runs if the inverter doesn't have target SOC functionality and writes to the inverter are made via a power to current conversion function, of which Solis is the only inverter that uses current rather than power. 

Finally I've noted that the target SOC value does vary considerably over the 6 hour IOG charging slot. Your FAQ suggests that this could be due to other automations modifying "reserve %". I hope that my disabling of backup SOC via setting "has_reserve_soc" to False is not related to this, otherwise more modifications are needed. I will raise this as an issue if having a full 7 days of history including car use being properly excluded does not stabilize the charge window SOC as constant each time it is calculated within the 6 hour charge window (which given no other input data is changing, it should?) 