### PR TITLE
Support for Solis invertiers with split charge/discharge update buttons

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2307,7 +2307,7 @@ class Inverter:
 
             if old_charge_schedule_enable == "off" or old_charge_schedule_enable == "disable":
                 self.base.log("Inverter {} Turning on scheduled charge".format(self.id))
-    
+
     def press_and_poll_button(self):
         """
         Press charge/discharge update button(s) for the inverter.
@@ -2316,7 +2316,7 @@ class Inverter:
         2. charge_update_button and discharge_update_button
         """
         success = True
-    
+
         # Try single combined button first
         entity_id = self.base.get_arg("charge_discharge_update_button", indirect=False, index=self.id)
         if entity_id:
@@ -2325,29 +2325,28 @@ class Inverter:
             # Try separate charge and discharge buttons
             charge_button = self.base.get_arg("charge_update_button", indirect=False, index=self.id)
             discharge_button = self.base.get_arg("discharge_update_button", indirect=False, index=self.id)
-    
+
             if charge_button:
                 if not self._press_single_button_and_poll(charge_button):
                     success = False
-    
+
             if discharge_button:
                 if not self._press_single_button_and_poll(discharge_button):
                     success = False
-    
+
             if not charge_button and not discharge_button:
                 self.base.log(f"Error: No update button found for inverter {self.id}")
                 return False
-    
+
         return success
-    
-    
+
     def _press_single_button_and_poll(self, entity_id):
         """
         Press a button and verify that its last_updated time changes.
         Returns True on success.
         """
         local_tz = pytz.timezone(self.base.get_arg("timezone", "Europe/London"))
-    
+
         for retry in range(8):
             self.base.call_service_wrapper("button/press", entity_id=entity_id)
             self.sleep(self.inv_write_and_poll_sleep)
@@ -2357,16 +2356,15 @@ class Inverter:
             except Exception as e:
                 self.base.log(f"Error parsing timestamp for {entity_id}: {e}")
                 continue
-    
+
             now_local = datetime.now(local_tz)
             if (now_local - time_pressed).seconds < 10:
                 self.base.log(f"Successfully pressed button {entity_id} on Inverter {self.id}")
                 return True
-    
+
         self.base.log(f"Warn: Inverter {self.id} Trying to press {entity_id} didn't complete")
         self.base.record_status(f"Warn: Inverter {self.id} Trying to press {entity_id} didn't complete")
         return False
-
 
     def rest_readData(self, api="readData", retry=True):
         """

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2334,10 +2334,6 @@ class Inverter:
                 if not self._press_single_button_and_poll(discharge_button):
                     success = False
 
-            if not charge_button and not discharge_button:
-                self.base.log(f"Error: No update button found for inverter {self.id}")
-                return False
-
         return success
 
     def _press_single_button_and_poll(self, entity_id):

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2307,27 +2307,66 @@ class Inverter:
 
             if old_charge_schedule_enable == "off" or old_charge_schedule_enable == "disable":
                 self.base.log("Inverter {} Turning on scheduled charge".format(self.id))
-
+    
     def press_and_poll_button(self):
         """
-        Call a button press service (Solis) and wait for the data to update
+        Press charge/discharge update button(s) for the inverter.
+        Priority:
+        1. charge_discharge_update_button
+        2. charge_update_button and discharge_update_button
         """
+        success = True
+    
+        # Try single combined button first
         entity_id = self.base.get_arg("charge_discharge_update_button", indirect=False, index=self.id)
-        if not entity_id:
-            return False
-
+        if entity_id:
+            success = self._press_single_button_and_poll(entity_id)
+        else:
+            # Try separate charge and discharge buttons
+            charge_button = self.base.get_arg("charge_update_button", indirect=False, index=self.id)
+            discharge_button = self.base.get_arg("discharge_update_button", indirect=False, index=self.id)
+    
+            if charge_button:
+                if not self._press_single_button_and_poll(charge_button):
+                    success = False
+    
+            if discharge_button:
+                if not self._press_single_button_and_poll(discharge_button):
+                    success = False
+    
+            if not charge_button and not discharge_button:
+                self.base.log(f"Error: No update button found for inverter {self.id}")
+                return False
+    
+        return success
+    
+    
+    def _press_single_button_and_poll(self, entity_id):
+        """
+        Press a button and verify that its last_updated time changes.
+        Returns True on success.
+        """
+        local_tz = pytz.timezone(self.base.get_arg("timezone", "Europe/London"))
+    
         for retry in range(8):
             self.base.call_service_wrapper("button/press", entity_id=entity_id)
             self.sleep(self.inv_write_and_poll_sleep)
-            time_pressed = datetime.strptime(self.base.get_state_wrapper(entity_id, refresh=True), TIME_FORMAT_SECONDS)
-            local_tz = pytz.timezone(self.base.get_arg("timezone", "Europe/London"))
-            now_utc = datetime.now(local_tz)
-            if (now_utc - time_pressed).seconds < 10:
+            state = self.base.get_state_wrapper(entity_id, refresh=True)
+            try:
+                time_pressed = datetime.strptime(state, TIME_FORMAT_SECONDS)
+            except Exception as e:
+                self.base.log(f"Error parsing timestamp for {entity_id}: {e}")
+                continue
+    
+            now_local = datetime.now(local_tz)
+            if (now_local - time_pressed).seconds < 10:
                 self.base.log(f"Successfully pressed button {entity_id} on Inverter {self.id}")
                 return True
+    
         self.base.log(f"Warn: Inverter {self.id} Trying to press {entity_id} didn't complete")
         self.base.record_status(f"Warn: Inverter {self.id} Trying to press {entity_id} didn't complete")
         return False
+
 
     def rest_readData(self, api="readData", retry=True):
         """

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -151,7 +151,6 @@ discharge_update_button:
 
 Ensure the correct entity IDs are used for your specific inverter setup. These entries should correspond to the buttons exposed by your Home Assistant Solis integration.
 
-
 ## Solax Gen4 Inverters
 
 Use the template configuration from: [solax.sx4.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/solax_sx4.yaml)

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -133,6 +133,24 @@ To run PredBat with Solis hybrid inverters, follow the following steps:
 6. Ensure that the inverter is set to Control Mode 35 - on the Solax integration this is `Timed Charge/Discharge`.
    If you want to use the `Reserve` functionality within PredBat you will need to select `Backup/Reserve` (code 51) instead but be aware that
    this is not fully tested. In due course, these mode settings will be incorporated into the code.
+7. Your inverter will require a "button press" triggered by Predbat to update the schedules. Some Solis inverter integrations feature a combined charge/discharge update button, in which case a single entry of:
+
+```yaml
+charge_discharge_update_button:
+  - button.solis_charge_discharge
+```
+
+is sufficient. For other configurations (for exmaple using the "solis_fb00" plugin) where separate buttons are used for charging and discharging, provide both:
+
+```yaml
+charge_update_button:
+  - button.solis_charge
+discharge_update_button:
+  - button.solis_discharge
+```
+
+Ensure the correct entity IDs are used for your specific inverter setup. These entries should correspond to the buttons exposed by your Home Assistant Solis integration.
+
 
 ## Solax Gen4 Inverters
 

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -140,7 +140,7 @@ charge_discharge_update_button:
   - button.solis_charge_discharge
 ```
 
-is sufficient. For other configurations (for exmaple using the "solis_fb00" plugin) where separate buttons are used for charging and discharging, provide both:
+is sufficient. For other configurations (for example using the "solis_fb00" plugin) where separate buttons are used for charging and discharging, provide both:
 
 ```yaml
 charge_update_button:


### PR DESCRIPTION
Some solis inverters have two buttons for charge/discharge time updates, the PR adds support for that while maintaining the combined "update_charge_discharge" feature.