### PR TITLE
Fix unit_of_measurement handling in history and add kW to W conversion test

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -310,6 +310,16 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Fetch, Plan, Execute, Outpu
         else:
             history = self.ha_interface.get_history(entity_id, days=days, now=self.now_utc)
 
+        if history and isinstance(history, list):
+            ## Get default units and patch it into missing entries in the history
+            unit_of_measurement = self.get_state_wrapper(entity_id, attribute="unit_of_measurement")
+            if unit_of_measurement:
+                for record in history[0]:
+                    if "attributes" not in record or not record["attributes"]:
+                        record["attributes"] = {}
+                    if "unit_of_measurement" not in record["attributes"]:
+                        record["attributes"]["unit_of_measurement"] = unit_of_measurement
+
         if required and (history is None):
             self.log("Error: Failure to fetch history for {}".format(entity_id))
             raise ValueError


### PR DESCRIPTION
This PR fixes issues with unit handling in history data and adds comprehensive testing for kW to W conversion.

## Changes

### Bug Fix: Missing unit_of_measurement in history records
- Added logic to patch missing `unit_of_measurement` attributes in history records
- Retrieves default units from current entity state and applies them to historical records that lack this attribute
- Prevents errors when processing historical data with missing metadata

### Test Enhancement: kW to W conversion
- Added Test 22 to `test_minute_data.py` to verify kW to W unit conversion
- Tests the conversion with `backwards=True` and `smoothing=False` parameters (matching `find_charge_curve` usage)
- Validates correct conversion at multiple time points to ensure accuracy

## Testing
- All pre-commit checks pass ✅
- New unit test added for kW to W conversion

## Related Issues
Fixes issues with missing unit metadata in historical sensor data.