### PR TITLE
Adding /addon to root for monitoring

### DIFF
--- a/apps/predbat/hass.py
+++ b/apps/predbat/hass.py
@@ -59,13 +59,17 @@ async def main():
 
     # Find all .py files in the directory hierarchy
     py_files = []
+    seen_files = set()
 
     # Directories to walk through
     for root_dir in roots:
         for root, dirs, files in os.walk(root_dir):
             for file in files:
                 if (file.endswith(".py") or file == "apps.yaml") and not file.startswith("."):
-                    py_files.append(os.path.join(root, file))
+                    full_path = os.path.abspath(os.path.join(root, file))
+                    if full_path not in seen_files:
+                        py_files.append(full_path)
+                        seen_files.add(full_path)
 
     print("Watching {} for changes".format(py_files))
 


### PR DESCRIPTION
With the changes to the addon and moving hass.py into the main batpred repository this has removed some of the modifications I have made to the file in the addon as they will now always be overwritten.  

This prevents the docker image in some versions from automatically rebooting when updating the application python files.

Many users in docker mount the config directory using bind mounts to allow for configuration to persist across updates therefore if the python files are all stored in the config directory there is a risk of file and version conflicts

So, In the docker image these python are stored in the /addon directory allowing the container to be completely removed and updated without affecting the configuration files

This also allows the container to be fully reset without impacting any other files and logs

This approach might also be beneficial for the Home Assistant Addon although I don't have much experience with the addon at the moment but will look at this for future versions

Let me know what you think