### PR TITLE
Detect & auto-restart 'stalled predbat'.  Set geserial manually for multi-AIO's & 3-phase inverters

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -4387,7 +4387,7 @@ class PredBat(hass.Hass):
 
             if discharge_window_n >= 0:
                 limit = self.discharge_limits_best[discharge_window_n]
-                if limit == 99:
+                if limit == 99:                               # freeze discharging
                     if state == soc_sym:
                         state = ""
                     if state:
@@ -4396,12 +4396,12 @@ class PredBat(hass.Hass):
                     else:
                         state_color = "#AAAAAA"
                     state += "FrzDis&rarr;"
-                    show_limit = str(int(limit))
+                    show_limit = ""                            # suppress displaying the limit (of 99) when freeze discharging as its a meaningless number
                 elif limit < 100:
                     if state == soc_sym:
                         state = ""
                     if state:
-                        state += "</td><td bgcolor=#FFFF00>"  # charging and discharging in the same slot
+                        state += "</td><td bgcolor=#FFFF00>"  # charging and discharging in the same slot, split the state into two
                         split = True
                     else:
                         state_color = "#FFFF00"

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -4387,7 +4387,7 @@ class PredBat(hass.Hass):
 
             if discharge_window_n >= 0:
                 limit = self.discharge_limits_best[discharge_window_n]
-                if limit == 99:                               # freeze discharging
+                if limit == 99:  # freeze discharging
                     if state == soc_sym:
                         state = ""
                     if state:
@@ -4396,7 +4396,7 @@ class PredBat(hass.Hass):
                     else:
                         state_color = "#AAAAAA"
                     state += "FrzDis&rarr;"
-                    show_limit = ""                            # suppress displaying the limit (of 99) when freeze discharging as its a meaningless number
+                    show_limit = ""  # suppress displaying the limit (of 99) when freeze discharging as its a meaningless number
                 elif limit < 100:
                     if state == soc_sym:
                         state = ""

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -237,8 +237,13 @@ and you will need to manually set geserial in apps.yaml to your inverter serial 
 geserial: 'chNNNNgZZZ'
 ```
 
-*TIP:* If you have multiple GivEnergy AIO's, all the AIO's are controlled by the AIO gateway and not controlled individually.
-geserial should be configured to be your AIO gateway serial number 'gwNNNNgZZZ' and all the geserial2 lines should be commented out in apps.yaml.
+*TIP:* If you have a single GivEnergy AIO, all control is directly to the AIO and the gateway is not required.<BR>
+Check the GivTCP configuration to determine whether inverter 1 (the givtcp sensors) is the AIO or the gateway, or inverter 2 (the givtcp2 sensors) is the AIO or gateway.<BR>
+Then in apps.yaml comment out the lines corresponding to the gateway, leaving just the givtcp or givtcp2 lines for the AIO.
+Also delete the [appropriate givtcp_rest inverter control line](#rest-interface-inverter-control) corresponding to the gateway so that Predbat controls the AIO directly.
+
+*TIP2:* If you have multiple GivEnergy AIO's, all the AIO's are controlled by the AIO gateway and not controlled individually.<BR>
+geserial should be manually configured to be your AIO gateway serial number 'gwNNNNgZZZ' and all the geserial2 lines should be commented out in apps.yaml.
 You should also delete the [second givtcp_rest inverter control line](#rest-interface-inverter-control) so that Predbat controls the AIO's via the gateway.
 
 GivTCP version 3 is required for multiple AIO's or a 3 phase inverter.

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -222,7 +222,7 @@ num_inverters: 1
 
 ### geserial
 
-Only for GE inverters, this is a helper regular expression to find your serial number, if it doesn't work edit it manually or change individual entities to match.
+Only for GE inverters, this is a helper regular expression to find your inverter serial number, if it doesn't work edit it manually or change individual entities to match.
 If you  have more than one inverter you will need one per inverter to be used in the later configuration lines
 
 ```yaml
@@ -230,9 +230,17 @@ geserial: 're:sensor.givtcp_(.+)_soc_kwh'
 geserial2: 're:sensor.givtcp2_(.+)_soc_kwh'
 ```
 
+If you are running GivTCP v3 and have an AIO or a 3 phase inverter then the helper regular expression will not correctly work
+and you will need to manually set geserial in apps.yaml to your inverter serial number, i.e.:
+
+```yaml
+geserial: 'chNNNNgZZZ'
+```
+
 *TIP:* If you have multiple GivEnergy AIO's, all the AIO's are controlled by the AIO gateway and not controlled individually.
-geserial should be configured to be your AIO gateway serial number and all the geserial2 lines should be commented out in apps.yaml.
-GivTCP version 3 is required for multiple AIO's.
+geserial should be configured to be your AIO gateway serial number 'gwNNNNgZZZ' and all the geserial2 lines should be commented out in apps.yaml.
+
+GivTCP version 3 is required for multiple AIO's or a 3 phase inverter.
 
 ## Historical data
 

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -231,7 +231,7 @@ geserial2: 're:sensor.givtcp2_(.+)_soc_kwh'
 ```
 
 If you are running GivTCP v3 and have an AIO or a 3 phase inverter then the helper regular expression will not correctly work
-and you will need to manually set geserial in apps.yaml to your inverter serial number, i.e.:
+and you will need to manually set geserial in apps.yaml to your inverter serial number, e.g.:
 
 ```yaml
 geserial: 'chNNNNgZZZ'
@@ -239,6 +239,7 @@ geserial: 'chNNNNgZZZ'
 
 *TIP:* If you have multiple GivEnergy AIO's, all the AIO's are controlled by the AIO gateway and not controlled individually.
 geserial should be configured to be your AIO gateway serial number 'gwNNNNgZZZ' and all the geserial2 lines should be commented out in apps.yaml.
+You should also delete the [second givtcp_rest inverter control line](#rest-interface-inverter-control) so that Predbat controls the AIO's via the gateway.
 
 GivTCP version 3 is required for multiple AIO's or a 3 phase inverter.
 
@@ -379,7 +380,8 @@ For GivEnergy inverters Predbat can control the inverter directly via REST inste
 When configured in apps.yaml, control communication from Predbat to GivTCP is via REST which bypasses some issues with MQTT.
 
 - **givtcp_rest** - One entry per Inverter, sets the GivTCP REST API URL ([http://homeassistant.local:6345](http://homeassistant.local:6345)
-is the normal address and port for the first inverter, and the same address but ending :6346 if you have a second inverter - if you haven't a second inverter, delete the second line.<BR>
+is the normal address and port for the first inverter, and the same address but ending :6346 if you have a second inverter - if you don't have a second inverter
+(or if you have multiple AIO's that are controlled through the gateway), delete the second line.<BR>
 If you are using Docker then change 'homeassistant.local' to the Docker IP address.
 
 *TIP:* You can replace *homeassistant.local* with the IP address of your Home Assistant server if you have it set to a fixed IP address.

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -56,10 +56,13 @@ the Configuration tab is now no longer used and all configuration is now done vi
 - On the GivTCP add-on, click 'START' to start the add-on
 - Once the add-on has started, click 'Open Web UI' or go to [http://homeassistant.local:8099/](http://homeassistant.local:8099/), then click 'Go to Config Page' to configure GivTCP
 - GivTCP will auto-discover your inverters and batteries so you shouldn't need to manually enter these, but check the IP address(s) it finds are correct
-- If you have multiple inverters you may wish to change the default device prefixes that GivTCP assigns (givtcp, givtcp2, givtcp3, etc)
-to make it easier to identify your devices within Home Assistant.
+- If you have multiple inverters you may wish to change the default device prefixes that GivTCP assigns ('givtcp', 'givtcp2', 'givtcp3', etc)
+to make it easier to identify your devices within Home Assistant.<BR>
 For example if you have a gateway and two AIO's you could use the prefixes 'GW', 'AIO-1' and 'AIO-2'.
-The prefixes should be set before you start using GivTCP in anger as changing the prefixes later on will result in both the old and new sensor names in Home Assistant!
+The prefixes should be set before you start using GivTCP in anger
+as changing the prefixes later on will result in both the old and new sensor names appearing in Home Assistant with the 'old' sensors being "unavailable".<BR>
+Note that if you do change the givtcp prefixes then you will also have to edit the apps.yaml configuration file to match,
+and change the sensor names that predbat is looking for (by default prefixed 'givtcp_xxx') to your new sensor naming structure
 - Click Next and Next to get to the Selfrun page, and turn on Self run. The Self Run Loop Timer is how often GivTCP will retrieve data from your inverters - it's
 recommended that set this to a value between 20 and 60, but not less than 15 seconds as otherwise the inverter will then spend all its time talking to GivTCP
 and won't communicate with the GivEnergy portal and app
@@ -84,8 +87,8 @@ These settings are documented in the appropriate place in the documentation, but
 as the battery size is incorrectly reported to GivTCP
 - If you have a Gen 2, Gen 3 or AIO then you may need to set [inverter_reserve_max in apps.yaml](apps-yaml.md#inverter-reserve-maximum) to 98.
 If you have a Gen 1 or a firmware version that allows reserve being set to 100 then you can change the default from 98 to 100
-- If your inverter has been wired as an EPS (Emergency Power Supply) or AIO 'whole home backup',
-[consider setting input_number.predbat_set_reserve_min](customisation.md#inverter-control-options) to reserve some battery power for use in emergencies.
+- If your inverter has been wired as an EPS (Emergency Power Supply) or AIO 'whole home backup', consider setting
+[input_number.predbat_set_reserve_min](customisation.md#inverter-control-options) to reserve some battery power for use in emergencies.
 
 **NB: GivTCP and Predbat do not currently yet work together for 3 phase inverters**.
 This is being worked on by the author of GivTCP, e.g. see [GivTCP issue: unable to charge or discharge 3 phase inverters with predbat](https://github.com/britkat1980/giv_tcp/issues/218)

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -82,6 +82,7 @@ but its worth highlighting that there are a few specific settings that should be
 These settings are documented in the appropriate place in the documentation, but for ease of identification, are repeated here:
 
 - If you are using GivTCP v3 and have an AIO or 3 phase inverter then you will need to manually set [geserial in apps.yaml](apps-yaml.md#geserial) to your inverter serial number
+- If you have a single AIO then control is directly to the AIO. Ensure [geserial in apps.yaml](apps-yaml.md#geserial) is correctly picking the AIO and comment out geserial2 lines
 - If you have multiple AIO's then all control of the AIO's is done through the Gateway so [geserial in apps.yaml](apps-yaml.md#geserial) should be set to the Gateway serial number
 - If you have a 2.6kWh, 5.2kWh or AIO battery then you will need to set [battery_scaling in apps.yaml](apps-yaml.md#battery-size-scaling)
 as the battery size is incorrectly reported to GivTCP

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -56,6 +56,10 @@ the Configuration tab is now no longer used and all configuration is now done vi
 - On the GivTCP add-on, click 'START' to start the add-on
 - Once the add-on has started, click 'Open Web UI' or go to [http://homeassistant.local:8099/](http://homeassistant.local:8099/), then click 'Go to Config Page' to configure GivTCP
 - GivTCP will auto-discover your inverters and batteries so you shouldn't need to manually enter these, but check the IP address(s) it finds are correct
+- If you have multiple inverters you may wish to change the default device prefixes that GivTCP assigns (givtcp, givtcp2, givtcp3, etc)
+to make it easier to identify your devices within Home Assistant.
+For example if you have a gateway and two AIO's you could use the prefixes 'GW', 'AIO-1' and 'AIO-2'.
+The prefixes should be set before you start using GivTCP in anger as changing the prefixes later on will result in both the old and new sensor names in Home Assistant!
 - Click Next and Next to get to the Selfrun page, and turn on Self run. The Self Run Loop Timer is how often GivTCP will retrieve data from your inverters - it's
 recommended that set this to a value between 20 and 60, but not less than 15 seconds as otherwise the inverter will then spend all its time talking to GivTCP
 and won't communicate with the GivEnergy portal and app

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -87,6 +87,9 @@ If you have a Gen 1 or a firmware version that allows reserve being set to 100 t
 - If your inverter has been wired as an EPS (Emergency Power Supply) or AIO 'whole home backup',
 [consider setting input_number.predbat_set_reserve_min](customisation.md#inverter-control-options) to reserve some battery power for use in emergencies.
 
+**NB: GivTCP and Predbat do not currently yet work together for 3 phase inverters**.
+This is being worked on by the author of GivTCP, e.g. see [GivTCP issue: unable to charge or discharge 3 phase inverters with predbat](https://github.com/britkat1980/giv_tcp/issues/218)
+
 ## Solis Inverters
 
 To run PredBat with Solis hybrid inverters, follow the following steps:

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -74,8 +74,8 @@ The rest of the [Predbat installation instructions](install.md) should now be fo
 but its worth highlighting that there are a few specific settings that should be set for certain GivEnergy equipment.
 These settings are documented in the appropriate place in the documentation, but for ease of identification, are repeated here:
 
-- If you have multiple AIO's then all control of the AIO's is done through the Gateway
-so you will need to manually set [geserial in apps.yaml](apps-yaml.md#geserial) to the Gateway serial number
+- If you are using GivTCP v3 and have an AIO or 3 phase inverter then you will need to manually set [geserial in apps.yaml](apps-yaml.md#geserial) to your inverter serial number
+- If you have multiple AIO's then all control of the AIO's is done through the Gateway so [geserial in apps.yaml](apps-yaml.md#geserial) should be set to the Gateway serial number
 - If you have a 2.6kWh, 5.2kWh or AIO battery then you will need to set [battery_scaling in apps.yaml](apps-yaml.md#battery-size-scaling)
 as the battery size is incorrectly reported to GivTCP
 - If you have a Gen 2, Gen 3 or AIO then you may need to set [inverter_reserve_max in apps.yaml](apps-yaml.md#inverter-reserve-maximum) to 98.

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -435,7 +435,15 @@ to view Predbat's logfile - see [editing configuration files within Home Assista
 ## Automated monitoring that Predbat and GivTCP are running OK
 
 With GivTCP and Predbat performing an important function, managing your battery charging and discharging to best reduce your electricity bills,
-you may find these automations useful to monitor that GivTCP and Predbat are running OK, and if not, to raise an alert on your mobile device.
+you may find these automations useful to monitor that GivTCP and Predbat are running OK, and if not, to raise an alert on your mobile device running the Home Assistant Companion app.
+
+To create a new automation:
+
+- Settings / Automations & Scenes
+- Create Automation / Create new Automation
+- Three dots (top right corner) / Edit in YAML
+- Delete the existing (template) automation code and copy/paste the supplied automation code below
+
 
 ### GivTCP activity monitor
 

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -532,7 +532,7 @@ action:
       title: GivTCP communication issue
       message: |
         {{now().strftime('%-d %b %H:%M')}} ISSUE:
-        {{ alert_text }} for the past 15 minutes, restarting 
+        {{ alert_text }} for the past 15 minutes, restarting
         {{ restart_app }}
       data:
         visibility: public

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -73,10 +73,11 @@ Installation steps:
 
 Now create the dynamic dashboard:
 
-- Go to System/Dashboards, click 'Open' against an existing dashboard or 'Add Dashboard'/'New dashboard from scratch'/enter a name/click Create, then click 'Open'
-
-- Click the pencil icon in the top right corner, click the blue 'Add card', scroll down the list of cards to the bottom and click 'Manual',
-delete the template card configuration and paste the following YAML into the dashboard and click 'Save':
+- Go to Settings/Dashboards, click 'Open' against an existing dashboard or 'Add Dashboard'/'New dashboard from scratch'/enter a name/click Create, then click 'Open'
+- Click the pencil icon in the top right corner, then the plus symbol on the far right of the next row to create a new View
+- Enter a title of the View, then Save
+- Click the blue 'Add card', scroll down the list of cards to the bottom and click 'Manual',
+delete the template card configuration and copy/paste the following YAML into the dashboard and click 'Save':
 
 ```yaml
 type: vertical-stack
@@ -443,7 +444,6 @@ To create a new automation:
 - Create Automation / Create new Automation
 - Three dots (top right corner) / Edit in YAML
 - Delete the existing (template) automation code and copy/paste the supplied automation code below
-
 
 ### GivTCP activity monitor
 

--- a/docs/predbat-plan-card.md
+++ b/docs/predbat-plan-card.md
@@ -97,7 +97,7 @@ Alongside the state is an arrow which points upwards if the battery SoC is incre
 or downwards if the battery SoC is decreasing (i.e. discharging).<BR>
 If Predbat's plan has been over-ridden and the [slot has been manually controlled](customisation.md#manual-control) to be a Charging slot, Discharging or Idle,
 then alongside the State and battery SoC arrow will be an upside down 'F' indicating it is a 'Forced' activity.<BR>
-The slot will be coloured Green for Charging, Yellow for Discharging, Silver Grey for Freeze Charging, Pale Blue for Hold Charging or White for Idle.<BR>
+The slot will be coloured Green for Charging, Yellow for Discharging, Silver Grey for Freeze Charging, Dark Grey for Freeze Discharging, Pale Blue for Hold Charging or White for Idle.<BR>
 NB: The Predbat plan is shown in 30 minute time slots but Predbat actually plans battery activity in 5 minute segments within the 30 minute slot.
 If the Home Assistant control *switch.predbat_calculate_discharge_oncharge* is set to True,
 then within a 30 minute slot (and depending on import and export rates) Predbat could potentially plan for there to be both

--- a/docs/what-does-predbat-do.md
+++ b/docs/what-does-predbat-do.md
@@ -85,7 +85,7 @@ but if there is excess Solar power above house load, the excess solar will be us
 
 - **Freeze discharging** - The battery is in Discharge mode, the same as Idle (Eco) mode, but with charging disabled.
 The battery or solar covers the house load. As charging is disabled, if there is excess solar generated, the current SoC level will be held and the excess solar will be exported.
-If there is a shortfall of solar power to meet house load, the battery will discharge.
+If there is a shortfall of generated solar power to meet house load, the battery will discharge to meet the extra load.
 
 - **Calibration** - The inverter is calibrating the batteries.
 On GivEnergy systems the battery state of charge (SoC) level has to be calibrated by performing a full battery discharge then a full charge


### PR DESCRIPTION
- #1348 detect 'stalled predbat' issues and auto-restart the Predbat add-on
- #1482 suppress display of freeze discharge limit (99) in plan. Add explanation of F-D colour to plan description
- Add auto-restart to GivTCP activity monitor
- Set geserial manually for multi-AIO's and 3 phase inverters with GivTCP v3
- Change givtcp prefixes if required
- Instructions for creating an automation
- Corrected Predbat dashboard instructions



























