### PR TITLE
Add Solcast docs para about hybrid inverters

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -205,6 +205,10 @@ Predbat is configured to automatically discover the Solcast forecast entities in
 Install the Solcast integration (<https://github.com/oziee/ha-solcast-solar>), create a [Solcast account](https://solcast.com/),
 configure details of your solar arrays, and request an API key that you enter into the Solcast integration in Home Assistant.
 
+**Hybrid inverters only**: If your hybrid inverter capacity is smaller than your array peak capacity, tell Solcast that your AC capacity is equal to your DC capacity
+(both equal to your array peak kW). Otherwise, Solcast will provide forecast data clipped at your inverter capacity. Let predbat handle any necessary clipping instead.
+When supplied with the unclipped Solcast forecast data, predbat can allow in its model for PV in excess of the inverter capacity going to battery charging (bypassing the hybrid inverter).
+
 Note that Predbat does not update Solcast for you so you will need to create your own Home Assistant automation that updates the solar forecast a few times a day
 (e.g. dawn, dusk, and just before your nightly charge slot).
 


### PR DESCRIPTION
Add docs paragraph telling hybrid inverter users how to set up their Solcast forecast: If the inverter capacity is smaller than the array peak capacity, tell Solcast that the AC capacity is equal to the DC capacity (both equal to the array peak kW). Otherwise, Solcast will provide forecast data clipped at the inverter capacity. Let predbat handle any necessary clipping instead. When supplied with the unclipped Solcast forecast data, predbat can allow in its model for PV in excess of the inverter capacity going to battery charging (bypassing the hybrid inverter).

I've been looking at line [1644 of predbat.py (Charge enable)](https://github.com/springfall2008/batpred/blob/7c5a0b72b47279c50c144fc851ac253713f3bdf4/apps/predbat/predbat.py#L1643). It seems to me the predbat model will take account of PV above inverter_limit providing it is included in the solar forecast.