### PR TITLE
Respect fill_load_from_power in ML model

### DIFF
--- a/apps/predbat/load_ml_component.py
+++ b/apps/predbat/load_ml_component.py
@@ -149,7 +149,7 @@ class LoadMLComponent(ComponentBase):
                 self.log("Warn: ML Component: Failed to convert load history to minute data")
                 return None, 0, 0, None, None, None, None
 
-            if self.get_arg("load_power", default=None, indirect=False):
+            if self.get_arg("load_power", default=None, indirect=False) and self.get_arg("load_power_fill_enable", True):
                 load_power_data, _ = self.base.minute_data_load(self.now_utc, "load_power", days_to_fetch, required_unit="W", load_scaling=1.0, interpolate=True)
                 load_minutes = self.base.fill_load_from_power(load_minutes, load_power_data)
 


### PR DESCRIPTION
The ML predictor will always use `load_power` to fill in `load_today`, but other code working similarly checks the `fill_load_from_power` arg.

Modify the ML code to respect this argument.

c.f. https://github.com/springfall2008/batpred/blob/e2dc95f0e7837fbb1520c65f46b8f34dc43db8ab/apps/predbat/fetch.py#L711