### PR TITLE
fix: Add missing 'previous' parameter to async_get_evc_device

### DIFF
--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -1149,7 +1149,7 @@ class GECloudDirect:
 
         return command_info
 
-    async def async_get_evc_device(self, uuid):
+    async def async_get_evc_device(self, uuid, previous={}):
         """
         Get EVC device
         """
@@ -1164,7 +1164,7 @@ class GECloudDirect:
             status = device.get("status", None)
             type = device.get("type", None)
             return {"uuid": uuid, "alias": alias, "serial_number": serial_number, "status": status, "online": online, "type": type, "went_offline_at": went_offline_at}
-        return {}
+        return previous
 
     async def async_get_smart_devices(self):
         """


### PR DESCRIPTION
## Summary

Fixes #2931

- Adds missing `previous={}` parameter to `async_get_evc_device` method definition
- Returns `previous` value on API failure to preserve cached data (consistent with other methods)

## Problem

The `async_get_evc_device` method was being called with a `previous` parameter for caching:
```python
self.evc_device[uuid] = await self.async_get_evc_device(uuid, self.evc_device.get(uuid, {}))
```

But the method definition didn't accept it:
```python
async def async_get_evc_device(self, uuid):  # Missing 'previous' parameter
```

This caused a TypeError that broke the main loop for all users with EVC (Electric Vehicle Charger) devices:
```
Error: GECloud: Exception in main loop GECloudDirect.async_get_evc_device() takes 2 positional arguments but 3 were given
```

## Test plan

- [x] Verify method signature matches the call pattern at line 854
- [x] Ensure consistency with `async_get_evc_device_data` which already has `previous={}` parameter
- [ ] Test with an EVC device to confirm the main loop no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)