### PR TITLE
Update docs to reflect binary_sensor batpred_discharging renamed to batpred_exporting

### DIFF
--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -998,7 +998,7 @@ If you wish to trigger activities based on Predbat charging or discharging the b
 - **binary_sensor.predbat_charging** - Will be True when the home battery is inside a charge slot (either being charged or being held at a level).
 Note that this does include charge freeze slots where the discharge rate is set to zero without charging the battery.
 
-- **binary_sensor.predbat_discharging** - Will be True when the home battery is inside a force discharge slot. This does not include
+- **binary_sensor.predbat_exporting** - Will be True when the home battery is inside a force discharge slot. This does not include
 discharge freeze slots where the charge rate is set to zero to export excess solar only.
 
 ## Understanding how days_previous works

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -273,12 +273,12 @@ trigger:
     id: predbat_charge_off
   - platform: state
     entity_id:
-      - binary_sensor.predbat_discharging
+      - binary_sensor.predbat_exporting
     to: "on"
     id: predbat_discharge_on
   - platform: state
     entity_id:
-      - binary_sensor.predbat_discharging
+      - binary_sensor.predbat_exporting
     to: "off"
     id: predbat_discharge_off
 condition: []

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -415,7 +415,7 @@ Note that if you have configured [battery scaling](apps-yaml.md#battery-size-sca
 The following sensors are set based upon what Predbat is currently controlling the battery to do:
 
 - binary_sensor.predbat_charging - Set to 'on' when Predbat is force charging the battery (from solar, or if that is insufficient, from grid import), or 'off' otherwise
-- binary_sensor.predbat_discharging - Set to 'on' when Predbat is force discharging the battery for export income, 'off' otherwise.
+- binary_sensor.predbat_exporting - Set to 'on' when Predbat is force discharging the battery for export income, 'off' otherwise.
 
 These are useful for automations if for example you want to turn off car charging when the battery is being exported.
 


### PR DESCRIPTION
The binary sensor `batpred_discharging` was renamed to `batpred_exporting` in https://github.com/springfall2008/batpred/pull/1633

This PR updates the docs to reflect this.

I missed this in the release notes, I have an automation which uses this binary sensor to determine if batpred is force discharging or not to set the discharge target SOC on my inverter, based on the target SOC. My inverter (luxpower) has separate  charge and discharge target SOC controls.