### PR TITLE
Fix #3052: Prevent merging of charge windows with active keep times

### DIFF
--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -1958,7 +1958,9 @@ class Plan:
                 and (start == new_window_best[-1]["end"])
                 and (limit == new_limit_best[-1])
                 and (start not in self.manual_all_times)
+                and (start not in self.all_active_keep)
                 and (new_window_best[-1]["start"] not in self.manual_all_times)
+                and (new_window_best[-1]["start"] not in self.all_active_keep)
                 and (new_window_best[-1]["average"] >= window["average"] or not self.set_charge_low_power or limit == self.reserve)
             ):
                 # Combine two windows of the same charge target provided the rates are the same or low power mode is off (low power mode can skew the charge into the more expensive slot)
@@ -1973,7 +1975,9 @@ class Plan:
                 and (limit >= new_limit_best[-1])
                 and not (limit != self.reserve and new_limit_best[-1] == self.reserve)
                 and (start not in self.manual_all_times)
+                and (start not in self.all_active_keep)
                 and (new_window_best[-1]["start"] not in self.manual_all_times)
+                and (new_window_best[-1]["start"] not in self.all_active_keep)
                 and new_window_best[-1]["average"] == window["average"]
                 and (new_window_best[-1]["target"] < new_limit_best[-1])
             ):

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -27,7 +27,7 @@ import pytz
 import requests
 import asyncio
 
-THIS_VERSION = "v8.29.7"
+THIS_VERSION = "v8.29.8"
 
 # fmt: off
 PREDBAT_FILES = ["predbat.py", "hass.py", "config.py", "prediction.py", "gecloud.py", "utils.py", "inverter.py", "ha.py", "download.py", "web.py", "web_helper.py", "predheat.py", "futurerate.py", "octopus.py", "solcast.py", "execute.py", "plan.py", "fetch.py", "output.py", "userinterface.py", "energydataservice.py", "alertfeed.py", "compare.py", "db_manager.py", "db_engine.py", "plugin_system.py", "ohme.py", "components.py", "fox.py", "carbon.py", "web_mcp.py", "component_base.py"]


### PR DESCRIPTION
## Description

Fixes #3052 - SoC override not working correctly when charge windows are being merged.

## Problem

When using the SoC override feature (set via `predbat.manual_soc_override`), charge windows with active keep times were being merged with adjacent windows, when low power mode was used this causes the manual SoC overrides to be lost or not applied correctly. This resulted in the target SoC not being reached as expected.

## Solution

Added checks in `discard_unused_charge_slots()` to prevent merging of charge windows when either:
- The current window start time has an active keep time (`self.all_active_keep`)
- The previous window start time has an active keep time

This ensures that manually set SoC overrides are preserved and not merged into adjacent windows, allowing the charge plan to correctly target the desired SoC level.

## Changes

- **apps/predbat/plan.py**: Added `all_active_keep` checks in two window merging conditions within `discard_unused_charge_slots()`
- **apps/predbat/predbat.py**: Version bumped to v8.29.8

## Testing

- Pre-commit checks passed ✅
- Should resolve the issue where SoC overrides were being ignored due to window merging

## Related Issues

Closes #3052