### PR TITLE
Add support for Fox reserve soc

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -1502,7 +1502,7 @@ INVERTER_DEF = {
         "has_charge_enable_time": False,
         "has_discharge_enable_time": False,
         "has_target_soc": False,
-        "has_reserve_soc": False,
+        "has_reserve_soc": True,
         "has_timed_pause": False,
         "charge_time_format": "S",
         "charge_time_entity_is_option": False,

--- a/templates/fox.yaml
+++ b/templates/fox.yaml
@@ -138,6 +138,10 @@ pred_bat:
     - 8.29
   battery_rate_max:
     - 4200
+  reserve:
+    - number.min_soc_on_grid
+  battery_min_soc:
+    - number.min_soc
   #reserve:
   #  - number.givtcp_{geserial}_battery_power_reserve
   #inverter_mode:
@@ -345,7 +349,7 @@ pred_bat:
   # If you have an 80% DoD battery that falsely reports it's kwh then set it to 0.8 to report the real figures
   # One per inverter
   battery_scaling:
-    - 0.9
+    - 1.0
 
   # Can be used to scale import and export data, used for workarounds
   import_export_scaling: 1.0


### PR DESCRIPTION
I believe these changes will add support for reserve soc on Fox inverters. I was using this before the recent changes to the Fox configuration so it should work ok.