### PR TITLE
HA cache fixes

### DIFF
--- a/apps/predbat/ha.py
+++ b/apps/predbat/ha.py
@@ -88,7 +88,7 @@ class HAHistory(ComponentBase):
                 if tracked:
                     self.update_entity(entity_id, history_data)
                 result = [history_data]
-        
+
         return deepcopy(result)
 
     def prune_history(self, now):
@@ -138,7 +138,7 @@ class HAHistory(ComponentBase):
         else:
             first_updated = None
             last_updated = None
-        
+
         if last_updated:
             # Find the last timestamp in the previous history data, data is always in order from oldest to newest
             first_timestamp = str2time(first_updated)
@@ -157,7 +157,7 @@ class HAHistory(ComponentBase):
                             add_all = True  # Remaining entries are all newer
                         elif entry_time < first_timestamp:
                             self.history_data[entity_id].append(entry)
-            
+
             self.history_data[entity_id].sort(key=lambda x: x.get("last_updated"))
         else:
             self.history_data[entity_id] = new_history_data

--- a/apps/predbat/tests/test_hahistory.py
+++ b/apps/predbat/tests/test_hahistory.py
@@ -283,14 +283,14 @@ def test_hahistory_get_history_fetch_and_cache(my_predbat=None):
     else:
         print("✓ Entity tracking updated to 60 days")
 
-    # Test 4: Request more days again - cache should have them populated 
+    # Test 4: Request more days again - cache should have them populated
     result4 = ha_history.get_history(entity_id, days=60, tracked=True)
     if len(result4[0]) != length_60_days_history:
         print("ERROR: Cache did not correctly return 60 days")
         failed += 1
     else:
         print("✓ Cache correctly populated with longer history")
-    
+
     sorted_result4 = sorted(result4[0], key=lambda x: x["last_updated"])
     if sorted_result4 != result4[0]:
         print("ERROR: Cache population did not correctly order entries when adding longer history")


### PR DESCRIPTION
The HA cache stores data as mutable lists, and returns these lists when a cache hit occurs. However, this means that if a caller modifies the result directly, then these changes are passed back to the cache.

Additionally, the cache only ever added new entries. If it was queried for a longer history (e.g. 7 days, then 8 days), it reported itself as having the longer length, but did not actually contain those values.

Ensure that the cache always returns an independent copy of its own data, and populate entries older than the earliest entry in cache when updating.