### PR TITLE
Update apps-yaml.md

### DIFF
--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -575,7 +575,7 @@ Recommended setting is 200 for Gen 1 hybrids with this issue.
   inverter_reserve_max: percent
 ```
 
-Global, sets the maximum reserve % that maybe set to the inverter, the default is 98 as some Gen 2 inverters and
+Global, sets the maximum reserve % that may be set to the inverter, the default is 98, as some Gen 2 & Gen 3 inverters and
 AIO firmware versions refuse to be set to 100.  Comment the line out or set to 100 if your inverter allows setting to 100%.
 
 ## Automatic restarts


### PR DESCRIPTION
Minor update to apps-yaml.md (inverter_reserve_max workaround section). Adding Gen 3 to the list of inverters as not accepting a reserve of 100. Plus a small typo edit.