### PR TITLE
Remove advanced settings endpoint call from Ohme integration due to api restrictions

### DIFF
--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -618,7 +618,7 @@ class OhmeApiClient:
 
     @property
     def available(self) -> bool:
-        """CT reading."""
+        """Always return true due to API limitations."""
         return True
 
     @property


### PR DESCRIPTION
Fixes #2938 by stripping out CT Clamp support, matching latest changes from ohme_py / Home Assistant.