### PR TITLE
Fix cost_yesterday_car sensor not appearing in Home Assistant

### DIFF
--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -2959,7 +2959,7 @@ class Output:
                 "json": plan_json_yesterday,
             },
         )
-        if self.num_cars > 0:
+        if num_cars > 0:
             self.dashboard_item(
                 self.prefix + ".cost_yesterday_car",
                 state=dp2(cost_yesterday_car),


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `predbat.cost_yesterday_car` sensor does not appear in Home Assistant, even when cars are configured.  (Issue: https://github.com/springfall2008/batpred/issues/3002)

## Root Cause
I think the bug was introduced in commit 465d24af (Nov 9, 2025) when sensor registration code was moved later in the `calculate_yesterday()` method.

In `calculate_yesterday()` at line 2794, `self.num_cars` is temporarily set to 0 to simulate yesterday's state. The sensor registration code (line 2962) was moved to execute **after** this temporary reset, causing the conditional check `if self.num_cars > 0:` to always fail, preventing the sensor from being registered.

## The Fix
Changed line 2962 in `apps/predbat/output.py`:

```diff
-        if self.num_cars > 0:
+        if num_cars > 0:
```

This uses the saved `num_cars` variable (preserved at line 2772 before the simulation) instead of the temporarily modified `self.num_cars`. This matches the pattern used elsewhere in the function where saved values are restored after the simulation completes.

## Testing

- The cost calculation logic was already working correctly
- This only fixes the conditional check for sensor registration
- The same pattern is used successfully for other restored variables in this function

## Impact

- Users with car charging configured will now see the `predbat.cost_yesterday_car` sensor appear in Home Assistant
- No changes to calculation logic or other sensors
- Restores functionality that existed before Nov 9, 2025