### PR TITLE
Add planning execution time and charge action timing metrics

### DIFF
--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -779,6 +779,9 @@ class Plan:
            self.export_window_best
            self.export_limits_best
         """
+        import time
+
+        plan_start_time = time.time()
 
         # Re-compute plan due to time wrap
         if self.plan_last_updated_minutes > self.minutes_now:
@@ -1157,6 +1160,11 @@ class Plan:
                 self.log("Warn: failed to close thread pool: {}".format(e))
                 self.log("Warn: " + traceback.format_exc())
             self.pool = None
+
+        # Record planning duration for SLO metrics
+        self.plan_last_duration_seconds = time.time() - plan_start_time
+        self.log("Plan calculation took {:.2f} seconds".format(self.plan_last_duration_seconds))
+
         # Return if we recomputed or not
         return recompute
 


### PR DESCRIPTION
## Summary

Adds timing instrumentation to track planning cycle execution duration and Intelligent Octopus Go charge action latency.

## Changes

### Planning Execution Time Tracking (`plan.py`)
- Records planning cycle duration in `plan_last_duration_seconds` attribute
- Logs planning execution time for visibility
- Useful for monitoring system performance and detecting slow planning cycles

### IOG Charge Action Timing (`execute.py`)
- Tracks time from IOG charge slot start to when charge command is sent
- Records latency in `iog_last_action_latency_seconds` attribute
- Only records when `octopus_intelligent_charging` is enabled
- Filters out stale data (> 10 minutes)
- Sets action status to track success/failure

## Use Case

These attributes can be read by monitoring plugins (e.g., Prometheus metrics exporters) to:
- Track planning cycle performance over time
- Monitor responsiveness of charge actions
- Identify performance degradation
- Set up alerting for slow operations

## Testing

- [ ] Planning duration is logged after each planning cycle
- [ ] IOG latency is recorded when charge windows are set
- [ ] Attributes are available for external monitoring tools