### PR TITLE
Fix stale inverter data

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -648,6 +648,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Solcast, GECloud, Alertfeed
                 status, status_extra = self.execute_plan()
             else:
                 self.log("Will not recompute the plan, it is {} minutes old and max age is {} minutes".format(dp1(plan_age_minutes), self.calculate_plan_every))
+                self.fetch_inverter_data()
 
         # iBoost solar diverter model update state, only on 5 minute intervals
         if self.iboost_enable and scheduled:


### PR DESCRIPTION
After the introduction of 74a46fa6c80c925c866ac2b9f36151a569faa556 the inverter data when using the ge_cloud native addon becomes stale and doesn't update very frequently. This change is to force the fetch of the inverter data regardless of what we do with the plan.

related #2221