### PR TITLE
Skip load forecast source if import fails

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1591,10 +1591,10 @@ class Fetch:
                 )
 
                 if load_forecast:
-                    self.log("Loaded load forecast from {} load sensor; from midnight {}kWh to now {}kWh to midnight {}kwh".format(entity_id, load_forecast.get(0, 0), load_forecast.get(self.minutes_now, 0), load_forecast.get(24 * 60, 0)))
+                    self.log("Loaded the load forecast from {} load sensor; from midnight {}kWh to now {}kWh to midnight {}kwh".format(entity_id, load_forecast.get(0, 0), load_forecast.get(self.minutes_now, 0), load_forecast.get(24 * 60, 0)))
                     load_forecast_array.append(load_forecast)
                 else:
-                    self.log("Warn: Unable to load load forecast from {}. Skipping forecast source.".format(entity_id))
+                    self.log("Warn: Unable to load the load forecast from {}. Skipping forecast source.".format(entity_id))
 
         # Add all the load forecasts together
         for load in load_forecast_array:


### PR DESCRIPTION
For example when using predheat, there is no forecast available when predbat first loads up (e.g. after system reboot). When predbat then attempts to import the `load_forecast` entity, it was failing to do so, warns that the entity has a None value, but then continues to use the empty value anyway.

This meant that the invalid entry gets fed into the prediction resulting in plan calculation problems (target battery was set to min for the next 48hrs as it assumed no load at all).

With this change if a load forecast entity is not valid, the invalid entry is not saved to the forecast array, stopping invalid data being fed into predbat.