### PR TITLE
Doc tidy up's

### DIFF
--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -759,7 +759,8 @@ if you have multiple batteries on an inverter that need scaling you should enter
 *TIP:* If you have a GivEnergy 2.6 or 5.2kWh battery then it will have an 80% depth of discharge but it will falsely report its capacity as being the 100% size,
 so set battery_scaling to 0.8 to report the correct usable capacity figure to Predbat.
 
-*TIP:* Likewise if you have a GivEnergy All in One, it will incorrectly report the 13.5kWh usable capacity as 15.9kWh, so set battery_scaling to 0.85 to correct this.
+*TIP:* Likewise, if you have one or multiple GivEnergy All in One (AIO)'s,
+it will incorrectly report the 13.5kWh usable capacity of each AIO as 15.9kWh, so set battery_scaling to 0.85 to correct this.
 
 If you are going chart your battery SoC in Home Assistant then you may want to use **predbat.soc_kw_h0** as your current SoC
 rather than the usual *givtcp_SERIAL_NUMBER_soc* GivTCP entity so everything lines up.

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -7,15 +7,7 @@ You will firstly need to have installed the appropriate Home Assistant integrati
 
 ## Configure apps.yaml for your car charging
 
-Next configure the [Car charging settings in apps.yaml](apps-yaml.md#car-charging-integration):
-
-### Car Charging Hold options
-
-Car charging hold is a feature to filter out previous car charging from your historical house load data so that future predictions are more accurate.
-
-See [Car charging filtering](apps-yaml.md#car-charging-filtering).
-
-and [Planned car charging](apps-yaml.md#planned-car-charging) so Predbat knows when you plan to charge your car.
+Start by configuring the [Car charging settings in apps.yaml](apps-yaml.md#car-charging-integration).
 
 ## Car Charging Planning
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -112,10 +112,11 @@ All grid charging (regardless of inverter type) has to undergo an AC to DC conve
 
 **input_number.predbat_metric_battery_cycle** (_expert mode_) This sets a 'virtual cost' in pence per kWh on using your battery for charging and discharging.
 Higher numbers will reduce battery cycles at the expense of using higher energy costs.<BR>
-In theory if you think your battery will last say 6000 complete cycles and cost you £4000 and is 9.5kWh then each full charge and discharge cycle is 19kWh
-and so the cost per cycle is £4000 / 19 / 6000 = 3.5p.
+In theory if you have a 9.5kWh battery and think it will last say 6000 complete cycles and it cost you £4000, then each full charge and discharge cycle is 19kWh
+and so the cost per complete cycle is £4000 / 19 / 6000 = 3.5p.
 
-Taking the 3.5p example, Predbat will apply a "virtual cost" of 3.5p to every kWh of charge and of discharge of the battery.
+Taking the 3.5p per cycle example, if you set predbat_metric_battery_cycle to 1.75 (half of 3.5) then Predbat will apply the "virtual cost" of 1.75p
+to every kWh of charge and of discharge of the battery.
 This cost will be included in Predbat's cost optimisation plan when it decides whether to charge, discharge the battery or let the house run on grid import.<BR>
 _NB: For clarity and to re-emphasise, the "virtual cost" will be applied to BOTH the cost calculation for charging AND for discharging the battery._
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -492,3 +492,15 @@ You may find that the Predbat add-on installed with an older version of Predbat 
 which might require you to [update Predbat to the correct version](#predbat-built-in-update).
 
 11. When you are happy running the Predbat add-on you can delete the AppDaemon or AppDaemon-predbat add-on.
+
+## Backing up Home Assistant and Predbat
+
+It's strongly recommended that you implement an automatic mechanism to backup your Home Assistant and Predbat system.
+
+There are several ways of backing up Home Assistant but one of the simplest is the [Home Assistant Google Drive Backup](https://github.com/sabeechen/hassio-google-drive-backup)
+which is an add-on that runs every night, automatically makes a backup of Home Assistant (including Predbat), and copies that backup to a Google Drive for safe keeping.
+
+If you create a new Google account specifically for your Home Assistant backups you will automatically get 15Gb of free Google Drive storage, enough for a couple of weeks of backups.
+
+As well as the full Home Assistant backup you manually copy the contents of Predbat's `apps.yaml` configuration file to somewhere safe so that if you accidentally mis-edit it,
+you can get Predbat working quickly again by copying it back again.

--- a/templates/example_chart.yml
+++ b/templates/example_chart.yml
@@ -757,7 +757,7 @@ yaxis:
   - id: header_only
     show: false
 series:
-  - entity: sensor.givtcp_sa2243g277_pv_power
+  - entity: sensor.INVERTER_CURRENT_PV_POWER_GENERATION_IN_WATTS
     name: Solar Power
     type: line
     stroke_width: 2
@@ -779,6 +779,7 @@ series:
     opacity: 0.3
     stroke_width: 0
     type: area
+    time_delta: +15min
     extend_to: false
     yaxis_id: kWh
     show:
@@ -794,6 +795,7 @@ series:
     opacity: 0.3
     stroke_width: 0
     type: area
+    time_delta: +15min
     extend_to: false
     yaxis_id: kWh
     show:
@@ -803,7 +805,7 @@ series:
       return entity.attributes.detailedForecast.map((entry) => {
             return [new Date(entry.period_start), entry.pv_estimate10];
           });
-  - entity: sensor.givtcp_sa2243g277_pv_energy_today_kwh
+  - entity: sensor.INVERTER_TOTAL_PV_GENERATION_TODAY_IN_KWH
     yaxis_id: header_only
     name: Today Actual
     stroke_width: 2

--- a/templates/example_chart.yml
+++ b/templates/example_chart.yml
@@ -757,7 +757,7 @@ yaxis:
   - id: header_only
     show: false
 series:
-  - entity: sensor.INVERTER_CURRENT_PV_POWER_GENERATION_IN_WATTS
+  - entity: predbat.pv_power
     name: Solar Power
     type: line
     stroke_width: 2
@@ -772,7 +772,7 @@ series:
       in_header: false
     group_by:
       func: avg
-      duration: 5m
+      duration: 15m
   - entity: sensor.predbat_pv_today
     name: Forecast
     color: grey
@@ -805,7 +805,7 @@ series:
       return entity.attributes.detailedForecast.map((entry) => {
             return [new Date(entry.period_start), entry.pv_estimate10];
           });
-  - entity: sensor.INVERTER_TOTAL_PV_GENERATION_TODAY_IN_KWH
+  - entity: predbat.pv_energy_h0
     yaxis_id: header_only
     name: Today Actual
     stroke_width: 2


### PR DESCRIPTION
- Added 15 min offset to PV chart as PV forecasts are for 30 min slots and this better aligns the actual PV with the slot
- Changed PV forecast chart to use generic sensor id's that must be customised #1330
- Expanded AIO battery scaling explanation for multiple AIO's #1360 
- Further explain metric_battery_cycle_cost #611 
- Add guidance on backing up Home Assistant and Predbat
- Minor car charging doc tidy up