### PR TITLE
Add warnings for missing entity_id

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1472,6 +1472,10 @@ class Inverter:
     def write_and_poll_value(self, name, entity_id, new_value, fuzzy=0, ignore_fail=False, required_unit=None):
         # Modified to cope with sensor entities and writing strings
         # Re-written to minimise writes
+        if not entity_id:
+            self.base.log("Warn: Inverter {} write_and_poll_value: No entity_id for {} to write {}".format(self.id, name, new_value))
+            self.base.record_status("Warn: Inverter {} write_and_poll_value: No entity_id for {} to write {}".format(self.id, name, new_value), had_errors=True)
+            return False
         domain, entity_name = entity_id.split(".")
         current_state = self.base.get_state_wrapper(entity_id, required_unit=required_unit)
 
@@ -1523,6 +1527,10 @@ class Inverter:
         """
         GivTCP Workaround, keep writing until correct
         """
+        if not entity_id:
+            self.base.log("Warn: Inverter {} write_and_poll_option: No entity_id for {} to write {}".format(self.id, name, new_value))
+            self.base.record_status("Warn: Inverter {} write_and_poll_option: No entity_id for {} to write {}".format(self.id, name, new_value), had_errors=True)
+            return False
         entity_base = entity_id.split(".")[0]
 
         if entity_base not in ["input_select", "select", "time"]:


### PR DESCRIPTION
Add error handling for missing or invalid `entity_id` values in the inverter control methods. The goal is to ensure that attempts to write values or options to an inverter without a valid `entity_id` are logged as warnings and handled gracefully, preventing crashes.

`write_and_poll_switch()` already has this check so this makes the code more consistent.

Background: an indentation error in `apps.yaml` caused my `has_target_soc` to be set incorrectly, leading to a predbat crash when scheduling an export. This change would prevent the crash and add a useful log to point towards the true issue.
