### PR TITLE
Update "example_chart.yml" section "PV Forecast vs actual chart"

### DIFF
--- a/templates/example_chart.yml
+++ b/templates/example_chart.yml
@@ -765,7 +765,6 @@ series:
     color: Orange
     yaxis_id: kWh
     unit: kW
-    transform: return x/1000;
     extend_to: now
     show:
       legend_value: true


### PR DESCRIPTION
Removed "transform: return x/1000;" as entity "predbat.pv_power" is already in kW and does not require a transform /1000.

Graph now showing correctly for Apexchart "PV Forecast vs actual chart"