### PR TITLE
Fix minute_data function parameter consistency

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -652,7 +652,7 @@ class Fetch:
             if to_key:
                 to_value = item[to_key]
                 if not to_value:
-                    to_time = now + timedelta(minutes=24 * 60 * self.forecast_days)
+                    to_time = now + timedelta(minutes=24 * 60 * days)
                 else:
                     to_time = str2time(item[to_key])
             else:


### PR DESCRIPTION
## Summary
- Fixes inconsistent parameter usage in `minute_data` function
- Function was using `self.forecast_days` instead of the `days` parameter in one location

## Bug Description
The `minute_data` function accepts a `days` parameter but was incorrectly using `self.forecast_days` on line 655 when calculating `to_time`. This could cause inconsistent behavior when the function is called with a different days value than `self.forecast_days`.

## Changes Made
- Line 655: Changed `self.forecast_days` to `days` parameter for consistency
- Ensures function behavior matches its parameter interface

## Impact
- Low risk fix - corrects parameter usage consistency
- Prevents potential edge cases where caller passes different days value
- No functional change for current usage patterns

🤖 Generated with [Claude Code](https://claude.ai/code)