### PR TITLE
Update the configuration guide to reference rate overrides

### DIFF
--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -79,7 +79,7 @@ If you are using expert mode then these options may be worth reviewing, otherwis
 You should set **select.predbat_mode** to 'Control charge & discharge'
 
 You may wish to use **rates_export_override** to override the night export rate to zero or turn off **calculate_export_during_charge** and turn on **combine_charge**.
-Either of these options will prevent charge / discharge cycling within the cheap period, which Predbat would see as economically sensible but may not be within terms of use for some Tariff's.
+Either of these options will prevent charge / discharge cycling within the cheap period, which Predbat would see as economically sensible but may not be within terms of use for some tariffs.
 
 With the overnight charging rate being cheaper than your export rate, you probably want to charge your EV overnight and export all your solar; and not charge the EV from Solar during the day.
 Settings for doing this vary by charger manufacturer, but for the Zappi charger, set _export margin_ to a value higher than your inverter can output (e.g. 6000W) to ensure that all solar is exported and not used to charge the EV.


### PR DESCRIPTION
As standard, Predbatt will schedule cycles of charge and discharge of the battery using the export period, as this is the most economic option (7p import / 15p export will make it economically feasible despite charge losses).

It's (IMHO) not in the spirit of the tariff, and Octopus are "not obliged" to pay for brown exports under 4.5.1(i) of their export terms.  IE Octopus could do something about it if enough people are operating outside of the spirit of the terms. 

Took me a while to work out how to work around this, thought it would help others.