### PR TITLE
Fix (Dis)Charge Curve for Inverters with `soc_percent`

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -765,18 +765,17 @@ class Inverter:
 
                         # If we have the correct data then output it
                         if rate_scaling > 0:
+                            if discharge:
+                                text = "  battery_discharge_power_curve:\n"
+                            else:
+                                text = "  battery_charge_power_curve:\n"
                             keys = sorted(final_curve.keys())
                             keys.reverse()
                             first = True
-                            text = ""
                             for key in keys:
                                 if (final_curve[key] < 1.0 or first) and final_curve[key] > 0.0:
                                     text += "    {} : {}\n".format(key, final_curve[key])
                                     first = False
-                            if discharge:
-                                text += "  battery_discharge_power_curve:\n"
-                            else:
-                                text += "  battery_charge_power_curve:\n"
                             if self.base.battery_charge_power_curve_auto:
                                 self.log("Curve automatically computed as:\n" + text)
                             else:


### PR DESCRIPTION
When a SoC is in %, the code chooses to convert it to kWh (then back to % later).
However to do that, it was using a function that converts kWh->%. This means the values used to calculate the charge curve were nonsense and it would simply issue a cryptic warning that sensors were missing history (even though they were not) and that the final charge curve was not found.

Instead for this step we need a utility to do the opposite conversion, %->kWh, and apply it in the charge curve code.

---

Furthermore, it is entirely possible to pass through multiple %age points of capacity within any given minute during the final charge period if the % is not linear (the bulge in that profile starts at ~88%):

<img width="959" height="813" alt="image" src="https://github.com/user-attachments/assets/bbeac3ca-fda3-4b71-9ded-5e255af76a8e" />

The averaging code was not accounting for this, instead assuming it was calculating the average power for a single % even if there were multiple. This resulted in some very odd results for the above charge profile:

```
battery_charge_power_curve:
  95 : 0.45
  96 : 0.45
  97 : 0.49
  98 : 0.49
  99 : 0.49
  100 : 0.49
```

Now we divide the average power by the amount of % the battery has changed in that period before saving the new smaller value to all of the crossed % points. This should result in the correct distribution of power if my understanding of the code is correct. Indeed the charge curve it produces for the above profile seems far more sensible.

```
battery_charge_power_curve:
  87 : 0.81
  88 : 0.55
  89 : 0.49
  90 : 0.49
  91 : 0.39
  92 : 0.28
  93 : 0.28
  94 : 0.2
  95 : 0.19
  96 : 0.19
  97 : 0.14
  98 : 0.14
  99 : 0.11
  100 : 0.11
```