### PR TITLE
Update givenergy_givtcp.yaml

### DIFF
--- a/templates/givenergy_givtcp.yaml
+++ b/templates/givenergy_givtcp.yaml
@@ -71,7 +71,8 @@ pred_bat:
   #
   # Controls/status - must by 1 per inverter
   #
-  inverter: "GE"
+  inverter_type:
+    - "GE"
   num_inverters: 1
   #
   # Run balance inverters every N seconds (0=disabled) - only for multi-inverter


### PR DESCRIPTION
Corrected line 74.

Config only listed option as "inverter", should have been "inverter type:" 

Line 75 now list inverter type as "GE".

This resolves an issue in the Predbat log that was saying stating "Warn: Inverter 0: inverter definition is not a dictionary".