### PR TITLE
Disable car charging subtraction in ML if no cars defined

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -596,7 +596,7 @@ CONFIG_ITEMS = [
         "name": "car_charging_hold",
         "friendly_name": "Car charging hold",
         "type": "switch",
-        "default": True,
+        "default": False,
     },
     {
         "name": "car_charging_manual_soc",

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -2197,7 +2197,7 @@ class Fetch:
         self.iboost_plan = []
 
         # Car options
-        self.car_charging_hold = self.get_arg("car_charging_hold")
+        self.car_charging_hold = self.get_arg("car_charging_hold", False)
         self.car_charging_manual_soc = [False for c in range(max(self.num_cars, 1))]
         for car_n in range(self.num_cars):
             car_postfix = "" if car_n == 0 else "_" + str(car_n)


### PR DESCRIPTION
The ML Load prediction will default to subtracting car charging load, assuming that `car_charging_hold` default to true ([the docs state it is off by default](https://springfall2008.github.io/batpred/apps-yaml/#car-charging-filtering)), and not verifying whether any cars are defined.

Additionally, the `car_delta` value is left in a stale state from previous iterations if car load was previously detected and but is then disabled.

Disable `car_charging_hold` by default, check that `num_cars>=1` before removing car load, and ensure that `car_delta` is reset to 0 if there is no charging load detected.