### PR TITLE
Sigenstor config - update grid_power value

### DIFF
--- a/templates/sigenergy_sigenstor.yaml
+++ b/templates/sigenergy_sigenstor.yaml
@@ -53,7 +53,7 @@ pred_bat:
   load_power:
     - sensor.sigen_plant_consumed_power
   grid_power:
-    - sensor.sigen_plant_grid_import_power
+    - sensor.sigen_plant_grid_active_power
 
   battery_power_invert: true
   grid_power_invert: true


### PR DESCRIPTION
Update to use the two-way grid active power value in the sigenstor example config file, as previously it was only showing imported power from the grid.