### PR TITLE
Remove IOG Free Energy Warning

### DIFF
--- a/docs/energy-rates.md
+++ b/docs/energy-rates.md
@@ -162,8 +162,6 @@ For Predbat to automatically manage Octopus free sessions the following addition
 
 Note: **You must have signed up to Octoplus and eligible to benefit from these events**
 
-Warning: **Octopus Intelligent customers are not eligible for free energy, Intelligent customers should leave this line commented out**
-
 Like the electricity rates, this is set in the apps.yaml template to a regular expression that should auto-discover the Octopus Energy integration.
 
 **octopus_free_session** - Will point to the free event sensor that is exposed by the Octopus Energy Integration. This event sensor contains the dates/times of


### PR DESCRIPTION
Following an email from Octopus Energy on 1st Aug, they've made a u-turn regarding normal household usage to now be included.

This PR updates the docs to remove the warning.