### PR TITLE
Be more defensive when failing to load entities

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -341,6 +341,9 @@ class Fetch:
 
         if isinstance(entity_ids, str):
             entity_ids = [entity_ids]
+        if entity_ids is None:
+            self.log("Error: No entity IDs provided for {}".format(key))
+            entity_ids = []
 
         import_today = {}
         for entity_id in entity_ids:


### PR DESCRIPTION
I have an Ohme charge, and batpred frequently crashes for me with the following traceback:

```
  File "/config/fetch.py", line 2252, in load_car_energy
    self.car_charging_energy = self.minute_data_import_export(now_utc, "car_charging_energy", scale=self.car_charging_energy_scale, required_unit="kWh")
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/fetch.py", line 346, in minute_data_import_export
    for entity_id in entity_ids:
TypeError: 'NoneType' object is not iterable
```

This is probably related to https://github.com/home-assistant/core/issues/144520, but batpred should handle more gracefully the failure to load an entity instead of crashing.