### PR TITLE
Fix bug with inverter time spanning midnight

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2326,7 +2326,13 @@ class Inverter:
         self.charge_start_time_minutes = charge_start_time.hour * 60 + charge_start_time.minute
         self.charge_end_time_minutes = charge_end_time.hour * 60 + charge_end_time.minute
         if self.charge_end_time_minutes < self.charge_start_time_minutes:
-            self.charge_end_time_minutes += 24 * 60
+            # Window spans midnight - adjust based on current time
+            if self.charge_end_time_minutes > minutes_now:
+                # We're past midnight but before end - move start back
+                self.charge_start_time_minutes -= 24 * 60
+            else:
+                # End has passed - move both forward
+                self.charge_end_time_minutes += 24 * 60
         if self.charge_end_time_minutes < minutes_now:
             self.charge_end_time_minutes += 24 * 60
             self.charge_start_time_minutes += 24 * 60


### PR DESCRIPTION
## Summary

https://github.com/springfall2008/batpred/issues/2997

This PR fixes a bug for the midnight-spanning charge window logic in `adjust_charge_window` and adds unit tests

## Changes

### `apps/predbat/inverter.py`

- Logic updated to correctly handle midnight-spanning charge windows:
  - When past midnight but before end time, move start back by 24 hours
  - When end has passed, move end forward by 24 hours

### `apps/predbat/unit_test.py`

- Updated `test_adjust_charge_window` function to accept two new optional parameters:
  - `expect_charge_start_time_minutes` - Expected value for `inv.charge_start_time_minutes`
  - `expect_charge_end_time_minutes` - Expected value for `inv.charge_end_time_minutes`

- Added verification logic to check these values when provided

- Added 4 new test cases covering the midnight-spanning window conditions:
  - `adjust_charge_window_normal` - Normal window where end > start (no adjustment needed)
  - `adjust_charge_window_midnight_before_end` - Window spans midnight, current time is past midnight but before end (start moved back by 24 hours)
  - `adjust_charge_window_midnight_end_passed` - Window spans midnight, end time has passed (end moved forward by 24 hours)
  - `adjust_charge_window_past_window` - Window entirely in the past (both start and end moved forward by 24 hours)

## Testing

All tests pass with `./run_all`.