### PR TITLE
feat: Add error tracking to API main loop exception handlers

### DIFF
--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -141,6 +141,9 @@ class FoxAPI:
             except Exception as e:
                 self.log("Error: Fox API: {}".format(e))
                 self.log("Error: " + traceback.format_exc())
+                self.failures_total += 1
+                if hasattr(self.base, "had_errors"):
+                    self.base.had_errors = True
 
             await asyncio.sleep(1)
             count_seconds += 1

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -873,6 +873,9 @@ class GECloudDirect:
 
             except Exception as e:
                 self.log("Error: GECloud: Exception in main loop {}".format(e))
+                self.failures_total += 1
+                if hasattr(self.base, "had_errors"):
+                    self.base.had_errors = True
 
             # Clear pending writes
             for device in device_list:
@@ -1450,6 +1453,9 @@ class GECloudData:
 
             except Exception as e:
                 self.log("Error: GECloudData: Exception in main loop {}".format(e))
+                self.failures_total += 1
+                if hasattr(self.base, "had_errors"):
+                    self.base.had_errors = True
 
             if not self.api_started:
                 print("GECloudData API Started")

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -439,6 +439,9 @@ class OctopusAPI:
             except Exception as e:
                 self.log("Error: Octopus API: {}".format(e))
                 self.log("Error: " + traceback.format_exc())
+                self.failures_total += 1
+                if hasattr(self.base, "had_errors"):
+                    self.base.had_errors = True
 
             await asyncio.sleep(10)
         await self.api.async_close()


### PR DESCRIPTION
## Summary

Fixes #2935

- Adds failure counter increment to API main loop exception handlers
- Sets `had_errors` flag for monitoring systems
- Applies to GECloud, GECloudData, Fox API, and Octopus API

## Problem

When exceptions occur in API main loops, they are logged but not tracked for monitoring. This makes it impossible to alert on repeated errors or track API health metrics accurately.

For example, the recent EVC device bug (#2931) was causing errors every 60 seconds, but monitoring systems couldn't detect it because:
- `failures_total` wasn't incremented
- `had_errors` wasn't set

## Changes

Added to each main loop exception handler:
```python
self.failures_total += 1
if hasattr(self.base, "had_errors"):
    self.base.had_errors = True
```

Files modified:
- `apps/predbat/gecloud.py` - GECloud and GECloudData main loops
- `apps/predbat/fox.py` - Fox API main loop
- `apps/predbat/octopus.py` - Octopus API main loop

## Test plan

- [x] Pre-commit hooks pass (ruff, black, cspell)
- [x] Uses hasattr() for backwards compatibility
- [x] Consistent with existing API failure tracking pattern
- [ ] Verify failures_total increments on exception
- [ ] Verify had_errors flag is set when present on base

🤖 Generated with [Claude Code](https://claude.com/claude-code)