### PR TITLE
Add `grid_power` to solaredge template

### DIFF
--- a/templates/solaredge.yaml
+++ b/templates/solaredge.yaml
@@ -75,6 +75,11 @@ pred_bat:
   scheduled_discharge_enable:
     - off
 
+  grid_power:
+    - sensor.solaredge_m1_ac_power
+  grid_power_invert:
+    - False
+
   # Services to control charging/discharging
   charge_start_service:
     service: select.select_option


### PR DESCRIPTION
As per discussion https://github.com/springfall2008/batpred/discussions/3161#discussioncomment-15388124

This setting was missing from the template. Fixes the Power Flow in the Web UI. 