### PR TITLE
Performance improvement: cache history data and top-up rather than requesting all history each run

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -84,6 +84,14 @@ CONFIG_ITEMS = [
         "restore": False,
     },
     {
+        "name": "history_cache_enable",
+        "friendly_name": "History Data Cache",
+        "type": "switch",
+        "default": False,
+        "restore": False,
+        "help": "Enable in-memory caching of Home Assistant history data to improve performance",
+    },
+    {
         "name": "pv_metric10_weight",
         "friendly_name": "Metric 10 Weight",
         "type": "input_number",

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -2279,6 +2279,11 @@ class Fetch:
         # Update list of config options to save/restore to
         self.update_save_restore_list()
 
+        # Configure history cache
+        self.history_cache_enable = self.get_arg("history_cache_enable", True)
+        if hasattr(self, 'ha_interface') and self.ha_interface:
+            self.ha_interface.configure_history_cache(self.history_cache_enable)
+
     def load_car_energy(self, now_utc):
         """
         Load previous car charging energy data

--- a/apps/predbat/history_cache.py
+++ b/apps/predbat/history_cache.py
@@ -1,0 +1,108 @@
+"""
+Simple history cache for Home Assistant data
+"""
+
+import threading
+from collections import deque
+from datetime import datetime
+from typing import Deque, Dict, List, Optional, Any
+
+
+class HistoryCache:
+    """Simple in-memory cache for Home Assistant history data"""
+
+    def __init__(self):
+        self.cache_lock = threading.RLock()
+        # Cache structure: {entity_id: {"data": deque([history_items]), "latest": datetime}}
+        self.cache_data: Dict[str, Dict[str, Any]] = {}
+        self.enabled = False
+
+    def configure(self, enabled: bool):
+        """Configure the cache"""
+        self.enabled = enabled
+        if not enabled:
+            with self.cache_lock:
+                self.cache_data.clear()
+
+    def _get_timestamp(self, item: Dict[str, Any]) -> Optional[datetime]:
+        """Extract timestamp from history item"""
+        if not isinstance(item, dict):
+            return None
+
+        timestamp_str = item.get("last_changed")
+        if timestamp_str:
+            try:
+                return datetime.fromisoformat(timestamp_str)
+            except (ValueError, TypeError):
+                pass
+        return None
+
+    def get_or_fetch(self, entity_id: str, start_time: datetime, end_time: datetime,
+                     fetch_func) -> Optional[List[Dict]]:
+        """Get cached data or fetch missing data using provided function."""
+        if not self.enabled:
+            return fetch_func(start_time, end_time)
+
+        entity_key = entity_id.lower()
+
+        fetch_start_time = None
+        with self.cache_lock:
+            cache_entry = self.cache_data.get(entity_key)
+
+            if not cache_entry:
+                fetch_start_time = start_time
+            else:
+                latest_time = cache_entry.get("latest")
+                if latest_time is None or latest_time < end_time:
+                    fetch_start_time = latest_time or start_time
+
+        if fetch_start_time:
+            new_data = fetch_func(fetch_start_time, end_time)
+            if new_data:
+                self.update_cache(entity_id, new_data)
+
+        with self.cache_lock:
+            cache_entry = self.cache_data.get(entity_key)
+            if not cache_entry:
+                return []
+
+            # Prune old data from cache in-place. We assume that start_time
+            # is consistent each time we're called for a specific entity
+            while cache_entry["data"]:
+                ts = self._get_timestamp(cache_entry["data"][0])
+                if ts and ts < start_time:
+                    cache_entry["data"].popleft()
+                else:
+                    break
+
+            # Return filtered cached data
+            return [item for item in cache_entry["data"]
+                    if (ts := self._get_timestamp(item)) and start_time <= ts <= end_time]
+
+    def update_cache(self, entity_id: str, new_data: List[Dict]):
+        """Update cache with new data, assuming new_data is chronologically sorted and newer than existing data."""
+        if not self.enabled or not new_data:
+            return
+
+        # The HA API can return data in a nested list, e.g., [[item1, item2]].
+        # This flattens it to [item1, item2] for consistent processing.
+        if isinstance(new_data, list) and len(new_data) > 0 and isinstance(new_data[0], list):
+            new_data = new_data[0]
+
+        with self.cache_lock:
+            entity_key = entity_id.lower()
+
+            if entity_key not in self.cache_data:
+                self.cache_data[entity_key] = {"data": deque(), "latest": None}
+
+            cache_entry = self.cache_data[entity_key]
+            existing_data: Deque[Dict] = cache_entry["data"]
+
+            existing_data.extend(new_data)
+
+            # Update the latest timestamp from the last item in the new data
+            if new_data:
+                latest_item = new_data[-1]
+                if (timestamp := self._get_timestamp(latest_item)):
+                    if cache_entry["latest"] is None or timestamp > cache_entry["latest"]:
+                        cache_entry["latest"] = timestamp

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -13,7 +13,6 @@ import os
 import sys
 from datetime import datetime, timedelta
 import traceback
-import sys
 import gc
 
 # from memory_profiler import profile
@@ -313,7 +312,10 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Solcast, GECloud, Alertfeed
             self.log("Error: get_history_wrapper - No HA interface available")
             return None
 
+        self.log("Getting history for {} for the last {} days".format(entity_id, days))
+
         history = self.ha_interface.get_history(entity_id, days=days, now=self.now_utc)
+        self.log("Got history for {}".format(entity_id))
 
         if required and (history is None):
             self.log("Error: Failure to fetch history for {}".format(entity_id))


### PR DESCRIPTION
I have been investigating the performance of predbat and generated some flame graphs to see where it was spending most of it's time each run. Even on a run with no replan, predbat was taking around 1m10s to run, and a full run was taking ~2m40s.

![predbat-noreplan](https://github.com/user-attachments/assets/daa1960c-74a7-4434-856e-97fdf85578ec)

Delving into this more deeply revealed that about 80% of the time taken during a "no replan" run was spent fetching history (`fetch_sensor_data`) from Home Assistant. I have `days_previous` set to look back 14 days, so fetching this much history each run is time consuming.

This PR introduces a (disabled by default) in-memory caching mechanism for Home Assistant history data to improve performance. On first run, the cache will be populated with the history data. Subsequent runs will evict older data and request only new data from Home Assistant. The cache is not persisted; a restart will cause it to be fully re-populated. A config option allows it to be enabled/disabled.

Runtimes reduced to 0m36s (no replan)/1m11s (full run) with the cache enabled. I've been running this since last week with no obvious issues.

**Summary of changes:**

* Added a new config option `history_cache_enable` to allow enabling/disabling the in-memory cache for Home Assistant history data (`apps/predbat/config.py`).
* Implemented the `HistoryCache` class for thread-safe, in-memory caching of history data (`apps/predbat/history_cache.py`).
* Integrated the history cache into the Home Assistant interface: initialized the cache, added a method to configure it, and updated the history fetching logic to use the cache when enabled (`apps/predbat/ha.py`). 
