### PR TITLE
Fix: Handle None attributes in history data

### DIFF
--- a/apps/predbat/ha.py
+++ b/apps/predbat/ha.py
@@ -148,7 +148,7 @@ class HAHistory:
 
         # Filter useless data from history data
         for entry in new_history_data:
-            if "attributes" in entry:
+            if entry.get("attributes"):
                 for attr in FILTER_ATTRIBUTES:
                     entry["attributes"].pop(attr, None)
             for entry_attr in FILTER_ENTRIES:


### PR DESCRIPTION
Fixes crash: 'NoneType' object has no attribute 'pop'

Issue: history data can contain entries where 'attributes' key exists but has a None value instead of a dictionary. This causes a crash when trying to call .pop() on it.

Solution: Changed from checking key existence ('attributes' in entry) to using entry.get('attributes') which returns None if the key doesn't exist or if its value is None, and only processes attributes when it's truthy.
