### PR TITLE
LuxPower Freeze Charging support: documentation updates, template improvements, and warning suppression

### DIFF
--- a/Inverter setup.md
+++ b/Inverter setup.md
@@ -1,0 +1,2733 @@
+# Inverter setup
+
+PredBat was originally written for GivEnergy inverters using the GivTCP integration but has been extended to many other inverter models.
+
+The table below lists the inverters and required Home Assistant integrations that have had Predbat configurations developed.
+
+Follow the [Predbat installation guide](install.md) for full instructions to setup and configure Predbat. This document covers only the steps that are specific to different inverter types.
+
+Additionally, if your inverter type is not listed, you can create a [custom inverter definition for Predbat](#i-want-to-add-an-unsupported-inverter-to-predbat).
+Once you get everything working please share the configuration as a github issue so it can be incorporated into the Predbat documentation.
+
+To setup the inverter with Predbat you will need to:
+
+1. Install the appropriate Home Assistant integration for your inverter
+2. Configure the integration according to its documentation
+3. Confirm that the integration is working.  Are you receiving data from the various sensors (grid energy, charge limit, solar PV generated, etc)?<BR>
+Can you control the inverter using its Home Assistant controls?
+4. For each inverter there is a custom `apps.yaml` template configuration file that must be used in place of the GivTCP template file installed by default with Predbat:
+
+    - Open the inverter-specific template file with a browser
+    - Using a [file editor in Home Assistant](install.md#editing-configuration-files-in-home-assistant), edit the default `apps.yaml` configuration file
+    - Select-all in the default `apps.yaml`, and delete the entire template contents
+    - Select-all in the inverter-specific template file opened earlier, and copy and paste the contents into the Home Assistant file editor - if
+    you copy but don't replace the standard `apps.yaml` template then Predbat will not function correctly.
+
+5. Follow the inverter-specific setup steps detailed below for each inverter (click on the inverter name in the table).<BR>
+Steps vary for each inverter, for some there are no additional steps, but for other inverters there are additional controls, scripts and automations that have to be created for Predbat to work with that inverter type.
+6. Follow the rest of the [Predbat install instructions](install.md), in particular review that `apps.yaml` is configured correctly for your inverter.
+
+   | Name | Integration | Template |
+   | :---------------------------- | :------------- | :------------ |
+   | [GivEnergy with GivTCP](#givenergy-with-givtcp) | [GivTCP](https://github.com/britkat1980/ha-addons) | [givenergy_givtcp.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/givenergy_givtcp.yaml) |
+   | [Givenergy with GE Cloud](#givenergy-with-ge_cloud) | [ge_cloud](https://github.com/springfall2008/ge_cloud) | [givenergy_cloud.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/givenergy_cloud.yaml) |
+   | [Givenergy with GE Cloud EMS](#givenergy-with-ems) | [ge_cloud EMS](https://github.com/springfall2008/ge_cloud) | [givenergy_ems.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/givenergy_ems.yaml) |
+   | [Givenergy/Octopus No Home Assistant](#givenergyoctopus-cloud-direct---no-home-assistant) | n/a | [ge_cloud_octopus_standalone.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/ge_cloud_octopus_standalone.yaml) |
+   | [Fox](#fox) | [Foxess](https://github.com/nathanmarlor/foxess_modbus/) | [fox.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/fox.yaml) |
+   | [Fox Cloud](#fox-cloud) | Predbat | [fox_cloud.yaml](https://raw.githubusercontent.com/springfall2008/batpred/refs/heads/main/templates/fox_cloud.yaml) |
+   | [Growatt with Solar Assistant](#growatt-with-solar-assistant) | [Solar Assistant](https://solar-assistant.io/help/home-assistant/setup) | [spa.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/solar_assistant_growatt_spa.yaml) or [sph.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/solar_assistant_growatt_sph.yaml) |
+   | [Huawei inverters](#huawei-inverters) | [Huawei Solar](https://github.com/wlcrs/huawei_solar) | [huawei.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/huawei.yaml) |
+   | [Kostal Plenticore](#kostal-plenticore) | [Kostal Plenticore](https://www.home-assistant.io/integrations/kostal_plenticore) | [kostal.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/kostal.yaml) |
+   | [LuxPower](#lux-power) | [LuxPython](https://github.com/guybw/LuxPython_DEV) | [luxpower.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/luxpower.yaml) |
+   | [SigEnergy](#sigenergy-sigenstor) | [SigEnergy](https://github.com/TypQxQ/Sigenergy-Home-Assistant-Integration) | [sigenergy_sigenstor.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/sigenergy_sigenstor.yaml) |
+   | [Sofar inverters](#sofar-inverters) | [Sofar MQTT integration](https://github.com/cmcgerty/Sofar2mqtt) | [sofar.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/sofar.yaml) |
+   | [SolarEdge inverters](#solaredge-inverters) | [Solaredge Modbus Multi](https://github.com/WillCodeForCats/solaredge-modbus-multi) | [solaredge.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/solaredge.yaml) |
+   | [Solax Gen4 inverters](#solax-gen4-inverters) | [Solax Modbus integration](https://github.com/wills106/homeassistant-solax-modbus)<BR>in Modbus Power Control Mode | [solax_sx4.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/solax_sx4.yaml) |
+   | [Solax Cloud](#solax-cloud) | Predbat | [solax_cloud.yaml](https://raw.githubusercontent.com/springfall2008/batpred/refs/heads/main/templates/solax_cloud.yaml) |
+   | [Solis Cloud](#solis-cloud) | Predbat | [solis_cloud.yaml](https://raw.githubusercontent.com/springfall2008/batpred/refs/heads/main/templates/solis_cloud.yaml) |
+   | [Solis Hybrid inverters (Firmware before FB00)](#solis-inverters-before-fb00) | [Solax Modbus integration](https://github.com/wills106/homeassistant-solax-modbus) | [ginlong_solis.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/ginlong_solis.yaml) |
+   | [Solis Hybrid inverters (Firmware FB00 and later)](#solis-inverters-fb00-or-later) | [Solax Modbus integration](https://github.com/wills106/homeassistant-solax-modbus) | [ginlong_solis.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/ginlong_solis.yaml) |
+   | [SunSynk](#sunsynk) | [Sunsynk](https://github.com/kellerza/sunsynk) | [sunsynk.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/sunsynk.yaml) |
+   | [Tesla Powerwall](#tesla-powerwall) | [Tesla Fleet](https://www.home-assistant.io/integrations/tesla_fleet) or [Teslemetry](https://www.home-assistant.io/integrations/teslemetry) | [tesla_powerwall.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/tesla_powerwall.yaml) |
+   | [Victron](#victron) | [Victron MQTT](https://github.com/tomer-w/victron_mqtt) | [victron.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/victron.yaml) |
+
+Note that support for all these inverters is in various stages of development. Please expect things to fail and report them as Issues on GitHub.
+
+## GivEnergy with GivTCP
+
+It's recommended that you first watch the [Installing GivTCP and Mosquitto Add-on's video from Speak to the Geek](https://www.youtube.com/watch?v=d06Mqeplvns).
+
+1. Install Mosquitto Broker add-on:
+
+- Go to Settings / Add-ons / Add-on Store (bottom right)
+- Scroll down the add-on store list, to find 'Mosquitto broker', click on the add-on, then click 'INSTALL'
+- Once the Mosquitto broker has been installed, ensure that the 'Start on boot' and 'Watchdog' options are turned on, and click 'START' to start the add-on
+- Next, configure Mosquitto broker by going to Settings / Devices and Services / Integrations.
+Mosquitto broker should appear as a Discovered integration so click the blue 'CONFIGURE' button, then SUBMIT to complete configuring Mosquitto broker
+
+2. Install the GivTCP add-on:
+
+- Go to Settings / Add-ons / Add-on Store
+- Click the three dots in the top right corner, then Repositories
+- You'll need to add the GivTCP repository as an additional custom repository so paste/type
+'[https://github.com/britkat1980/ha-addons](https://github.com/britkat1980/ha-addons')' into the text box and click 'Add' the 'Close'<BR>
+NB: this URL is for GivTCP v3, not v2 as covered in the video.
+- Click the back button and then re-navigate to Settings / Add-ons / Add-on Store so Home Assistant picks up the GivTCP add-on from the custom repository
+- Scroll down the add-on store list, to find 'GivTCP-V3', you should see the three addons; the production version, the latest beta and the latest dev versions.
+Click on the 'GivTCP' add-on, then click 'INSTALL'
+- Once GivTCP has been installed, ensure that the 'Start on boot' and 'Watchdog' options are turned on
+
+3. Configure GivTCP:
+
+- All configuration for GivTCP is done via the add-on's Web interface
+- On the GivTCP add-on, click 'START' to start the add-on
+- Once the add-on has started, click 'Open Web UI' or go to [http://homeassistant.local:8099/](http://homeassistant.local:8099/), then click 'Go to Config Page' to configure GivTCP
+- GivTCP will auto-discover your inverters and batteries so you shouldn't need to manually enter these, but check the IP address(s) it finds are correct
+- If you have a single AIO then for Predbat to be able to communicate via REST to the AIO, it MUST be the first device configured in GivTCP.  Conversely if you have a gateway and multiple AIO's then the gateway MUST be the first device in GivTCP
+- If you have multiple inverters you may wish to change the default device prefixes that GivTCP assigns ('givtcp', 'givtcp2', 'givtcp3', etc)
+to make it easier to identify your devices within Home Assistant.<BR>
+For example, if you have a gateway and two AIOs you could use the prefixes 'GW', 'AIO-1' and 'AIO-2'.
+The prefixes should be set before you start using GivTCP in anger
+as changing the prefixes later on will result in both the old and new sensor names appearing in Home Assistant with the 'old' sensors being "unavailable".<BR>
+Note that if you do change the givtcp prefixes then you will also have to edit the apps.yaml configuration file to match,
+and change the sensor names that Predbat is looking for (by default prefixed 'givtcp_xxx') to your new sensor naming structure
+- Click Next and Next to get to the Selfrun page, and turn on Self Run so that GivTCP automatically retrieves data from your inverter. The Self Run Loop Timer is how often GivTCP will retrieve data - it's
+recommended that set this to a value between 20 and 60, but not less than 15 seconds as otherwise the inverter will then spend all its time talking to GivTCP
+and won't communicate with the GivEnergy portal and app
+- GivTCP auto-populates the MQTT page so as long as you're using Mosquitto broker within Home Assistant;
+you won't need to create a dedicated MQTT user or enter the details on the MQTT page
+- You don't need to configure the Influx page. Tariff and Palm pages can also be skipped as these functions are done by Predbat
+- (Optional) On the Web page, you can turn the Dashboard on to see a simple power flow diagram for your inverters (similar to the GivEnergy mobile app)
+- On the 'Misc' page check that 'Print Raw' is set to on for added monitoring
+- Finally, click 'Save and Restart' and GivTCP should start communicating with your inverters
+and will automatically create a set of 'givtcp_xxx' entities in Home Assistant for your inverter data, inverter controls and battery data
+- Check the GivTCP Log tab that there aren't any errors; it should end with 'Publishing Home Assistant Discovery messages'
+
+4. Before you start using GivTCP to control your inverter
+
+Verify in the GivEnergy portal settings the following inverter settings are set correctly as these are settings that Predbat doesn't control, and if not set correctly could affect your battery activity:
+
+- "Inverter Charge Power Percentage" is set to 100 (Predbat has its own low-rate charge control you can use if you wish)
+- "Inverter Discharge Power Percentage" is set to 100. If you do wish to set a lower discharge rate then its recommended that instead you set [inverter_limit_discharge in apps.yaml](apps-yaml.md#inverter-control-configurations) to the rate
+- "Battery Cutoff % Limit" is set to 4
+- "Enable AC Charge Upper Limit' is enabled (if you have this option)
+- That charge slot 2 (or more) are disabled (as Predbat only uses slot1)
+- That discharge slot 2 (or more) are disabled  (as Predbat only uses slot1)
+
+5. Specific Predbat configuration requirements for certain GivEnergy equipment
+
+The rest of the [Predbat installation instructions](install.md) should now be followed,
+but its worth highlighting that there are a few specific settings that should be set for certain GivEnergy equipment.
+These settings are documented in the appropriate place in the documentation, but for ease of identification, are repeated here:
+
+- If you are using GivTCP v3 and have an AIO or 3-phase inverter then you will need to manually set [geserial in apps.yaml](apps-yaml.md#geserial) to your inverter serial number in lower case as the auto-detect doesn't work for this setup
+- If you have a single AIO then control is directly to the AIO. Ensure [geserial in apps.yaml](apps-yaml.md#geserial) is correctly picking the AIO and comment out geserial2 lines
+- If you have multiple AIOs then all control of the AIOs is done through the Gateway so [geserial in apps.yaml](apps-yaml.md#geserial) should be set to the Gateway serial number in lower case
+- If you have multiple AIOs you might want to consider setting [inverter charge and discharge limits](apps-yaml.md#inverter-control-configurations)
+unless you want to charge and discharge at the full 12kWh!
+- If you have a 2.6kWh, 5.2kWh or AIO battery then you will need to set [battery_scaling in apps.yaml](apps-yaml.md#battery-size-scaling)
+as the battery size is incorrectly reported to GivTCP
+- If you have an older inverter (AC3 or Gen 1 hybrid) with firmware that has battery pause support you may need to [comment out pause start and end time controls in apps.yaml](apps-yaml.md#schedule)
+- If you have a Gen 2, Gen 3 or AIO then you may need to set [inverter_reserve_max in apps.yaml](apps-yaml.md#inverter-reserve-maximum) to 98.
+If you have a Gen 1 or a firmware version that allows the reserve being set to 100 then you can change the default from 98 to 100
+- If your inverter has been wired as an EPS (Emergency Power Supply) or AIO 'whole home backup', consider setting
+[input_number.predbat_set_reserve_min](customisation.md#inverter-control-options) to reserve some battery power for use in emergencies.
+
+**NB: GivTCP and Predbat do not currently yet work together for 3-phase inverters**.
+This is being worked on by the author of GivTCP, e.g. see [GivTCP issue: unable to charge or discharge 3 phase inverters with Predbat](https://github.com/britkat1980/giv_tcp/issues/218)
+
+## GivEnergy with ge_cloud
+
+This is an experimental system, please discuss it on the ticket: <https://github.com/springfall2008/batpred/issues/905>
+
+- First set up ge_cloud integration using your API key <https://github.com/springfall2008/ge_cloud>
+- Now copy the template `givenergy_cloud.yaml` from templates over the top of your `apps.yaml` and edit
+    - Set geserial to your inverter serial number
+- Make sure that the 'discharge down to' registers are set to 4% and slots 2, 3 and 4 for charge and discharge are disabled in the portal (if you have them)
+
+## GivEnergy with EMS
+
+- First set up ge_cloud integration using your API key <https://github.com/springfall2008/ge_cloud>
+- Now copy the template `givenergy_ems.yaml` from templates over the top of your `apps.yaml` and edit
+    - Set geserial to your first inverter serial and geserial2 to the second (look in HA for entity names)
+    - Set geseriale to the EMS inverter serial number (look in HA for the entity names)
+- Turn off charge, export and discharge slots 2, 3 and 4 as Predbat will only use slot 1 - set the start and end times for these to 00:00
+
+## GivEnergy/Octopus Cloud Direct - No Home Assistant
+
+- Take the template and enter your GivEnergy API key directly into `apps.yaml`
+- Set your Octopus API key in `apps.yaml`
+- Set your Solcast API key in `apps.yaml`
+- Review any other configuration settings
+
+Launch Predbat with hass.py (from the Predbat-addon repository) either via a Docker or just on a Linux/MAC/WSL command line shell.
+
+## Fox
+
+Thanks to the work of @PeterHaban, for this Predbat configuration for Fox ESS inverters which Peter has working with a ECS4100h7 and UK Octopus Cosy.  It runs off the work modes and charge/discharge rates.
+
+- Copy the Fox template over the top of the supplied `apps.yaml`, and edit for your system.
+
+- Create an input_number helper using the HA to hold the minimum battery soc level %, and set it to 10%:
+
+```yaml
+  name: Battery Min SoC
+  Min value: 0
+  Max value: 100
+```
+
+- Create a template sensor helper using the HA UI to hold the SoC remaining percentage converted to kWh
+
+```yaml
+  - sensor:
+    - name: "FoxESS SoC kWh remaining"
+      unit_of_measurement: "kWh"
+      device_class: energy
+      state_class: total
+      state: >
+        {{ ((float(states.sensor.foxess_battery_soc.state)/100) *float(states.sensor.foxess_bms_kwh_remaining.state)) }}
+```
+
+- Create a template sensor helper using the HA UI to hold the net grid power, combining the separate FoxESS integration import and export power sensors
+
+```yaml
+  - sensor:
+    - name: "FoxESS Grid Power"
+      unit_of_measurement: "kW"
+      device_class: power
+      state_class: measurement
+      state: >
+        {% set import_p = states('sensor.foxess_grid_consumption') | float(0) %}
+        {% set export_p = states('sensor.foxess_feed_in') | float(0) %}
+        {{ import_p - export_p }}
+```
+
+- For an AC-coupled FoxESS inverter you will need a method to measure Solar Generation power and energy today for Predbat to use. The author of this configuration used an ESPHome flashed Emporia Vue 2, or you can use a Shelly EM or similar energy monitor.
+Replace the **pv_today** and **pv_power** entries in `apps.yaml` with the appropriate sensor names.
+
+## Fox Cloud
+
+- Predbat now has a built-in Fox cloud integration. Today it requires a battery that supports the scheduler mode to function.
+
+See the components documentation for details [Components - Fox cloud](components.md#fox-ess-api-fox)
+
+## Solax Cloud
+
+**Experimental**
+
+- Predbat now has a built-in Solax cloud integration.
+
+See the components documentation for details [Components - Solax cloud](components.md#solax-cloud-api-solax)
+
+## Solis Cloud
+
+**Experimental**
+
+- Predbat now has a built-in Solis cloud integration.
+
+See the components documentation for details [Components - Solis cloud](components.md#solis-cloud-api-solax)
+
+## Growatt with Solar Assistant
+
+You need to have a Solar Assistant installation <https://solar-assistant.io>
+
+Growatt has two popular series of inverters, SPA and SPH. Copy the template that matches your model from templates over the top of your `apps.yaml`, and edit inverter and battery settings as required. Yours may have different entity IDs on Home Assistant.
+
+## Huawei Inverters
+
+The discussion ticket is here: <https://github.com/springfall2008/batpred/issues/684>
+
+- Please copy the template <https://github.com/springfall2008/batpred/blob/main/templates/huawei.yaml> over the top of your `apps.yaml`, and modify it for your system
+- Ensure you set **input_number.predbat_set_reserve_min** to the minimum value for your system which may be 12%
+
+- Huawei inverters can charge the battery from DC solar and discharge at one power level (e.g. 5kWh), but have a lower limit (e.g. 3kWh) for AC charging.
+At present Predbat doesn't have the ability to model separate DC and AC charging limits,
+so battery_rate_max is set to the lower limit in watts (e.g. 3000) in the template `apps.yaml` to ensure that Predbat correctly plans AC charging of the battery at the right rate.
+
+- However this means Predbat will also limit DC solar charging to this lower limit and to avoid that an automation is used to overwrite the **inverter_limit_charge** during the hours of sunrise and sunset:
+
+```yaml
+alias: Predbat change inverter charge rate at sunrise and sunset
+description: Using predbat_manual_api
+triggers:
+  - trigger: time
+    at:
+      entity_id: sensor.sun_next_rising
+    id: sunrise
+  - trigger: time
+    at:
+      entity_id: sensor.sun_next_setting
+    id: sunset
+conditions: []
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            alias: Sunrise
+            id:
+              - sunrise
+        sequence:
+          - action: select.select_option
+            alias: set inverter charge rate to 5000W at sunrise for maximum DC solar charging
+            target:
+              entity_id:
+                - select.predbat_manual_api
+            data:
+              option: inverter_limit_charge(0)=5000
+      - conditions:
+          - condition: trigger
+            alias: Sunset
+            id:
+              - sunset
+        sequence:
+          - action: select.select_option
+            alias: set inverter charge rate to 1500W at sunset for reduced AC charging rate
+            target:
+              entity_id:
+                - select.predbat_manual_api
+            data:
+              option: inverter_limit_charge(0)=3000
+mode: single
+```
+
+- Set the Huawei inverter work mode to 'TOU' (Time Of Use).
+
+## Kostal Plenticore
+
+Thanks to the work of @mbuhansen for this Predbat configuration for Kostal Plenticore inverters.  It should work with both the G1/G2 and G3 inverters.
+
+- Copy the Kostal template over the top of your `apps.yaml`, and edit for your system.
+
+- Create four new input_boolean and six input_number helpers using the HA UI:
+
+```yaml
+input_boolean.charge_start_service
+
+input_boolean.discharge_start_service
+
+input_boolean.charge_freeze_service
+
+input_boolean.discharge_freeze_service
+
+input_number.plenticore_max_charge    # this is how fast inverter has to charge in %, is set to -100 when charge from grid
+Min value: -100
+Max value: 0
+
+input_number.plenticore_max_discharge  # this is how fast inverter has to charge in %, is set to 100 when discharge to grid
+Min value: 0
+Max value: 100
+
+input_number.predbat_charge_limit      # this can be used if charge limit is set to true
+Min value: 0
+Max value: 100
+
+input_number.predbat_reserve           # this is used to set Min_soc in inverter
+Min value: 0
+Max value: 100
+
+input_number.predbat_charge_rate       # This can be used to if low power charge mode is Enabled, remember to switch from "write -100 charging" to "write power rate charging" in automation
+Min value: 0
+Max value: (Inverter Battery max charge in watt)
+
+input_number.predbat_discharge_rate     # this is used to set battery discharge to zero
+Min value: 0
+Max value: (Inverter Battery max discharge in watt)
+```
+
+- To control the Kostal inverter you need to use a modbus/tcp connection, this is not a part of the Kostal integration. Add the following modbus configuration to your `configuration.yaml`:
+
+```yaml
+modbus:
+    - name: kostalplenticore              # name on modbus connection
+      type: tcp                           # Use TCP
+      host: 192.168.xxx.xxx               # Modbus device IP-address
+      port: 1502                          # Port to Modbus-server
+```
+
+- Next, create the automation that sends the modbus commands to the Kostal inverter integration, when each input_boolean is activated from Predbat:
+
+```yaml
+alias: Predbat Charge / Discharge Control
+description: ""
+triggers:
+  - trigger: state
+    entity_id:
+      - input_boolean.charge_start_service
+    to:
+      - "on"
+    id: charge
+    for:
+      hours: 0
+      minutes: 0
+      seconds: 5
+  - trigger: state
+    entity_id:
+      - input_boolean.discharge_start_service
+    to: "on"
+    id: Discharge
+  - trigger: state
+    entity_id:
+      - input_boolean.charge_freeze_service
+    to: "on"
+    id: Charge freeze
+  - trigger: state
+    entity_id:
+      - input_boolean.discharge_freeze_service
+    to: "on"
+    id: Discharge freeze
+conditions: []
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id:
+              - charge
+        sequence:
+          - repeat:
+              sequence:
+                - if:
+                    - condition: state
+                      entity_id: binary_sensor.predbat_charging
+                      state: "on"
+                      enabled: true
+                  then:
+                    - delay:
+                        hours: 0
+                        minutes: 0
+                        seconds: 45
+                        milliseconds: 0
+                    - repeat:
+                        sequence:
+                          - alias: Write -100 charging
+                            action: modbus.write_register
+                            metadata: {}
+                            data:
+                              slave: 71
+                              address: 1028
+                              hub: kostalplenticore
+                              value: >
+                                [ {{ '0x%x' %
+                                unpack(pack(states('input_number.plenticore_g3_max_charge')
+                                |float(0),
+                                    ">f"), ">H", offset=2) | abs }}, {{ '0x%04x' %
+                                    unpack(pack(states('input_number.plenticore_g3_max_charge')|float(0), ">f"), ">H")|abs }}
+                                    ]
+                            enabled: true
+                          - alias: Write power rate charging
+                            action: modbus.write_register
+                            metadata: {}
+                            data:
+                              slave: 71
+                              address: 1034
+                              hub: kostalplenticore
+                              value: |-
+                                [
+                                  {{ '0x%x' % unpack(pack((states('input_number.predbat_charge_rate')|float(0)) * -1, ">f"), ">H", offset=2) | abs }},
+                                  {{ '0x%04x' % unpack(pack((states('input_number.predbat_charge_rate')|float(0)) * -1, ">f"), ">H") | abs }}
+                                ]
+                            enabled: false
+                          - delay:
+                              hours: 0
+                              minutes: 0
+                              seconds: 15
+                              milliseconds: 0
+                        while:
+                          - condition: state
+                            entity_id: input_boolean.charge_start_service
+                            state: "on"
+                          - condition: state
+                            entity_id: binary_sensor.predbat_charging
+                            state: "on"
+                            enabled: true
+                      enabled: true
+                  else:
+                    - delay:
+                        hours: 0
+                        minutes: 0
+                        seconds: 45
+                        milliseconds: 0
+                    - repeat:
+                        sequence:
+                          - alias: Write discharge rate zero
+                            action: modbus.write_register
+                            metadata: {}
+                            data:
+                              hub: kostalplenticore
+                              address: 1040
+                              slave: 71
+                              value: >
+                                [ {{ '0x%x' %
+                                unpack(pack(states('input_number.predbat_discharge_rate')
+                                |float(0),
+                                    ">f"), ">H", offset=2) | abs }}, {{ '0x%04x' %    unpack(pack(states('input_number.predbat_discharge_rate') |float(0), ">f"), ">H")|abs }}
+                                    ]
+                            enabled: false
+                          - alias: Write min SOC
+                            action: modbus.write_register
+                            metadata: {}
+                            data:
+                              hub: kostalplenticore
+                              address: 1042
+                              slave: 71
+                              value: >
+                                [ {{ '0x%x' %
+                                unpack(pack((states('input_number.predbat_reserve')
+                                |float(0) - 1),
+                                    ">f"), ">H", offset=2) | abs }}, {{ '0x%04x' %    unpack(pack((states('input_number.predbat_reserve') |float(0) - 1), ">f"), ">H")|abs }}
+                                    ]
+                            enabled: true
+                          - delay:
+                              hours: 0
+                              minutes: 0
+                              seconds: 15
+                              milliseconds: 0
+                        while:
+                          - condition: template
+                            value_template: >-
+                              {{ states('sensor.scb_battery_soc') | float <=
+                              (states('predbat.best_charge_limit') | float +
+                              1.0) }}
+                          - condition: state
+                            entity_id: binary_sensor.predbat_charging
+                            state:
+                              - "off"
+                            enabled: true
+                      enabled: true
+              while:
+                - condition: state
+                  entity_id: input_boolean.charge_start_service
+                  state: "on"
+      - conditions:
+          - condition: trigger
+            id:
+              - Discharge
+        sequence:
+          - delay:
+              hours: 0
+              minutes: 0
+              seconds: 40
+              milliseconds: 0
+            enabled: true
+          - repeat:
+              sequence:
+                - action: modbus.write_register
+                  metadata: {}
+                  data:
+                    slave: 71
+                    address: 1028
+                    hub: kostalplenticore
+                    value: >
+                      [ {{ '0x%x' %
+                      unpack(pack(states('input_number.plenticore_max_discharge')
+                      |float(0),
+                          ">f"), ">H", offset=2) | abs }}, {{ '0x%04x' %
+                          unpack(pack(states('input_number.plenticore_max_discharge')|float(0), ">f"), ">H")|abs }}
+                          ]
+                  alias: Write 100 Discharge
+                - delay:
+                    hours: 0
+                    minutes: 0
+                    seconds: 15
+                    milliseconds: 0
+              while:
+                - condition: state
+                  entity_id: input_boolean.discharge_start_service
+                  state: "on"
+      - conditions:
+          - condition: trigger
+            id:
+              - Charge freeze
+          - condition: template
+            value_template: |2-
+                    {% set rate = states('sensor.predbat_rates') | float(0) %}
+                    {% set high_rate = states('sensor.predbat_high_rate_export_cost_2') | float(0) %}
+                    {{ rate < high_rate }}
+            enabled: false
+        sequence:
+          - delay:
+              hours: 0
+              minutes: 0
+              seconds: 45
+              milliseconds: 0
+          - repeat:
+              sequence:
+                - action: modbus.write_register
+                  data:
+                    address: 1040
+                    hub: kostalplenticore
+                    slave: 71
+                    value: >
+                      [{{ '0x%04x' %
+                      unpack(pack(states('input_number.predbat_discharge_rate')
+                      |float(0),
+                          ">f"), ">H", offset=2) | abs }}, {{ '0x%04x' %
+                          unpack(pack(states('input_number.predbat_discharge_rate')|float(0), ">f"), ">H")|abs }}]
+                  metadata: {}
+                  alias: Write discharge rate
+                  enabled: false
+                - alias: Write min. SOC
+                  action: modbus.write_register
+                  data:
+                    address: 1042
+                    hub: kostalplenticore
+                    slave: 71
+                    value: >
+                      [ {{ '0x%x' %
+                      unpack(pack((states('input_number.predbat_reserve')
+                      |float(0) - 1),
+                          ">f"), ">H", offset=2) | abs }}, {{ '0x%04x' %
+                          unpack(pack((states('input_number.predbat_reserve')|float(0) - 1), ">f"), ">H")|abs }}
+                          ]
+                  metadata: {}
+                  enabled: true
+                - delay:
+                    hours: 0
+                    minutes: 0
+                    seconds: 15
+                    milliseconds: 0
+              while:
+                - condition: state
+                  entity_id: input_boolean.charge_freeze_service
+                  state: "on"
+      - conditions:
+          - condition: trigger
+            id:
+              - Discharge freeze
+        sequence:
+          - delay:
+              hours: 0
+              minutes: 0
+              seconds: 45
+              milliseconds: 0
+          - repeat:
+              sequence:
+                - action: modbus.write_register
+                  data:
+                    address: 1038
+                    hub: kostalplenticore
+                    slave: 71
+                    value: >
+                      [{{ '0x%04x' %
+                      unpack(pack(states('input_number.predbat_charge_rate')
+                      |float(0),
+                          ">f"), ">H", offset=2) | abs }}, {{ '0x%04x' %
+                          unpack(pack(states('input_number.predbat_charge_rate')|float(0), ">f"), ">H")|abs }}]
+                  metadata: {}
+                  alias: Write charge rate
+                - delay:
+                    hours: 0
+                    minutes: 0
+                    seconds: 15
+                    milliseconds: 0
+              while:
+                - condition: state
+                  entity_id: input_boolean.discharge_freeze_service
+                  state: "on"
+mode: queued
+max: 10
+```
+
+## LuxPower Inverters
+
+This requires the LuxPython integration, which communicates with your LuxPower inverter.
+
+- Copy the template `luxpower.yaml` from `templates` over the top of your <span style="color:red">`apps.yaml`</span>, and edit inverter and battery settings as required.
+- Predbat should have access to the full usable capacity of your battery system. In the LuxPowerTek web portal (not the app), ensure that:
+
+  - **System Charge SOC Limit (%)** is set to 100% (default).
+  - **On-Grid Cut-Off SOC (%)** is set to 100% minus battery depth of discharge(%). Depending on your battery, this is typically between 20% and 0%.
+- If you want to use Predbat in **Control charge** mode, go to the LuxPowerTek app or web portal and set all start and end time slots for AC Charge to `00:00`.
+  For **Control charge and discharge** mode, set all AC Charge and Forced Discharge slots to `00:00`.
+  Predbat only uses the first time slots and will set these automatically.
+- LuxPower inverters do not have an SoC max entity in kWh, and the SoC percentage entity never reports the battery reaching 100%. Create the following template helper sensors using the Home Assistant UI.
+
+```yaml
+name: Lux SoC Max kWh
+template options:
+  state: >
+    {{ (states("sensor.lux_battery_capacity_ah") | float)
+       * (states("sensor.lux_battery_voltage_live") | float) / 1000 }}
+unit of measurement: kWh
+device class: energy
+state class: total
+```
+
+```yaml
+name: Lux Battery SoC Corrected
+template options:
+  state: >
+    {% set soc = states('sensor.lux_battery') | int %}
+    {% set charging_stopped = states('sensor.lux_bms_limit_charge_live') | float == 0 %}
+    {% if charging_stopped and soc > 97 %}
+      100
+    {% else %}
+      {{ soc }}
+    {% endif %}
+unit of measurement: "%"
+device class: battery
+state class: measurement
+```
+
+- Create the following number helper. The maximum value (in Watts) can be found in your inverter datasheet. A more accurate figure can be obtained by observing the flow chart in the Monitor section of the LuxPower app/portal or by inspecting `sensor.lux_battery_flow_live` when the battery is force charging or discharging.
+
+```yaml
+name: Battery Rate Max
+entity_id: input_number.battery_rate_max
+minimum value: 0
+maximum value: YOUR_INVERTER_MAXIMUM_CHARGE/DISCHARGE_RATE
+unit of measurement: W
+```
+ 
+ Thanks to the work of **@brickatius**, the following automations and configurations enable LuxPower inverters to provide **Freeze Charging** and **Freeze Exporting** functionality when Predbat is operating in **Control charge and discharge** mode.
+
+---
+
+**Important:**
+The Freeze Charging and Freeze Exporting setup described below relies on a set of carefully designed helpers and automations that work together. Each component has a specific role in safely entering, maintaining, and exiting Freeze Charging mode. Removing or skipping any part can lead to missed triggers, stuck AC charging, or incomplete cleanup. For reliable operation, make sure all helpers and automations in this section are created exactly as described before using Freeze Charging or Freeze Exporting modes.
+
+---
+
+### Freeze Charging 
+
+**Note:**
+Although LuxPower inverters have the *Charge first / Charge priority* feature, Predbat achieves a similar outcome by directly manipulating AC charge settings. This is why the following implementation is required.
+
+### LuxPower Integration
+
+- Set up your LuxPower Integration as follows:
+
+	- If you have not already done so, set up the blueprint for changing the refresh interval as described in the LuxPython_DEV README. 
+	- In the LUX Refresh Interval automation set the refresh interval to **20 seconds**. Freeze Charging relies on frequent state updates; intervals above 30 seconds may result in delayed or missed AC arbitration.
+
+### Predbat configuration
+
+- In your `apps.yaml` file:
+
+  - Look for `support_charge_freeze` in the inverter section and change `False` to `True`.
+  - On the next line also change `maintain_freeze_charge_status` from  `False` to `True`.
+  - Uncomment the three lines in the `charge_freeze_service` section so Predbat turns on `automation.luxpower_freeze_charge` when Freeze Charging starts.
+  - Ensure the indentation and alignment match the other service entries.
+
+---
+
+**Helpers**
+
+- Create the following **Freeze Charge Guard** toggle helper and **Solar compare Home** binary sensor helper using the HA user interface. 
+
+**Toggle helper**
+
+```yaml
+name: Freeze Charge Guard
+entity_id: input_boolean.freeze_charge_guard
+```
+
+The `freeze_charge_guard` helper acts as a lifecycle gate. It is enabled only when Predbat explicitly requests Freeze Charging and is cleared on exit, watchdog abort, or Home Assistant restart. All Freeze Charging automations check this guard to prevent unintended operation.
+
+
+**Binary sensor template helper**¹
+
+
+```yaml
+name: Solar compare Home
+entity_id: binary_sensor.solar_compare_home
+template options:
+  state: >
+    {{ 'on' if states('sensor.lux_solar_output_live') | float(0)
+         <= states('sensor.lux_home_consumption_live') | float(0)
+       else 'off' }}
+```
+
+---
+### Automations
+
+- Create the following **Freeze Charge**² and **Freeze Charge Predbat Override**³ automations.
+These are enabled when Predbat enters Freeze Charging mode and disabled when it exits.
+Under other Predbat modes, they remain disabled — this is expected behaviour.
+
+**Note:** The Freeze Charge automation uses `sensor.lux_battery_soc_corrected` as described above.
+
+```yaml
+alias: LuxPower Freeze Charge
+description: >
+  Controls AC charging during Predbat freeze charge mode. Arms and triggers
+  freeze subsystems and watchdog via freeze guard.
+triggers:
+  - entity_id: automation.luxpower_freeze_charge
+    from: "off"
+    to: "on"
+    id: freeze_enabled
+    trigger: state
+  - entity_id: binary_sensor.solar_compare_home
+    to: "on"
+    for: "00:00:10"
+    id: solar_on
+    trigger: state
+  - entity_id: binary_sensor.solar_compare_home
+    to: "off"
+    for: "00:00:10"
+    id: solar_off
+    trigger: state
+conditions:
+  - condition: state
+    entity_id: input_boolean.predbat_ready
+    state: "on"
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: freeze_enabled
+        sequence:
+          - alias: "FreezeEntry: Enable exit & override automations"
+            action: automation.turn_on
+            target:
+              entity_id:
+                - automation.luxpower_freeze_charge_exit
+                - automation.luxpower_freeze_charge_predbat_override
+          - alias: "FreezeEntry: Arm watchdog"
+            action: automation.turn_on
+            target:
+              entity_id: automation.luxpower_freeze_charge_watchdog
+          - alias: "FreezeEntry: Set freeze guard ON (triggers watchdog)"
+            action: input_boolean.turn_on
+            target:
+              entity_id: input_boolean.freeze_charge_guard
+          - alias: "FreezeEntry: Set initial SOC charge level"
+            action: number.set_value
+            target:
+              entity_id: number.lux_ac_battery_charge_level
+            data:
+              value: "{{ states('sensor.lux_battery_soc_corrected') | float(0) }}"
+          - alias: "FreezeEntry: Initial AC arbitration"
+            choose:
+              - conditions:
+                  - condition: state
+                    entity_id: binary_sensor.solar_compare_home
+                    state: "on"
+                  - condition: state
+                    entity_id: switch.lux_ac_charge_enable
+                    state: "off"
+                sequence:
+                  - action: switch.turn_on
+                    target:
+                      entity_id: switch.lux_ac_charge_enable
+              - conditions:
+                  - condition: state
+                    entity_id: binary_sensor.solar_compare_home
+                    state: "off"
+                  - condition: state
+                    entity_id: switch.lux_ac_charge_enable
+                    state: "on"
+                sequence:
+                  - action: switch.turn_off
+                    target:
+                      entity_id: switch.lux_ac_charge_enable
+      - conditions:
+          - condition: trigger
+            id:
+              - solar_on
+              - solar_off
+          - condition: state
+            entity_id: input_boolean.freeze_charge_guard
+            state: "on"
+        sequence:
+          - alias: "FreezeSolar: AC arbitration"
+            choose:
+              - conditions:
+                  - condition: state
+                    entity_id: binary_sensor.solar_compare_home
+                    state: "on"
+                  - condition: state
+                    entity_id: switch.lux_ac_charge_enable
+                    state: "off"
+                sequence:
+                  - action: switch.turn_on
+                    target:
+                      entity_id: switch.lux_ac_charge_enable
+              - conditions:
+                  - condition: state
+                    entity_id: binary_sensor.solar_compare_home
+                    state: "off"
+                  - condition: state
+                    entity_id: switch.lux_ac_charge_enable
+                    state: "on"
+                sequence:
+                  - action: switch.turn_off
+                    target:
+                      entity_id: switch.lux_ac_charge_enable
+mode: single
+
+```
+
+```yaml
+alias: LuxPower Freeze Charge Predbat Override
+description: >
+  Handles Predbat forcing AC ON during Freeze Charge. Uses template trigger to
+  avoid repeated retriggers every few seconds.
+triggers:
+  - value_template: |
+      {{ is_state('switch.lux_ac_charge_enable', 'on')
+         and is_state('binary_sensor.solar_compare_home', 'off')
+         and is_state('input_boolean.freeze_charge_guard', 'on')
+         and is_state('input_boolean.predbat_ready', 'on') }}
+    trigger: template
+conditions: []
+actions:
+  - alias: "Predbat Override: Turn AC OFF due to Solar > Home"
+    action: switch.turn_off
+    target:
+      entity_id: switch.lux_ac_charge_enable
+  - alias: "Predbat Override: Log AC override"
+    action: system_log.write
+    data:
+      level: debug
+      message: >
+        FreezeCharge: Predbat forced AC ON → overridden OFF (Solar=OFF,
+        FreezeGuard=ON, PredbatReady=ON)
+mode: single
+
+```
+
+
+---
+
+
+- Create the **Freeze Charge Exit** automation to cleanly restore inverter state when Freeze Charging ends.
+
+```yaml
+alias: LuxPower Freeze Charge Exit
+description: |
+  Cleanup when Predbat leaves Freeze charging (ignore warn/error noise).
+triggers:
+  - entity_id: predbat.status
+    from: Freeze charging
+    trigger: state
+conditions:
+  - condition: state
+    entity_id: input_boolean.freeze_charge_guard
+    state: "on"
+  - condition: template
+    value_template: |
+      {{ not trigger.to_state.state.startswith('Warn:')
+         and not trigger.to_state.state.startswith('Error:')
+         and trigger.to_state.state not in ['unknown','unavailable'] }}
+actions:
+  - target:
+      entity_id:
+        - automation.luxpower_freeze_charge
+        - automation.luxpower_freeze_charge_predbat_override
+        - automation.luxpower_freeze_charge_watchdog
+    action: automation.turn_off
+  - target:
+      entity_id: input_boolean.freeze_charge_guard
+    action: input_boolean.turn_off
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: |
+              {{ trigger.to_state.state.startswith('Charging')
+                 or trigger.to_state.state == 'Hold charging' }}
+        sequence:
+          - target:
+              entity_id: switch.lux_ac_charge_enable
+            action: switch.turn_on
+    default:
+      - target:
+          entity_id: switch.lux_ac_charge_enable
+        action: switch.turn_off
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: |
+              {{ trigger.to_state.state.startswith('Charging') }}
+        sequence:
+          - target:
+              entity_id: number.lux_ac_battery_charge_level
+            data:
+              value: "{{ states('number.lux_system_charge_soc_limit') | int(0) }}"
+            action: number.set_value
+      - conditions:
+          - condition: template
+            value_template: |
+              {{ trigger.to_state.state == 'Hold charging' }}
+        sequence:
+          - target:
+              entity_id: number.lux_ac_battery_charge_level
+            data:
+              value: >-
+                {{ states('number.lux_on_grid_discharge_cut_off_soc') | int(0)
+                }}
+            action: number.set_value
+  - target:
+      entity_id: automation.luxpower_freeze_charge_exit
+    action: automation.turn_off
+mode: single
+
+```
+
+Occasionally, when a Manual Freeze Charge is requested, Predbat may immediately decide that **Hold Charging** is the more appropriate state based on current conditions. In this case, Freeze Charging automations may remain enabled even though Predbat reports Hold Charging. The watchdog safely exits Freeze Charging after a short grace period.
+
+- Create the **Freeze Charge Watchdog** automation to handle cases where Manual Freeze Charging immediately transitions to **Hold Charging**.
+
+```yaml
+alias: LuxPower Freeze Charge Watchdog
+description: >
+  Cancels freeze charge if Predbat does not commit to Freeze charging. Triggered
+  by freeze guard Boolean; self-disarms after execution.
+triggers:
+  - entity_id: input_boolean.freeze_charge_guard
+    from: "off"
+    to: "on"
+    trigger: state
+conditions: []
+actions:
+  - alias: "Watchdog: Grace period"
+    delay: "00:00:30"
+  - alias: "Watchdog: Abort if no Freeze charging"
+    if:
+      - condition: template
+        value_template: |
+          {{ not states('predbat.status').startswith('Freeze charging') }}
+    then:
+      - alias: "Watchdog: Trace cancellation"
+        action: system_log.write
+        data:
+          level: warning
+          message: >
+            Predbat never entered Freeze charging (status="{{
+            states('predbat.status') }}") → cancelling freeze
+      - alias: "Watchdog: Disable freeze automations"
+        action: automation.turn_off
+        target:
+          entity_id:
+            - automation.luxpower_freeze_charge
+            - automation.luxpower_freeze_charge_predbat_override
+            - automation.luxpower_freeze_charge_exit
+      - alias: "Watchdog: Reset guard Boolean"
+        action: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.freeze_charge_guard
+      - alias: "Watchdog: AC handling"
+        choose:
+          - conditions:
+              - condition: template
+                value_template: |
+                  {{ states('predbat.status').startswith('Charging') 
+                     or states('predbat.status') == 'Hold charging' }}
+            sequence:
+              - if:
+                  - condition: state
+                    entity_id: switch.lux_ac_charge_enable
+                    state: "off"
+                then:
+                  - action: switch.turn_on
+                    target:
+                      entity_id: switch.lux_ac_charge_enable
+        default:
+          - if:
+              - condition: state
+                entity_id: switch.lux_ac_charge_enable
+                state: "on"
+            then:
+              - action: switch.turn_off
+                target:
+                  entity_id: switch.lux_ac_charge_enable
+      - alias: "Watchdog: Restore SOC limits"
+        choose:
+          - conditions:
+              - condition: template
+                value_template: |
+                  {{ states('predbat.status').startswith('Charging') }}
+            sequence:
+              - action: number.set_value
+                target:
+                  entity_id: number.lux_ac_battery_charge_level
+                data:
+                  value: "{{ states('number.lux_system_charge_soc_limit') | int(0) }}"
+          - conditions:
+              - condition: template
+                value_template: |
+                  {{ states('predbat.status') == 'Hold charging' }}
+            sequence:
+              - action: number.set_value
+                target:
+                  entity_id: number.lux_ac_battery_charge_level
+                data:
+                  value: >-
+                    {{ states('number.lux_on_grid_discharge_cut_off_soc') |
+                    int(0) }}
+  - alias: "Watchdog: Disarm self"
+    action: automation.turn_off
+    target:
+      entity_id: automation.luxpower_freeze_charge_watchdog
+mode: single
+
+```
+**Enable Freeze Charging**
+
+- Ensure **`switch.predbat_set_charge_freeze`** is turned On.
+
+After Predbat recomputes, you may see some light grey **FrzChrg** slots in the state column of the plan. To disable Freeze Charging simply turn the switch Off. Predbat will no longer schedule any FrzChrg slots. 
+
+
+---
+
+### Freeze Exporting
+
+If you have a LuxPower inverter with the *Charge Last* feature, enable the Predbat `discharge_freeze_service`.
+
+**Note:**
+Freeze Exporting requires fewer supporting automations than Freeze Charging, as it relies primarily on inverter-side behaviour. No additional watchdog or guard logic is required.
+
+- In your `apps.yaml` file:
+
+  - Look for `support_discharge_freeze` in the inverter section and change `False` to `True`
+  - Uncomment the last two lines of the `discharge_stop_service` section so Predbat turns `switch.lux_charge_last` off when Freeze exporting stops.
+  - Uncomment the three lines of the `discharge_freeze_service` section so that Predbat turns on the LuxPower Charge Last switch. 
+  - Ensure the indentation and alignment match the other service entries.
+
+  
+**Enable Freeze Exporting**
+
+- Ensure **`switch.predbat_set_export_freeze`** is turned On.
+
+After Predbat recomputes, you may see some dark grey **FrzExp** slots in the state column of the plan. To disable Freeze Exporting simply turn the switch Off. Predbat will no longer schedule any FrzExp slots. 
+
+
+
+---
+
+### Home Assistant restart recovery
+
+- Create the following toggle helper and automation to ensure the inverter and Predbat return to a known safe state after a Home Assistant restart.
+This automation must always be enabled.
+
+```yaml
+name: Predbat Ready
+entity_id: input_boolean.predbat_ready
+```
+
+The `predbat_ready` helper prevents automation actions until LuxPower entities are fully available after startup. Ensure it is On after it has been created. 
+
+
+```yaml
+alias: LuxPower HA Startup Reset
+description: >
+  On Home Assistant restart, wait for LuxPower entities to be available, then
+  safely disable freeze charge, override, watchdog, guard boolean, AC/charge and
+  charge last switches, and reset discharge current limit. Marks Predbat ready
+  only after HA and Lux are stable.
+triggers:
+  - event: start
+    trigger: homeassistant
+actions:
+  - alias: "StartupReset: Mark Predbat NOT ready"
+    target:
+      entity_id: input_boolean.predbat_ready
+    action: input_boolean.turn_off
+  - alias: "StartupReset: Wait for Lux entities"
+    wait_template: |
+      {{ states('switch.lux_ac_charge_enable') not in ['unknown','unavailable']
+         and states('switch.lux_charge_last') not in ['unknown','unavailable']
+         and states('switch.lux_force_discharge_enable') not in ['unknown','unavailable']
+         and states('number.lux_discharge_current_limit') not in ['unknown','unavailable'] }}
+    timeout: "00:02:00"
+    continue_on_timeout: true
+  - alias: "StartupReset: Disable freeze/override/watchdog"
+    target:
+      entity_id:
+        - automation.luxpower_freeze_charge
+        - automation.luxpower_freeze_charge_predbat_override
+        - automation.luxpower_freeze_charge_exit
+        - automation.luxpower_freeze_charge_watchdog
+    action: automation.turn_off
+  - alias: "StartupReset: Reset guard boolean"
+    target:
+      entity_id: input_boolean.freeze_charge_guard
+    action: input_boolean.turn_off
+  - alias: "StartupReset: Wait for battery voltage to be > 0"
+    wait_template: "{{ states('sensor.lux_battery_voltage_live') | float > 0 }}"
+    timeout: "00:01:00"
+    continue_on_timeout: true
+  - alias: "StartupReset: Set discharge current limit from battery_rate_max"
+    target:
+      entity_id: number.lux_discharge_current_limit
+    data:
+      value: |
+        {{ (states('input_number.battery_rate_max') | float
+            / states('sensor.lux_battery_voltage_live') | float(1))
+            | round(0) }}
+    action: number.set_value
+  - alias: "StartupReset: Turn off AC if on"
+    if:
+      - condition: state
+        entity_id: switch.lux_ac_charge_enable
+        state: "on"
+    then:
+      - target:
+          entity_id: switch.lux_ac_charge_enable
+        action: switch.turn_off
+  - alias: "StartupReset: Turn off charge last if on"
+    if:
+      - condition: state
+        entity_id: switch.lux_charge_last
+        state: "on"
+    then:
+      - target:
+          entity_id: switch.lux_charge_last
+        action: switch.turn_off
+  - alias: "StartupReset: Turn off force discharge if on"
+    if:
+      - condition: state
+        entity_id: switch.lux_force_discharge_enable
+        state: "on"
+    then:
+      - target:
+          entity_id: switch.lux_force_discharge_enable
+        action: switch.turn_off
+  - alias: "StartupReset: Final settle delay"
+    delay: "00:01:30"
+  - alias: "StartupReset: Mark Predbat ready"
+    target:
+      entity_id: input_boolean.predbat_ready
+    action: input_boolean.turn_on
+  - alias: "StartupReset: Log completion"
+    data:
+      level: debug
+      message: "StartupReset: cleanup complete, watchdog and guard OFF, Predbat ready"
+    action: system_log.write
+mode: single
+
+```
+
+
+---
+
+### Notes
+
+¹
+If you do not need to record the binary sensor, you can exclude it from the HA recorder by adding the following to your `configuration.yaml` file: *(HA restart required)*
+
+```yaml
+recorder:
+  exclude:
+    entities:
+      - binary_sensor.solar_compare_home
+```
+
+²
+While LuxPower inverters cannot exactly replicate Predbat’s native Freeze Charging behaviour, these automations achieve an equivalent outcome. Any small differences are corrected the next time Predbat recalculates its plan.
+
+³ 
+You shouldn't encounter any warnings or errors like those below but if you do they can safely be ignored. They are benign and purely informational. They do not indicate a fault with Predbat. 
+
+```yaml
+Predbat log:
+Completed run status Freeze charging with Errors reported (check log)
+Warn: record_status – Inverter 0 write to scheduled_charge_enable failed
+Warn: Inverter 0 Trying to write scheduled_charge_enable to True didn’t complete (got off)
+
+Predbat Status:
+Warn: Inverter 0 write to scheduled_charge_enable failed
+```
+
+---
+
+
+## Sigenergy Sigenstor
+
+To integrate your Sigenergy Sigenstor inverter with Predbat, you will need to follow the steps below:
+
+- make sure the inverter is already integrated into Home Assistant. Here is a ([repo](https://github.com/TypQxQ/Sigenergy-Local-Modbus)) with full integration (this is the Python version of the Sigenergy Home Assistant integration).
+- Copy the template [sigenergy_sigenstor.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/sigenergy_sigenstor.yaml) template over your `apps.yaml`, and edit for your system.
+
+- All the Sigenergy entities referenced in `apps.yaml` need to be enabled for Predbat to use them. The following are disabled by default and will need enabling:
+
+    - sensor.sigen_plant_available_max_discharging_capacity
+    - sensor.sigen_plant_daily_consumed_energy
+    - number.sigen_plant_ess_backup_state_of_charge
+    - number.sigen_plant_ess_charge_cut_off_state_of_charge
+    - number.sigen_plant_ess_discharge_cut_off_state_of_charge
+    - sensor.sigen_plant_max_active_power
+
+- The following additions are needed to facilitate integration with Predbat and need to be put into Home Assistant's `configuration.yaml` or configured via the HA user interface:
+
+```yaml
+input_select:
+  predbat_requested_mode:
+    name: "Predbat Requested Mode"
+    options:
+      - "Demand"
+      - "Charging"
+      - "Freeze Charging"
+      - "Discharging"
+      - "Freeze Discharging"
+    initial: "Demand"
+    icon: mdi:battery-unknown
+
+input_number:
+  charge_rate:
+    name: Battery charge rate
+    initial: 6950
+    min: 0
+    max: 20000
+    step: 1
+    mode: box
+    unit_of_measurement: W
+
+  discharge_rate:
+    name: Battery discharge rate
+    initial: 8000
+    min: 0
+    max: 20000
+    step: 1
+    mode: box
+    unit_of_measurement: W
+```
+
+Add the following automations to `automations.yaml` (or configure via the UI):
+
+```yaml
+- id: predbat_requested_mode_action
+  alias: "Predbat Requested Mode Action"
+  description: "Acts as a mapper for the input_select.predbat_requested_mode to the select.sigen_plant_remote_ems_control_mode"
+  mode: restart
+  triggers:
+    - trigger: state
+      entity_id:
+        - input_select.predbat_requested_mode
+  conditions: []
+  actions:
+    - action: select.select_option
+      metadata: {}
+      target:
+        entity_id: select.sigen_plant_remote_ems_control_mode
+      data:
+        option: >
+          {% if is_state('input_select.predbat_requested_mode', "Demand") %}Maximum Self Consumption
+          {% elif is_state('input_select.predbat_requested_mode', "Charging") %}Command Charging (PV First)
+          {% elif is_state('input_select.predbat_requested_mode', "Freeze Charging") %}Maximum Self Consumption
+          {% elif is_state('input_select.predbat_requested_mode', "Discharging") %}Command Discharging (PV First)
+          {% elif is_state('input_select.predbat_requested_mode', "Freeze Discharging") %}Maximum Self Consumption
+          {% endif %}
+
+    - choose:
+        # Freeze Charging
+        # Docs:
+        #  Freeze charging - The battery is charging but the current battery level (SoC) is frozen (held). Think of it
+        #  as a charge to the current battery level. The grid or solar covers any house load. If there is a shortfall of
+        #  Solar power to meet house load, the excess house load is met from grid import, but if there is excess Solar
+        #  power above the house load, the excess solar will be used to charge the battery
+        # In Sigenergy, this is effectively "self consumption" mode with discharging prohibited
+        - conditions:
+            - condition: state
+              entity_id: input_select.predbat_requested_mode
+              state: "Freeze Charging"
+          sequence:
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_ess_charge_cut_off_state_of_charge
+                value: 100
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_ess_discharge_cut_off_state_of_charge
+                value: 100
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_grid_import_limitation
+                value: 0
+
+        # Freeze Discharging
+        # Docs:
+        #  Freeze exporting (mapped to Freeze Discharging in sigenergy_sigenstor.yaml) - The battery is in demand mode,
+        #  but with charging disabled. The battery or solar covers the house load. As charging is disabled, if there is
+        #  excess solar generated, the current SoC level will be held and the excess solar will be exported. If there is
+        #  a shortfall of generated solar power to meet the house load, the battery will discharge to meet the extra load.
+        # In Sigenergy, this is effectively "self consumption" mode with charging prohibited
+        - conditions:
+            - condition: state
+              entity_id: input_select.predbat_requested_mode
+              state: "Freeze Discharging"
+          sequence:
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_ess_charge_cut_off_state_of_charge
+                value: 0
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_ess_discharge_cut_off_state_of_charge
+                value: 0
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_grid_import_limitation
+                value: 0
+
+        # If neither of the above conditions are met, set the limits to the input numbers
+        - conditions:
+          - condition: not
+            conditions:
+              - condition: state
+                entity_id: input_select.predbat_requested_mode
+                state: "Freeze Charging"
+              - condition: state
+                entity_id: input_select.predbat_requested_mode
+                state: "Freeze Discharging"
+          sequence:
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_ess_charge_cut_off_state_of_charge
+                value: 100
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_ess_discharge_cut_off_state_of_charge
+                value: 0
+            - service: number.set_value
+              data_template:
+                entity_id: number.sigen_plant_grid_import_limitation
+                value: 100
+
+- id: "automation_sigen_ess_max_charging_limit_input_number_action"
+  alias: "Predbat max charging limit action"
+  description: "Mapper from input_number.charge_rate to number sigen_plant_ess_max_charging_limit"
+  triggers:
+    - trigger: state
+      entity_id: input_number.charge_rate
+  action:
+    - action: number.set_value
+      target:
+        entity_id: number.sigen_plant_ess_max_charging_limit
+      data:
+        value: >-
+          "{{ [(states('input_number.charge_rate') | float / 1000) | round(2),
+          states('sensor.sigen_inverter_ess_rated_charging_power') | float] | min}}"
+  mode: single
+
+- id: "automation_sigen_ess_max_discharging_limit_input_number_action"
+  alias: "Predbat max discharging limit action"
+  description: "Mapper from input_number.discharge_rate to number.sigen_plant_ess_max_discharging_limit"
+  triggers:
+    - trigger: state
+      entity_id: input_number.discharge_rate
+  action:
+    - action: number.set_value
+      target:
+        entity_id: number.sigen_plant_ess_max_discharging_limit
+      data:
+        value: >-
+          "{{ [(states('input_number.discharge_rate') | float / 1000) | round(2),
+          states('sensor.sigen_inverter_ess_rated_discharging_power') | float] | min}}"
+  mode: single
+```
+
+## Sofar Inverters
+
+For this integration, the key elements are:
+
+- Hardware - [sofar2mqtt EPS board](https://www.instructables.com/Sofar2mqtt-Remote-Control-for-Sofar-Solar-Inverter/) - Relatively easy to solder and flash, or can be bought pre-made.
+- Software - [Sofar MQTT integration](https://github.com/cmcgerty/Sofar2mqtt) - MQTT integration
+- Home Assistant configuration - [sofar_inverter.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/sofar_inverter.yaml) (in templates directory),
+defines the custom HA entities and should be added to HA's `configuration.yaml`. This is the default Sofar HA configuration with a couple of additional inputs to support battery capacity.
+- Predbat configuration - [sofar.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/sofar.yaml) template for Predbat (in templates directory).
+This file should be copied over the top of your `apps.yaml` and edited for your installation
+
+- Please note that the inverter needs to be put into "Passive Mode" for the sofar2mqtt to control the inverter.
+- This integration has various limitations, it can charge and discharge the battery but does not have finer control over reserve and target SoC%
+- Note: You will need to change the min reserve in Home Assistant to match your minimum battery level (**input_number.predbat_set_reserve_min**).
+
+Please see this ticket in Github for ongoing discussions: <https://github.com/springfall2008/batpred/issues/395>
+
+## SolarEdge Inverters
+
+- Please copy the template <https://github.com/springfall2008/batpred/blob/main/templates/solaredge.yaml> over the top of your `apps.yaml` and modify it for your system
+- The default entity name prefix for the integration is 'solaredge' but if you have changed this on installation then you will need to amend the `apps.yaml` template and the template sensors to match your new prefix
+- Ensure that **number.solaredge_i1_storage_command_timeout** is set to a reasonably high value e.g. 3600 seconds to avoid the commands issued being cancelled
+- Power Control Options, as well as Enable Battery Control, must be enabled in the Solaredge Modbus Multi integration configuration,
+and **switch.solaredge_i1_advanced_power_control** must be on.
+
+- For **pv_today**, **pv_power** and **load_power** sensors to work you need to create these as a template entities within your Home Assistant `configuration.yaml`.
+These sensors are not critical so you can just comment them out in `apps.yaml` if you can't get them to work:
+
+```yaml
+template:
+  - sensor:
+      - name: "Solar Panel Production W"
+        unique_id: solar_panel_production_w
+        unit_of_measurement: "W"
+        icon: mdi:solar-power
+        state: >
+          {% set i1_dc_power = states('sensor.solaredge_i1_dc_power') | float(0) %}
+          {% set b1_dc_power = states('sensor.solaredge_b1_dc_power') | float(0) %}
+          {% if (i1_dc_power + b1_dc_power <= 0) %}
+            0
+          {% else %}
+            {{ (i1_dc_power + b1_dc_power) }}
+          {% endif %}
+        availability: >
+          {{ states('sensor.solaredge_i1_dc_power') | is_number and states('sensor.solaredge_b1_dc_power') | is_number }}
+
+      - name: "Solar House Consumption W"
+        unique_id: solar_house_consumption_w
+        unit_of_measurement: "W"
+        icon: mdi:home
+        state: >
+          {% set i1_ac_power = states('sensor.solaredge_i1_ac_power') | float(0) %}
+          {% set m1_ac_power = states('sensor.solaredge_m1_ac_power') | float(0) %}
+          {% if (i1_ac_power - m1_ac_power <= 0) %}
+            0
+          {% else %}
+            {{ (i1_ac_power - m1_ac_power) }}
+          {% endif %}
+        availability: >
+          {{ states('sensor.solaredge_i1_ac_power') | is_number and states('sensor.solaredge_m1_ac_power') | is_number }}
+
+sensor:
+  - platform: integration
+    source: sensor.solar_panel_production_w
+    method: left
+    unit_prefix: k
+    name: solar_panel_production_kwh
+
+sensor:
+  - platform: integration
+    source: sensor.solar_house_consumption_w
+    method: left
+    unit_prefix: k
+    name: solar_house_consumption_kwh
+```
+
+If you have multiple batteries connected to your SolarEdge inverter and are using the SolarEdge Modbus Multi integration, this enumerates the multiple batteries as b1, b2, b3, etc with separate entities per battery.
+
+You will need to make a number of changes to the solaredge apps.yaml, replacing the following entries:
+
+```yaml
+  battery_rate_max:
+    - sensor.calc_power_batteries_max_charge_power # maximum charge power of all the batteries
+  battery_power:
+    - sensor.calc_power_batteries_dc_power
+  soc_percent:
+    - sensor.calc_battery_all_state # average SoC of the batteries
+  soc_max:
+    - sensor.calc_battery_total_capacity # combined kWh maximum value of all the batteries
+  soc_kw:
+    - sensor.calc_battery_current_capacity
+```
+
+- set charge_rate and discharge_rate to the SolarEdge inverter values, e.g. 5000
+
+- And add the following additional template sensors to `configuration.yaml` after the existing 'template:' line (from the earlier template sensor definitions):
+
+```yaml
+  - sensor:
+    # Template sensor for Max Battery Charge rate
+    # This is the sum of all three batteries charge rate as the max charge rate can be higher than inverter capacity (e.g. 8k) when charging from AC+Solar
+    # Returns 5000W as the minimum max value, the single battery charge/discharge limit to ensure at least one battery can always be charged if one or more batteries have 'gone offline' to modbus
+    # Remove all 'B3' entries if you only have two batteries, or follow the same pattern for adding 'B4', etc if you have more than 3 batteries
+    - name: "Calc Power - Batteries Max Charge Power"
+      unique_id: calc_power_batteries_max_charge_power
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"
+      state: >
+        {% set myB1 = float(states('sensor.solaredge_b1_max_charge_power'),0) %}
+        {% set myB2 = float(states('sensor.solaredge_b2_max_charge_power'),0) %}
+        {% set myB3 = float(states('sensor.solaredge_b3_max_charge_power'),0) %}
+        {% set myValue = ((myB1 + myB2 + myB3)) | int %}
+        {{ (myValue if (myValue) > 5000 else 5000) }}
+
+    # Calculate Total Battery Power Value
+    - name: "Calc Power - Batteries DC Power"
+      unique_id: calc_power_batteries_dc_power
+      unit_of_measurement: "W"
+      device_class: "power"
+      state_class: "measurement"
+      state: >
+        {% set myB1 = float(states('sensor.solaredge_b1_dc_power'),0) %}
+        {% set myB2 = float(states('sensor.solaredge_b2_dc_power'),0) %}
+        {% set myB3 = float(states('sensor.solaredge_b3_dc_power'),0) %}
+        {% set myValue = ((myB1 + myB2 + myB3)) %}
+        {{ myValue }}
+
+    # Average state of charge across the batteries
+    - name: "Calc Battery All State"
+      unique_id: calc_battery_all_state
+      unit_of_measurement: "%"
+      state: >
+        {% set myB1 = float(states('sensor.solaredge_b1_state_of_energy'),0) %}
+        {% set myB2 = float(states('sensor.solaredge_b2_state_of_energy'),0) %}
+        {% set myB3 = float(states('sensor.solaredge_b3_state_of_energy'),0) %}
+        {% set myValue = ((myB1 + myB2 + myB3) / 3) | round(0) %}
+        {{ myValue }}
+
+    # Total Energy Stored in the Batteries
+    - name: "Calc Battery Total Capacity"
+      unique_id: calc_battery_total_capacity
+      unit_of_measurement: kWh
+      state: >
+        {% set myB1 = float(states('sensor.solaredge_b1_maximum_energy'),0) %}
+        {% set myB2 = float(states('sensor.solaredge_b2_maximum_energy'),0) %}
+        {% set myB3 = float(states('sensor.solaredge_b3_maximum_energy'),0) %}
+        {% set myValue = ((myB1 + myB2 + myB3)) %}
+        {{ myValue }}
+
+    # Current Energy Stored in the Batteries
+    - name: "Calc Battery Current Capacity"
+      unique_id: calc_battery_current_capacity
+      unit_of_measurement: kWh
+      state: >
+        {% set myValue = (float(states('sensor.calc_battery_all_state'),0) / 100) * float(states('sensor.calc_battery_total_capacity'),0) %}
+        {{ myValue }}
+```
+
+## Solax Gen4+ Inverters
+
+The Predbat Solax configuration can either either use the Mode1 remote control or the newer Mode8 option. Both should work with the SolaX Gen 4, 5 or 6 inverters.  Thanks @TCWORLD for this configuration.
+
+- Please copy the template <https://github.com/springfall2008/batpred/blob/main/templates/solax_sx4.yaml> over the top of your `apps.yaml`, and modify it for your system and the work mode that your inverter is set to
+- Install and configure the Solax Modbus integration in Home Assistant and confirm that it is connected to your inverter
+- The regular expressions in the custom SX4+ `apps.yaml` should auto-match to the entity names provided by your Solax Modbus integration, but do double-check that they do
+- To use Mode 1 remote control, create and save the following automation script (Settings/Automations/Scripts) which will act as the interface between Predbat and the Solax Modbus integration.<BR>
+You can change the limits for the power field if you have a larger inverter, it doesn't matter if this limit is larger than the inverter can handle as the value gets clipped to the inverter limits by the Solax Modbus integration.<BR>
+You may need to amend the 'solax_' prefixes on the entity names that this script sets if your Modbus integration has slightly different entity names (e.g. 'solaxmodbus_' or 'solax_inverter_'):
+
+```yaml
+alias: SolaX Remote Control
+description: ""
+fields:
+  power:
+    selector:
+      number:
+        min: 0
+        max: 6600
+    default: 0
+  operation:
+    selector:
+      select:
+        multiple: false
+        options:
+          - Disabled
+          - Force Charge
+          - Force Discharge
+          - Freeze Charge
+          - Freeze Discharge
+    default: Disabled
+    required: false
+  duration:
+    selector:
+      number:
+        min: 300
+        max: 86400
+    default: 28800
+    required: false
+sequence:
+  - variables:
+      defaultPower: "{{ 200 }}"
+      mode: |-
+        {% set map = {
+           'Disabled': 'Disabled',
+           'Force Charge': 'Enabled Battery Control',
+           'Force Discharge': 'Enabled Battery Control',
+           'Freeze Charge': 'Enabled No Discharge',
+           'Freeze Discharge': 'Enabled Feedin Priority'} %}
+        {{ map.get( operation, 'Disabled' ) }}
+      activeP: >-
+        {% set chargePower = (power | int(defaultPower)) if power is defined else
+        defaultPower %}
+
+        {% set dischargePower = (0 - chargePower) %}
+
+        {% set map = {
+           'Disabled': 0,
+           'Force Charge': chargePower,
+           'Force Discharge': dischargePower,
+           'Freeze Charge': 0,
+           'Freeze Discharge': 0} %}
+        {{ map.get( operation, 0 ) }}
+  - action: number.set_value
+    data:
+      value: "{{ activeP }}"
+    target:
+      entity_id: number.solax_remotecontrol_active_power
+  - action: number.set_value
+    data:
+      value: "60"
+    target:
+      entity_id: number.solax_remotecontrol_duration
+  - action: number.set_value
+    data:
+      value: "{{ duration if duration is defined else 28800 }}"
+    target:
+      entity_id: number.solax_remotecontrol_autorepeat_duration
+  - action: select.select_option
+    data:
+      option: "{{ mode if mode is defined else Disabled }}"
+    target:
+      entity_id: select.solax_remotecontrol_power_control
+  - action: button.press
+    data: {}
+    target:
+      entity_id: button.solax_remotecontrol_trigger
+mode: queued
+max: 10
+```
+
+- To use Mode 1 remote control, ensure the following entities are enabled:
+
+    - number.solax_remotecontrol_active_power
+    - number.solax_remotecontrol_duration
+    - number.solax_remotecontrol_autorepeat_duration
+    - select.solax_remotecontrol_power_control
+    - button.solax_remotecontrol_trigger
+
+- To use Mode 8 power control API (Gen 4 or newer inverter) which has direct control over the battery charge/discharge rate, and can directly set the battery (dis)charge rate without limiting any PV generation,
+create and save the following automation script (Settings/Automations/Scripts) which will act as the interface between Predbat and the Solax Modbus integration.<BR>
+In the script, change 'maxPvPower: "{{ 12000 }}"' to a value larger than your PV array size so the script doesn't limit PV generation.<BR>
+Change 'max: 6600' - to a value larger than the maximum charge/discharge power for your battery (doesn't matter if higher).<BR>
+Note: Mode8 requires version 2025.10.7 or newer of the SolaX Modbus integration as there are some necessary Mode 8 improvements added:
+
+```yaml
+alias: SolaX Remote Control (Mode 8)
+description: ""
+fields:
+  power:
+    selector:
+      number:
+        min: 0
+        max: 6600
+    default: 0
+  operation:
+    selector:
+      select:
+        multiple: false
+        options:
+          - Disabled
+          - Force Charge
+          - Force Discharge
+          - Freeze Charge
+          - Freeze Discharge
+    default: Disabled
+    required: false
+  duration:
+    selector:
+      number:
+        min: 60
+        max: 86400
+    default: 28800
+sequence:
+  - variables:
+      maxPvPower: "{{ 12000 }}"
+      defaultPower: "{{ 200 }}"
+      mode: |-
+        {% set map = {
+           'Disabled': 'Disabled',
+           'Force Charge': 'Mode 8 - PV and BAT control - Duration',
+           'Force Discharge': 'Mode 8 - PV and BAT control - Duration',
+           'Freeze Charge': 'Enabled No Discharge',
+           'Freeze Discharge': 'Export-First Battery Limit'} %}
+        {{ map.get( operation, 'Disabled' ) }}
+      activeP: >-
+        {% set dischargePower = (power | int(defaultPower)) if power is defined
+        else defaultPower %} {% set chargePower = (0 - dischargePower) %} {% set map
+        = {
+           'Disabled': 0,
+           'Force Charge': chargePower,
+           'Force Discharge': dischargePower,
+           'Freeze Charge': 0,
+           'Freeze Discharge': 0} %}
+        {{ map.get( operation, 0 ) }}
+  - action: number.set_value
+    data:
+      value: "{{ activeP }}"
+    target:
+      entity_id: number.solax_remotecontrol_push_mode_power_8_9
+  - action: number.set_value
+    data:
+      value: "{{ maxPvPower }}"
+    target:
+      entity_id: number.solax_remotecontrol_pv_power_limit
+  - action: number.set_value
+    data:
+      value: "30"
+    target:
+      entity_id: number.solax_remotecontrol_duration
+  - action: number.set_value
+    data:
+      value: "300"
+    target:
+      entity_id: number.solax_remotecontrol_timeout
+  - action: number.set_value
+    data:
+      value: "{{ duration if duration is defined else 28800 }}"
+    target:
+      entity_id: number.solax_remotecontrol_autorepeat_duration
+  - action: select.select_option
+    data:
+      option: VPP Off
+    target:
+      entity_id: select.solax_inverter_remotecontrol_timeout_next_motion_mode_1_9
+  - action: select.select_option
+    data:
+      option: "{{ mode if mode is defined else Disabled }}"
+    target:
+      entity_id: select.solax_remotecontrol_power_control_mode
+  - action: button.press
+    data: {}
+    enabled: true
+    target:
+      entity_id: button.solax_powercontrolmode8_trigger
+mode: queued
+max: 10
+```
+
+- To use Mode 8 power control, ensure the following entities are enabled:
+
+    - number.solax_remotecontrol_push_mode_power_8_9
+    - number.solax_remotecontrol_pv_power_limit
+    - number.solax_remotecontrol_duration
+    - number.solax_remotecontrol_timeout
+    - number.solax_remotecontrol_autorepeat_duration
+    - select.solax_inverter_remotecontrol_timeout_next_motion_mode_1_9
+    - select.solax_remotecontrol_power_control_mode
+    - button.solax_powercontrolmode8_trigger
+
+- Predbat needs a 'Todays House Load' sensor, this can be created from inverter-supplied information by creating two custom helper entities:
+    - Create a helper entity of type 'Integral', set the Name to 'Todays House Load Integral', Metric Prefix to 'k (kilo)', Time unit to 'Hours', Input sensor to 'House Load', Integration method to 'Trapezoidal', Precision to '2'
+    and Max sub-interval to '0:05:00'
+    - Create a helper entity of type 'Utility Meter', set the Name to 'Todays House Load', Input sensor to 'Todays House Load Integral' (that you just created) and Meter Reset Cycle to 'Daily'
+
+- When you first start Predbat, check the [Predbat log](output-data.md#predbat-logfile) to confirm that the correct sensor names are identified by the regular expressions in `apps.yaml`. Any non-matching expressions should be investigated and resolved
+
+Please see this ticket in Github for ongoing discussion: <https://github.com/springfall2008/batpred/issues/259>
+
+## Solis Inverters before FB00
+
+To run PredBat with Solis hybrid inverters with firmware level prior to FB00 (you can recognise these by having fewer than 6 slots for charging times), follow the following steps:
+
+1. Install PredBat as per the [Installation Summary](installation-summary.md)
+2. Ensure that you have the Solax Modbus integration running and select the inverter type solis.
+There are a number of entities which this integration disables by default that you will need to enable via the Home Assistant GUI:
+
+   | Name | Description |
+   | :---------------------------- | :-------------- |
+   | `sensor.solis_rtc` | Real Time Clock |
+   | `sensor.solis_battery_power` | Battery Power |
+
+3. Copy the template <https://github.com/springfall2008/batpred/blob/main/templates/gilong_solis.yaml> over the top of your `apps.yaml`, and modify it for your system
+4. Set **solax_modbus_new** in `apps.yaml` to True if you have integration version 2024.03.2 or greater
+5. Ensure that the inverter is set to Control Mode 35 - on the Solax integration this is `Timed Charge/Discharge`.
+If you want to use the `Reserve` functionality within PredBat you will need to select `Backup/Reserve` (code 51) instead but be aware that this is not fully tested.
+In due course, these mode settings will be incorporated into the code.
+6. Your inverter will require a "button press" triggered by Predbat to update the schedules. Some Solis inverter integrations feature a combined charge/discharge update button, in which case a single `apps.yaml` entry of:
+
+```yaml
+  charge_discharge_update_button:
+    - button.solis_update_charge_discharge_times
+```
+
+7. Ensure the correct entity IDs are used for your specific inverter setup. These entries should correspond to the buttons exposed by your Home Assistant Solis integration.
+
+## Solis Inverters FB00 or later
+
+To run PredBat with Solis hybrid inverters with firmware level FB00 or later (you can recognise these by having 6 slots for charging times), follow the following steps:
+
+1. Install PredBat as per the [Installation Summary](installation-summary.md)
+2. Ensure that you have the Solax Modbus integration running and select the inverter type solis_fb00.
+There are a number of entities which this integration disables by default that you will need to enable via the Home Assistant GUI:
+
+   | Name                          | Description     |
+   | :---------------------------- | :-------------- |
+   | `sensor.solisx_rtc`           | Real Time Clock |
+   | `sensor.solisx_battery_power` | Battery Power   |
+
+3. Copy the template <https://github.com/springfall2008/batpred/blob/main/templates/gilong_solis.yaml> over the top of your `apps.yaml`, and modify it for your system.
+You will need to update these lines:
+
+- Replace **inverter_type: "GS"** with **inverter_type: "GS_fb00"** to enable the inverter template for the newer firmware version of Solis inverters
+- Un-comment **charge_update_button** and **discharge_update_button** and comment out **charge_discharge_update_button** to enable the two "button presses" needed for writing charge/discharge times to the inverter
+- Un-comment **scheduled_charge_enable** and **scheduled_discharge_enable** to enable Predbat to enable/disable the charge/discharge slots
+- Un-comment **charge_limit** to enable the charge limit through setting an upper SoC value
+- Set **solax_modbus_new** to True if you have integration version 2024.03.2 or greater
+- Lastly you will need to comment out or delete the **template** line to enable the configuration
+
+4. Save the file as `apps.yaml` to the appropriate [Predbat software directory](apps-yaml.md#appsyaml-settings).
+
+5. Ensure that the inverter is set to Control Mode 35 - on the Solax integration this is `Timed Charge/Discharge`.
+If you want to use the `Reserve` functionality within PredBat you will need to select `Backup/Reserve` (code 51) instead but be aware that this is not fully tested.
+In due course, these mode settings will be incorporated into the code.
+
+6. Note: Predbat will read the minimum SoC level set on the inverter via **sensor.solis_battery_minimum_soc** configured in `apps.yaml`.
+You must set the minimum SoC level that Predbat will set in **input_number.predbat_set_reserve_min** to at least 1% more than the inverter minimum SoC.<BR>
+So for example, if the inverter minimum SoC is set to 20%, predbat_set_reserve_min must be set to at least 21%. If this is not done then when Predbat sets the reserve SoC, the instruction will be rejected by the inverter and Predbat will error.
+
+7. Ensure the correct entity IDs are used for your specific inverter setup. These entries should correspond to the buttons exposed by your Home Assistant Solis integration.
+
+## Sunsynk
+
+- Copy the Sunsynk template over the top of your `apps.yaml`, and edit for your system.
+- Create the following Home Assistant automations:
+
+```yaml
+alias: Predbat Charge / Discharge Control
+description: "Turn SunSynk charge/discharge on/off to mirror Predbat"
+trigger:
+  - platform: state
+    entity_id:
+      - binary_sensor.predbat_charging
+    to: "on"
+    id: predbat_charge_on
+  - platform: state
+    entity_id:
+      - binary_sensor.predbat_charging
+    to: "off"
+    id: predbat_charge_off
+  - platform: state
+    entity_id:
+      - binary_sensor.predbat_exporting
+    to: "on"
+    id: predbat_discharge_on
+  - platform: state
+    entity_id:
+      - binary_sensor.predbat_exporting
+    to: "off"
+    id: predbat_discharge_off
+condition: []
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id:
+              - predbat_charge_on
+        sequence:
+          - service: switch.turn_on
+            data: {}
+            target:
+              entity_id: switch.sunsynk_grid_charge_timezone1
+      - conditions:
+          - condition: trigger
+            id:
+              - predbat_charge_off
+        sequence:
+          - service: switch.turn_off
+            target:
+              entity_id:
+                - switch.sunsynk_grid_charge_timezone1
+            data: {}
+      - conditions:
+          - condition: trigger
+            id:
+              - predbat_discharge_on
+        sequence:
+          - service: switch.turn_on
+            data: {}
+            target:
+              entity_id: switch.sunsynk_solar_sell
+      - conditions:
+          - condition: trigger
+            id:
+              - predbat_discharge_off
+        sequence:
+          - service: switch.turn_off
+            target:
+              entity_id:
+                - switch.sunsynk_solar_sell
+            data: {}
+mode: single
+```
+
+```yaml
+alias: PredBat - Copy Charge Limit
+description: Copy Battery SoC to all timezone (time) slots
+trigger:
+  - platform: state
+    entity_id:
+      - number.sunsynk_set_soc_timezone1
+    to: null
+condition: []
+action:
+  - service: number.set_value
+    data_template:
+      entity_id:
+        - number.sunsynk_set_soc_timezone2
+        - number.sunsynk_set_soc_timezone3
+        - number.sunsynk_set_soc_timezone4
+        - number.sunsynk_set_soc_timezone5
+        - number.sunsynk_set_soc_timezone6
+      value: "{{ states('number.sunsynk_set_soc_timezone1')|int(20) }}"
+mode: single
+```
+
+- Create the following templates sensors in your `configuration.yaml`:
+
+```yaml
+template:
+  sensor:
+    - name: "sunsynk_max_battery_charge_rate"
+      unit_of_measurement: "w"
+      state_class: measurement
+      state: >
+        {{ [8000,[states('input_number.sunsynk_battery_max_charge_current_limit')|int,states('sensor.sunsynk_battery_charge_limit_current')|int]|min
+        * states('sensor.sunsynk_battery_voltage')|float]|min }}
+
+    - name: "sunsynk_max_battery_discharge_rate"
+      unit_of_measurement: "w"
+      state_class: measurement
+      state: >
+        {{ [8000,[states('input_number.sunsynk_battery_max_discharge_current_limit')|int,states('sensor.sunsynk_battery_discharge_limit_current')|int]|min
+        * states('sensor.sunsynk_battery_voltage')|float]|min }}
+
+    - name: "sunsynk_charge_rate_calc"
+      unit_of_measurement: "w"
+      state_class: measurement
+      state: >
+        {{ [8000,[states('input_number.test_sunsynk_battery_max_charge_current')|int,states('sensor.sunsynk_battery_charge_limit_current')|int]|min
+        * states('sensor.sunsynk_battery_voltage')|float]|min }}
+
+    - name: "sunsynk_discharge_rate_calc"
+      unit_of_measurement: "w"
+      state_class: measurement
+      state: >
+        {{ [8000,[states('input_number.test_sunsynk_battery_max_discharge_current')|int,states('sensor.sunsynk_battery_discharge_limit_current')|int]|min
+         * states('sensor.sunsynk_battery_voltage')|float]|min }}
+```
+
+## Tesla Powerwall
+
+Integration of the Tesla Powerwall follows the approach outlined in [Ed Hull's blog](https://edhull.co.uk/blog/2025-08-24/predbat-docker-tesla).
+Ed's setup only covered Predbat controlling charging the Powerwall, the below configuration (thanks @Slee2112) covers both charging and discharging (exporting).
+
+*Note:* This Predbat Tesla configuration has been developed with a Powerwall 3. It may require changes for older Powerwall models. Please raise a GitHub issue with details of any changes you find are required so the documentation can be updated.
+
+- The Predbat Tesla `apps.yaml` configuration was developed using the Tesla Fleet integration, and you can use this, or you can use the Teslemetry integration which provides easier access to Tesla API's, but requires a [Teslemetry subscription](https://teslemetry.com/)
+- Install and configure either the Tesla Fleet integration or Teslemetry integration in Home Assistant
+- Copy the template [tesla_powerwall.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/tesla_powerwall.yaml) template over the top of your `apps.yaml`, and edit for your system
+
+Exporting with Powerwall is tricky, as there is no built in button as such to do it, you have to trick the Powerwall to export by changing the tariff options using the Tesla API.
+
+In order to do this you firstly need to create an API refresh token.
+
+- Create 8 input_text helpers to hold the Tesla access and refresh security tokens and your Tesla site id. These can be created via the HA UI, or added to `configuration.yaml`:
+
+```yaml
+input_text:
+  tesla_refresh_token_part1:
+    name: "Tesla Refresh Token - Part 1"
+    max: 255
+    mode: password
+
+  tesla_refresh_token_part2:
+    name: "Tesla Refresh Token - Part 2"
+    max: 255
+    mode: password
+
+  tesla_refresh_token_part3:
+    name: "Tesla Refresh Token - Part 3"
+    max: 255
+    mode: password
+
+  tesla_refresh_token_part4:
+    name: "Tesla Refresh Token - Part 4"
+    max: 255
+    mode: password
+
+  tesla_access_token_part1:
+    name: "Tesla Access Token - Part 1"
+    max: 255
+    mode: password
+
+  tesla_access_token_part2:
+    name: "Tesla Access Token - Part 2"
+    max: 255
+    mode: password
+
+  tesla_access_token_part3:
+    name: "Tesla Access Token - Part 3"
+    max: 255
+    mode: password
+
+  tesla_access_token_part4:
+    name: "Tesla Access Token - Part 4"
+    max: 255
+    mode: password
+
+  tesla_energy_site_id:
+    name: "Tesla Energy Site ID"
+    unit_of_measurement: ""
+    icon: mdi:lightning-bolt-outline
+```
+
+- Use the [Access Token Generator for Tesla](https://chromewebstore.google.com/detail/access-token-generator-fo/djpjpanpjaimfjalnpkppkjiedmgpjpe?hl=en) to create a token
+
+- This token needs to be copied, and then split into 4 parts (up to 255 characters long), so each part can be copied into the "refresh" input helpers
+
+- An automation then uses the refresh token to generate an access token valid for 8 hours, and a new refresh token than is valid for ~30 days.<BR>
+Create the following automation using the HA UI or by adding to `configuration.yaml`, the automation triggers an automatic refresh of the access token every 8 hours:
+
+```yaml
+automation:
+  alias: "Refresh Tesla Access Token"
+  description: "Refresh Tesla access token every 8 hours"
+  trigger:
+    platform: time_pattern
+    hours: "/8"
+  action:
+    - service: rest_command.tesla_refresh_token
+      response_variable: tesla_response
+    - service: input_text.set_value
+      target:
+        entity_id: input_text.tesla_access_token_part1
+      data:
+        value: "{{ tesla_response.content.access_token[0:250] }}"
+    - service: input_text.set_value
+      target:
+        entity_id: input_text.tesla_access_token_part2
+      data:
+       value: "{{ tesla_response.content.access_token[250:500] }}"
+    - service: input_text.set_value
+      target:
+        entity_id: input_text.tesla_access_token_part3
+      data:
+        value: "{{ tesla_response.content.access_token[500:750] }}"
+    - service: input_text.set_value
+      target:
+        entity_id: input_text.tesla_access_token_part4
+      data:
+        value: "{{ tesla_response.content.access_token[750:] }}"
+    - service: input_text.set_value
+      target:
+        entity_id: input_text.tesla_refresh_token_part1
+      data:
+        value: "{{ tesla_response.content.refresh_token[0:250] }}"
+    - service: input_text.set_value
+      target:
+        entity_id: input_text.tesla_refresh_token_part2
+      data:
+        value: "{{ tesla_response.content.refresh_token[250:500] }}"
+    - service: input_text.set_value
+      target:
+        entity_id: input_text.tesla_refresh_token_part3
+      data:
+        value: "{{ tesla_response.content.refresh_token[500:750] }}"
+    - service: input_text.set_value
+      target:
+        entity_id: input_text.tesla_refresh_token_part4
+      data:
+        value: "{{ tesla_response.content.refresh_token[750:] }}"
+    - service: persistent_notification.create
+      data:
+        title: "Tesla Tokens Updated"
+        message: "Access and refresh tokens have been successfully updated"
+      notification_id: "tesla_token_update"
+```
+
+- An automation executes every time HA starts and every midnight to populate the Tesla site id input_helper.
+Create the following automation using the HA UI or by adding to `configuration.yaml`:
+
+```yaml
+automation:
+  - alias: "Update Tesla Energy Site ID"
+    trigger:
+      - platform: homeassistant
+        event: start
+      - platform: time
+        at: "00:00:00"
+    action:
+      - service: rest_command.tesla_api_get_products
+        response_variable: products_response
+      - service: input_text.set_value
+        target:
+          entity_id: input_text.tesla_energy_site_id
+        data:
+          value: "{{ products_response.content.response[0].energy_site_id }}"
+```
+
+- A number of REST commands are required to communicate to the Tesla API's:
+
+    - tesla_refresh_token - automatically regenerates access and refresh tokens,
+    - tesla_api_get_products - used to retrieve your Tesla site id,
+    - tesla_api_get_current_tariff - retrieves your current Tariff information from the Powerwall,
+    - tesla_api_set_export_now_tariff - sets a custom export rate tariff to force the Powerwall to export,
+    - tesla_api_set_iog_custom_tariff - returns the Powerwall to the Octopus IOG tariff.  If you are on a different tariff you will need to customise the REST payload to your tariff details
+
+  In `configuration.yaml` add the following lines:
+
+```yaml
+rest_command:
+  tesla_refresh_token:
+    url: "https://auth.tesla.com/oauth2/v3/token"
+    method: POST
+    content_type: "application/x-www-form-urlencoded"
+    payload: >-
+      grant_type=refresh_token&client_id=ownerapi&refresh_token={{
+        (states('input_text.tesla_refresh_token_part1') or '') +
+        (states('input_text.tesla_refresh_token_part2') or '') +
+        (states('input_text.tesla_refresh_token_part3') or '') +
+        (states('input_text.tesla_refresh_token_part4') or '') }}&scope=openid%20email%20offline_access"
+
+  tesla_api_get_products:
+    url: "https://owner-api.teslamotors.com/api/1/products"
+    method: GET
+    headers:
+      Authorization: >-
+        Bearer {{ (states('input_text.tesla_access_token_part1') or '') +
+          (states('input_text.tesla_access_token_part2') or '') +
+          (states('input_text.tesla_access_token_part3') or '') +
+          (states('input_text.tesla_access_token_part4') or '') }}
+
+  tesla_api_get_current_tariff:
+    url: "https://owner-api.teslamotors.com/api/1/energy_sites/{{ states('input_text.tesla_energy_site_id') }}/tariff_rate"
+    method: GET
+    headers:
+      Authorization: >-
+        Bearer {{ (states('input_text.tesla_access_token_part1') or '') +
+          (states('input_text.tesla_access_token_part2') or '') +
+          (states('input_text.tesla_access_token_part3') or '') +
+          (states('input_text.tesla_access_token_part4') or '') }}
+
+  tesla_api_set_export_now_tariff:
+    url: "https://owner-api.teslamotors.com/api/1/energy_sites/{{ states('input_text.tesla_energy_site_id') }}/time_of_use_settings"
+    method: POST
+    headers:
+      Authorization: >-
+        Bearer {{ (states('input_text.tesla_access_token_part1') or '') +
+          (states('input_text.tesla_access_token_part2') or '') +
+          (states('input_text.tesla_access_token_part3') or '') +
+          (states('input_text.tesla_access_token_part4') or '') }}
+      Content-Type: application/json
+    payload: >
+      {% set now = now() %}
+      {% set minute = now.minute %}
+      {% set start = now.replace(minute=0) if minute < 30 else now.replace(minute=30) %}
+      {% set end = start + timedelta(minutes=60) %}
+      {% set ns = namespace(super_off_peak_periods=[]) %}
+      {% if start.hour > 0 %}
+        {% set ns.super_off_peak_periods = ns.super_off_peak_periods + [{"fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 0, "fromMinute": 0, "toHour": start.hour, "toMinute": start.minute}] %}
+      {% endif %}
+      {% if end.hour > 0 %}
+        {% set ns.super_off_peak_periods = ns.super_off_peak_periods + [{"fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": end.hour, "fromMinute": end.minute, "toHour": 0, "toMinute": 0}] %}
+      {% endif %}
+      {
+        "tou_settings": {
+          "tariff_content_v2": {
+            "version": 1,
+            "utility": "Octopus Energy",
+            "code": "OCTO-IOG-CUSTOM",
+            "name": "Octopus IOG (Force Export Now)",
+            "currency": "GBP",
+            "monthly_minimum_bill": 0,
+            "min_applicable_demand": 0,
+            "max_applicable_demand": 0,
+            "monthly_charges": 0,
+            "daily_charges": [
+              { "name": "Charge", "amount": 0 }
+            ],
+            "daily_demand_charges": {},
+            "demand_charges": {
+              "ALL": { "rates": { "ALL": 0 } },
+              "AllYear": { "rates": {} }
+            },
+            "energy_charges": {
+              "ALL": { "rates": { "ALL": 0 } },
+              "AllYear": {
+                "rates": {
+                  "SUPER_OFF_PEAK": 0.07,
+                  "ON_PEAK": 0.31
+                }
+              }
+            },
+            "seasons": {
+              "AllYear": {
+                "fromMonth": 1,
+                "fromDay": 1,
+                "toMonth": 12,
+                "toDay": 31,
+                "tou_periods": {
+                  "SUPER_OFF_PEAK": {
+                    "periods": {{ ns.super_off_peak_periods | tojson }}
+                  },
+                  "ON_PEAK": {
+                    "periods": [
+                      { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": {{ start.hour }}, "fromMinute": {{ start.minute }}, "toHour": {{ end.hour }}, "toMinute": {{ end.minute }} }
+                    ]
+                  }
+                }
+              }
+            },
+            "sell_tariff": {
+              "min_applicable_demand": 0,
+              "max_applicable_demand": 0,
+              "monthly_minimum_bill": 0,
+              "monthly_charges": 0,
+              "utility": "Octopus Energy",
+              "daily_charges": [
+                { "name": "Charge", "amount": 0 }
+              ],
+              "demand_charges": {
+                "ALL": { "rates": { "ALL": 0 } },
+                "AllYear": { "rates": {} }
+              },
+              "energy_charges": {
+                "ALL": { "rates": { "ALL": 0 } },
+                "AllYear": {
+                  "rates": {
+                    "SUPER_OFF_PEAK": 0.07,
+                    "ON_PEAK": 0.30
+                  }
+                }
+              },
+              "seasons": {
+                "AllYear": {
+                  "fromMonth": 1,
+                  "fromDay": 1,
+                  "toMonth": 12,
+                  "toDay": 31,
+                  "tou_periods": {
+                    "SUPER_OFF_PEAK": {
+                      "periods": {{ ns.super_off_peak_periods | tojson }}
+                    },
+                    "ON_PEAK": {
+                      "periods": [
+                        { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": {{ start.hour }}, "fromMinute": {{ start.minute }}, "toHour": {{ end.hour }}, "toMinute": {{ end.minute }} }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+  tesla_api_set_iog_custom_tariff:
+    url: "https://owner-api.teslamotors.com/api/1/energy_sites/{{ states('input_text.tesla_energy_site_id') }}/time_of_use_settings"
+    method: POST
+    headers:
+      Authorization: >-
+        Bearer {{ (states('input_text.tesla_access_token_part1') or '') +
+          (states('input_text.tesla_access_token_part2') or '') +
+          (states('input_text.tesla_access_token_part3') or '') +
+          (states('input_text.tesla_access_token_part4') or '') }}
+      Content-Type: application/json
+    payload: >
+      {
+        "tou_settings": {
+          "tariff_content_v2": {
+            "version": 1,
+            "monthly_minimum_bill": 0,
+            "min_applicable_demand": 0,
+            "max_applicable_demand": 0,
+            "monthly_charges": 0,
+            "utility": "Octopus Energy",
+            "code": "OCTO-IOG-CUSTOM",
+            "name": "Octopus IOG (Custom-restored)",
+            "currency": "GBP",
+            "daily_charges": [
+              { "name": "Charge", "amount": 0 }
+            ],
+            "daily_demand_charges": {},
+            "demand_charges": {
+              "ALL": { "rates": { "ALL": 0 } },
+              "AllYear": { "rates": {} }
+            },
+            "energy_charges": {
+              "ALL": { "rates": { "ALL": 0 } },
+              "AllYear": {
+                "rates": {
+                  "SUPER_OFF_PEAK": 0.07,
+                  "PARTIAL_PEAK": 0.31,
+                  "ON_PEAK": 0.31
+                }
+              }
+            },
+            "seasons": {
+              "AllYear": {
+                "fromMonth": 1,
+                "fromDay": 1,
+                "toMonth": 12,
+                "toDay": 31,
+                "tou_periods": {
+                  "SUPER_OFF_PEAK": {
+                    "periods": [
+                      { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 0, "fromMinute": 0, "toHour": 5, "toMinute": 30 },
+                      { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 23, "fromMinute": 30, "toHour": 0, "toMinute": 0 }
+                    ]
+                  },
+                  "ON_PEAK": {
+                    "periods": [
+                      { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 2, "fromMinute": 0, "toHour": 3, "toMinute": 0 },
+                      { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 5, "fromMinute": 30, "toHour": 16, "toMinute": 0 },
+                      { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 16, "fromMinute": 0, "toHour": 19, "toMinute": 0 },
+                      { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 19, "fromMinute": 0, "toHour": 23, "toMinute": 30 }
+                    ]
+                  }
+                }
+              }
+            },
+            "sell_tariff": {
+              "min_applicable_demand": 0,
+              "max_applicable_demand": 0,
+              "monthly_minimum_bill": 0,
+              "monthly_charges": 0,
+              "utility": "Octopus Energy",
+              "daily_charges": [
+                { "name": "Charge", "amount": 0 }
+              ],
+              "demand_charges": {
+                "ALL": { "rates": { "ALL": 0 } },
+                "AllYear": { "rates": {} }
+              },
+              "energy_charges": {
+                "ALL": { "rates": { "ALL": 0 } },
+                "AllYear": {
+                  "rates": {
+                    "SUPER_OFF_PEAK": 0.07,
+                    "PARTIAL_PEAK": 0.30,
+                    "ON_PEAK": 0.22
+                  }
+                }
+              },
+              "seasons": {
+                "AllYear": {
+                  "fromMonth": 1,
+                  "fromDay": 1,
+                  "toMonth": 12,
+                  "toDay": 31,
+                  "tou_periods": {
+                    "SUPER_OFF_PEAK": {
+                      "periods": [
+                        { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 0, "fromMinute": 0, "toHour": 5, "toMinute": 30 },
+                        { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 23, "fromMinute": 30, "toHour": 0, "toMinute": 0 }
+                      ]
+                    },
+                    "ON_PEAK": {
+                      "periods": [
+                        { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 2, "fromMinute": 0, "toHour": 3, "toMinute": 0 },
+                        { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 5, "fromMinute": 30, "toHour": 16, "toMinute": 0 },
+                        { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 16, "fromMinute": 0, "toHour": 19, "toMinute": 0 },
+                        { "fromDayOfWeek": 0, "toDayOfWeek": 6, "fromHour": 19, "fromMinute": 0, "toHour": 23, "toMinute": 30 }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+```
+
+- Manually run the two automations to ensure the helper input_texts are all pre-populated before use.
+
+## Victron
+
+This is at an early stage of development, see Github discussion [#789](https://github.com/springfall2008/batpred/discussions/798) and [#2846](https://github.com/springfall2008/batpred/issues/2846)
+
+## I want to add an unsupported inverter to Predbat
+
+- First copy one of the template configurations that is close to your system and try to configure it to match the sensors you have
+- Create a GitHub ticket for support and add what you know to the ticket
+- Then find out how to control your inverter inside Home Assistant, ideally share any automation you have to control the inverter
+- You can create a new inverter type in `apps.yaml` and change the options as to which controls it has
+- You **must** set [inverter_type in apps.yaml](apps-yaml.md#inverter_type) with a custom name ('MINE' in the example below) - if you do not do this then Predbat will assume you have a GivEnergy inverter
+and will apply inverter limits for that inverter (e.g. max charge/discharge of 2600W)
+- Configure Predbat with the appropriate Home Assistant services to start charges and discharges, etc.
+
+The following template can be used as a starting point:
+
+```yaml
+  inverter_type: MINE
+  inverter:
+    name: "MINE"
+    has_rest_api: False
+    has_mqtt_api: False
+    has_service_api: True
+    output_charge_control: "power"
+    charge_control_immediate: False
+    current_dp: 1
+    charge_discharge_with_rate: False
+    has_charge_enable_time: False
+    has_discharge_enable_time: False
+    has_target_soc: False
+    target_soc_used_for_discharge: True
+    has_reserve_soc: False
+    has_timed_pause: False
+    time_button_press: False
+    support_charge_freeze: False
+    support_discharge_freeze: False
+    has_ge_inverter_mode: False
+    has_fox_inverter_mode: False
+    has_idle_time: False
+    has_time_window: False
+    charge_time_format: "S"
+    charge_time_entity_is_option: False
+    can_span_midnight: False
+    clock_time_format: "%Y-%m-%d %H:%M:%S"
+    num_load_entities: 1
+    soc_units: "%"
+    write_and_poll_sleep: 2
+
+  # Services to control charging/discharging
+  charge_start_service:
+    service: select.select_option
+    entity_id: "select.solaredge_i1_storage_command_mode"
+    option: "Charge from Solar Power and Grid"
+  charge_stop_service:
+    service: select.select_option
+    entity_id: "select.solaredge_i1_storage_command_mode"
+    option: "Charge from Solar Power"
+  discharge_start_service:
+    service: select.select_option
+    entity_id: "select.solaredge_i1_storage_command_mode"
+    option: "Maximize Self Consumption"
+```
+
+## Inverter control options
+
+The following options are supported per inverter:
+
+### `has_rest_api`
+
+When True the REST API will be used to fetch data/control the inverter. This is currently only for GivEnergy inverters with GivTCP and **givtcp_rest** must be set in `apps.yaml`
+
+### `has_mqtt_api`
+
+When True the Home Assistant MQTT API will be used to issue control messages for the inverter
+
+The MQTT/publish service is used with the topic as defined by **mqtt_topic** in `apps.yaml`
+
+Messages will be sent through these controls:
+
+Values that are updated:
+
+- **topic**/set/reserve - payload=reserve
+- **topic**/set/charge_rate - payload=new_rate
+- **topic**/set/discharge_rate - payload=new_rate
+- **topic**/set/target_soc - payload=target_soc
+
+These three messages change between battery charge/discharge and auto (demand) mode:
+
+- **topic**/set/charge - payload=charge_rate
+- **topic**/set/discharge - payload=discharge_rate
+- **topic**/set/auto - payload=true
+
+### `has_service_api`
+
+When True a Home Assistant service will be used to issue control messages for the inverter.
+
+For each service you wish to use it must be defined in `apps.yaml`.
+
+There are two ways to define a service, the basic mode:
+
+```yaml
+  charge_start_service: my_service_name_charge
+```
+
+Will call `my_service_name_charge` for the charge start service.
+
+Or the custom method where you can define all the parameter values passed to the service and use the default values from the template, or define your own:
+
+```yaml
+  charge_start_service:
+    - service: my_charge_start_service
+      device_id: "{device_id}"
+      power: "{power}"
+      soc: "{target_soc}"
+      charge_start_time: "{charge_start_time}"
+      charge_end_time: "{charge_end_time}"
+```
+
+You can also call more than one service e.g:
+
+```yaml
+  charge_start_service:
+    - service: my_charge_start_service
+      device_id: "{device_id}"
+      power: "{power}"
+      soc: "{target_soc}"
+    - service: switch.turn_off
+      entity_id: switch.tsunami_charger
+```
+
+Note: By default the service will only be called once until things change, e.g. **charge_start_service** will be called once and then won't be called again until **charge_stop_service** stops the charge.
+If however, you want the service to be called on each Predbat run then you should set **repeat** to True for the given service e.g:
+
+```yaml
+  charge_start_service:
+    - service: my_charge_start_service
+      device_id: "{device_id}"
+      power: "{power}"
+      soc: "{target_soc}"
+      repeat: True
+```
+
+#### `charge_start_service`
+
+Called to start a charge
+
+The default options passed in are:
+
+- device_id - as defined in `apps.yaml` by **device_id**
+- target_soc - The SoC to charge to
+- power - The charge power to use
+- charge_start_time - Start time for the charge
+- charge_end_time - End time for the charge
+
+#### `charge_freeze_service`
+
+If defined will be called for freeze charge, otherwise, charge_start_service is used for freeze charge also.
+
+#### `charge_stop_service`
+
+Called to stop a charge
+
+- device_id - as defined in `apps.yaml` by **device_id**
+
+#### `discharge_start_service`
+
+Called to start a discharge
+
+The default options passed in are:
+
+- device_id - as defined in `apps.yaml` by **device_id**
+- target_soc - The SoC to discharge to
+- power - The discharge power to use
+
+#### `discharge_freeze_service`
+
+If defined will be called for Discharge freeze, otherwise, discharge_start_service is used for freeze discharge also.
+
+#### `discharge_stop_service`
+
+Called to stop a discharge, if not set then **charge_stop_service** will be used instead
+
+- device_id - as defined in `apps.yaml` by **device_id**
+
+### `output_charge_control`
+
+Controls what charge control units are to be used when starting charging. Set to "power", "current" or "none".
+
+When set to "power", Predbat will use the inverter sensors configured as **charge_rate** and **discharge_rate** in `apps.yaml` to set the inverter charge/discharge power levels. These inverter sensors must be in watts.
+
+When set to "current", Predbat will use the inverter sensors configured as  **timed_charge_current** and **timed_discharge_current** in `apps.yaml` to set the inverter charge/discharge current levels. These inverter sensors must be in amps.<BR>
+Additionally if you are using "current" control for your inverter you must set **battery_voltage** in `apps.yaml` to your nominal maximum battery voltage (NB: not the current battery voltage)
+as Predbat will use this to convert its output commands from watts to amps for the inverter.
+
+### `charge_control_immediate`
+
+When True, the inverter uses **timed_charge_current** and **timed_discharge_current** in `apps.yaml` to control charging and discharging by setting current levels directly, instead of following a time-based plan.
+
+### `current_dp`
+
+Sets the number of decimal places to be used when setting the current in Amps, which should be 0 or 1.
+
+### `charge_discharge_with_rate`
+
+When True, the inverter requires that when charging the discharge rate must set be 0; and vice-versa, when discharging the charge rate must be set to 0.
+
+When False, the charge/discharge rate does not have to change.
+
+### `has_charge_enable_time`
+
+When True, Predbat uses the **scheduled_charge_enable** switch configured in `apps.yaml` to enable/disable timed charging on the inverter.
+
+### `has_discharge_enable_time`
+
+When True, Predbat uses the **scheduled_discharge_enable** switch configured in `apps.yaml` to enable/disable timed discharging on the inverter.
+
+### `has_target_soc`
+
+When True, Predbat uses the **charge_limit** sensor configured in `apps.yaml` to set the target charge SoC % setting for the inverter. The charge limit is the limit that the inverter will charge the battery up to.
+When False, charging will be turned on and off by Predbat rather than the inverter doing it based on the target SoC %.
+
+### `target_soc_used_for_discharge`
+
+When True, Predbat will use the **charge_limit** sensor configured in `apps.yaml` to control the target discharge SoC% for the inverter.
+
+When False, Predbat will not adjust the **charge_limit** sensor when discharging.
+
+### `has_reserve_soc`
+
+When True, Predbat uses the **reserve** sensor configured in `apps.yaml` to set the discharge reserve SoC % for the inverter. The reserve SoC is the target % to discharge the battery down to.
+When False, discharging will be turned on and off by Predbat rather than the inverter doing it based on discharge SoC %.
+
+### `has_timed_pause`
+
+When True, Predbat uses the **pause_mode** and optional **pause_start_time** and **pause_end_time**  settings in `apps.yaml` to pause the inverter from charging and discharging the battery. This setting is for GivEnergy systems only right now.
+
+### `time_button_press`
+
+When True, the inverter requires a button press to update the inverter registers from the Home Assistant values.
+
+The `apps.yaml` setting **charge_discharge_update_button** is the entity name of the button that Predbat will "push" to update the inverter registers.
+
+### `support_charge_freeze`
+
+When True, the inverter supports charge freeze modes.
+
+### `maintain_freeze_charge_status` 
+
+Only required for inverters without native Freeze Charging support.
+When True, suppresses expected warnings resulting from the manipulation of `scheduled_charge_enable` during Freeze Charging, ensuring that `predbat.status` remains stable instead of transitioning to `Warn:` states.
+
+### `support_discharge_freeze`
+
+When True, the inverter supports discharge freeze modes.
+
+### `has_ge_inverter_mode`
+
+When True, the inverter supports the GivEnergy inverter modes (ECO, Timed Export etc).
+
+### `has_fox_inverter_mode`
+
+When True, the inverter supports Fox inverter modes, i.e. Eco (Paused) is treated the same as Eco mode and the inverter mode is always set to "SelfUse" as all charging and discharging is controlled by schedule, not inverter modes.
+
+### `has_idle_time`
+
+When True, the inverter has an idle time register which must be set to the start and end times for Eco mode (GivEnergy EMS).  **idle_start_time** and **idle_end_time** must be configured in `apps.yaml` to the appropriate inverter controls.
+
+### `has_time_window`
+
+Not currently used by Predbat.
+
+### `charge_time_format`
+
+This setting is used to control what format of charge and discharge times the inverter requires.
+
+When set to "HH:MM:SS", Predbat will control the inverter charge/discharge start and end times by setting the entities defined by **charge_start_time**, **charge_end_time**, **discharge_start_time** and **discharge_end_time** in `apps.yaml`.
+
+The format of these entities depends on **charge_time_entity_is_option** as defined below.
+
+When set to "H M", Predbat will control the inverter charge/discharge start and end times by setting the entities defined by **charge_start_hour**, **charge_start_minute**, **charge_end_hour**, **charge_end_minute**,
+**discharge_start_hour**,  **discharge_start_minute**, **discharge_end_hour** and **discharge_end_minute** in `apps.yaml`.
+
+These entities are used to set the start and end hours and minutes of charges and discharges.
+
+When set to "H:M-H:M", Predbat will control the inverter charge/discharge start and end times by setting the entities defined by **charge_time** and **discharge_time** in `apps.yaml`.
+The entities take a single time range value in the format "*start hour*:*start minute*-*end hour*:*end minute*"
+
+### `charge_time_entity_is_option`
+
+When True, **charge_start_time** **charge_end_time** **discharge_start_time** and **discharge_end_time** are all option selectors for time in the format HH:MM:SS (e.g. 12:23:00) where seconds are always 00.
+
+When False, these entities are all number values.
+
+### `can_span_midnight`
+
+When True, start and end times for charge and discharge can span midnight e.g. 23:00:00 - 01:00:00 is a 2-hour slot.
+
+When False, start and end times can't span midnight and Predbat will control the inverter with separate charges/discharges up to and then after midnight if required by the plan.
+
+### `clock_time_format`
+
+Defines the time format of the inverter clock setting **inverter_time** in `apps.yaml`
+
+### `num_load_entities`
+
+Enables you to define additional house load power sensors in `apps.yaml` in addition to the default **load_power** sensor.  e.g. if set to 2 then Predbat will additionally use **load_power_1** and **load_power_2** settings in `apps.yaml`.
+This setting might be required for 3-phase inverters.
+
+### `soc_units`
+
+Defines the units of the SoC setting (currently not used), it defaults to "%".
+
+### `write_and_poll_sleep`
+
+Sets the number of seconds between polls of inverter settings.
+

--- a/inverter.py
+++ b/inverter.py
@@ -1,0 +1,3019 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2024 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+import os
+import time
+import pytz
+import requests
+from datetime import datetime, timedelta
+from config import INVERTER_DEF, SOLAX_SOLIS_MODES_NEW, SOLAX_SOLIS_MODES
+from const import MINUTE_WATT, TIME_FORMAT, TIME_FORMAT_OCTOPUS, INVERTER_TEST, TIME_FORMAT_SECONDS, INVERTER_MAX_RETRY, INVERTER_MAX_RETRY_REST
+from utils import calc_percent_limit, compute_window_minutes, dp0, dp2, dp3, dp4, time_string_to_stamp, minute_data, minute_data_state, window2minutes
+
+TIME_FORMAT_HMS = "%H:%M:%S"
+
+
+class Inverter:
+    def self_test(self, minutes_now):
+        self.base.log(f"======= INVERTER CONTROL SELF TEST START - REST={self.rest_api} ========")
+        self.adjust_battery_target(99, False)
+        self.adjust_battery_target(100, False)
+        self.adjust_charge_rate(215)
+        self.adjust_charge_rate(self.battery_rate_max_charge)
+        self.adjust_discharge_rate(220)
+        self.adjust_discharge_rate(self.battery_rate_max_discharge)
+        self.adjust_reserve(100)
+        self.adjust_reserve(6)
+        self.adjust_reserve(4)
+        self.adjust_pause_mode(pause_charge=True)
+        self.adjust_pause_mode(pause_discharge=True)
+        self.adjust_pause_mode(pause_charge=True, pause_discharge=True)
+        self.adjust_pause_mode()
+        self.disable_charge_window()
+        timea = time_string_to_stamp("23:00:00")
+        timeb = time_string_to_stamp("23:01:00")
+        timec = time_string_to_stamp("05:00:00")
+        timed = time_string_to_stamp("05:01:00")
+        self.adjust_charge_window(timeb, timed, minutes_now)
+        self.adjust_charge_window(timea, timec, minutes_now)
+        self.adjust_force_export(False, timec, timed)
+        self.adjust_force_export(True, timea, timeb)
+        self.adjust_force_export(False)
+        self.base.log("======= INVERTER CONTROL SELF TEST END ========")
+
+        if self.rest_api:
+            self.rest_api = None
+            self.rest_data = None
+            self.self_test(minutes_now)
+        exit
+
+    def sleep(self, seconds):
+        """
+        Sleep for x seconds
+        """
+        time.sleep(seconds)
+
+    def auto_restart(self, reason):
+        """
+        Attempt to restart the services required
+        """
+        if self.base.restart_active:
+            self.base.log("Warn: Inverter control auto restart already active, waiting...")
+            return
+
+        # Trigger restart
+        restart_command = self.base.get_arg("auto_restart", [])
+        self.base.log("Warn: Inverter control auto restart trigger: {} command {}".format(reason, restart_command))
+        if restart_command:
+            self.base.restart_active = True
+            if isinstance(restart_command, dict):
+                restart_command = [restart_command]
+            for command in restart_command:
+                shell = command.get("shell", None)
+                service = command.get("service", None)
+                addon = command.get("addon", None)
+                if addon:
+                    addon = self.base.resolve_arg(service, addon, indirect=False)
+                entity_id = command.get("entity_id", None)
+                if entity_id:
+                    entity_id = self.base.resolve_arg(service, entity_id, indirect=False)
+                if shell:
+                    self.log("Warn: Calling restart shell command: {}".format(shell))
+                    os.system(shell)
+                if service:
+                    if addon:
+                        self.log("Warn: Calling restart service {} with addon {}".format(service, addon))
+                        self.base.call_service_wrapper(service, addon=addon)
+                    elif entity_id:
+                        self.log("Warn: Calling restart service {} with entity_id {}".format(service, entity_id))
+                        self.base.call_service_wrapper(service, entity_id=entity_id)
+                    else:
+                        self.log("Warn: Calling restart service {}".format(service))
+                        self.base.call_service_wrapper(service)
+                    if self.base.get_arg("set_system_notify"):
+                        self.base.call_notify("Auto-restart service {} called due to: {}".format(service, reason))
+                    self.sleep(15)
+            raise Exception("Auto-restart triggered")
+        else:
+            self.log("Info: auto_restart not defined in apps.yaml, Predbat can't auto-restart inverter control")
+
+    def create_missing_arg(self, arg, default):
+        """
+        Create a missing inverter argument which will be assigned to a dummy entity
+        """
+        if (arg not in self.base.args) or (not isinstance(self.base.args[arg], list)):
+            self.base.args[arg] = [default, default, default, default]
+
+    def __init__(self, base, id=0, quiet=False, rest_postCommand=None, rest_getData=None):
+        """
+        Inverter class
+        """
+        self.id = id
+        self.base = base
+        self.log = self.base.log
+        self.charge_enable_time = False
+        self.charge_start_time_minutes = self.base.forecast_minutes
+        self.charge_start_end_minutes = self.base.forecast_minutes
+        self.charge_window = []
+        self.export_window = []
+        self.export_limits = []
+        self.current_charge_limit = 0.0
+        self.soc_kw = 0
+        self.soc_percent = 0
+        self.soc_max = None
+        self.rest_data = None
+        self.inverter_limit = 7500.0 / MINUTE_WATT
+        self.export_limit = 99999.0 / MINUTE_WATT
+        self.inverter_time = None
+        self.reserve_percent = self.base.get_arg("battery_min_soc", default=4.0, index=self.id, required_unit="%")
+        self.reserve_percent_current = self.base.get_arg("battery_min_soc", default=4.0, index=self.id, required_unit="%")
+        self.battery_scaling = self.base.get_arg("battery_scaling", default=1.0, index=self.id)
+
+        self.reserve_max = 100
+        self.battery_rate_max_raw = 2600.0
+        self.battery_rate_max_charge = 2600.0 / MINUTE_WATT
+        self.battery_rate_max_discharge = 2600.0 / MINUTE_WATT
+        self.battery_rate_max_charge_scaled = 2600.0 / MINUTE_WATT
+        self.battery_rate_max_discharge_scaled = 2600.0 / MINUTE_WATT
+        self.battery_temperature = 20
+        self.battery_power = 0
+        self.battery_voltage = 52.0
+        self.pv_power = 0
+        self.load_power = 0
+        self.rest_api = None
+        self.in_calibration = False
+        self.firmware_version = "Unknown"
+        self.givtcp_version = "n/a"
+        self.rest_v3 = False
+        self.serial_number = "Unknown"
+        self.count_register_writes = 0
+        self.created_attributes = {}
+        self.track_charge_start = "00:00:00"
+        self.track_charge_end = "00:00:00"
+        self.track_discharge_start = "00:00:00"
+        self.track_discharge_end = "00:00:00"
+        self.idle_start_minutes = 0
+        self.idle_end_minutes = 0
+
+        if rest_postCommand:
+            self.rest_postCommand = rest_postCommand
+        if rest_getData:
+            self.rest_getData = rest_getData
+
+        self.inverter_type = self.base.get_arg("inverter_type", "GE", indirect=False, index=self.id)
+
+        # Read user defined inverter type
+        if "inverter" in self.base.args:
+            if self.inverter_type not in INVERTER_DEF:
+                INVERTER_DEF[self.inverter_type] = INVERTER_DEF["GE"].copy()
+
+            inverter_def = self.base.args["inverter"]
+            if isinstance(inverter_def, list):
+                inverter_def = inverter_def[self.id]
+
+            if isinstance(inverter_def, dict):
+                for key in inverter_def:
+                    INVERTER_DEF[self.inverter_type][key] = inverter_def[key]
+            else:
+                self.log("Warn: Inverter {}: inverter definition is not a dictionary".format(self.id))
+
+        if self.inverter_type in INVERTER_DEF:
+            self.log(f"Inverter {self.id}: Type {self.inverter_type} {INVERTER_DEF[self.inverter_type]['name']}")
+        else:
+            raise ValueError("Inverter type {} not defined".format(self.inverter_type))
+
+        if self.inverter_type != "GE":
+            self.log("Note: Inverter {}: Using inverter type {} - not all features are available on all Inverter types".format(self.id, self.inverter_type))
+
+        # Load inverter brand definitions
+        self.reserve_max = self.base.get_arg("inverter_reserve_max", 100)
+        self.inv_has_rest_api = INVERTER_DEF[self.inverter_type]["has_rest_api"]
+        self.inv_has_mqtt_api = INVERTER_DEF[self.inverter_type]["has_mqtt_api"]
+        self.inv_mqtt_topic = self.base.get_arg("mqtt_topic", "Sofar2mqtt")
+        self.inv_output_charge_control = INVERTER_DEF[self.inverter_type]["output_charge_control"]
+        self.inv_charge_control_immediate = INVERTER_DEF[self.inverter_type]["charge_control_immediate"]
+        self.inv_current_dp = INVERTER_DEF[self.inverter_type].get("current_dp", 1)
+        self.inv_has_charge_enable_time = INVERTER_DEF[self.inverter_type]["has_charge_enable_time"]
+        self.inv_has_discharge_enable_time = INVERTER_DEF[self.inverter_type]["has_discharge_enable_time"]
+        self.inv_has_target_soc = INVERTER_DEF[self.inverter_type]["has_target_soc"]
+        self.inv_has_reserve_soc = INVERTER_DEF[self.inverter_type]["has_reserve_soc"]
+        self.inv_has_timed_pause = INVERTER_DEF[self.inverter_type]["has_timed_pause"]
+        self.inv_charge_time_format = INVERTER_DEF[self.inverter_type]["charge_time_format"]
+        self.inv_charge_time_entity_is_option = INVERTER_DEF[self.inverter_type]["charge_time_entity_is_option"]
+        self.inv_clock_time_format = INVERTER_DEF[self.inverter_type]["clock_time_format"]
+        self.inv_soc_units = INVERTER_DEF[self.inverter_type]["soc_units"]
+        self.inv_time_button_press = INVERTER_DEF[self.inverter_type]["time_button_press"]
+        self.inv_support_charge_freeze = INVERTER_DEF[self.inverter_type]["support_charge_freeze"]
+        self.inv_support_discharge_freeze = INVERTER_DEF[self.inverter_type]["support_discharge_freeze"]
+        self.inv_has_ge_inverter_mode = INVERTER_DEF[self.inverter_type]["has_ge_inverter_mode"]
+        self.inv_num_load_entities = INVERTER_DEF[self.inverter_type]["num_load_entities"]
+        self.inv_write_and_poll_sleep = INVERTER_DEF[self.inverter_type]["write_and_poll_sleep"]
+        self.inv_has_idle_time = INVERTER_DEF[self.inverter_type]["has_idle_time"]
+        self.inv_can_span_midnight = INVERTER_DEF[self.inverter_type]["can_span_midnight"]
+        self.inv_charge_discharge_with_rate = INVERTER_DEF[self.inverter_type].get("charge_discharge_with_rate", False)
+        self.inv_target_soc_used_for_discharge = INVERTER_DEF[self.inverter_type].get("target_soc_used_for_discharge", True)
+        self.inv_has_fox_inverter_mode = INVERTER_DEF[self.inverter_type].get("has_fox_inverter_mode", False)
+        self.inv_maintain_freeze_charge_status = bool(INVERTER_DEF[self.inverter_type].get("maintain_freeze_charge_status", False))
+        
+        # If it's not a GE inverter then turn Quiet off
+        if self.inverter_type != "GE":
+            quiet = False
+
+        # Rest API for GivEnergy
+        if self.inverter_type == "GE":
+            self.rest_api = self.base.get_arg("givtcp_rest", None, indirect=False, index=self.id)
+            if self.rest_api:
+                if not quiet:
+                    self.base.log("Inverter {} using REST API {}".format(self.id, self.rest_api))
+                self.rest_data = self.rest_readData()
+                if not self.rest_data:
+                    self.auto_restart("REST read failure")
+                else:
+                    self.givtcp_version = self.rest_data.get("Stats", {}).get("GivTCP_Version", "Unknown")
+                    self.firmware_version = self.rest_data.get("raw", {}).get("invertor", {}).get("firmware_version", "Unknown")
+                    self.serial_number = self.rest_data.get("raw", {}).get("invertor", {}).get("serial_number", "Unknown")
+                    if self.givtcp_version.startswith("3"):
+                        self.rest_v3 = True
+                    self.log("Inverter {} GivTCP Version: {}, Firmware: {}, serial {}".format(self.id, self.givtcp_version, self.firmware_version, self.serial_number))
+
+        # Timed pause support?
+        if self.inv_has_timed_pause:
+            entity_mode = self.base.get_arg("pause_mode", indirect=False, index=self.id)
+            if entity_mode:
+                old_pause_mode = self.base.get_state_wrapper(entity_mode)
+                if old_pause_mode is None:
+                    self.inv_has_timed_pause = False
+                    self.log("Inverter {} does not have timed pause support enabled".format(self.id))
+                else:
+                    self.log("Inverter {} has timed pause support enabled".format(self.id))
+            else:
+                self.inv_has_timed_pause = False
+                self.log("Inverter {} does not have timed pause support enabled".format(self.id))
+
+        # Battery size, charge and discharge rates
+        ivtime = None
+        if self.rest_data and ("Battery_Details" in self.rest_data):
+            average_temp = 0
+            battery_count = 0
+            battery_capacity = 0
+            battery_voltage = 0
+            for battery in self.rest_data["Battery_Details"]:
+                battery_details = self.rest_data["Battery_Details"][battery]
+                if "BMS_Temperature" in battery_details:
+                    average_temp += float(battery_details["BMS_Temperature"])
+                    battery_count += 1
+                elif "Battery_Temperature" in battery_details:
+                    average_temp += float(battery_details["Battery_Temperature"])
+                    battery_count += 1
+                else:
+                    for item in battery_details.values():
+                        if type(item) is dict:
+                            if "Battery_Temperature" in item:
+                                average_temp += float(item["Battery_Temperature"])
+                                battery_count += 1
+            if battery_count > 0:
+                average_temp /= battery_count
+                self.battery_temperature = dp2(average_temp)
+
+        if self.rest_data and ("Invertor_Details" in self.rest_data):
+            idetails = self.rest_data["Invertor_Details"]
+            if "Battery_Capacity_kWh" in idetails:
+                self.soc_max = float(idetails["Battery_Capacity_kWh"])
+                self.nominal_capacity = self.soc_max
+                self.soc_max *= self.battery_scaling
+                self.soc_max = dp3(self.soc_max)
+
+        if self.rest_data and ("raw" in self.rest_data):
+            raw_data = self.rest_data["raw"]
+
+            # for V3 the inverter details is now named after the serial number
+            if self.serial_number in self.rest_data:
+                idetails = self.rest_data[self.serial_number]
+                if "Battery_Capacity_kWh" in idetails:
+                    self.soc_max = float(idetails["Battery_Capacity_kWh"])
+                    self.nominal_capacity = self.soc_max
+                    self.soc_max *= self.battery_scaling
+                    self.soc_max = dp3(self.soc_max)
+
+            # Battery capacity nominal
+            battery_capacity_nominal = raw_data.get("invertor", {}).get("battery_nominal_capacity", None)
+            if battery_capacity_nominal:
+                if self.rest_v3:
+                    self.nominal_capacity = float(battery_capacity_nominal)
+                else:
+                    self.nominal_capacity = float(battery_capacity_nominal) / 19.53125  # XXX: Where does 19.53125 come from? I back calculated but why that number...
+
+                if self.base.battery_capacity_nominal:
+                    if abs(self.soc_max - self.nominal_capacity) > 1.0:
+                        # XXX: Weird workaround for battery reporting wrong capacity issue
+                        self.base.log("Warn: REST data reports Battery Capacity kWh as {} but nominal indicates {} - using nominal".format(self.soc_max, self.nominal_capacity))
+                    self.soc_max = self.nominal_capacity * self.battery_scaling
+
+            if self.rest_v3:
+                # GivTCP v3 indicates battery is being calibrated via [Control][Battery_Calibration]
+                if ("Control" in self.rest_data) and ("Battery_Calibration" in self.rest_data["Control"]):
+                    soc_force_adjust = self.rest_data["Control"]["Battery_Calibration"]
+                    if soc_force_adjust != "Off":
+                        self.in_calibration = True
+            else:
+                # older GivTCP uses soc_force_adjust to indicate battery calibration
+                soc_force_adjust = raw_data.get("invertor", {}).get("soc_force_adjust", None)
+                if soc_force_adjust:
+                    try:
+                        soc_force_adjust = int(soc_force_adjust)
+                    except ValueError:
+                        soc_force_adjust = 0
+                    if (soc_force_adjust > 0) and (soc_force_adjust < 7):
+                        self.in_calibration = True
+
+            if self.in_calibration:
+                self.log("Warn: Inverter is in calibration mode {}, Predbat will not function correctly and will be disabled".format(soc_force_adjust))
+
+            # Max battery rate
+            if "Invertor_Max_Bat_Rate" in idetails:
+                self.battery_rate_max_raw = idetails["Invertor_Max_Bat_Rate"]
+            elif "Invertor_Max_Rate" in idetails:
+                self.battery_rate_max_raw = idetails["Invertor_Max_Rate"]
+            else:
+                self.battery_rate_max_raw = self.base.get_arg("charge_rate", attribute="max", index=self.id, default=2600.0, required_unit="W")
+
+            # Max invertor rate
+            if "Invertor_Max_Inv_Rate" in idetails:
+                self.inverter_limit = idetails["Invertor_Max_Inv_Rate"] / MINUTE_WATT
+
+            # Inverter time
+            if "Invertor_Time" in idetails:
+                ivtime = idetails["Invertor_Time"]
+        else:
+            self.battery_temperature = self.base.get_arg("battery_temperature", default=20, index=self.id, required_unit="°C")
+            self.soc_max = self.base.get_arg("soc_max", default=0.0, index=self.id) * self.battery_scaling
+            self.nominal_capacity = self.soc_max
+
+            if self.inverter_type in ["GE", "GEC", "GEE"]:
+                self.battery_rate_max_raw = self.base.get_arg("charge_rate", attribute="max", index=self.id, default=2600.0, required_unit="W")
+            elif "battery_rate_max" in self.base.args:
+                self.battery_rate_max_raw = self.base.get_arg("battery_rate_max", index=self.id, default=2600.0, required_unit="W")
+            else:
+                self.battery_rate_max_raw = 2600.0
+
+            ivtime = self.base.get_arg("inverter_time", index=self.id, default=None)
+
+        # Battery cannot be zero size
+        if not self.soc_max or self.soc_max <= 0:
+            self.log("Note: Battery size was not set, attempting to find it..")
+            found_size = self.find_battery_size()
+            if not found_size or found_size <= 0:
+                self.log("Warn: Unable to determine battery size, setting to 8 kWh default, you must set soc_max in apps.yaml or wait until enough data is collected to estimate battery size")
+                self.soc_max = 8.0
+            else:
+                # Store found battery size so we don't keep having to fetch it
+                self.soc_max = found_size * self.battery_scaling
+                self.base.set_arg("soc_max", found_size, index=self.id)
+            self.nominal_capacity = self.soc_max
+
+        # Battery rate max charge, discharge (all converted to kW/min)
+        inverter_limit_charge = self.base.get_arg("inverter_limit_charge", self.battery_rate_max_raw, index=self.id, required_unit="W")
+        inverter_limit_discharge = self.base.get_arg("inverter_limit_discharge", self.battery_rate_max_raw, index=self.id, required_unit="W")
+        inverter_limit_override = self.base.get_arg("inverter_limit_override", 0, index=self.id, required_unit="W")
+        if inverter_limit_override > 0:
+            self.log("Info: Inverter {} applying inverter_limit_override of {} W to charge and discharge limits".format(self.id, inverter_limit_override))
+            inverter_limit_charge = min(inverter_limit_override, inverter_limit_charge)
+            inverter_limit_discharge = min(inverter_limit_override, inverter_limit_discharge)
+        self.battery_rate_max_charge = min(inverter_limit_charge, self.battery_rate_max_raw) / MINUTE_WATT
+        self.battery_rate_max_discharge = min(inverter_limit_discharge, self.battery_rate_max_raw) / MINUTE_WATT
+        self.battery_rate_max_charge_scaled = self.battery_rate_max_charge * self.base.battery_rate_max_scaling
+        self.battery_rate_max_discharge_scaled = self.battery_rate_max_discharge * self.base.battery_rate_max_scaling_discharge
+        self.battery_rate_min = min(self.base.get_arg("inverter_battery_rate_min", 0, index=self.id, required_unit="W"), self.battery_rate_max_raw) / MINUTE_WATT
+
+        # Convert inverter time into timestamp
+        if ivtime:
+            try:
+                self.inverter_time = datetime.strptime(ivtime, TIME_FORMAT)
+            except (ValueError, TypeError):
+                try:
+                    self.inverter_time = datetime.strptime(ivtime, TIME_FORMAT_OCTOPUS)
+                except (ValueError, TypeError):
+                    try:
+                        tz = pytz.timezone(self.base.get_arg("timezone", "Europe/London"))
+                        self.inverter_time = tz.localize(datetime.strptime(ivtime, self.inv_clock_time_format))
+                    except (ValueError, TypeError):
+                        self.base.log(f"Warn: Unable to read inverter time string {ivtime} using formats {[TIME_FORMAT, TIME_FORMAT_OCTOPUS, self.inv_clock_time_format]}")
+                        self.inverter_time = None
+                        self.auto_restart("Unable to read inverter time")
+
+        # Check inverter time and confirm skew
+        if self.inverter_time:
+            # Fetch current time again as it may have changed since we run this inverter update
+            local_tz = pytz.timezone(self.base.get_arg("timezone", "Europe/London"))
+            now_utc = datetime.now(local_tz)
+
+            tdiff = self.inverter_time - now_utc
+            tdiff = dp2(tdiff.seconds / 60 + tdiff.days * 60 * 24)
+            if not quiet:
+                self.base.log("Inverter time {}, Predbat computer time {}, difference {} minutes".format(self.inverter_time, now_utc, tdiff))
+            if abs(tdiff) >= 30:
+                self.base.log(
+                    "Warn: Inverter time is {}, Predbat computer time {}, this is {} minutes skewed, Predbat may not function correctly, please fix this by updating your inverter time, checking HA is synchronising with your inverter, or fixing Predbat computer time zone".format(
+                        self.inverter_time, now_utc, tdiff
+                    )
+                )
+                self.base.record_status(
+                    "Inverter time is {}, Predbat computer time {}, this is {} minutes skewed, Predbat may not function correctly, please fix this by updating your inverter time, checking HA is synchronising with your inverter, or fixing Predbat computer time zone".format(
+                        self.inverter_time, now_utc, tdiff
+                    ),
+                    had_errors=True,
+                )
+                # Trigger restart
+                self.auto_restart("Clock skew >=10 minutes")
+            else:
+                self.base.restart_active = False
+
+        # Get the expected minimum reserve value for the current inverter
+        reserve_min_postfix = "" if self.id == 0 else "_" + str(self.id)
+        self.reserve_min = int(self.base.get_arg("set_reserve_min" + reserve_min_postfix))
+
+        # Min soc setting
+        battery_min_soc = self.base.get_arg("battery_min_soc", default=max(self.reserve_min, 4), index=self.id)
+
+        # Get current reserve value
+        if self.rest_data and ("Control" in self.rest_data) and ("Battery_Power_Reserve" in self.rest_data["Control"]):
+            self.reserve_percent_current = float(self.rest_data["Control"]["Battery_Power_Reserve"])
+        else:
+            self.reserve_percent_current = max(self.base.get_arg("reserve", default=battery_min_soc, index=self.id, required_unit="%"), battery_min_soc)
+        self.reserve_current = dp2(self.soc_max * self.reserve_percent_current / 100.0)
+
+        if self.reserve_min < battery_min_soc:
+            self.base.log("Increasing set_reserve_min{} from {}%  to battery_min_soc of {}%".format(reserve_min_postfix, self.reserve_min, battery_min_soc))
+            self.base.expose_config("set_reserve_min" + reserve_min_postfix, battery_min_soc)
+            self.reserve_min = battery_min_soc
+
+        self.base.log("Reserve min: {}%, battery_min: {}%".format(self.reserve_min, dp0(battery_min_soc)))
+        if self.base.set_reserve_enable and self.inv_has_reserve_soc:
+            self.reserve_percent = self.reserve_min
+        else:
+            self.reserve_percent = self.reserve_percent_current
+        self.reserve = dp3(self.soc_max * self.reserve_percent / 100.0)
+
+        # Max inverter rate override
+        if "inverter_limit" in self.base.args:
+            self.inverter_limit = self.base.get_arg("inverter_limit", self.inverter_limit * MINUTE_WATT, index=self.id, required_unit="W") / MINUTE_WATT
+        if "export_limit" in self.base.args:
+            self.export_limit = self.base.get_arg("export_limit", self.export_limit * MINUTE_WATT, index=self.id, required_unit="W") / MINUTE_WATT
+
+        # Log inverter details
+        if not quiet:
+            self.base.log(
+                "Inverter {} with soc_max {}kWh, nominal_capacity {}kWh, battery rate raw {}W, charge rate {}kW, discharge rate {}kW, battery_rate_min {}W, AC limit {}kW, export limit {}kW, reserve {}%, current_reserve {}%, temperature {}°C".format(
+                    self.id,
+                    dp2(self.soc_max),
+                    dp2(self.nominal_capacity),
+                    dp2(self.battery_rate_max_raw),
+                    dp2(self.battery_rate_max_charge * 60.0),
+                    dp2(self.battery_rate_max_discharge * 60.0),
+                    dp2(self.battery_rate_min * MINUTE_WATT),
+                    dp2(self.inverter_limit * 60),
+                    dp2(self.export_limit * 60),
+                    self.reserve_percent,
+                    self.reserve_percent_current,
+                    self.battery_temperature,
+                )
+            )
+
+        # Create some dummy entities if PredBat expects them but they don't exist for this Inverter Type:
+        # Args are also set for these so that no entries are needed for the dummies in the config file
+        if not self.inv_has_charge_enable_time:
+            self.create_missing_arg("scheduled_charge_enable", "on")
+            self.base.args["scheduled_charge_enable"][id] = self.create_entity("scheduled_charge_enable", "on")
+
+        if not self.inv_has_discharge_enable_time:
+            self.create_missing_arg("scheduled_discharge_enable", "on")
+            self.base.args["scheduled_discharge_enable"][id] = self.create_entity("scheduled_discharge_enable", "on")
+
+        if not self.inv_has_reserve_soc:
+            self.create_missing_arg("reserve", self.reserve)
+            self.base.args["reserve"][id] = self.create_entity("reserve", self.reserve, device_class="battery", uom="%")
+
+        if not self.inv_has_target_soc:
+            self.create_missing_arg("charge_limit", 100)
+            self.base.args["charge_limit"][id] = self.create_entity("charge_limit", 100, device_class="battery", uom="%")
+
+        if self.inv_output_charge_control != "power":
+            max_charge = self.battery_rate_max_charge * MINUTE_WATT
+            max_discharge = self.battery_rate_max_discharge * MINUTE_WATT
+            self.create_missing_arg("charge_rate", max_charge)
+            self.create_missing_arg("discharge_rate", max_discharge)
+            self.base.args["charge_rate"][id] = self.create_entity("charge_rate", max_charge, uom="W", device_class="power")
+            self.base.args["discharge_rate"][id] = self.create_entity("discharge_rate", max_discharge, uom="W", device_class="power")
+
+        if not self.inv_has_ge_inverter_mode and not self.inv_has_fox_inverter_mode:
+            self.create_missing_arg("inverter_mode", "Eco")
+            self.base.args["inverter_mode"][id] = self.create_entity("inverter_mode", "Eco")
+
+        if self.inv_charge_time_format != "HH:MM:SS":
+            for x in ["charge", "discharge"]:
+                for y in ["start", "end"]:
+                    entity_name = f"{x}_{y}_time"
+                    self.create_missing_arg(entity_name, "23:59:00")
+                    self.base.args[entity_name][id] = self.create_entity(entity_name, "23:59:00")
+
+        # Create dummy idle time entities
+        if not self.inv_has_idle_time:
+            self.create_missing_arg("idle_start_time", "00:00:00")
+            self.create_missing_arg("idle_end_time", "00:00:00")
+            self.base.args["idle_start_time"][id] = self.create_entity("idle_start_time", "00:00:00")
+            self.base.args["idle_end_time"][id] = self.create_entity("idle_end_time", "00:00:00")
+
+    def find_battery_size(self):
+        """
+        Given SOC Percent and battery power figure out the approximate battery size in kWh
+        """
+        soc_percent_sensor = self.base.get_arg("soc_percent", indirect=False, index=self.id)
+        battery_power_sensor = self.base.get_arg("battery_power", indirect=False, index=self.id)
+        battery_power_invert = self.base.get_arg("battery_power_invert", False, index=self.id)
+        max_power = int(self.battery_rate_max_charge * MINUTE_WATT)
+
+        if soc_percent_sensor and battery_power_sensor:
+            soc_percent_data = self.base.get_history_wrapper(entity_id=soc_percent_sensor, days=self.base.max_days_previous, required=False)
+            battery_power_data = self.base.get_history_wrapper(entity_id=battery_power_sensor, days=self.base.max_days_previous, required=False)
+
+            if not soc_percent_data or not battery_power_data:
+                self.log("Warn: Unable to estimate battery size - no history data available")
+                return None
+
+            soc_percent, _ = minute_data(
+                soc_percent_data[0],
+                self.base.max_days_previous,
+                self.base.now_utc,
+                "state",
+                "last_updated",
+                backwards=True,
+                clean_increment=False,
+                smoothing=False,
+                divide_by=1.0,
+                scale=self.battery_scaling,
+                required_unit="%",
+            )
+            battery_power, _ = minute_data(
+                battery_power_data[0],
+                self.base.max_days_previous,
+                self.base.now_utc,
+                "state",
+                "last_updated",
+                backwards=True,
+                clean_increment=False,
+                smoothing=False,
+                divide_by=1.0,
+                scale=1.0,
+                required_unit="W",
+            )
+            if battery_power_invert:
+                # Invert the battery power if required
+                for minute in battery_power:
+                    battery_power[minute] = -battery_power[minute]
+            min_len = min(len(soc_percent), len(battery_power))
+            self.log("Find battery size has {} days of data, max days {}".format(min_len / 60 / 24.0, self.base.max_days_previous))
+
+            estimate_battery_sizes = []
+
+            # Find continuous charging periods and calculate battery size from energy/SoC relationship
+            # Data is indexed backwards: minute 0 = now, minute N = N minutes ago
+            max_power_threshold = max_power * 0.9
+
+            # Scan backwards through time to find charging periods
+            in_charge = False
+            charge_start_minute = None  # Higher minute = older = start of charge
+
+            for minute in range(min_len - 1, -1, -1):
+                power = battery_power.get(minute, 0)
+                is_charging = power < -max_power_threshold
+
+                if is_charging and not in_charge:
+                    # Start of a charging period (going forward in real time, backwards in minute index)
+                    in_charge = True
+                    charge_start_minute = minute
+
+                elif not is_charging and in_charge:
+                    # End of a charging period
+                    charge_end_minute = minute + 1  # Previous minute was still charging
+                    in_charge = False
+
+                    if charge_start_minute is not None and charge_end_minute < charge_start_minute:
+                        # We have a valid charge period (start_minute > end_minute because of backwards indexing)
+                        # charge_start_minute is OLDER (beginning of charge, lower SoC)
+                        # charge_end_minute is NEWER (end of charge, higher SoC)
+
+                        start_soc = soc_percent.get(charge_start_minute, 0)
+                        end_soc = soc_percent.get(charge_end_minute, 0)
+
+                        self.log(
+                            "Charge start {} soc {} end {} soc {}".format(
+                                charge_start_minute,
+                                start_soc,
+                                charge_end_minute,
+                                end_soc,
+                            )
+                        )
+
+                        # Clip to 20-80% range and align to percentage boundaries
+                        # to avoid partial energy from transition minutes
+                        # A "transition minute" is one where the SoC changed from the previous minute
+                        # We want to start AFTER a transition and end BEFORE a transition
+                        clipped_start_minute = charge_start_minute
+                        clipped_end_minute = charge_end_minute
+
+                        # Find first stable minute ≥20% (where SoC didn't just change)
+                        # Search forward in real time (decreasing minute index)
+                        found_start = False
+                        for m in range(charge_start_minute, charge_end_minute - 1, -1):
+                            curr_soc = int(soc_percent.get(m, 0))
+                            prev_soc = int(soc_percent.get(m + 1, 0))  # m+1 is older
+                            # Check if this is a stable minute (no transition) and within range
+                            if curr_soc >= 20 and curr_soc <= 80 and curr_soc != prev_soc:
+                                clipped_start_minute = m
+                                found_start = True
+                                break
+                        if not found_start:
+                            # No stable minute found in 20-80% range, skip this period
+                            continue
+
+                        # Find last stable minute ≤80% (where SoC won't change next minute)
+                        # Search backward in real time (increasing minute index)
+                        found_end = False
+                        for m in range(charge_end_minute, charge_start_minute + 1):
+                            curr_soc = int(soc_percent.get(m, 0))
+                            next_soc = int(soc_percent.get(m + 1, 0))  # m+1 is older
+                            # Check if this is a stable minute (no upcoming transition) and within range
+                            if curr_soc >= 20 and curr_soc <= 80 and curr_soc != next_soc:
+                                clipped_end_minute = m
+                                found_end = True
+                                break
+                        if not found_end:
+                            # No stable minute found in 20-80% range, skip this period
+                            continue
+
+                        # Validate the clipped range is still valid
+                        if clipped_start_minute <= clipped_end_minute:
+                            continue  # Invalid range after clipping
+
+                        # Get the clipped SoC values (as integers for consistent percentage)
+                        clipped_start_soc = int(soc_percent.get(clipped_start_minute, 0))
+                        clipped_end_soc = int(soc_percent.get(clipped_end_minute, 0))
+                        percent_change = clipped_end_soc - clipped_start_soc
+
+                        self.log(
+                            "Charging clipped start at {} percent {} end {} percent {}, percent change {}".format(
+                                clipped_start_minute,
+                                clipped_start_soc,
+                                clipped_end_minute,
+                                clipped_end_soc,
+                                percent_change,
+                            )
+                        )
+
+                        if percent_change > 15:  # Need at least 15% change for a meaningful estimate
+                            # Calculate energy added during this period (using clipped range)
+                            power_added = 0.0
+                            sample_count = 0
+                            for power_minute in range(clipped_start_minute, clipped_end_minute - 1, -1):
+                                minute_power = -battery_power.get(power_minute, 0)
+                                power_added += minute_power / 60.0  # W to Wh
+                                sample_count += 1
+
+                            self.log("  Power added over {} samples is {} Wh".format(sample_count, power_added))
+
+                            if power_added > 0:
+                                estimated_battery_size = (power_added / percent_change) * 100.0 / 1000.0  # Convert Wh to kWh
+                                estimated_battery_size = dp2(estimated_battery_size)
+                                estimate_battery_sizes.append(estimated_battery_size)
+
+            # Average the estimated battery sizes
+            if len(estimate_battery_sizes) > 0:
+                average_battery_size = sum(estimate_battery_sizes) / len(estimate_battery_sizes)
+                average_battery_size = dp2(average_battery_size)
+                # Add in charging loss factor, assume the inverter loss is not counted in the charge rate sensor (as it's AC side)
+                average_battery_size *= self.base.battery_loss * self.base.inverter_loss
+                self.log("Estimated battery size is {} kWh from {} samples (assumed charging loss factor {})".format(average_battery_size, len(estimate_battery_sizes), self.base.battery_loss * self.base.inverter_loss))
+                return average_battery_size
+            else:
+                self.log("Warn: Unable to find any suitable charge periods to estimate battery size")
+                return None
+        else:
+            self.log("Warn: Unable to estimate battery size from soc_percent and battery_power data")
+        return None
+
+    def find_charge_curve(self, discharge):
+        """
+        Find expected charge curve
+        """
+        curve_type = "charge"
+        if discharge:
+            curve_type = "discharge"
+
+        predbat_status_sensor = self.base.prefix + ".status"
+
+        if "soc_percent" in self.base.args:
+            soc_kwh_sensor = self.base.get_arg("soc_percent", indirect=False, index=self.id)
+            soc_kwh_percent = True
+            soc_label = "soc_percent"
+        else:
+            soc_kwh_percent = False
+            soc_label = "soc_kwh"
+            soc_kwh_sensor = self.base.get_arg("soc_kw", indirect=False, index=self.id)
+
+        if discharge:
+            charge_rate_sensor = self.base.get_arg("discharge_rate", indirect=False, index=self.id)
+            curve_label = "empty"
+        else:
+            charge_rate_sensor = self.base.get_arg("charge_rate", indirect=False, index=self.id)
+            curve_label = "full"
+
+        battery_power_sensor = self.base.get_arg("battery_power", indirect=False, index=self.id)
+        battery_power_invert = self.base.get_arg("battery_power_invert", False, index=self.id)
+
+        final_curve = {}
+        final_curve_count = {}
+        soc_kwh = []
+        charge_rate = []
+        battery_power = []
+        predbat_status = []
+
+        if discharge:
+            max_power = int(self.battery_rate_max_discharge * MINUTE_WATT)
+        else:
+            max_power = int(self.battery_rate_max_charge * MINUTE_WATT)
+
+        max_power_scaled = max_power * 0.95
+
+        if soc_kwh_sensor and charge_rate_sensor and battery_power_sensor and predbat_status_sensor:
+            battery_power_sensor = battery_power_sensor.replace("number.", "sensor.")  # Workaround as old template had number.
+            self.log("Find {} curve with sensors {}, {}, {} and {}".format(curve_type, soc_kwh_sensor, charge_rate_sensor, predbat_status_sensor, battery_power_sensor))
+            if soc_kwh_percent:
+                soc_kwh_data = self.base.get_history_wrapper(entity_id=soc_kwh_sensor, days=self.base.max_days_previous, required=False)
+            else:
+                soc_kwh_data = self.base.get_history_wrapper(entity_id=soc_kwh_sensor, days=self.base.max_days_previous, required=False)
+            charge_rate_data = self.base.get_history_wrapper(entity_id=charge_rate_sensor, days=self.base.max_days_previous, required=False)
+            battery_power_data = self.base.get_history_wrapper(entity_id=battery_power_sensor, days=self.base.max_days_previous, required=False)
+            predbat_status_data = self.base.get_history_wrapper(entity_id=predbat_status_sensor, days=self.base.max_days_previous, required=False)
+
+            if soc_kwh_data and charge_rate_data and battery_power_data and predbat_status_data:
+                if soc_kwh_percent:
+                    # If its in percent convert to kWh
+                    soc_kwh, ignore_io = minute_data(
+                        soc_kwh_data[0],
+                        self.base.max_days_previous,
+                        self.base.now_utc,
+                        "state",
+                        "last_updated",
+                        backwards=True,
+                        clean_increment=False,
+                        smoothing=False,
+                        divide_by=1.0,
+                        scale=self.battery_scaling,
+                        required_unit="%",
+                    )
+                    for entry in soc_kwh:
+                        soc_kwh[entry] = dp4(soc_kwh[entry] * self.soc_max / 100.0)
+                else:
+                    soc_kwh, ignore_io = minute_data(
+                        soc_kwh_data[0],
+                        self.base.max_days_previous,
+                        self.base.now_utc,
+                        "state",
+                        "last_updated",
+                        backwards=True,
+                        clean_increment=False,
+                        smoothing=False,
+                        divide_by=1.0,
+                        scale=self.battery_scaling,
+                        required_unit="kWh",
+                    )
+                charge_rate, ignore_io = minute_data(
+                    charge_rate_data[0],
+                    self.base.max_days_previous,
+                    self.base.now_utc,
+                    "state",
+                    "last_updated",
+                    backwards=True,
+                    clean_increment=False,
+                    smoothing=False,
+                    divide_by=1.0,
+                    scale=1.0,
+                    required_unit="W",
+                )
+                predbat_status = minute_data_state(predbat_status_data[0], self.base.max_days_previous, self.base.now_utc, "state", "last_updated")
+                for minute in predbat_status:
+                    status = predbat_status[minute]
+                    if "," in status:
+                        # If there are multiple statuses take the first one
+                        predbat_status[minute] = status.split(",")[0].strip()
+                battery_power, ignore_io = minute_data(
+                    battery_power_data[0],
+                    self.base.max_days_previous,
+                    self.base.now_utc,
+                    "state",
+                    "last_updated",
+                    backwards=True,
+                    clean_increment=False,
+                    smoothing=False,
+                    divide_by=1.0,
+                    scale=1.0,
+                    required_unit="W",
+                )
+                if battery_power_invert:
+                    # Invert the battery power if required
+                    for minute in battery_power:
+                        battery_power[minute] = -battery_power[minute]
+                min_len = min(len(soc_kwh), len(charge_rate), len(predbat_status), len(battery_power))
+                self.log("Find {} curve has {} days of data, max days {}".format(curve_type, min_len / 60 / 24.0, self.base.max_days_previous))
+
+                soc_percent = {}
+                for minute in range(0, min_len):
+                    soc_percent[minute] = calc_percent_limit(soc_kwh.get(minute, 0), self.soc_max)
+
+                if discharge:
+                    search_range = range(5, 20, 1)
+                else:
+                    search_range = range(99, 85, -1)
+
+                # Find 100% end points
+                for data_point in search_range:
+                    for minute in range(1, min_len):
+                        # Start trigger is when the SoC just increased above the data point
+                        previous_point = soc_percent.get(minute - 1, 0)
+                        if (
+                            not discharge
+                            and previous_point > data_point
+                            and soc_percent.get(minute, 0) == data_point
+                            and predbat_status.get(minute - 1, "") == "Charging"
+                            and predbat_status.get(minute, "") == "Charging"
+                            and predbat_status.get(minute + 1, "") == "Charging"
+                            and charge_rate.get(minute - 1, 0) >= max_power_scaled
+                            and charge_rate.get(minute, 0) >= max_power_scaled
+                            and battery_power.get(minute, 0) < 0
+                        ) or (
+                            discharge
+                            and previous_point < data_point
+                            and soc_percent.get(minute, 0) == data_point
+                            and predbat_status.get(minute - 1, "") in ["Exporting", "Discharging"]
+                            and predbat_status.get(minute, "") in ["Exporting", "Discharging"]
+                            and predbat_status.get(minute + 1, "") in ["Exporting", "Discharging"]
+                            and charge_rate.get(minute - 1, 0) >= max_power_scaled
+                            and charge_rate.get(minute, 0) >= max_power_scaled
+                            and battery_power.get(minute, 0) > 0
+                        ):
+                            total_power = 0
+                            total_count = 0
+                            # Find a period where charging was at full rate and the SoC just drops below the data point
+                            for target_minute in range(minute, min_len):
+                                this_soc = soc_percent.get(target_minute, 0)
+                                if not discharge and (predbat_status.get(target_minute, "") != "Charging" or charge_rate.get(minute, 0) < max_power_scaled or battery_power.get(minute, 0) >= 0):
+                                    break
+                                if discharge and (not ((predbat_status.get(target_minute, "") in ["Exporting", "Discharging"])) or charge_rate.get(minute, 0) < max_power_scaled or battery_power.get(minute, 0) <= 0):
+                                    break
+
+                                if (discharge and (this_soc > data_point)) or (not discharge and (this_soc < data_point)):
+                                    if total_power == 0:
+                                        # No power data, so skip this data point
+                                        break
+                                    if discharge:
+                                        this_soc -= 1
+                                    else:
+                                        this_soc += 1
+                                    # So the power for this data point average has been stored, it's possible we spanned more than one data point
+                                    # if not all SoC %'s are represented for this battery size
+                                    from_soc = soc_kwh.get(minute, 0)
+                                    to_soc = soc_kwh.get(target_minute, 0)
+                                    soc_charged = from_soc - to_soc
+                                    average_power = total_power / total_count
+                                    charge_curve = round(min(average_power / max_power / self.base.battery_loss, 1.0), 2)
+                                    if self.base.debug_enable:
+                                        self.log(
+                                            "Curve Percent: {}-{} at {} took {} minutes charged {} curve {} average_power {}".format(
+                                                data_point,
+                                                this_soc,
+                                                self.base.time_abs_str(self.base.minutes_now - minute),
+                                                total_count,
+                                                round(soc_charged, 2),
+                                                charge_curve,
+                                                average_power,
+                                            )
+                                        )
+                                    # Store data points
+                                    if discharge:
+                                        store_range = range(this_soc, previous_point, -1)
+                                    else:
+                                        store_range = range(this_soc, previous_point)
+
+                                    for point in store_range:
+                                        if point not in final_curve:
+                                            final_curve[point] = charge_curve
+                                            final_curve_count[point] = 1
+                                        else:
+                                            final_curve[point] += charge_curve
+                                            final_curve_count[point] += 1
+
+                                    break
+                                else:
+                                    # Store data
+                                    total_power += abs(battery_power.get(minute, 0))
+                                    total_count += 1
+                if final_curve:
+                    # Average the data points
+                    for index in final_curve:
+                        if final_curve_count[index] > 0:
+                            final_curve[index] = dp2(final_curve[index] / final_curve_count[index])
+
+                    self.log("{} curve before adjustment is: {}".format(curve_type, final_curve))
+
+                    # Find info for gap filling
+                    found_required = False
+                    if discharge:
+                        fill_range = range(4, 21, 1)
+                        value = min(final_curve.values())
+                    else:
+                        value = max(final_curve.values())
+                        fill_range = range(85, 101)
+
+                    # Pick the first value point for fill below
+                    for point in fill_range:
+                        if point in final_curve:
+                            value = final_curve[point]
+                            break
+
+                    # Fill gaps
+                    for point in fill_range:
+                        if point not in final_curve:
+                            final_curve[point] = value
+                            found_required = True
+                        else:
+                            value = final_curve[point]
+
+                    if found_required:
+                        # Scale curve to 1.0
+                        rate_scaling = 0
+
+                        # Work out the maximum power to use as a scale factor
+                        for index in final_curve:
+                            rate_scaling = max(final_curve[index], rate_scaling)
+
+                        # Scale the curve
+                        if rate_scaling > 0:
+                            for index in final_curve:
+                                final_curve[index] = round(final_curve[index] / rate_scaling, 2)
+
+                        # If we have the correct data then output it
+                        if rate_scaling > 0:
+                            if discharge:
+                                text = "  battery_discharge_power_curve:\n"
+                            else:
+                                text = "  battery_charge_power_curve:\n"
+                            keys = sorted(final_curve.keys())
+                            keys.reverse()
+                            first = True
+                            for key in keys:
+                                if (final_curve[key] < 1.0 or first) and final_curve[key] > 0.0:
+                                    text += "    {} : {}\n".format(key, final_curve[key])
+                                    first = False
+                            if self.base.battery_charge_power_curve_auto:
+                                self.log("Curve automatically computed as:\n" + text)
+                            else:
+                                self.log("{} curve can be entered into apps.yaml or set to auto:\n".format(curve_type) + text)
+                            rate_scaling = round(rate_scaling, 2)
+                            if discharge:
+                                if rate_scaling != self.base.battery_rate_max_scaling_discharge:
+                                    self.log("Consider setting in HA: input_number.battery_rate_max_scaling_discharge: {} - currently {}".format(rate_scaling, self.base.battery_rate_max_scaling_discharge))
+                            else:
+                                if rate_scaling != self.base.battery_rate_max_scaling:
+                                    self.log("Consider setting in HA: input_number.battery_rate_max_scaling: {} - currently {}".format(rate_scaling, self.base.battery_rate_max_scaling))
+                            return final_curve
+                        else:
+                            self.log("Note: Found incorrect battery {} curve (was 0), maybe try again when you have more data.".format(curve_type))
+                    else:
+                        self.log("Note: Found incomplete battery {} curve (no data points), maybe try again when you have more data.".format(curve_type))
+                else:
+                    self.log(
+                        "Note: Cannot find battery {} curve (no final curve found for battery to {}), one of the required settings for {}, {}_rate, battery_power and predbat.status do not have history, check apps.yaml".format(
+                            curve_type, curve_label, soc_label, curve_type
+                        )
+                    )
+            else:
+                self.log("Note: Cannot find battery {} curve (missing history), one of the required settings for {}, {}_rate, battery_power and predbat.status do not have history, check apps.yaml".format(curve_type, soc_label, curve_type))
+                self.log("Note: Sensor with history data lengths: {} {}, {}_rate {}, battery_power {}, predbat_status {}".format(soc_label, len(soc_kwh), curve_type, len(charge_rate), len(battery_power), len(predbat_status)))
+        else:
+            self.log("Note: Cannot find battery {} curve (settings missing), one of the required settings for {}, {}_rate and battery_power are missing from apps.yaml".format(curve_type, soc_label, curve_type))
+        return {}
+
+    def create_entity(self, entity_name, value, uom=None, device_class="None"):
+        """
+        Create dummy entities required by non GE inverters to mimic GE behaviour
+        """
+        prefix = self.base.prefix
+        entity_id = f"sensor.{prefix}_{self.inverter_type}_{self.id}_{entity_name}"
+
+        attributes = {
+            "state_class": "measurement",
+        }
+        if uom is not None:
+            attributes["unit_of_measurement"] = uom
+        if device_class is not None:
+            attributes["device_class"] = device_class
+
+        self.created_attributes[entity_id] = attributes
+
+        if self.base.get_state_wrapper(entity_id) is None:
+            self.log("**** Creating dummy entity {} with value {} and attributes {}".format(entity_id, value, attributes))
+            self.base.set_state_wrapper(entity_id, state=value, attributes=attributes)
+        return entity_id
+
+    def update_status(self, minutes_now, quiet=False):
+        """
+        Update the following with inverter status.
+
+        Inverter Class Parameters
+        =========================
+
+            Parameter                          Type    Units
+            ---------                          ----    -----
+            self.rest_data                     dict
+            self.charge_enable_time            bool
+            self.discharge_enable_time         bool
+            self.charge_rate_now               float
+            self.discharge_rate_now            float
+            self.soc_kw                        float   kWh
+            self.soc_percent                   float   %
+            self.battery_power                 float   W
+            self.pv_power                      float   W
+            self.load_power                    float   W
+            self.charge_start_time_minutes     int
+            self.charge_end_time_minutes       int
+            self.charge_window                 list of dicts
+            self.discharge_start_time_minutes  int
+            self.discharge_end_time_minutes    int
+            self.export_window              list of dicts
+            self.battery_voltage               float   V
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            None
+        """
+
+        self.battery_power = 0
+        self.pv_power = 0
+        self.load_power = 0
+        self.grid_power = 0
+
+        if self.rest_api:
+            self.rest_data = self.rest_readData()
+
+        self.charge_rate_now = self.get_current_charge_rate() / MINUTE_WATT
+        self.discharge_rate_now = self.get_current_discharge_rate() / MINUTE_WATT
+
+        if self.rest_data:
+            self.charge_enable_time = self.rest_data["Control"]["Enable_Charge_Schedule"] == "enable"
+            self.discharge_enable_time = self.rest_data["Control"]["Enable_Discharge_Schedule"] == "enable"
+        else:
+            self.charge_enable_time = self.base.get_arg("scheduled_charge_enable", "on", index=self.id) == "on"
+            self.discharge_enable_time = self.base.get_arg("scheduled_discharge_enable", "off", index=self.id) == "on"
+
+        # Scale charge and discharge rates with battery scaling
+        self.charge_rate_now = max(self.charge_rate_now * self.base.battery_rate_max_scaling, self.battery_rate_min)
+        self.discharge_rate_now = max(self.discharge_rate_now * self.base.battery_rate_max_scaling_discharge, self.battery_rate_min)
+
+        if self.rest_data and self.rest_data.get("Power", {}).get("Power", {}).get("SOC_kWh", None) is not None:
+            self.soc_kw = dp3(self.rest_data["Power"]["Power"]["SOC_kWh"] * self.battery_scaling)
+        else:
+            if "soc_percent" in self.base.args:
+                self.soc_kw = dp3(self.base.get_arg("soc_percent", default=0.0, index=self.id, required_unit="%") * self.soc_max / 100.0)
+            else:
+                self.soc_kw = dp3(self.base.get_arg("soc_kw", default=0.0, index=self.id, required_unit="kWh") * self.battery_scaling)
+
+        if self.soc_max <= 0.0:
+            self.soc_percent = 0
+        else:
+            self.soc_percent = calc_percent_limit(self.soc_kw, self.soc_max)
+
+        if self.rest_data and ("Power" in self.rest_data):
+            pdetails = self.rest_data["Power"]
+            if "Power" in pdetails:
+                ppdetails = pdetails["Power"]
+                self.battery_power = float(ppdetails.get("Battery_Power", 0.0))
+                self.pv_power = float(ppdetails.get("PV_Power", 0.0))
+                self.load_power = float(ppdetails.get("Load_Power", 0.0))
+                self.grid_power = float(ppdetails.get("Grid_Power", 0.0))
+                if self.rest_v3:
+                    self.battery_voltage = float(ppdetails.get("Battery_Voltage", 0.0))
+                else:
+                    self.battery_voltage = self.base.get_arg("battery_voltage", default=52.0, index=self.id, required_unit="V")
+        else:
+            # Battery power
+            self.battery_power = self.base.get_arg("battery_power", default=0.0, index=self.id, required_unit="W")
+            if self.base.get_arg("battery_power_invert", default=False, index=self.id):
+                # If battery power is inverted then invert it
+                self.battery_power = -self.battery_power
+
+            # PV Power
+            self.pv_power = self.base.get_arg("pv_power", default=0.0, index=self.id, required_unit="W")
+
+            # Grid Power
+            self.grid_power = self.base.get_arg("grid_power", default=0.0, index=self.id, required_unit="W")
+            if self.base.get_arg("grid_power_invert", default=False, index=self.id):
+                # If grid power is inverted then invert it
+                self.grid_power = -self.grid_power
+
+            # Load Power
+            self.load_power = self.base.get_arg("load_power", default=0.0, index=self.id, required_unit="W")
+            for i in range(1, self.inv_num_load_entities):
+                self.load_power += self.base.get_arg(f"load_power_{i}", default=0.0, index=self.id, required_unit="W")
+            if self.base.get_arg("load_power_invert", default=False, index=self.id):
+                # If load power is inverted then invert it
+                self.load_power = -self.load_power
+
+            # Battery Voltage
+            self.battery_voltage = self.base.get_arg("battery_voltage", default=52.0, index=self.id, required_unit="V")
+
+        if not quiet:
+            self.base.log(
+                "Inverter {} SoC: {}kW {}%, current charge rate {}W, current discharge rate {}W, current battery power {}W, current battery voltage {}V, grid power {}W, load power {}W, PV Power {}W".format(
+                    self.id, dp2(self.soc_kw), self.soc_percent, dp0(self.charge_rate_now * MINUTE_WATT), dp0(self.discharge_rate_now * MINUTE_WATT), self.battery_power, self.battery_voltage, self.grid_power, self.load_power, self.pv_power
+                )
+            )
+
+        # If the battery is being charged then find the charge window
+        if self.charge_enable_time or not self.inv_has_charge_enable_time:
+            # Find current charge window
+            if self.rest_data:
+                charge_start_time = time_string_to_stamp(self.rest_data["Timeslots"]["Charge_start_time_slot_1"])
+                charge_end_time = time_string_to_stamp(self.rest_data["Timeslots"]["Charge_end_time_slot_1"])
+            elif "charge_start_time" in self.base.args:
+                charge_start_time = time_string_to_stamp(self.base.get_arg("charge_start_time", index=self.id))
+                charge_end_time = time_string_to_stamp(self.base.get_arg("charge_end_time", index=self.id))
+            else:
+                self.log("Error: Inverter {} unable to read charge window time as neither REST, charge_start_time or charge_start_hour are set".format(self.id))
+                self.base.record_status("Error: Inverter {} unable to read charge window time as neither REST, charge_start_time or charge_start_hour are set".format(self.id), had_errors=True)
+                raise ValueError
+
+            if charge_start_time is None or charge_end_time is None:
+                self.log("Warn: Inverter {} unable to read charge window time as charge_start_time or charge_end_time is None, will retry next update".format(self.id))
+                self.base.record_status("Warn: Inverter {} unable to read charge window time, will retry next update".format(self.id), had_errors=True)
+                # Set safe defaults to allow graceful recovery on next update
+                self.charge_enable_time = False
+                self.charge_start_time_minutes = self.base.forecast_minutes
+                self.charge_end_time_minutes = self.base.forecast_minutes
+                self.track_charge_start = "00:00:00"
+                self.track_charge_end = "00:00:00"
+            else:
+                # Update simulated charge enable time to match the charge window time.
+                if not self.inv_has_charge_enable_time:
+                    if charge_start_time == charge_end_time:
+                        self.charge_enable_time = False
+                    else:
+                        self.charge_enable_time = True
+                    self.write_and_poll_switch("scheduled_charge_enable", self.base.get_arg("scheduled_charge_enable", indirect=False, index=self.id), self.charge_enable_time)
+
+                # Track charge start/end
+                if charge_start_time and charge_end_time:
+                    self.track_charge_start = charge_start_time.strftime(TIME_FORMAT_HMS)
+                    self.track_charge_end = charge_end_time.strftime(TIME_FORMAT_HMS)
+                else:
+                    self.track_charge_start = "00:00:00"
+                    self.track_charge_end = "00:00:00"
+
+                # Reverse clock skew
+                charge_start_time -= timedelta(seconds=self.base.inverter_clock_skew_start * 60)
+                charge_end_time -= timedelta(seconds=self.base.inverter_clock_skew_end * 60)
+
+                # Compute charge window minutes start/end just for the next charge window
+                self.charge_start_time_minutes, self.charge_end_time_minutes = compute_window_minutes(charge_start_time, charge_end_time, minutes_now)
+
+                # Charge is off due to start/end time being same
+                if not self.inv_has_charge_enable_time and not self.charge_enable_time:
+                    self.charge_start_time_minutes = self.base.forecast_minutes
+                    self.charge_end_time_minutes = self.base.forecast_minutes
+                    self.track_charge_start = "00:00:00"
+                    self.track_charge_end = "00:00:00"
+        else:
+            # If charging is disabled set a fake window outside
+            self.charge_start_time_minutes = self.base.forecast_minutes
+            self.charge_end_time_minutes = self.base.forecast_minutes
+            self.track_charge_start = "00:00:00"
+            self.track_charge_end = "00:00:00"
+
+        # Construct charge window from the GivTCP settings
+        self.charge_window = []
+
+        if not quiet:
+            self.base.log("Inverter {} scheduled charge enable is {}".format(self.id, self.charge_enable_time))
+
+        if self.charge_enable_time:
+            minute = max(0, self.charge_start_time_minutes)  # Max is here is start could be before midnight now
+            minute_end = self.charge_end_time_minutes
+            while minute < (self.base.forecast_minutes + minutes_now):
+                window = {}
+                window["start"] = minute
+                window["end"] = minute_end
+                window["average"] = 0  # Rates are not known yet
+                self.charge_window.append(window)
+                minute += 24 * 60
+                minute_end += 24 * 60
+
+        if not quiet:
+            self.base.log("Inverter {} charge windows currently {}".format(self.id, self.charge_window))
+
+        # Work out existing charge limits and percent
+        if self.charge_enable_time:
+            if self.rest_data:
+                self.current_charge_limit = float(self.rest_data["Control"]["Target_SOC"])
+            else:
+                self.current_charge_limit = float(self.base.get_arg("charge_limit", index=self.id, default=100.0, required_unit="%"))
+        else:
+            self.current_charge_limit = 0.0
+
+        if not quiet:
+            if self.charge_enable_time:
+                self.base.log(
+                    "Inverter {} Charge settings: {}-{}, limit {}%, power {}kW".format(
+                        self.id,
+                        self.base.time_abs_str(self.charge_start_time_minutes),
+                        self.base.time_abs_str(self.charge_end_time_minutes),
+                        self.current_charge_limit,
+                        dp2(self.charge_rate_now * 60.0),
+                    )
+                )
+            else:
+                self.base.log("Inverter {} Charge settings: timed charged is disabled, power {}kW".format(self.id, round(self.charge_rate_now * 60.0, 2)))
+
+        # Construct discharge window from GivTCP settings
+        self.export_window = []
+
+        if self.rest_data:
+            discharge_start = time_string_to_stamp(self.rest_data["Timeslots"]["Discharge_start_time_slot_1"])
+            discharge_end = time_string_to_stamp(self.rest_data["Timeslots"]["Discharge_end_time_slot_1"])
+        elif "discharge_start_time" in self.base.args:
+            discharge_start = time_string_to_stamp(self.base.get_arg("discharge_start_time", index=self.id))
+            discharge_end = time_string_to_stamp(self.base.get_arg("discharge_end_time", index=self.id))
+        else:
+            self.log("Error: Inverter {} unable to read Export window as neither REST or discharge_start_time are set".format(self.id))
+            self.base.record_status("Error: Inverter {} unable to read Export window as neither REST or discharge_start_time are set".format(self.id), had_errors=True)
+            raise ValueError
+
+        if discharge_start is None or discharge_end is None:
+            self.log("Warn: Inverter {} unable to read Export window as discharge_start or discharge_end is None, will retry next update".format(self.id))
+            self.base.record_status("Warn: Inverter {} unable to read Export window, will retry next update".format(self.id), had_errors=True)
+            # Set safe defaults to allow graceful recovery on next update
+            self.discharge_enable_time = False
+            self.discharge_start_time_minutes = 0
+            self.discharge_end_time_minutes = 0
+            self.track_discharge_start = "00:00:00"
+            self.track_discharge_end = "00:00:00"
+        else:
+            # Update simulated discharge enable time to match the discharge window time.
+            if not self.inv_has_discharge_enable_time and not self.inv_has_ge_inverter_mode:
+                if discharge_start == discharge_end:
+                    self.discharge_enable_time = False
+                else:
+                    self.discharge_enable_time = True
+                entity_id = self.base.get_arg("scheduled_discharge_enable", indirect=False, index=self.id)
+                self.write_and_poll_switch("scheduled_discharge_enable", entity_id, self.discharge_enable_time)
+                self.log("Inverter {} {} set to {}".format(self.id, entity_id, self.discharge_enable_time))
+
+            # Tracking for idle time
+            if self.discharge_enable_time:
+                self.track_discharge_start = discharge_start.strftime(TIME_FORMAT_HMS)
+                self.track_discharge_end = discharge_end.strftime(TIME_FORMAT_HMS)
+            else:
+                self.track_discharge_start = "00:00:00"
+                self.track_discharge_end = "00:00:00"
+
+            # Reverse clock skew
+            discharge_start -= timedelta(seconds=self.base.inverter_clock_skew_discharge_start * 60)
+            discharge_end -= timedelta(seconds=self.base.inverter_clock_skew_discharge_end * 60)
+
+            # Compute discharge window minutes start/end just for the next discharge window
+            self.discharge_start_time_minutes, self.discharge_end_time_minutes = compute_window_minutes(discharge_start, discharge_end, minutes_now)
+
+        if not quiet:
+            self.base.log("Inverter {} scheduled discharge enable is {}".format(self.id, self.discharge_enable_time))
+        # Pre-fill current discharge window
+        # Store it even when discharge timed isn't enabled as it won't be outside the actual slot
+        if self.discharge_start_time_minutes != self.discharge_end_time_minutes:
+            minute = max(0, self.discharge_start_time_minutes)  # Max is here is start could be before midnight now
+            minute_end = self.discharge_end_time_minutes
+            while minute < self.base.forecast_minutes:
+                window = {}
+                window["start"] = minute
+                window["end"] = minute_end
+                window["average"] = 0  # Rates are not known yet
+                self.export_window.append(window)
+                minute += 24 * 60
+                minute_end += 24 * 60
+
+        # Pre-fill best discharge enables
+        if self.discharge_enable_time:
+            self.export_limits = [0.0 for i in range(len(self.export_window))]
+        else:
+            self.export_limits = [100.0 for i in range(len(self.export_window))]
+
+        # Idle time?
+        # Get previous idle start and end
+        idle_start = self.base.get_arg("idle_start_time", index=self.id)
+        idle_end = self.base.get_arg("idle_end_time", index=self.id)
+
+        # Convert to minutes using helper function
+        try:
+            idle_start_time = time_string_to_stamp(idle_start)
+            idle_end_time = time_string_to_stamp(idle_end)
+            self.idle_start_minutes, self.idle_end_minutes = compute_window_minutes(idle_start_time, idle_end_time, minutes_now)
+        except (ValueError, TypeError):
+            self.base.log("Warn: Inverter {} unable to read idle start/end time, check your setting of idle_start_time/idle_end_time".format(self.id))
+            self.idle_start_minutes = 0
+            self.idle_end_minutes = 0
+
+        self.base.log("Inverter {} idle time is {}-{}".format(self.id, self.base.time_abs_str(self.idle_start_minutes), self.base.time_abs_str(self.idle_end_minutes)))
+
+        if not quiet:
+            self.base.log("Inverter {} discharge windows currently {}".format(self.id, self.export_window))
+
+        if INVERTER_TEST:
+            self.self_test(minutes_now)
+
+    def mimic_target_soc(self, current_charge_limit, discharge=False):
+        """
+        Function to turn on/off charging based on the current SoC and the set charge limit
+
+        Parameters:
+            current_charge_limit (float): The target SoC (State of Charge) limit for charging.
+
+        Returns:
+            None
+        """
+        charge_power = self.base.get_arg("charge_rate", index=self.id, default=2600.0, required_unit="W")
+        discharge_power = self.base.get_arg("discharge_rate", index=self.id, default=2600.0, required_unit="W")
+
+        if discharge:
+            if current_charge_limit == 100:
+                self.alt_charge_discharge_enable("eco", True)  # ECO Mode
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("discharge", discharge_power)
+            elif self.soc_percent < float(current_charge_limit):
+                self.base.log(f"Current SoC {self.soc_percent}% is less than Target SoC {current_charge_limit}. Grid Discharge disabled.")
+                self.alt_charge_discharge_enable("discharge", False)
+            elif self.soc_percent == float(current_charge_limit):  # If SoC target is reached
+                if self.inv_output_charge_control == "current":
+                    self.alt_charge_discharge_enable("discharge", True)
+                    self.set_current_from_power("discharge", (0))  # Set charge current to zero (i.e hold SoC)
+                else:
+                    self.alt_charge_discharge_enable("discharge", False)
+            else:
+                self.base.log(f"Current SoC {self.soc_percent}% is greater than Target SoC {current_charge_limit}. Grid Discharge enabled.")
+                self.alt_charge_discharge_enable("discharge", True)
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("discharge", discharge_power)
+                    self.base.log(f"Current SoC {self.soc_percent}% is greater than Target SoC {current_charge_limit}. Grid Discharge enabled, amp rate written to inverter.")
+        else:
+            if current_charge_limit == 0:
+                self.alt_charge_discharge_enable("eco", True)  # ECO Mode
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("charge", charge_power)  # Write previous current setting to inverter
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("discharge", discharge_power)  # Reset discharge power too
+            elif self.soc_percent > float(current_charge_limit):
+                # If current SoC is above Target SoC, turn Grid Charging off
+                self.alt_charge_discharge_enable("charge", False)
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("charge", (0))  # Set charge current to zero (i.e hold SoC)
+                self.base.log(f"Current SoC {self.soc_percent}% is greater than Target SoC {current_charge_limit}. Grid Charge disabled.")
+            elif self.soc_percent == float(current_charge_limit):  # If SoC target is reached
+                self.alt_charge_discharge_enable("charge", True)  # Make sure charging is on
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("charge", (0))  # Set charge current to zero (i.e hold SoC)
+                    self.base.log(f"Current SoC {self.soc_percent}% is same as Target SoC {current_charge_limit}. Grid Charge enabled, Amps rate set to 0.")
+            else:
+                # If we drop below the target, turn grid charging back on and make sure the charge current is correct
+                self.alt_charge_discharge_enable("charge", True)
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("charge", charge_power)  # Write previous current setting to inverter
+                    self.base.log(f"Current SoC {self.soc_percent}% is less than Target SoC {current_charge_limit}. Grid Charge enabled, amp rate written to inverter.")
+                self.base.log(f"Current SoC {self.soc_percent}% is less than Target SoC {current_charge_limit}. Grid charging enabled with charge current set to {self.base.get_arg('timed_charge_current', index=self.id, default=65):0.2f}")
+
+    def adjust_reserve(self, reserve):
+        """
+        Adjust the output reserve target %
+
+        Inverter Class Parameters
+        =========================
+
+            None
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            reserve                            int           %
+
+        """
+
+        if self.rest_data:
+            current_reserve = float(self.rest_data["Control"]["Battery_Power_Reserve"])
+        else:
+            current_reserve = self.base.get_arg("reserve", index=self.id, default=0.0, required_unit="%")
+
+        # Round to integer and clamp to minimum
+        reserve = int(reserve + 0.5)
+        if reserve < self.reserve_percent:
+            reserve = self.reserve_percent
+
+        # Clamp reserve at max setting
+        reserve = min(reserve, self.reserve_max)
+
+        if current_reserve != reserve:
+            self.base.log("Inverter {} Current Reserve is {}% and new target is {}%".format(self.id, dp0(current_reserve), dp0(reserve)))
+            if self.rest_data:
+                self.rest_setReserve(reserve)
+            else:
+                self.write_and_poll_value("reserve", self.base.get_arg("reserve", indirect=False, index=self.id, required_unit="%"), reserve)
+            if self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} Target Reserve has been changed to {}% at {}".format(self.id, dp0(reserve), self.base.time_now_str()))
+            self.mqtt_message(topic="set/reserve", payload=reserve)
+        else:
+            self.base.log("Inverter {} Current reserve is {}%, already at target".format(self.id, dp0(current_reserve)))
+
+    def get_current_discharge_rate(self):
+        """
+        Get the current discharge rate in watts
+        """
+
+        if self.rest_data and "Control" in self.rest_data and "Battery_Discharge_Rate" in self.rest_data["Control"]:
+            current_rate = self.rest_data["Control"]["Battery_Discharge_Rate"]
+        else:
+            if "discharge_rate_percent" in self.base.args:
+                current_rate = int(self.base.get_arg("discharge_rate_percent", index=self.id, default=100.0, required_unit="%") * self.battery_rate_max_raw / 100)
+            else:
+                current_rate = self.base.get_arg("discharge_rate", index=self.id, default=self.battery_rate_max_raw, required_unit="W")
+
+        try:
+            current_rate = int(current_rate)
+        except (ValueError, TypeError) as e:
+            self.base.log("Error: Inverter {} charge discharge {} is not a number, setting to {}W".format(current_rate, self.id, self.battery_rate_max_raw))
+            current_rate = self.battery_rate_max_raw
+
+        return current_rate
+
+    def get_current_charge_rate(self):
+        """
+        Get the current charge rate in watts
+        """
+        if self.rest_data and "Control" in self.rest_data and "Battery_Charge_Rate" in self.rest_data["Control"]:
+            current_rate = int(self.rest_data["Control"]["Battery_Charge_Rate"])
+        else:
+            if "charge_rate_percent" in self.base.args:
+                current_rate = self.base.get_arg("charge_rate_percent", index=self.id, default=100.0, required_unit="%") * self.battery_rate_max_raw / 100
+            else:
+                current_rate = self.base.get_arg("charge_rate", index=self.id, default=self.battery_rate_max_raw, required_unit="W")
+        try:
+            current_rate = int(current_rate)
+        except (ValueError, TypeError) as e:
+            self.base.log("Error: Inverter {} charge rate {} is not a number, setting to {}W".format(current_rate, self.id, self.battery_rate_max_raw))
+            current_rate = self.battery_rate_max_raw
+
+        return current_rate
+
+    def adjust_charge_rate(self, new_rate, notify=True):
+        """
+        Adjust charging rate
+
+        Inverter Class Parameters
+        =========================
+
+            None
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            charge_rate                        float         W
+            *timed_charge_current              float         A
+
+
+        *If the inverter uses current rather than power we create a dummy entity for the power anyway but also write to the current entity
+        """
+
+        new_rate = int(new_rate + 0.5)
+        current_rate = self.get_current_charge_rate()
+
+        if abs(current_rate - new_rate) > (self.battery_rate_max_charge * MINUTE_WATT / 20):
+            self.base.log("Inverter {} current charge rate is {}W and new target is {}W".format(self.id, current_rate, new_rate))
+            if self.rest_data:
+                self.rest_setChargeRate(new_rate)
+            else:
+                if "charge_rate" in self.base.args:
+                    self.write_and_poll_value("charge_rate", self.base.get_arg("charge_rate", indirect=False, index=self.id, required_unit="W"), new_rate, fuzzy=(self.battery_rate_max_charge * MINUTE_WATT / 20), required_unit="W")
+                if "charge_rate_percent" in self.base.args:
+                    self.write_and_poll_value("charge_rate_percent", self.base.get_arg("charge_rate_percent", indirect=False, index=self.id, required_unit="%"), min(int(new_rate / self.battery_rate_max_raw * 100), 100), fuzzy=5, required_unit="%")
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("charge", new_rate)
+
+            if notify and self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} charge rate changes to {}W at {}".format(self.id, new_rate, self.base.time_now_str()))
+            self.mqtt_message(topic="set/charge_rate", payload=new_rate)
+
+    def adjust_discharge_rate(self, new_rate, notify=True):
+        """
+        Adjust discharging rate
+
+        Inverter Class Parameters
+        =========================
+
+            None
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            discharge_rate                        float         W
+            *timed_discharge_current              float         A
+
+        *If the inverter uses current rather than power we create a dummy entity for the power anyway but also write to the current entity
+        """
+        new_rate = int(new_rate + 0.5)
+        current_rate = self.get_current_discharge_rate()
+
+        if abs(current_rate - new_rate) > (self.battery_rate_max_discharge * MINUTE_WATT / 20):
+            self.base.log("Inverter {} current discharge rate is {}W and new target is {}W".format(self.id, current_rate, new_rate))
+            if self.rest_data:
+                self.rest_setDischargeRate(new_rate)
+            else:
+                if "discharge_rate" in self.base.args:
+                    self.write_and_poll_value("discharge_rate", self.base.get_arg("discharge_rate", indirect=False, index=self.id), new_rate, fuzzy=(self.battery_rate_max_discharge * MINUTE_WATT / 20), required_unit="W")
+                if "discharge_rate_percent" in self.base.args:
+                    self.write_and_poll_value("discharge_rate_percent", self.base.get_arg("discharge_rate_percent", indirect=False, index=self.id, required_unit="%"), min(int(new_rate / self.battery_rate_max_raw * 100), 100), fuzzy=5, required_unit="%")
+                if self.inv_output_charge_control == "current":
+                    self.set_current_from_power("discharge", new_rate)
+
+            if notify and self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} discharge rate changes to {}W at {}".format(self.id, new_rate, self.base.time_now_str()))
+            self.mqtt_message(topic="set/discharge_rate", payload=new_rate)
+
+    def adjust_battery_target(self, soc, isCharging=False, isExporting=False):
+        """
+        Adjust the battery charging target SoC % in GivTCP
+
+        Inverter Class Parameters
+        =========================
+
+            None
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            charge_limit                       int           %
+
+        """
+        # SoC has no decimal places and clamp in min
+        soc = int(max(soc, self.reserve_percent))
+
+        if isExporting and self.inv_has_target_soc and not self.inv_target_soc_used_for_discharge:
+            self.log("Inverter {} Exporting, not adjusting SoC target".format(self.id))
+            return
+
+        # Check current setting and adjust
+        if self.rest_data:
+            current_soc = int(float(self.rest_data["Control"]["Target_SOC"]))
+        else:
+            current_soc = int(float(self.base.get_arg("charge_limit", index=self.id, default=100.0, required_unit="%")))
+
+        if current_soc != soc:
+            self.base.log("Inverter {} Current charge limit is {}% and new target is {}%".format(self.id, current_soc, soc))
+            self.current_charge_limit = soc
+            if self.rest_data:
+                self.rest_setChargeTarget(soc)
+            else:
+                self.write_and_poll_value("charge_limit", self.base.get_arg("charge_limit", indirect=False, index=self.id, required_unit="%"), soc)
+
+            # For inverters that need a button press to apply changes (e.g., Fox), press the button now
+            if self.inv_time_button_press:
+                self.press_and_poll_button()
+
+            if self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} Target SoC has been changed to {}% at {}".format(self.id, soc, self.base.time_now_str()))
+            self.mqtt_message(topic="set/target_soc", payload=soc)
+        else:
+            self.base.log("Inverter {} Current Target SoC is {}%, already at target".format(self.id, current_soc))
+
+        # Inverters that need on/off controls rather than target SoC
+        if not self.inv_has_target_soc:
+            if isCharging:
+                self.mimic_target_soc(soc)
+            elif isExporting:
+                self.mimic_target_soc(soc, discharge=True)
+            else:
+                self.mimic_target_soc(0)
+
+    def write_and_poll_switch(self, name, entity_id, new_value):
+        """
+        GivTCP Workaround, keep writing until correct
+        """
+        # Re-written to minimise writes
+        if not entity_id:
+            self.base.log("Warn: Inverter {} write_and_poll_switch: No entity_id for {} to write {}".format(self.id, name, new_value))
+            self.base.record_status("Warn: Inverter {} write_and_poll_switch: No entity_id for {} to write {}".format(self.id, name, new_value), had_errors=True)
+            return False
+        domain, entity_name = entity_id.split(".")
+
+        current_state = self.base.get_state_wrapper(entity_id=entity_id)
+        if isinstance(current_state, str):
+            current_state = current_state.lower() in ["on", "enable", "true"]
+
+        if current_state == new_value:
+            self.base.log("Inverter {} write_and_poll_switch: No write needed for {} as {} == {}".format(self.id, name, new_value, current_state))
+            return True
+
+        retry = 0
+        while current_state != new_value and retry < INVERTER_MAX_RETRY:
+            retry += 1
+            if domain == "sensor":
+                if new_value:
+                    self.base.set_state_wrapper(state="on", entity_id=entity_id, attributes=self.created_attributes.get(entity_id, {}))
+                else:
+                    self.base.set_state_wrapper(state="off", entity_id=entity_id, attributes=self.created_attributes.get(entity_id, {}))
+            else:
+                base_entity = entity_id.split(".")[0]
+                service = base_entity + "/turn_" + ("on" if new_value else "off")
+                self.base.call_service_wrapper(service, entity_id=entity_id)
+
+            self.sleep(self.inv_write_and_poll_sleep)
+            current_state = self.base.get_state_wrapper(entity_id=entity_id, refresh=domain != "sensor")
+            if isinstance(current_state, str):
+                current_state = current_state.lower() in ["on", "enable", "true"]
+
+        if current_state == new_value:
+            self.base.log("Inverter {} Wrote {} to {} successfully and got {}".format(self.id, name, new_value, self.base.get_state_wrapper(entity_id=entity_id)))
+            if domain != "sensor":
+                self.count_register_writes += 1
+            return True
+        else:
+            # Optional suppression for inverters (e.g. LuxPower) that don't reliably reflect
+            # scheduled_charge_enable writes during Freeze charging.
+            status = self.base.get_state_wrapper(entity_id="predbat.status", default="") or ""
+
+            suppress = (
+                name == "scheduled_charge_enable"
+                and self.inv_maintain_freeze_charge_status
+                and str(status).startswith("Freeze charging")
+            )
+
+            # If we're suppressing, treat the failure as expected *only* during Freeze charging
+            # so we don't pollute predbat.status with warnings.
+            if suppress:
+                return True
+
+            self.base.log(
+                "Warn: Inverter {} Trying to write {} to {} didn't complete got {}".format(
+                    self.id,
+                    name,
+                    new_value,
+                    self.base.get_state_wrapper(entity_id=entity_id),
+                )
+            )
+            self.base.record_status(
+                "Warn: Inverter {} write to {} failed".format(self.id, name),
+                had_errors=True,
+            )
+            return False
+
+    def write_and_poll_value(self, name, entity_id, new_value, fuzzy=0, ignore_fail=False, required_unit=None):
+        # Modified to cope with sensor entities and writing strings
+        # Re-written to minimise writes
+        if not entity_id:
+            self.base.log("Warn: Inverter {} write_and_poll_value: No entity_id for {} to write {}".format(self.id, name, new_value))
+            self.base.record_status("Warn: Inverter {} write_and_poll_value: No entity_id for {} to write {}".format(self.id, name, new_value), had_errors=True)
+            return False
+        domain, entity_name = entity_id.split(".")
+        current_state = self.base.get_state_wrapper(entity_id, required_unit=required_unit)
+
+        if isinstance(new_value, str):
+            matched = current_state == new_value
+        else:
+            try:
+                current_state = float(current_state)
+            except (ValueError, TypeError):
+                self.log("Warn: Inverter {} write_and_poll_value: Current state for {} is {}".format(self.id, name, current_state))
+                current_state = 0.0
+            matched = abs(current_state - new_value) <= fuzzy
+
+        retry = 0
+        while (not matched) and (retry < INVERTER_MAX_RETRY):
+            retry += 1
+            if domain == "sensor":
+                self.base.set_state_wrapper(entity_id, state=new_value, attributes=self.created_attributes.get(entity_id, {}), required_unit=required_unit)
+            else:
+                entity_base = entity_id.split(".")[0]
+                service = entity_base + "/set_value"
+                new_value_conv = self.base.unit_conversion(entity_id, new_value, None, required_unit, going_to=True)
+                self.base.call_service_wrapper(service, value=new_value_conv, entity_id=entity_id)
+
+            if ignore_fail:
+                return True
+
+            self.sleep(self.inv_write_and_poll_sleep)
+            current_state = self.base.get_state_wrapper(entity_id, refresh=domain != "sensor", required_unit=required_unit)
+            if isinstance(new_value, str):
+                matched = current_state == new_value
+            else:
+                matched = abs(float(current_state) - new_value) <= fuzzy
+
+        if retry == 0:
+            self.base.log(f"Inverter {self.id} write_and_poll_value: No write needed for {name}: {new_value} == {current_state} fuzzy {fuzzy}")
+            return True
+        elif matched:
+            self.base.log(f"Inverter {self.id} write_and_poll_value: Wrote {new_value} to {name}, successfully now {current_state}")
+            if domain != "sensor":
+                self.count_register_writes += 1
+            return True
+        else:
+            self.base.log(f"Warn: Inverter {self.id} Trying to write {new_value} to {name} didn't complete got {current_state}")
+            self.base.record_status(f"Warn: Inverter {self.id} write to {name} failed", had_errors=True)
+            return False
+
+    def write_and_poll_option(self, name, entity_id, new_value, ignore_fail=False):
+        """
+        GivTCP Workaround, keep writing until correct
+        """
+        if not entity_id:
+            self.base.log("Warn: Inverter {} write_and_poll_option: No entity_id for {} to write {}".format(self.id, name, new_value))
+            self.base.record_status("Warn: Inverter {} write_and_poll_option: No entity_id for {} to write {}".format(self.id, name, new_value), had_errors=True)
+            return False
+        entity_base = entity_id.split(".")[0]
+
+        if entity_base not in ["input_select", "select", "time"]:
+            return self.write_and_poll_value(name, entity_id, new_value, ignore_fail=ignore_fail)
+
+        old_value = self.base.get_state_wrapper(entity_id, refresh=True)
+
+        # If time format of the selector is %H:%M and we pass in %H:%M:%S then we need to strip the seconds
+        if old_value and (":" in old_value) and (":" in new_value) and (len(old_value) == 5) and (len(new_value) == 8):
+            new_value = new_value[:5]
+
+        for retry in range(INVERTER_MAX_RETRY):
+            if entity_base == "time":
+                service = entity_base + "/set_value"
+                self.base.call_service_wrapper(service, time=new_value, entity_id=entity_id)
+            else:
+                service = entity_base + "/select_option"
+                self.base.call_service_wrapper(service, option=new_value, entity_id=entity_id)
+            if ignore_fail:
+                return True
+            self.sleep(self.inv_write_and_poll_sleep)
+            old_value = self.base.get_state_wrapper(entity_id, refresh=True)
+            if old_value == new_value:
+                self.base.log("Inverter {} Wrote {} to {} successfully".format(self.id, name, new_value))
+                self.count_register_writes += 1
+                return True
+        self.base.log("Warn: Inverter {} Trying to write {} to {} didn't complete got {}".format(self.id, name, new_value, self.base.get_state_wrapper(entity_id, refresh=True)))
+        self.base.record_status("Warn: Inverter {} write to {} failed".format(self.id, name), had_errors=True)
+        return False
+
+    def adjust_pause_mode(self, pause_charge=False, pause_discharge=False):
+        """
+        Inverter control for Pause mode
+        """
+
+        # Ignore if inverter doesn't have pause mode
+        if not self.inv_has_timed_pause:
+            return
+
+        # For now we have to use the pause start/end entity to know if we have a pause time window (must be a better way)
+        entity_start = self.base.get_arg("pause_start_time", indirect=False, index=self.id)
+        entity_end = self.base.get_arg("pause_end_time", indirect=False, index=self.id)
+
+        if self.rest_data and self.rest_v3:
+            old_pause_mode = self.rest_data.get("Control", {}).get("Battery_pause_mode", "Disabled")
+            old_start_time = self.rest_data.get("Timeslots", {}).get("Battery_pause_start_time_slot", "00:00:00")
+            old_end_time = self.rest_data.get("Timeslots", {}).get("Battery_pause_end_time_slot", "00:00:00")
+        else:
+            entity_mode = self.base.get_arg("pause_mode", indirect=False, index=self.id)
+            old_pause_mode = None
+            old_start_time = None
+            old_end_time = None
+
+            # As not all inverters have these options we need to gracefully give up if its missing
+            if entity_mode:
+                old_pause_mode = self.base.get_state_wrapper(entity_mode)
+                if old_pause_mode is None:
+                    entity_mode = None
+
+            if entity_start:
+                old_start_time = self.base.get_state_wrapper(entity_start)
+                if old_start_time is None:
+                    entity_start = None
+                    self.log("Note: Inverter {} does not have pause_start_time entity".format(self.id))
+
+            if entity_end:
+                old_end_time = self.base.get_state_wrapper(entity_end)
+                if old_end_time is None:
+                    self.log("Note: Inverter {} does not have pause_end_time entity".format(self.id))
+                    entity_end = None
+
+            if not entity_mode:
+                self.log("Warn: Inverter {} does not have pause_mode entity configured correctly".format(self.id))
+                return
+
+        # Some inverters have start/end time registers
+        new_start_time = "00:00:00"
+        new_end_time = "23:59:00"
+
+        # GE Cloud has different pause names
+        if self.rest_data and self.rest_v3:
+            pause_cloud = False
+        if old_pause_mode in ["Not Paused", "Pause Charge", "Pause Discharge", "Pause Charge & Discharge"]:
+            pause_cloud = True
+        else:
+            pause_cloud = False
+
+        # Not Paused, Pause Charge, Pause Discharge, Pause Charge & Discharge
+        if pause_charge and pause_discharge:
+            new_pause_mode = "Pause Charge & Discharge" if pause_cloud else "PauseBoth"
+        elif pause_charge:
+            new_pause_mode = "Pause Charge" if pause_cloud else "PauseCharge"
+        elif pause_discharge:
+            new_pause_mode = "Pause Discharge" if pause_cloud else "PauseDischarge"
+        else:
+            new_pause_mode = "Not Paused" if pause_cloud else "Disabled"
+
+        if self.rest_data and self.rest_v3:
+            if entity_start and ((old_start_time != new_start_time) or (old_end_time != new_end_time)):
+                self.base.log("Inverter {} set pause slot to {} - {}".format(self.id, new_start_time, new_end_time))
+                self.rest_setPauseSlot(new_start_time, new_end_time)
+        else:
+            if old_start_time and old_start_time != new_start_time:
+                # Don't poll as inverters with no registers will fail
+                self.write_and_poll_option("pause_start_time", entity_start, new_start_time, ignore_fail=True)
+                self.base.log("Inverter {} set pause start time to {}".format(self.id, new_start_time))
+
+            if old_end_time and old_end_time != new_end_time:
+                # Don't poll as inverters with no registers will fail
+                self.write_and_poll_option("pause_end_time", entity_end, new_end_time, ignore_fail=True)
+                self.base.log("Inverter {} set pause end time to {}".format(self.id, new_end_time))
+
+        # Set the mode
+        if new_pause_mode != old_pause_mode:
+            if self.rest_data and self.rest_v3:
+                self.rest_setBatteryPauseMode(new_pause_mode)
+            else:
+                self.write_and_poll_option("pause_mode", entity_mode, new_pause_mode)
+
+            if self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} pause mode to set {} at time {}".format(self.id, new_pause_mode, self.base.time_now_str()))
+
+            self.base.log("Inverter {} set pause mode to {}".format(self.id, new_pause_mode))
+
+    def adjust_inverter_mode(self, force_export, changed_start_end=False):
+        """
+        Adjust inverter mode between force export and Demand mode (ECO)
+
+        Inverter Class Parameters
+        =========================
+
+            None
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            inverter_mode                      string
+
+        """
+        if self.rest_data:
+            old_inverter_mode = self.rest_data["Control"]["Mode"]
+        else:
+            # Inverter mode
+            if changed_start_end and not self.rest_data:
+                # XXX: Workaround for GivTCP window state update time to take effort
+                self.base.log("Sleeping (workaround) as start/end of discharge window was just adjusted")
+                self.sleep(30)
+            old_inverter_mode = self.base.get_arg("inverter_mode", index=self.id)
+
+        if not self.inv_has_fox_inverter_mode:
+            # For the purpose of this function consider Eco Paused as the same as Eco (it's a difference in reserve setting)
+            if old_inverter_mode == "Eco (Paused)":
+                old_inverter_mode = "Eco"
+
+        if self.inv_has_fox_inverter_mode:
+            # For fox we only use selfuse as the rest is done by schedule
+            new_inverter_mode = "SelfUse"
+        else:
+            # Force export or Eco mode?
+            if force_export:
+                new_inverter_mode = "Timed Export"
+            else:
+                new_inverter_mode = "Eco"
+
+        # Change inverter mode
+        if old_inverter_mode != new_inverter_mode:
+            if self.rest_data:
+                self.rest_setBatteryMode(new_inverter_mode)
+            else:
+                entity_id = self.base.get_arg("inverter_mode", indirect=False, index=self.id)
+                self.write_and_poll_option("inverter_mode", entity_id, new_inverter_mode)
+
+            # Notify
+            if self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} Force export set to {} at time {}".format(self.id, force_export, self.base.time_now_str()))
+
+            self.base.log("Inverter {} set force export to {}".format(self.id, force_export))
+
+    def adjust_idle_time(self, charge_start=None, charge_end=None, discharge_start=None, discharge_end=None):
+        """
+        Adjust inverter idle time based on charge/discharge times
+        """
+        if charge_start:
+            self.track_charge_start = charge_start
+        if charge_end:
+            self.track_charge_end = charge_end
+        if discharge_start:
+            self.track_discharge_start = discharge_start
+        if discharge_end:
+            self.track_discharge_end = discharge_end
+
+        self.log("Adjust idle time, charge {}-{} discharge {}-{}".format(self.track_charge_start, self.track_charge_end, self.track_discharge_start, self.track_discharge_end))
+
+        minutes_now = self.base.minutes_now
+        charge_start_minutes, charge_end_minutes = window2minutes(self.track_charge_start, self.track_charge_end, minutes_now)
+        discharge_start_minutes, discharge_end_minutes = window2minutes(self.track_discharge_start, self.track_discharge_end, minutes_now)
+
+        # Idle from now (or previous idle time) until midnight
+        idle_start_minutes = max(min(minutes_now, self.idle_start_minutes), 0)
+        idle_end_minutes = 2 * 24 * 60 - 1
+
+        if charge_start_minutes <= minutes_now and charge_end_minutes > minutes_now:
+            # We are in a charge window so move on the idle start
+            idle_start_minutes = max(idle_start_minutes, charge_end_minutes)
+            # self.log("Clamp idle start until after charge start - idle start now {}".format(idle_start_minutes))
+
+        if idle_end_minutes > charge_start_minutes and idle_start_minutes < charge_start_minutes:
+            # Avoid the end running over the charge start
+            idle_end_minutes = min(idle_end_minutes, charge_start_minutes)
+            # self.log("Clamp idle end until before start charge - idle end now {}".format(idle_end_minutes))
+
+        if discharge_start_minutes <= minutes_now and discharge_end_minutes > minutes_now:
+            # We are in a discharge window so move on the idle start
+            idle_start_minutes = max(idle_start_minutes, discharge_end_minutes)
+            # self.log("Clamp idle start until after discharge start - idle start now {}".format(idle_start_minutes))
+
+        if idle_end_minutes > discharge_start_minutes and idle_start_minutes < discharge_start_minutes:
+            # Avoid the end running over the discharge start
+            idle_end_minutes = min(idle_end_minutes, discharge_start_minutes)
+            # self.log("Clamp idle end until before discharge charge - idle end now {}".format(idle_end_minutes))
+
+        # Avoid midnight span
+        if idle_start_minutes < 24 * 60:
+            idle_end_minutes = min(24 * 60 - 1, idle_end_minutes)
+            # self.log("clamp idle end at midnight, now {}".format(idle_end_minutes))
+
+        if idle_start_minutes >= idle_end_minutes:
+            # Not until tomorrow so skip for now
+            idle_start_minutes = 0
+            idle_end_minutes = 0
+            # self.log("Reset idle start/end due to being no window")
+
+        # Work out new idle start/end time
+        idle_start_time = self.base.midnight_utc + timedelta(minutes=idle_start_minutes)
+        idle_end_time = self.base.midnight_utc + timedelta(minutes=idle_end_minutes)
+        idle_start = idle_start_time.strftime(TIME_FORMAT_HMS)
+        idle_end = idle_end_time.strftime(TIME_FORMAT_HMS)
+
+        self.base.log("Adjust demand (idle) time computed is {}-{}".format(idle_start, idle_end))
+
+        # Get previous start/end
+        old_start = self.base.get_arg("idle_start_time", index=self.id)
+        old_end = self.base.get_arg("idle_end_time", index=self.id)
+
+        # Write new idle start/end time
+        idle_start_time_id = self.base.get_arg("idle_start_time", indirect=False, index=self.id)
+        idle_end_time_id = self.base.get_arg("idle_end_time", indirect=False, index=self.id)
+
+        if idle_start_time_id and idle_end_time_id:
+            if old_start != idle_start:
+                self.base.log("Inverter {} set new demand (idle) start time to {} was {}".format(self.id, idle_start, old_start))
+                self.write_and_poll_option("idle_start_time", idle_start_time_id, idle_start)
+                self.idle_start_minutes = idle_start_minutes
+            if old_end != idle_end:
+                self.base.log("Inverter {} set new demand (idle) end time to {} was {}".format(self.id, idle_end, old_end))
+                self.write_and_poll_option("idle_end_time", idle_end_time_id, idle_end)
+                self.idle_end_minutes = idle_end_minutes
+
+    def adjust_force_export(self, force_export, new_start_time=None, new_end_time=None):
+        """
+        Adjust force export on/off and set the time window correctly
+
+        Inverter Class Parameters
+        =========================
+
+            None
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            discharge_start_time               string
+            discharge_end_time                 string
+            *discharge_start_hour              int
+            *discharge_start_minute            int
+            *discharge_end_hour                int
+            *discharge_end_minute              int
+            *charge_discharge_update_button    button
+
+        """
+
+        if self.rest_data:
+            old_start = self.rest_data["Timeslots"]["Discharge_start_time_slot_1"]
+            old_end = self.rest_data["Timeslots"]["Discharge_end_time_slot_1"]
+            old_discharge_enable = self.rest_data["Control"]["Enable_Discharge_Schedule"]
+        elif "discharge_start_time" in self.base.args:
+            old_start = self.base.get_arg("discharge_start_time", index=self.id)
+            old_end = self.base.get_arg("discharge_end_time", index=self.id)
+            if old_start is None:
+                old_start = "00:00:00"
+            if old_end is None:
+                old_end = "00:00:00"
+            if len(old_start) == 5:
+                old_start += ":00"
+            if len(old_end) == 5:
+                old_end += ":00"
+            old_discharge_enable = self.base.get_arg("scheduled_discharge_enable", "off", index=self.id) == "on"
+        else:
+            self.log("Warn: Inverter {} unable read discharge window as neither REST, discharge_start_time or discharge_start_hour are set".format(self.id))
+            return False
+
+        # Start time to correct format
+        if new_start_time:
+            new_start_time += timedelta(seconds=self.base.inverter_clock_skew_discharge_start * 60)
+            new_start = new_start_time.strftime(TIME_FORMAT_HMS)
+        else:
+            new_start = None
+
+        # End time to correct format
+        if new_end_time:
+            new_end_time += timedelta(seconds=self.base.inverter_clock_skew_discharge_end * 60)
+            new_end = new_end_time.strftime(TIME_FORMAT_HMS)
+        else:
+            new_end = None
+
+        # If the inverter doesn't have a discharge enable time then use midnight-midnight as an alternative disable
+        # GE Mode is a special case of timed discharge which we control at the time of export
+        if not self.inv_has_discharge_enable_time and not self.inv_has_ge_inverter_mode and not force_export:
+            new_start_time = self.base.midnight_utc
+            new_end_time = self.base.midnight_utc
+            new_start = new_start_time.strftime(TIME_FORMAT_HMS)
+            new_end = new_end_time.strftime(TIME_FORMAT_HMS)
+
+        # For GE Inverter mode as we use immediate controls no point in changing times before we enable export
+        if self.inv_has_ge_inverter_mode and not force_export:
+            new_start = None
+            new_end = None
+
+        # Eco mode, turn it on before we change the discharge window
+        if not force_export:
+            self.adjust_inverter_mode(force_export)
+            if not self.inv_has_charge_enable_time and (self.inv_output_charge_control == "current"):
+                if self.inv_charge_control_immediate:
+                    self.enable_charge_discharge_with_time_current("discharge", False)
+
+        # Turn off scheduled discharge
+        if not force_export and old_discharge_enable:
+            self.write_and_poll_switch("scheduled_discharge_enable", self.base.get_arg("scheduled_discharge_enable", indirect=False, index=self.id), False)
+            self.log("Inverter {} Turning off scheduled export".format(self.id))
+
+        self.base.log("Inverter {} Adjust force export to {}, change times from {} - {} to {} - {}".format(self.id, force_export, old_start, old_end, new_start, new_end))
+        changed_start_end = False
+
+        # Some inverters have an idle time setting
+        if force_export:
+            self.adjust_idle_time(discharge_start=new_start, discharge_end=new_end)
+        else:
+            self.adjust_idle_time(discharge_start="00:00:00", discharge_end="00:00:00")
+
+        # Change start time
+        if new_start and new_start != old_start:
+            self.base.log("Inverter {} set new export start time to {}".format(self.id, new_start))
+            if self.rest_data:
+                pass  # REST writes as a single start/end time
+
+            elif "discharge_start_time" in self.base.args:
+                # Always write to this as it is the GE default
+                changed_start_end = True
+                entity_discharge_start_time_id = self.base.get_arg("discharge_start_time", indirect=False, index=self.id)
+                self.write_and_poll_option("discharge_start_time", entity_discharge_start_time_id, new_start)
+
+                if self.inv_charge_time_format == "H M":
+                    # If the inverter uses hours and minutes then write to these entities too
+                    self.write_and_poll_option("discharge_start_hour", self.base.get_arg("discharge_start_hour", indirect=False, index=self.id), int(new_start[:2]))
+                    self.write_and_poll_option("discharge_start_minute", self.base.get_arg("discharge_start_minute", indirect=False, index=self.id), int(new_start[3:5]))
+                elif self.inv_charge_time_format == "H:M-H:M":
+                    # If the inverter uses hours and minutes then write to these entities too
+                    discharge_time = new_start + "-" + new_end
+                    self.write_and_poll_option("discharge_time", self.base.get_arg("discharge_time", indirect=False, index=self.id), discharge_time)
+            else:
+                self.log("Warn: Inverter {} unable write export start time as neither REST or discharge_start_time are set".format(self.id))
+
+        # Change end time
+        if new_end and new_end != old_end:
+            self.base.log("Inverter {} Set new export end time to {} was {}".format(self.id, new_end, old_end))
+            if self.rest_data:
+                pass  # REST writes as a single start/end time
+            elif "discharge_end_time" in self.base.args:
+                # Always write to this as it is the GE default
+                changed_start_end = True
+                entity_discharge_end_time_id = self.base.get_arg("discharge_end_time", indirect=False, index=self.id)
+                self.write_and_poll_option("discharge_end_time", entity_discharge_end_time_id, new_end)
+
+                # If the inverter uses hours and minutes then write to these entities too
+                if self.inv_charge_time_format == "H M":
+                    self.write_and_poll_option("discharge_end_hour", self.base.get_arg("discharge_end_hour", indirect=False, index=self.id), int(new_end[:2]))
+                    self.write_and_poll_option("discharge_end_minute", self.base.get_arg("discharge_end_minute", indirect=False, index=self.id), int(new_end[3:5]))
+                elif self.inv_charge_time_format == "H:M-H:M":
+                    pass
+            else:
+                self.log("Warn: Inverter {} unable write export end time as neither REST or discharge_end_time are set".format(self.id))
+
+        # REST export target, always set to minimum
+        if force_export:
+            if self.rest_data and self.rest_v3:
+                if "raw" in self.rest_data and "invertor" in self.rest_data["raw"] and "discharge_target_soc_1" in self.rest_data["raw"]["invertor"]:
+                    current = self.rest_data["raw"]["invertor"]["discharge_target_soc_1"]
+                    try:
+                        current = float(current)
+                    except (ValueError, TypeError) as e:
+                        current = 0
+
+                    if current > self.reserve_percent:
+                        self.rest_setDischargeTarget(int(self.reserve_percent))
+                    else:
+                        self.log("Inverter {} Current discharge target is already set to {}".format(self.id, current))
+            elif "discharge_target_soc" in self.base.args:
+                current = self.base.get_arg("discharge_target_soc", index=self.id, required_unit="%")
+                try:
+                    current = float(current)
+                except (ValueError, TypeError) as e:
+                    current = 0
+                if current > self.reserve_percent:
+                    self.write_and_poll_value("discharge_target_soc", self.base.get_arg("discharge_target_soc", indirect=False, index=self.id, required_unit="%"), int(self.reserve_percent))
+                else:
+                    self.log("Inverter {} Current discharge target is already set to {}".format(self.id, current))
+
+        # REST version of writing slot
+        if self.rest_data and new_start and new_end and ((new_start != old_start) or (new_end != old_end)):
+            changed_start_end = True
+            self.rest_setDischargeSlot1(new_start, new_end)
+
+        # Change scheduled discharge enable
+        if force_export and not old_discharge_enable:
+            self.write_and_poll_switch("scheduled_discharge_enable", self.base.get_arg("scheduled_discharge_enable", indirect=False, index=self.id), True)
+            self.log("Inverter {} Turning on scheduled export".format(self.id))
+
+        if (new_end != old_end) or (new_start != old_start) or (force_export != old_discharge_enable):
+            if self.inv_time_button_press:
+                self.press_and_poll_button()
+
+        # Force export, turn it on after we change the window
+        if force_export:
+            self.adjust_inverter_mode(force_export, changed_start_end=changed_start_end)
+            if not self.inv_has_charge_enable_time and (self.inv_output_charge_control == "current"):
+                if self.inv_charge_control_immediate:
+                    self.enable_charge_discharge_with_time_current("discharge", True)
+
+        # Notify
+        if changed_start_end:
+            if self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} Export time slot set to {} - {} at time {}".format(self.id, new_start, new_end, self.base.time_now_str()))
+
+    def disable_charge_window(self, notify=True):
+        """
+        Disable charge window
+        """
+        """
+
+        Inverter Class Parameters
+        =========================
+
+            Parameter                          Type          Units
+            ----------                         ----          -----
+            self.charge_enable_time            boole
+
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            scheduled_charge_enable            bool
+            *charge_start_hour                 int
+            *charge_start_minute               int
+            *charge_end_hour                   int
+            *charge_end_minute                 int
+            *charge_discharge_update_button    button
+
+        """
+        if self.rest_data:
+            old_charge_schedule_enable = self.rest_data["Control"]["Enable_Charge_Schedule"]
+        else:
+            old_charge_schedule_enable = self.base.get_arg("scheduled_charge_enable", "on", index=self.id)
+
+        self.adjust_idle_time(charge_start="00:00:00", charge_end="00:00:00")
+
+        if old_charge_schedule_enable == "on" or old_charge_schedule_enable == "enable":
+            # Enable scheduled charge if not turned on
+            if self.rest_data:
+                self.rest_enableChargeSchedule(False)
+            else:
+                self.write_and_poll_switch("scheduled_charge_enable", self.base.get_arg("scheduled_charge_enable", indirect=False, index=self.id), False)
+                # If there's no charge enable switch then we can enable using start and end time
+                if not self.inv_has_charge_enable_time and (self.inv_output_charge_control == "current"):
+                    if self.inv_charge_control_immediate:
+                        self.enable_charge_discharge_with_time_current("charge", False)
+
+            if self.base.set_inverter_notify and notify:
+                self.base.call_notify("Predbat: Inverter {} Disabled scheduled charging at {}".format(self.id, self.base.time_now_str()))
+
+            self.base.log("Inverter {} Turning off scheduled charge".format(self.id))
+
+            # Reset charge window to midnight if there is no charge enable time
+            if not self.inv_has_charge_enable_time:
+                self.adjust_charge_window(self.base.midnight_utc, self.base.midnight_utc, self.base.minutes_now)
+            else:
+                # Press button if needed
+                if self.inv_time_button_press:
+                    self.press_and_poll_button()
+
+        # Updated cached status to disabled
+        # Don't do it if notify is not set as this is just a temporary call when setting the charge window
+        if notify:
+            self.charge_enable_time = False
+            self.charge_start_time_minutes = self.base.forecast_minutes
+            self.charge_end_time_minutes = self.base.forecast_minutes
+
+    def alt_charge_discharge_enable(self, direction, enable):
+        """
+        Alternative enable and disable of timed charging for non-GE inverters
+        """
+
+        current_rate_charge = self.get_current_charge_rate()
+        current_rate_discharge = self.get_current_discharge_rate()
+
+        if self.inverter_type == "GS":
+            # Solis just has a single switch for both directions
+            # Need to check the logic of how this is called if both charging and exporting
+
+            solax_modes = SOLAX_SOLIS_MODES_NEW if self.base.get_arg("solax_modbus_new", True) else SOLAX_SOLIS_MODES
+
+            entity_id = self.base.get_arg("energy_control_switch", indirect=False, index=self.id)
+            switch = solax_modes.get(self.base.get_state_wrapper(entity_id), 0)
+
+            if direction == "charge":
+                if enable:
+                    new_switch = 35
+                else:
+                    new_switch = 33
+            elif direction == "discharge":
+                if enable:
+                    new_switch = 35
+                else:
+                    new_switch = 33
+            else:
+                # ECO
+                new_switch = 35
+
+            # Find mode names
+            old_mode = {solax_modes[x]: x for x in solax_modes}[switch]
+            new_mode = {solax_modes[x]: x for x in solax_modes}[new_switch]
+
+            if new_switch != switch:
+                self.base.log(f"Setting Solis Energy Control Switch to {new_switch} {new_mode} from {switch} {old_mode} for {direction} {enable}")
+                self.write_and_poll_option(name=entity_id, entity_id=entity_id, new_value=new_mode)
+            else:
+                self.base.log(f"Solis Energy Control Switch setting {switch} {new_mode} unchanged for {direction} {enable}")
+
+        # MQTT
+        if direction == "charge" and enable:
+            self.mqtt_message("set/charge", payload=int(current_rate_charge))
+        elif direction == "discharge" and enable:
+            self.mqtt_message("set/discharge", payload=int(current_rate_discharge))
+        elif current_rate_discharge == 0:
+            # Model disable discharge in eco mode with force discharge at rate 0
+            self.mqtt_message("set/discharge", payload=int(current_rate_discharge))
+        else:
+            self.mqtt_message("set/auto", payload="true")
+
+    def mqtt_message(self, topic, payload):
+        """
+        Send an MQTT message via service
+        """
+        if self.inv_has_mqtt_api:
+            self.base.call_service_wrapper("mqtt/publish", qos=1, retain=True, topic=(self.inv_mqtt_topic + "/" + topic), payload=payload)
+
+    def enable_charge_discharge_with_time_current(self, direction, enable):
+        """
+        Enable or disable timed charge/discharge
+        """
+        # To enable we set the current based on the required power
+        if enable:
+            power = self.base.get_arg(f"{direction}_rate", index=self.id, default=2600.0)
+            self.set_current_from_power(direction, power)
+        else:
+            if self.inv_charge_time_format == "H M":
+                # To disable we set both times to 00:00
+                for x in ["start", "end"]:
+                    for y in ["hour", "minute"]:
+                        name = f"{direction}_{x}_{y}"
+                        self.write_and_poll_value(name, self.base.get_arg(name, indirect=False, index=self.id), 0)
+            elif self.inv_charge_time_format == "H:M-H:M":
+                # To disable we set both times to 00:00
+                name = f"{direction}_time"
+                self.write_and_poll_value(name, self.base.get_arg(name, indirect=False, index=self.id), "00:00-00:00")
+            else:
+                self.set_current_from_power(direction, 0)
+
+    def set_current_from_power(self, direction, power):
+        """
+        Set the timed charge/discharge current setting by converting power to current
+        """
+        new_current = round(power / self.battery_voltage, self.inv_current_dp)
+        self.write_and_poll_value(f"timed_{direction}_current", self.base.get_arg(f"timed_{direction}_current", indirect=False, index=self.id), new_current, fuzzy=1)
+
+    def call_service_template(self, service, data, domain="charge", extra_data={}):
+        """
+        Call a service template with data
+        """
+        service_list = self.base.args.get(service, "")
+        if not service_list:
+            return False
+
+        if not isinstance(service_list, list):
+            service_list = [service_list]
+
+        hash_index = domain
+        last_service_hash = self.base.last_service_hash.get(hash_index, "")
+        this_service_hash = hash(str(service) + "_" + str(data) + "_" + str(extra_data))
+
+        if last_service_hash == this_service_hash:
+            service_repeat = True
+        else:
+            # Record the last service called
+            self.base.last_service_hash[hash_index] = this_service_hash
+            service_repeat = False
+
+        for service_template in service_list:
+            service_data = {}
+            service_name = ""
+            service_always = False
+
+            if isinstance(service_template, str):
+                service_name = service_template
+                service_data = data
+            else:
+                full_data = {}
+                full_data.update(data)
+                full_data.update(extra_data)
+
+                for key in service_template:
+                    if key == "service":
+                        service_name = service_template[key]
+                    elif key in ["always", "repeat"]:
+                        service_always = service_template[key]
+                    else:
+                        value = service_template[key]
+                        use_index = None
+                        if isinstance(value, list):
+                            use_index = self.id
+                        value = self.base.resolve_arg(service_template, value, indirect=False, index=use_index, default="", extra_args=full_data)
+                        if value:
+                            service_data[key] = value
+
+            if service_name and service_repeat and not service_always:
+                self.log("Inverter {} Skipped service {} domain {} service_name {} as it was previously called.".format(self.id, service, domain, service_name))
+            elif service_name:
+                service_name = service_name.replace(".", "/")
+                self.log("Inverter {} Calling service {} domain {} service_name {} with data {}".format(self.id, service, domain, service_name, service_data))
+                self.base.call_service_wrapper(service_name, **service_data)
+            else:
+                self.log("Warn: Inverter {} unable to find service name for {}".format(self.id, service))
+
+        return True
+
+    def adjust_charge_immediate(self, target_soc, freeze=False):
+        """
+        Adjust from charging or not charging based on passed target soc
+        """
+        service_data_stop = {"device_id": self.base.get_arg("device_id", index=self.id, default="")}
+        extra_data = {"charge_start_time": self.base.get_arg("charge_start_time", index=self.id, default="00:00:00"), "charge_end_time": self.base.get_arg("charge_end_time", index=self.id, default="00:00:00")}
+        if target_soc > 0:
+            current_rate = self.get_current_charge_rate()
+            service_data = {
+                "device_id": self.base.get_arg("device_id", index=self.id, default=""),
+                "target_soc": target_soc,
+                "power": int(current_rate),
+            }
+
+            # Stop discharge
+            if not self.call_service_template("discharge_stop_service", service_data_stop, domain="discharge"):
+                self.call_service_template("charge_stop_service", service_data_stop, domain="discharge")
+
+            # Start charge or charge freeze
+            if target_soc == self.soc_percent or freeze:
+                if not self.call_service_template("charge_freeze_service", service_data, domain="charge", extra_data=extra_data):
+                    self.call_service_template("charge_start_service", service_data, domain="charge", extra_data=extra_data)
+            elif not self.inv_has_target_soc and target_soc < self.soc_percent:
+                self.call_service_template("charge_stop_service", service_data_stop, domain="charge")
+            else:
+                self.call_service_template("charge_start_service", service_data, domain="charge", extra_data=extra_data)
+        else:
+            self.call_service_template("charge_stop_service", service_data_stop, domain="charge")
+
+    def adjust_export_immediate(self, target_soc, freeze=False):
+        """
+        Adjust from exporting or not exporting based on passed target soc
+        """
+        service_data_stop = {"device_id": self.base.get_arg("device_id", index=self.id, default="")}
+        extra_data = {"discharge_start_time": self.base.get_arg("discharge_start_time", index=self.id, default="00:00:00"), "discharge_end_time": self.base.get_arg("discharge_end_time", index=self.id, default="00:00:00")}
+        if target_soc < 100:
+            service_data = {
+                "device_id": self.base.get_arg("device_id", index=self.id, default=""),
+                "target_soc": target_soc,
+                "power": int(self.battery_rate_max_discharge * MINUTE_WATT),
+            }
+
+            # Stop charge
+            self.call_service_template("charge_stop_service", service_data_stop, domain="charge")
+
+            # Start discharge or discharge freeze
+            if target_soc == self.soc_percent or freeze:
+                if not self.call_service_template("discharge_freeze_service", service_data, domain="discharge", extra_data=extra_data):
+                    self.call_service_template("discharge_start_service", service_data, domain="discharge", extra_data=extra_data)
+            elif target_soc > self.soc_percent:
+                self.call_service_template("discharge_stop_service", service_data_stop, domain="discharge")
+            else:
+                self.call_service_template("discharge_start_service", service_data, domain="discharge", extra_data=extra_data)
+        else:
+            if not self.call_service_template("discharge_stop_service", service_data_stop, domain="discharge"):
+                self.call_service_template("charge_stop_service", service_data_stop, domain="discharge")
+
+    def adjust_charge_window(self, charge_start_time, charge_end_time, minutes_now):
+        """
+        Adjust the charging window times (start and end) in GivTCP
+
+        Inverter Class Parameters
+        =========================
+
+            Parameter                          Type          Units
+            ----------                         ----          -----
+            self.charge_enable_time            boole
+
+
+        Output Entities:
+        ================
+
+            Config arg                         Type          Units
+            ----------                         ----          -----
+            scheduled_charge_enable            bool
+            charge_start_time                  string
+            charge_end_time                    string
+            *charge_start_hour                 int
+            *charge_start_minute               int
+            *charge_end_hour                   int
+            *charge_end_minute                 int
+            *charge_discharge_update_button    button
+
+        """
+
+        if self.rest_data:
+            old_start = self.rest_data["Timeslots"]["Charge_start_time_slot_1"]
+            old_end = self.rest_data["Timeslots"]["Charge_end_time_slot_1"]
+            old_charge_schedule_enable = self.rest_data["Control"]["Enable_Charge_Schedule"]
+        elif "charge_start_time" in self.base.args:
+            old_start = self.base.get_arg("charge_start_time", index=self.id)
+            old_end = self.base.get_arg("charge_end_time", index=self.id)
+            if old_start is None:
+                old_start = "00:00:00"
+            if old_end is None:
+                old_end = "00:00:00"
+            if len(old_start) == 5:
+                old_start += ":00"
+            if len(old_end) == 5:
+                old_end += ":00"
+            old_charge_schedule_enable = self.base.get_arg("scheduled_charge_enable", "on", index=self.id)
+        else:
+            self.log("Warn: Inverter {} unable read charge window as neither REST or discharge_start_time".format(self.id))
+            old_charge_schedule_enable = "off"
+
+        # Normalize old charge schedule enable
+        if old_charge_schedule_enable in ["off", "disable"]:
+            old_charge_schedule_enable = "off"
+
+        # Store the new start/end minutes using helper to handle midnight-spanning windows
+        self.charge_start_time_minutes, self.charge_end_time_minutes = compute_window_minutes(charge_start_time, charge_end_time, minutes_now)
+
+        # Apply clock skew
+        charge_start_time += timedelta(seconds=self.base.inverter_clock_skew_start * 60)
+        charge_end_time += timedelta(seconds=self.base.inverter_clock_skew_end * 60)
+
+        # Convert to string
+        new_start = charge_start_time.strftime(TIME_FORMAT_HMS)
+        new_end = charge_end_time.strftime(TIME_FORMAT_HMS)
+
+        # Disable scheduled charge during change of window to avoid a blip in charging if not required
+        have_disabled = False
+
+        # If we are in the new window no need to disable
+        if minutes_now >= self.charge_start_time_minutes and minutes_now < self.charge_end_time_minutes:
+            in_new_window = True
+        else:
+            in_new_window = False
+
+        # Some inverters have an idle time setting
+        self.adjust_idle_time(charge_start=new_start, charge_end=new_end)
+
+        # Disable charging if required, for REST no need as we change start and end together anyhow
+        if not in_new_window and not self.rest_data and ((new_start != old_start) or (new_end != old_end)) and self.inv_has_charge_enable_time:
+            self.disable_charge_window(notify=False)
+            have_disabled = True
+
+        if new_start != old_start or (self.inv_charge_time_format in ["H M", "H:M-H:M"]):
+            if self.rest_data:
+                pass  # REST will be written as start/end together
+            elif "charge_start_time" in self.base.args:
+                # Always write to this as it is the GE default
+                entity_id_start = self.base.get_arg("charge_start_time", indirect=False, index=self.id)
+                self.write_and_poll_option("charge_start_time", entity_id_start, new_start)
+
+                if self.inv_charge_time_format == "H M":
+                    # If the inverter uses hours and minutes then write to these entities too
+                    self.write_and_poll_option("charge_start_hour", self.base.get_arg("charge_start_hour", indirect=False, index=self.id), int(new_start[:2]))
+                    self.write_and_poll_option("charge_start_minute", self.base.get_arg("charge_start_minute", indirect=False, index=self.id), int(new_start[3:5]))
+                elif self.inv_charge_time_format == "H:M-H:M":
+                    # If the inverter uses hours and minutes then write to these entities too
+                    charge_time = new_start + "-" + new_end
+                    self.write_and_poll_option("charge_time", self.base.get_arg("charge_time", indirect=False, index=self.id), charge_time)
+            else:
+                self.log("Warn: Inverter {} unable write charge window start as neither REST or charge_start_time are set".format(self.id))
+
+        # Program end slot
+        if new_end != old_end or (self.inv_charge_time_format in ["H M", "H:M-H:M"]):
+            if self.rest_data:
+                pass  # REST will be written as start/end together
+            elif "charge_end_time" in self.base.args:
+                # Always write to this as it is the GE default
+                entity_id_end = self.base.get_arg("charge_end_time", indirect=False, index=self.id)
+                self.write_and_poll_option("charge_end_time", entity_id_end, new_end)
+
+                if self.inv_charge_time_format == "H M":
+                    self.write_and_poll_option("charge_end_hour", self.base.get_arg("charge_end_hour", indirect=False, index=self.id), int(new_end[:2]))
+                    self.write_and_poll_option("charge_end_minute", self.base.get_arg("charge_end_minute", indirect=False, index=self.id), int(new_end[3:5]))
+                elif self.inv_charge_time_format == "H:M-H:M":
+                    pass
+            else:
+                self.log("Warn: Inverter {} unable write charge window end as neither REST, charge_end_hour or charge_end_time are set".format(self.id))
+
+        if new_start != old_start or new_end != old_end or (self.inv_charge_time_format in ["H M", "H:M-H:M"]):
+            if self.rest_data:
+                self.rest_setChargeSlot1(new_start, new_end)
+
+            if self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} Charge window change to: {} - {} at {}".format(self.id, new_start, new_end, self.base.time_now_str()))
+            self.base.log("Inverter {} Updated start and end charge window to {} - {} (old {} - {})".format(self.id, new_start, new_end, old_start, old_end))
+
+        if (old_charge_schedule_enable == "off" or have_disabled) and (new_start != new_end):
+            # Enable scheduled charge if not turned on, unless the start and end are the same (disabled)
+            if self.rest_data:
+                self.rest_enableChargeSchedule(True)
+            elif "scheduled_charge_enable" in self.base.args:
+                self.write_and_poll_switch("scheduled_charge_enable", self.base.get_arg("scheduled_charge_enable", indirect=False, index=self.id), True)
+                if not self.inv_has_charge_enable_time and (self.inv_output_charge_control == "current"):
+                    if self.inv_charge_control_immediate:
+                        self.enable_charge_discharge_with_time_current("charge", True)
+            else:
+                self.log("Warn: Inverter {} unable write charge window enable as neither REST or scheduled_charge_enable are set".format(self.id))
+
+            # Only notify if it's a real change and not a temporary one
+            if old_charge_schedule_enable == "off" and self.base.set_inverter_notify:
+                self.base.call_notify("Predbat: Inverter {} Enabling scheduled charging at {}".format(self.id, self.base.time_now_str()))
+
+            self.charge_enable_time = True
+
+            if old_charge_schedule_enable == "off":
+                self.base.log("Inverter {} Turning on scheduled charge".format(self.id))
+
+        if (new_start != old_start) or (new_end != old_end) or (old_charge_schedule_enable == "off"):
+            # For Solis inverters and fox we also have to press the update_charge_discharge button to send the times to the inverter
+            if self.inv_time_button_press:
+                self.press_and_poll_button()
+
+    def press_and_poll_button(self):
+        """
+        Press charge/discharge update button(s) for the inverter.
+        Priority:
+        1. charge_discharge_update_button
+        2. charge_update_button and discharge_update_button
+        """
+        success = True
+
+        entity_id_schedule_write_button = self.base.get_arg("schedule_write_button", indirect=False, index=self.id)
+        entity_id_charge_discharge_updated_button = self.base.get_arg("charge_discharge_update_button", indirect=False, index=self.id)
+
+        # Try single combined button first
+        if entity_id_schedule_write_button:
+            success = self._press_single_toggle_button(entity_id_schedule_write_button)
+        elif entity_id_charge_discharge_updated_button:
+            success = self._press_single_button_and_poll(entity_id_charge_discharge_updated_button)
+        else:
+            # Try separate charge and discharge buttons
+            charge_button = self.base.get_arg("charge_update_button", indirect=False, index=self.id)
+            discharge_button = self.base.get_arg("discharge_update_button", indirect=False, index=self.id)
+
+            if charge_button:
+                if not self._press_single_button_and_poll(charge_button):
+                    success = False
+
+            if discharge_button:
+                if not self._press_single_button_and_poll(discharge_button):
+                    success = False
+
+        return success
+
+    def _press_single_toggle_button(self, entity_id):
+        """
+        This is just a switch we can toggle to on, it will turn off again automatically.
+        """
+        self.base.call_service_wrapper("switch/turn_on", entity_id=entity_id)
+        self.log(f"Pressed toggle button {entity_id} on Inverter {self.id}")
+        return True
+
+    def _press_single_button_and_poll(self, entity_id):
+        """
+        Press a button and verify that its last_updated time changes.
+        Returns True on success.
+        """
+        local_tz = pytz.timezone(self.base.get_arg("timezone", "Europe/London"))
+
+        for retry in range(INVERTER_MAX_RETRY):
+            self.base.call_service_wrapper("button/press", entity_id=entity_id)
+            self.sleep(self.inv_write_and_poll_sleep)
+            state = self.base.get_state_wrapper(entity_id, refresh=True)
+            try:
+                time_pressed = datetime.strptime(state, TIME_FORMAT_SECONDS)
+            except Exception as e:
+                self.base.log(f"Error parsing timestamp for {entity_id}: {e}")
+                continue
+
+            now_local = datetime.now(local_tz)
+            if (now_local - time_pressed).seconds < 10:
+                self.base.log(f"Successfully pressed button {entity_id} on Inverter {self.id}")
+                return True
+
+        self.base.log(f"Warn: Inverter {self.id} Trying to press {entity_id} didn't complete")
+        self.base.record_status(f"Warn: Inverter {self.id} Trying to press {entity_id} didn't complete", had_errors=True)
+        return False
+
+    def rest_readData(self, api="readData", retry=True):
+        """
+        Get inverter status
+
+        :param api: The API endpoint to retrieve data from (default is "readData")
+        :retry: if the REST GET fails then should the GET be retried? (default is True)
+        :return: The JSON response containing the inverter status, or None if there was an error
+        """
+        url = self.rest_api + "/" + api
+
+        # repeatedly try to get inverter data via REST, sleeping after each failed attempt to enable GivTCP to re-get the data
+        for loop in range(INVERTER_MAX_RETRY_REST):
+            json = self.rest_getData(url)
+
+            if json:
+                if "Control" in json:
+                    if loop == 0:
+                        self.base.log("Inverter {} REST GET {} successful".format(self.id, url))
+                    else:
+                        self.base.log("Info: Inverter {} REST GET {} successful on retry {}".format(self.id, url, loop))
+                    return json
+
+            # if retry = False then don't retry further GET calls
+            if not retry:
+                break
+
+            # firstly retry after a short delay to allow the REST endpoint to get the data, then try longer delays
+            if loop == 0:
+                delay = 20
+            else:
+                delay = 40
+
+            self.base.log('Warn: inverter {} didn\'t receive JSON response from REST GET {}, received "{}". Waiting {}s then retrying'.format(self.id, url, json, delay))
+            self.sleep(delay)
+
+        # Exhausted retry attempts, fail REST GET and fallback to using HA entities (if they have been configured in apps.yaml)
+        self.base.log("Warn: Inverter {} unable to read REST data from {} - REST will be skipped for this run".format(self.id, url))
+        self.base.record_status("Inverter {} unable to read REST data from {} - REST will be skipped".format(self.id, url), had_errors=True)
+        return None
+
+    def rest_runAll(self, old_data=None):
+        """
+        Updated and get inverter status
+        """
+        new_data = self.rest_readData(api="runAll", retry=False)
+        if new_data:
+            return new_data
+        else:
+            return old_data
+
+    def rest_postCommand(self, url, json):
+        """
+        Send REST Command
+        """
+        r = requests.post(url, json=json)
+
+    def rest_getData(self, url):
+        """
+        Get REST Data
+        """
+        r = None
+
+        try:
+            r = requests.get(url)
+        except Exception as e:
+            self.base.log("Error: Exception raised {}".format(e))
+
+        if r and (r.status_code == 200):
+            return r.json()
+        else:
+            return None
+
+    def rest_setChargeTarget(self, target):
+        """
+        Configure charge target % via REST
+        """
+        target = int(target)
+        url = self.rest_api + "/setChargeTarget"
+        data = {"chargeToPercent": target}
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            if float(self.rest_data["Control"]["Target_SOC"]) == target:
+                self.count_register_writes += 1
+                self.base.log("Inverter {} charge target {} via REST successful on retry {}".format(self.id, target, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Inverter {} charge target {} via REST failed".format(self.id, target))
+        self.base.record_status("Warn: Inverter {} REST failed to setChargeTarget".format(self.id), had_errors=True)
+        return False
+
+    def rest_setChargeRate(self, rate):
+        """
+        Configure charge target % via REST
+        """
+        rate = int(rate)
+        url = self.rest_api + "/setChargeRate"
+        data = {"chargeRate": rate}
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            new = int(self.rest_data["Control"]["Battery_Charge_Rate"])
+            if abs(new - rate) < (self.battery_rate_max_charge * MINUTE_WATT / 12):
+                self.count_register_writes += 1
+                self.base.log("Inverter {} set charge rate {} via REST successful on retry {}".format(self.id, rate, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Inverter {} set charge rate {} via REST failed got {}".format(self.id, rate, self.rest_data["Control"]["Battery_Charge_Rate"]))
+        self.base.record_status("Warn: Inverter {} REST failed to setChargeRate".format(self.id), had_errors=True)
+        return False
+
+    def rest_setDischargeRate(self, rate):
+        """
+        Configure charge target % via REST
+        """
+        rate = int(rate)
+        url = self.rest_api + "/setDischargeRate"
+        data = {"dischargeRate": rate}
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            new = int(self.rest_data["Control"]["Battery_Discharge_Rate"])
+            if abs(new - rate) < (self.battery_rate_max_discharge * MINUTE_WATT / 25):
+                self.count_register_writes += 1
+                self.base.log("Inverter {} set discharge rate {} via REST successful on retry {}".format(self.id, rate, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Inverter {} set discharge rate {} via REST failed got {}".format(self.id, rate, self.rest_data["Control"]["Battery_Discharge_Rate"]))
+        self.base.record_status("Warn: Inverter {} REST failed to setDischargeRate to {} got {}".format(self.id, rate, self.rest_data["Control"]["Battery_Discharge_Rate"]), had_errors=True)
+        return False
+
+    def rest_setBatteryMode(self, inverter_mode):
+        """
+        Configure invert mode via REST
+        """
+        url = self.rest_api + "/setBatteryMode"
+        data = {"mode": inverter_mode}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            if inverter_mode == self.rest_data["Control"]["Mode"]:
+                self.count_register_writes += 1
+                self.base.log("Set inverter {} mode {} via REST successful on retry {}".format(self.id, inverter_mode, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Set inverter {} mode {} via REST failed".format(self.id, inverter_mode))
+        self.base.record_status("Warn: Inverter {} REST failed to setBatteryMode".format(self.id), had_errors=True)
+        return False
+
+    def rest_setBatteryPauseMode(self, pause_mode):
+        """
+        Configure inverter pause mode via REST - v3.x+
+        """
+        url = self.rest_api + "/setBatteryPauseMode"
+        data = {"state": pause_mode}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            if pause_mode == self.rest_data["Control"]["Battery_pause_mode"]:
+                self.count_register_writes += 1
+                self.base.log("Set inverter {} pause mode {} via REST successful on retry {}".format(self.id, pause_mode, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Set inverter {} pause mode {} via REST failed".format(self.id, pause_mode))
+        self.base.record_status("Warn: Inverter {} REST failed to setBatteryPauseMode got {}".format(self.id, self.rest_data["Control"]["Battery_pause_mode"]), had_errors=True)
+        return False
+
+    def rest_setReserve(self, target):
+        """
+        Configure reserve % via REST
+        """
+        target = int(target)
+        result = target
+        url = self.rest_api + "/setBatteryReserve"
+        data = {"reservePercent": target}
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            result = int(float(self.rest_data["Control"]["Battery_Power_Reserve"]))
+            if result == target:
+                self.count_register_writes += 1
+                self.base.log("Set inverter {} reserve {} via REST successful on retry {}".format(self.id, target, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Set inverter {} reserve {} via REST failed on retry {} got {}".format(self.id, target, retry, result))
+        self.base.record_status("Warn: Inverter {} REST failed to setReserve to {} got {}".format(self.id, target, result), had_errors=True)
+        return False
+
+    def rest_enableChargeSchedule(self, enable):
+        """
+        Configure enable charge schedule via REST
+        """
+        url = self.rest_api + "/enableChargeSchedule"
+        data = {"state": "enable" if enable else "disable"}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            new_value = self.rest_data["Control"]["Enable_Charge_Schedule"]
+            if isinstance(new_value, str):
+                if new_value.lower() in ["enable", "on", "true"]:
+                    new_value = True
+                else:
+                    new_value = False
+            if new_value == enable:
+                self.count_register_writes += 1
+                self.base.log("Set inverter {} charge schedule {} via REST successful on retry {}".format(self.id, enable, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Set inverter {} charge schedule {} via REST failed got {}".format(self.id, enable, self.rest_data["Control"]["Enable_Charge_Schedule"]))
+        self.base.record_status("Warn: Inverter {} REST failed to enableChargeSchedule".format(self.id), had_errors=True)
+        return False
+
+    def rest_enableDischargeSchedule(self, enable):
+        """
+        Configure enable discharge schedule via REST (V3.x+)
+        """
+        url = self.rest_api + "/enableDischargeSchedule"
+        data = {"state": "enable" if enable else "disable"}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            new_value = self.rest_data["Control"]["Enable_Discharge_Schedule"]
+            if isinstance(new_value, str):
+                if new_value.lower() in ["enable", "on", "true"]:
+                    new_value = True
+                else:
+                    new_value = False
+            if new_value == enable:
+                self.count_register_writes += 1
+                self.base.log("Set inverter {} discharge schedule {} via REST successful on retry {}".format(self.id, enable, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Set inverter {} discharge schedule {} via REST failed got {}".format(self.id, enable, self.rest_data["Control"]["Enable_Discharge_Schedule"]))
+        self.base.record_status("Warn: Inverter {} REST failed to enableDischargeSchedule".format(self.id), had_errors=True)
+        return False
+
+    def rest_setPauseSlot(self, start, finish):
+        """
+        Configure pause slot via REST - v3.x+
+        """
+        url = self.rest_api + "/setPauseSlot"
+        data = {"start": start[:5], "finish": finish[:5]}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            if self.rest_data["Timeslots"]["Battery_pause_start_time_slot"] == start and self.rest_data["Timeslots"]["Battery_pause_end_time_slot"] == finish:
+                self.count_register_writes += 1
+                self.base.log("Inverter {} set pause slot {} via REST successful after retry {}".format(self.id, data, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Inverter {} set pause slot {} via REST failed".format(self.id, data))
+        self.base.record_status("Warn: Inverter {} REST failed to setPauseSlot".format(self.id), had_errors=True)
+        return False
+
+    def rest_setChargeSlot1(self, start, finish):
+        """
+        Configure charge slot via REST
+        """
+        url = self.rest_api + "/setChargeSlot1"
+        data = {"start": start[:5], "finish": finish[:5]}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            if self.rest_data["Timeslots"]["Charge_start_time_slot_1"] == start and self.rest_data["Timeslots"]["Charge_end_time_slot_1"] == finish:
+                self.count_register_writes += 1
+                self.base.log("Inverter {} set charge slot 1 {} via REST successful after retry {}".format(self.id, data, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Inverter {} set charge slot 1 {} via REST failed".format(self.id, data))
+        self.base.record_status("Warn: Inverter {} REST failed to setChargeSlot1".format(self.id), had_errors=True)
+        return False
+
+    def rest_setDischargeTarget(self, target):
+        """
+        Configure discharge to percent via REST
+        """
+        target = int(target)
+        url = self.rest_api + "/setDischargeTarget"
+        data = {"dischargeToPercent": target, "slot": 1}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            if self.rest_data["raw"]["invertor"]["discharge_target_soc_1"] == target:
+                self.count_register_writes += 1
+                self.base.log("Inverter {} Set export target slot 1 {} via REST successful after retry {}".format(self.id, data, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Inverter {} Set export target slot 1 {} via REST failed".format(self.id, data))
+        self.base.record_status("Warn: Inverter {} REST failed to setExportTarget".format(self.id), had_errors=True)
+        return False
+
+    def rest_setDischargeSlot1(self, start, finish):
+        """
+        Configure charge slot via REST
+        """
+        url = self.rest_api + "/setDischargeSlot1"
+        data = {"start": start[:5], "finish": finish[:5]}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            if self.rest_data["Timeslots"]["Discharge_start_time_slot_1"] == start and self.rest_data["Timeslots"]["Discharge_end_time_slot_1"] == finish:
+                self.count_register_writes += 1
+                self.base.log("Inverter {} Set discharge slot 1 {} via REST successful after retry {}".format(self.id, data, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Inverter {} Set discharge slot 1 {} via REST failed".format(self.id, data))
+        self.base.record_status("Warn: Inverter {} REST failed to setDischargeSlot1".format(self.id), had_errors=True)
+        return False

--- a/luxpower.yaml
+++ b/luxpower.yaml
@@ -1,0 +1,441 @@
+# ------------------------------------------------------------------
+# This is an example configuration, please modify it
+# ------------------------------------------------------------------
+---
+pred_bat:
+  module: predbat
+  class: PredBat
+
+  # Sets the prefix for all created entities in HA - only change if you want to run more than once instance
+  prefix: predbat
+
+  # Timezone to work in
+  timezone: Europe/London
+
+  # XXX: Template - You must delete the following line once you have configured your inverter
+  template: True
+
+  # Currency, symbol for main currency second symbol for 1/100s e.g. $ c or £ p or e c
+  currency_symbols:
+   - '£'
+   - 'p'
+
+  # Number of threads to use in plan calculation
+  # Can be auto for automatic, 0 for off or values 1-N for a fixed number
+  threads: auto
+
+  # If you are using Predbat outside of HA then set the HA URL and Key (long lived access token here)
+  #ha_url: 'http://homeassistant.local:8123'
+  #ha_key: 'xxx'
+
+  # Sets the maximum period of zero load before the gap is filled, default 30 minutes
+  # To disable set it to 1440
+  load_filter_threshold: 30
+
+  #
+  # Sensors, more than one can be specified and they will be summed up automatically
+  #
+  # For two inverters the load today would normally be the master load sensor only (to cover the entire house)
+  # If you have three phase and one inverter per phase then you would need three load sensors
+  #
+  # For pv_today if you have multiple solar inverter inputs then you should include one entry for each inverter
+  #
+  load_today:
+    - sensor.lux_home_consumption_daily
+  import_today:
+    - sensor.lux_power_from_grid_daily
+  export_today:
+    - sensor.lux_power_to_grid_daily
+  pv_today:
+    - sensor.lux_solar_output_daily
+
+  # Load forecast can be used to add to the historical load data (heat-pump)
+  # To link to Predheat
+  # Data must be in the format of 'last_updated' timestamp and 'energy' for incrementing kWh
+  #load_forecast:
+  #  - predheat.heat_energy$external
+
+  # Controls/status - must by 1 per inverter
+  num_inverters: 1
+  inverter_type: LuxPower
+  inverter:
+    name: "LuxPower"
+    has_rest_api: False
+    has_mqtt_api: False
+    has_service_api: True
+    output_charge_control: "current"
+    current_dp: 0
+    has_charge_enable_time: True
+    has_discharge_enable_time: True
+    has_target_soc: True
+    has_reserve_soc: False
+    has_timed_pause: False
+    charge_time_format: "HH:MM:SS"
+    charge_time_entity_is_option: False
+    soc_units: "%"
+    num_load_entities: 1
+    has_ge_inverter_mode: False
+    time_button_press: False
+    clock_time_format: "%Y-%m-%d %H:%M:%S"
+    write_and_poll_sleep: 10
+    has_time_window: False
+    # If you want to enable Freeze charging, change support_charge_freeze and maintain_freeze_charge_status from False to True
+    support_charge_freeze: False
+    maintain_freeze_charge_status: False
+    # if you have a LuxPower inverter with the 'Charge Last' feature you can take advantage of Freeze exporting change support_discharge_freeze to True
+    support_discharge_freeze: False
+  charge_start_service:
+    - service: switch.turn_on
+      entity_id: "switch.lux_ac_charge_enable"
+  # To enable Freeze charging uncomment the next 3 lines
+  # charge_freeze_service:
+  #   - service: automation.turn_on
+  #     entity_id: "automation.luxpower_freeze_charge"
+  charge_stop_service:
+    - service: switch.turn_off
+      entity_id: "switch.lux_ac_charge_enable"
+  discharge_start_service:
+    - service: switch.turn_on
+      entity_id: "switch.lux_force_discharge_enable"
+  discharge_stop_service:
+    - service: switch.turn_off
+      entity_id: "switch.lux_force_discharge_enable"
+  # if you have a LuxPower inverter with the 'Charge Last' feature you can take advantage of Freeze exporting by uncommenting the following five lines
+  # - service: switch.turn_off
+  #   entity_id: "switch.lux_charge_last"
+  # discharge_freeze_service:
+  #   - service: switch.turn_on
+  #     entity_id: "switch.lux_charge_last"
+
+  # Run balance inverters every N seconds (0=disabled) - only for multi-inverter
+  # balance_inverters_seconds: 60
+
+  timed_charge_current:
+    - number.lux_charge_current_limit
+  timed_discharge_current:
+    - number.lux_discharge_current_limit
+  battery_power:
+    - sensor.lux_battery_discharge_live
+  pv_power:
+    - sensor.lux_solar_output_live
+  load_power:
+    - sensor.lux_home_consumption_live
+  soc_percent:
+    - sensor.lux_battery_soc_corrected  # This is a custom template sensor - see LuxPower section of 'Inverter Setup' documentation for how to create
+  soc_max:
+    - sensor.lux_soc_max_kwh  # Custom template sensor - see LuxPower inverter setup for details
+  battery_rate_max:
+    - input_number.battery_rate_max # See the LuxPower setup documentation for details of how to configure this. 
+  battery_min_soc:
+    - number.lux_on_grid_discharge_cut_off_soc
+  battery_voltage:
+    - sensor.lux_battery_voltage_live
+  scheduled_charge_enable:
+    - switch.lux_ac_charge_enable
+  charge_start_time:
+    - time.lux_ac_charge_start1
+  charge_end_time:
+    - time.lux_ac_charge_end1
+  charge_limit:
+    - number.lux_ac_battery_charge_level
+  scheduled_discharge_enable:
+    - switch.lux_force_discharge_enable
+  discharge_start_time:
+    - time.lux_force_discharge_start1
+  discharge_end_time:
+    - time.lux_force_discharge_end1
+  discharge_target_soc:
+    - number.lux_forced_discharge_battery_level
+
+  # Inverter max AC limit (one per inverter). E.g for a 3.6kw inverter set to 3600
+  # If you have a second inverter for PV only please add the two values together
+  inverter_limit:
+    - 7500
+
+  # Export limit is a software limit set on your inverter that prevents exporting above a given level
+  # When enabled Predbat will model this limit
+  #export_limit:
+  # - 3600
+  # - 3600
+
+  # Some inverters don't turn off when the rate is set to 0, still charge or discharge at around 200w
+  # The value can be set here in watts to model this (doesn't change operation)
+  #inverter_battery_rate_min:
+  #  - 200
+
+  # Workaround to limit the maximum reserve setting, some inverters won't allow 100% to be set
+  # Comment out if your inverter allows 100%
+  # inverter_reserve_max : 98
+
+  # Some batteries tail off their charge rate at high soc%
+  # enter the charging curve here as a % of the max charge rate for each soc percentage.
+  # the default is 1.0 (full power)
+  #
+  # Predbat can compute this curve automatically if you have enough data, restart the add-on and look in the logfile for the data
+  # once set here Predbat will no longer re-compute the curve.
+  # Can also be set to 'auto' to just use the calculation curve, not recommended if you are using low power charging mode.
+  #
+  # uncomment the following charge_rate and discharge_rate lines if you want Predbat to create the charge curves for you
+  # charge_rate:
+  #   - number.lux_target_charge_current_w
+  # discharge_rate:
+  #   - number.lux_target_discharge_current_w
+  #
+  # Example curves from Hanchu batteries with Luxpower inverter:
+  battery_charge_power_curve:
+    97 : 0.5
+    98 : 0.2
+    99 : 0.1
+  battery_discharge_power_curve:
+    4 : 1.0
+
+  # Inverter clock skew in minutes, e.g. 1 means it's 1 minute fast and -1 is 1 minute slow
+  # Separate start and end options are applied to the start and end time windows, mostly as you want to start late (not early) and finish early (not late)
+  # Separate discharge skew for discharge windows only
+  inverter_clock_skew_start: 0
+  inverter_clock_skew_end: 0
+  inverter_clock_skew_discharge_start: 0
+  inverter_clock_skew_discharge_end: 0
+  inverter_can_charge_during_export: False
+
+  # Clock skew adjusts the Predbat computer reported time
+  # This is the time that Predbat takes actions like starting discharge/charging
+  # Only use this for workarounds if your inverter time is correct but Predbat is somehow wrong (AppDaemon issue)
+  # 1 means add 1 minute to Predbat computer time, -1 takes it away
+  clock_skew: 0
+
+  # Solcast cloud interface, set this or the local interface below
+  #solcast_host: 'https://api.solcast.com.au/'
+  #solcast_api_key: 'xxxx'
+  #solcast_poll_hours: 8
+
+  # Set these to match solcast sensor names if not using the cloud interface
+  # The regular expression (re:) makes the solcast bit optional
+  # If these don't match find your own names in Home Assistant
+  pv_forecast_today: re:(sensor.(solcast_|)(pv_forecast_|)forecast_today)
+  pv_forecast_tomorrow: re:(sensor.(solcast_|)(pv_forecast_|)forecast_tomorrow)
+  pv_forecast_d3: re:(sensor.(solcast_|)(pv_forecast_|)forecast_(day_3|d3))
+  pv_forecast_d4: re:(sensor.(solcast_|)(pv_forecast_|)forecast_(day_4|d4))
+
+  # car_charging_energy defines an incrementing sensor which measures the charge added to your car
+  # is used for car_charging_hold feature to filter out car charging from the previous load data
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
+  # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
+
+  # Defines the number of cars modelled by the system, set to 0 for no car
+  num_cars: 0
+
+  # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots
+  # This should not be needed if you use Intelligent Octopus slots which will take priority if enabled
+  # The list of possible values is in car_charging_planned_response
+  # Auto matches Zappi and Wallbox, or change it for your own
+  # One entry per car
+  # car_charging_planned:
+  #   - 're:(sensor.wallbox_portal_status_description|sensor.myenergi_zappi_[0-9a-z]+_plug_status)'
+
+  # car_charging_planned_response:
+  #   - 'yes'
+  #   - 'on'
+  #   - 'true'
+  #   - 'connected'
+  #   - 'ev connected'
+  #   - 'charging'
+  #   - 'paused'
+  #   - 'waiting for car demand'
+  #   - 'waiting for ev'
+  #   - 'scheduled'
+  #   - 'enabled'
+  #   - 'latched'
+  #   - 'locked'
+  #   - 'plugged in'
+
+  # In some cases car planning is difficult (e.g. Ohme with Intelligent doesn't report slots)
+  # The car charging now can be set to a sensor to indicate the car is charging and to plan
+  # for it to charge during this 30 minute slot
+  #car_charging_now:
+  #  - off
+
+  # Positive responses for car_charging_now
+  # car_charging_now_response:
+  #   - 'yes'
+  #   - 'on'
+  #   - 'true'
+
+  # To make planned car charging more accurate, either using car_charging_planned or the Octopus Energy plugin,
+  # specify your battery size in kwh, charge limit % and current car battery soc % sensors/values.
+  # If you have Intelligent Octopus the battery size and limit will be extracted from the Octopus Energy plugin directly.
+  # Set the car SoC% if you have it to give an accurate forecast of the cars battery levels.
+  # One entry per car if you have multiple cars.
+  #car_charging_battery_size:
+  #  - 75
+  #car_charging_limit:
+  #  - 're:number.tsunami_charge_limit'
+  #car_charging_soc:
+  #  - 're:sensor.tsunami_battery'
+
+  # One per car, when true only one car can charge at once, when False multiple cars can charge at once
+  #car_charging_exclusive:
+  #  - True
+
+  # If you have Octopus Intelligent Go and are not using the Octopus Direct connection method, enable the intelligent slot information to add to pricing
+  # Will automatically disable if not found, or comment out to disable fully
+  # When enabled it overrides the 'car_charging_planned' feature and predict the car charging based on the intelligent plan (unless Octopus intelligent charging is False)
+  # This matches the intelligent slot from the Octopus Energy integration
+  octopus_intelligent_slot: 're:(binary_sensor.octopus_energy([0-9a-z_]+|)_intelligent_dispatching)'
+  octopus_ready_time: 're:((select|time).octopus_energy_([0-9a-z_]+|)_intelligent_target_time)'
+  octopus_charge_limit: 're:(number.octopus_energy([0-9a-z_]+|)_intelligent_charge_target)'
+
+  # Example alternative configuration for Ohme integration release >=v0.6.1
+  #octopus_intelligent_slot: 'binary_sensor.ohme_slot_active'
+  #octopus_ready_time: 'time.ohme_target_time'
+  #octopus_charge_limit: 'number.ohme_target_percent'
+
+  # Carbon Intensity data from National grid
+  carbon_intensity: 're:(sensor.carbon_intensity_uk)'
+
+  # Octopus saving session points to the saving session Sensor in the Octopus plugin, when enabled saving sessions will be at the assumed
+  # Rate is read automatically from the add-in and converted to pence using the conversion rate below (default is 8)
+  octopus_saving_session: 're:(binary_sensor.octopus_energy([0-9a-z_]+|)_saving_session(s|))'
+  octopus_saving_session_octopoints_per_penny: 8
+
+  # Octopus free session points to the free session Sensor in the Octopus plugin
+  # Note: You must enable this event sensor in the Octopus Integration in Home Assistant for it to work
+  octopus_free_session: 're:(event.octopus_energy_([0-9a-z_]+|)_octoplus_free_electricity_session_events)'
+
+  # Energy rates
+  # Please set one of these three, if multiple are set then Octopus is used first, second rates_import/rates_export and latest basic metric
+
+  # Set import and export entity to point to the Octopus Energy plugin import and export sensors
+  # automatically matches your meter number assuming you have only one (no need to edit the below)
+  # Will be ignored if you don't have the sensor but will error if you do have one and it's incorrect
+  # NOTE: To get detailed energy rates you need to go in and manually enable the following events in HA
+  #       event.octopus_energy_electricity_xxxxxxxx_previous_day_rates
+  #       event.octopus_energy_electricity_xxxxxxxx_current_day_rates
+  #       event.octopus_energy_electricity_xxxxxxxx_next_day_rates
+  # and if you have export enable:
+  #       event.octopus_energy_electricity_xxxxxxxx_export_previous_day_rates
+  #       event.octopus_energy_electricity_xxxxxxxx_export_current_day_rates
+  #       event.octopus_energy_electricity_xxxxxxxx_export_next_day_rates
+  # Predbat will automatically find the event. entities from the link below to the sensors
+  metric_octopus_import: 're:(sensor.(octopus_energy_|)electricity_[0-9a-z]+_[0-9a-z]+_current_rate)'
+  metric_octopus_export: 're:(sensor.(octopus_energy_|)electricity_[0-9a-z]+_[0-9a-z]+_export_current_rate)'
+
+  # Standing charge in pounds, can be set to a sensor or manually entered (e.g. 0.50 is 50p)
+  # The default below will pick up the standing charge from the Octopus Plugin
+  # The standing charge only impacts the cost graphs and doesn't change the way Predbat plans
+  # If you don't want to show the standing charge then just delete this line or set to zero
+  metric_standing_charge: 're:(sensor.(octopus_energy_|)electricity_[0-9a-z]+_[0-9a-z]+_current_standing_charge)'
+
+  # Or set your actual rates across time for import and export
+  # If start/end is missing it's assumed to be a fixed rate
+  # Gaps are filled with zero rate
+  #rates_import:
+  #  -  start: "00:30:00"
+  #     end: "04:30:00"
+  #     rate: 7.5
+  #  -  start: "04:30:00"
+  #     end: "00:30:00"
+  #     rate: 40.0
+  #
+  #rates_export:
+  #  -  rate: 4.2
+
+  # Can be used instead of the plugin to get import rates directly online
+  # Overrides metric_octopus_import and rates_import
+  # See the 'energy rates' part of the documentation for instructions on how to find the correct URL for your tariff and DNO region
+  #
+  # rates_import_octopus_url : "https://api.octopus.energy/v1/products/FLUX-IMPORT-23-02-14/electricity-tariffs/E-1R-FLUX-IMPORT-23-02-14-A/standard-unit-rates"
+  # rates_import_octopus_url : "https://api.octopus.energy/v1/products/AGILE-24-10-01/electricity-tariffs/E-1R-AGILE-24-10-01-A/standard-unit-rates"
+
+  # Overrides metric_octopus_export and rates_export
+  # rates_export_octopus_url: "https://api.octopus.energy/v1/products/FLUX-EXPORT-23-02-14/electricity-tariffs/E-1R-FLUX-EXPORT-23-02-14-A/standard-unit-rates"
+  # rates_export_octopus_url: "https://api.octopus.energy/v1/products/AGILE-OUTGOING-19-05-13/electricity-tariffs/E-1R-AGILE-OUTGOING-19-05-13-A/standard-unit-rates/"
+
+  # Import rates can be overridden with rate_import_override
+  # Export rates can be overridden with rate_export_override
+  # Use the same format as above, but a date can be included if it just applies for a set day (e.g. Octopus power ups)
+  # This will override even the Octopus plugin rates if enabled
+  #
+  #rates_import_override:
+  # -  date: '2023-09-10'
+  #    start: '14:00:00'
+  #    end: '14:30:00'
+  #    rate: 112
+  #    load_scaling: 0.8
+
+  # For pv estimate, leave blank for central estimate, or add 10 for 10% curve (worst case) or 90 or 90% curve (best case)
+  # If you use 10 then disable pv_metric10_weight below
+  # pv_estimate: 10
+
+  # Days previous is the number of days back to find historical load data
+  # Recommended is 7 to capture day of the week but 1 can also be used
+  # if you have more history you could use 7 and 14 (in a list) but the standard data in HA only lasts 10 days
+  days_previous:
+    - 7
+
+  # Days previous weight can be used to control the weighting of the previous load points, the values are multiplied by their
+  # weights and then divided through by the total weight. E.g. if you used 1 and 0.5 then the first value would have 2/3rd of the weight and the second 1/3rd
+  # Include one value for each days_previous value, each weighting on a separate line.
+  # If any days_previous's that are not given a weighting they will assume a default weighting of 1.
+  days_previous_weight:
+    - 1
+
+  # Number of hours forward to forecast, best left as-is unless you have specific reason
+  forecast_hours: 48
+
+  # Specify the devices that notifies are sent to, the default is 'notify' which goes to all
+  #notify_devices:
+  #  - mobile_app_treforsiphone12_2
+
+  # Battery scaling makes the battery smaller (e.g. 0.9) or bigger than its reported
+  # If you have an 80% DoD battery that falsely reports it's kwh then set it to 0.8 to report the real figures
+  # One per inverter
+  battery_scaling:
+    - 1.0
+
+  # Can be used to scale import and export data, used for workarounds
+  import_export_scaling: 1.0
+
+  # Export triggers:
+  # For each trigger give a name, the minutes of export needed and the energy required in that time
+  # Multiple triggers can be set at once so in total you could use too much energy if all run
+  # Creates an entity called 'binary_sensor.predbat_export_trigger_<name>' which will be turned On when the condition is valid
+  # connect this to your automation to start whatever you want to trigger
+  # export_triggers:
+  #    - name: 'large'
+  #      minutes: 60
+  #      energy: 1.0
+  #    - name: 'small'
+  #      minutes: 15
+  #      energy: 0.25
+
+  # If you have a sensor that gives the energy consumed by your solar diverter then add it here
+  # this will make the predictions more accurate. It should be an incrementing sensor, it can reset at midnight or not
+  # It's assumed to be in Kwh but scaling can be applied if need be
+  #iboost_energy_today: 'sensor.xxxxx'
+  #iboost_energy_scaling: 1.0
+  # Gas rates for comparison
+  # metric_octopus_gas: 're:(sensor.(octopus_energy_|)gas_[0-9a-z]+_[0-9a-z]+_current_rate)'
+
+  # Nordpool market energy rates
+  #futurerate_url: 'https://www.nordpoolgroup.com/api/marketdata/page/325?currency=GBP'
+  #futurerate_adjust_import: True
+  #futurerate_adjust_export: False
+  #futurerate_peak_start: "16:00:00"
+  #futurerate_peak_end: "19:00:00"
+  #futurerate_peak_premium_import: 14
+  #futurerate_peak_premium_export: 6.5
+
+  # Watch list, a list of sensors to watch for changes and then update the plan if they change
+  # This is useful for things like the Octopus Intelligent Slot sensor so that the plan update as soon as you plugin in
+  # Only uncomment the items you actually have set up above in apps.yaml, of course you can add your own as well
+  # Note those using +[] are lists that are appended to this list, whereas {} items are single items only
+  #watch_list:
+  #  - '{octopus_intelligent_slot}'
+  #  - '{octopus_ready_time}'
+  #  - '{octopus_charge_limit}'
+  #  - '{octopus_saving_session}'
+  #  - '+[car_charging_planned]'
+  #  - '+[car_charging_soc]'
+  #  - '{car_charging_now}'


### PR DESCRIPTION
## PR Description

This PR improves support for LuxPower inverters when using Predbat Freeze Charging and Freeze Export, focusing on documentation clarity, configuration correctness, and stable runtime behaviour.

### Summary of changes
**Documentation**

- Revises the LuxPower section of Inverter Setup to fully document how Freeze Charging and Freeze Export are implemented for LuxPower inverters.

- Explains the required Home Assistant helpers and automations.

- Introduces and documents the new `maintain_freeze_charge_status` inverter option, including why it is required for LuxPower.

**Configuration**

Updates the luxpower.yaml example template to:

- Enable Freeze Charging / Freeze Export where supported.

- Reference `battery_min_soc` from the LuxPython integration to avoid discrepancies between user configuration and inverter state.

- Reference `battery_rate_max` from an 'input_number' helper rather than a hard-coded value.

- Adds `maintain_freeze_charge_status` to the inverter configuration options and documents its purpose.

**Runtime behaviour**

- Updates inverter.py to support `maintain_freeze_charge_status`.

- When enabled, Predbat suppresses expected warnings caused by manipulating `scheduled_charge_enable` during Freeze Charging.

- This prevents predbat.status from transitioning into Warn: states during normal Freeze Charging operation, allowing existing automations (e.g. Freeze exit handling) to behave reliably.

- Suppression only applies during Freeze Charging and does not affect normal charging behaviour or genuine error conditions.

**Rationale**

- LuxPower inverters do not provide native Freeze Charging support and rely on controlled manipulation of `scheduled_charge_enable`. During Freeze Charging, this can legitimately cause Predbat to observe a mismatch between expected and reported state, resulting in warnings that are expected but disruptive.

- `maintain_freeze_charge_status` ensures Predbat treats these cases as expected behaviour only while Freeze Charging is active, keeping predbat.status stable and avoiding unintended automation triggers.

**Notes**

No functional changes to Predbat planning logic.

Changes are opt-in and limited to inverters that enable `maintain_freeze_charge_status`.

Fixes #2916