### PR TITLE
Update mkdocs.yml, correct car charging filename

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ nav:
     - 'Install details': install.md
     - energy-rates.md
     - apps-yaml.md
-    - car-charge-planning.md
+    - car-charging.md
     - configuration-guide.md
     - customisation.md
     - video-guides.md


### PR DESCRIPTION
Car charging missing from Predbat documentation because it has been renamed in 8.3.3