### PR TITLE
Fix plugin web endpoint registration order

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -1335,14 +1335,11 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Solcast, GECloud, Alertfeed
             self.web_interface_task = None
             self.log("Starting web interface")
             self.web_interface = WebInterface(self)
-            self.web_interface_task = self.create_task(self.web_interface.start())
 
             # Initialize plugin system and discover plugins
             self.init_plugin_system()
 
-            # Allow plugins to register with web interface now that it's started
-            if self.plugin_system:
-                self.plugin_system.call_hooks("on_web_start")
+            self.web_interface_task = self.create_task(self.web_interface.start())
 
             if self.get_arg("octopus_api_key", "") and self.get_arg("octopus_api_account", ""):
                 self.log("Starting Octopus API interface")

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -131,8 +131,8 @@ class WebInterface:
         app.router.add_post("/api/login", self.html_api_login)
 
         # Notify plugin system that web interface is ready
-        if hasattr(self.base, 'plugin_system') and self.base.plugin_system:
-          self.base.plugin_system.call_hooks('on_web_start')
+        if hasattr(self.base, "plugin_system") and self.base.plugin_system:
+            self.base.plugin_system.call_hooks("on_web_start")
 
         # Register any dynamically registered endpoints
         for endpoint in self.registered_endpoints:

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -130,6 +130,10 @@ class WebInterface:
         app.router.add_post("/api/service", self.html_api_post_service)
         app.router.add_post("/api/login", self.html_api_login)
 
+        # Notify plugin system that web interface is ready
+        if hasattr(self.base, 'plugin_system') and self.base.plugin_system:
+          self.base.plugin_system.call_hooks('on_web_start')
+
         # Register any dynamically registered endpoints
         for endpoint in self.registered_endpoints:
             if endpoint["method"] == "GET":


### PR DESCRIPTION
Fix initialization order issue where web server started before plugins could register endpoints, causing 404 errors on plugin-registered routes.

- Move web interface start after plugin system initialization
- Add on_web_start hook trigger before processing registered endpoints
- Allows plugins to register endpoints during initialization phase