### PR TITLE
Fix Solis uppercase serial number causing invalid HA entity IDs (#3433)

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -36,7 +36,7 @@ import pytz
 import requests
 import asyncio
 
-THIS_VERSION = "v8.33.8"
+THIS_VERSION = "v8.33.9"
 
 # fmt: off
 PREDBAT_FILES = ["predbat.py", "const.py", "hass.py", "config.py", "prediction.py", "gecloud.py", "utils.py", "inverter.py", "ha.py", "download.py", "web.py", "web_helper.py", "predheat.py", "futurerate.py", "octopus.py", "solcast.py", "execute.py", "plan.py", "fetch.py", "output.py", "userinterface.py", "energydataservice.py", "alertfeed.py", "compare.py", "db_manager.py", "db_engine.py", "plugin_system.py", "ohme.py", "components.py", "fox.py", "carbon.py", "temperature.py", "web_mcp.py", "component_base.py", "axle.py", "solax.py", "solis.py", "unit_test.py", "load_ml_component.py", "load_predictor.py"]

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1121,6 +1121,7 @@ class SolisAPI(ComponentBase):
         Loop over each of the windows (that are present) and get the values from HA
         """
 
+        sn_lower = sn.lower()
         for slot in range (1,7):
             for direction in ['charge', 'discharge']:
                 if sn not in self.charge_discharge_time_windows:
@@ -1128,11 +1129,11 @@ class SolisAPI(ComponentBase):
                 if slot not in self.charge_discharge_time_windows[sn]:
                     continue
                 # Build the entity IDs
-                enable_entity_id = f"switch.{self.prefix}_solis_{sn}_{direction}_slot{slot}_enable"
-                start_time_entity_id = f"select.{self.prefix}_solis_{sn}_{direction}_slot{slot}_start_time"
-                end_time_entity_id = f"select.{self.prefix}_solis_{sn}_{direction}_slot{slot}_end_time"
-                soc_entity_id = f"number.{self.prefix}_solis_{sn}_{direction}_slot{slot}_soc"
-                power_entity_id = f"number.{self.prefix}_solis_{sn}_{direction}_slot{slot}_power"
+                enable_entity_id = f"switch.{self.prefix}_solis_{sn_lower}_{direction}_slot{slot}_enable"
+                start_time_entity_id = f"select.{self.prefix}_solis_{sn_lower}_{direction}_slot{slot}_start_time"
+                end_time_entity_id = f"select.{self.prefix}_solis_{sn_lower}_{direction}_slot{slot}_end_time"
+                soc_entity_id = f"number.{self.prefix}_solis_{sn_lower}_{direction}_slot{slot}_soc"
+                power_entity_id = f"number.{self.prefix}_solis_{sn_lower}_{direction}_slot{slot}_power"
                 # Fetch the values from HA
                 enable_state = self.get_state_wrapper(enable_entity_id)
                 start_time_state = self.get_state_wrapper(start_time_entity_id)
@@ -1168,6 +1169,7 @@ class SolisAPI(ComponentBase):
             # Get inverter details for friendly name
             detail = self.inverter_details.get(inverter_sn, {})
             inverter_name = detail.get("inverterName", inverter_sn)
+            inverter_sn_lower = inverter_sn.lower()
 
             # Get cached values for this inverter
             values = self.cached_values.get(inverter_sn, {})
@@ -1175,7 +1177,7 @@ class SolisAPI(ComponentBase):
             # Inverter size
             power = detail.get("power")
             powerStr = detail.get("powerStr", "kW")
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_inverter_size"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_inverter_size"
             self.dashboard_item(
                 entity_id,
                 state=power,
@@ -1191,7 +1193,7 @@ class SolisAPI(ComponentBase):
 
             # Publish sensors from inverter detail API (not CID-based)
             # Total Load Energy
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_total_load_energy"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_total_load_energy"
             total_load = detail.get("homeLoadTotalEnergy")
             total_load_units = detail.get("homeLoadTotalEnergyStr", "kWh")
             try:
@@ -1215,7 +1217,7 @@ class SolisAPI(ComponentBase):
             )
             total_today = detail.get('homeLoadTodayEnergy')
             total_load_units = detail.get("homeLoadTodayEnergyStr", "kWh")
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_today_load_energy"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_today_load_energy"
             self.dashboard_item(
                 entity_id,
                 state=total_today,
@@ -1230,7 +1232,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Total Export Energy
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_today_export_energy"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_today_export_energy"
             total_export = detail.get("gridSellTodayEnergy")
             total_export_units = detail.get("gridSellTodayEnergyStr", "kWh")
             self.dashboard_item(
@@ -1247,7 +1249,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Total Import Energy
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_today_import_energy"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_today_import_energy"
             total_import = detail.get("gridPurchasedTodayEnergy")
             total_import_units = detail.get("gridPurchasedTodayEnergyStr", "kWh")
             self.dashboard_item(
@@ -1269,7 +1271,7 @@ class SolisAPI(ComponentBase):
                 battery_soh = float(battery_soh) / 100.0
             except (ValueError, TypeError):
                 battery_soh = None
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_battery_soh"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_soh"
             self.dashboard_item(
                 entity_id,
                 state=battery_soh,
@@ -1284,7 +1286,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Battery Capacity SOC (from detail API, not live CID)
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_battery_soc"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_soc"
             battery_soc = detail.get("batteryCapacitySoc")
             try:
                 battery_soc = float(battery_soc)
@@ -1304,7 +1306,7 @@ class SolisAPI(ComponentBase):
             )
 
             # PV Energy Total
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_pv_energy_total"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_pv_energy_total"
             pv_total = detail.get("eTotal")
             pv_total_unit = detail.get("eTotalStr", "kWh")
             if pv_total_unit == 'MWh':
@@ -1327,7 +1329,7 @@ class SolisAPI(ComponentBase):
             )
 
             # PV Power (Real-time AC output power)
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_pv_power"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_pv_power"
             pv_power = detail.get("pac")
             pv_power_unit = detail.get("pacStr", "kW")
             self.dashboard_item(
@@ -1344,7 +1346,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Product Model
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_product_model"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_product_model"
             product_model = detail.get("productModel")
             self.dashboard_item(
                 entity_id,
@@ -1357,7 +1359,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Inverter Temperature
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_inverter_temperature"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_inverter_temperature"
             inverter_temp = detail.get("inverterTemperature")
             self.dashboard_item(
                 entity_id,
@@ -1373,7 +1375,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Battery Power (from detail)
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_battery_power"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_power"
             battery_power = detail.get("batteryPower")
             battery_power_unit = detail.get("batteryPowerStr", "kW")
             self.dashboard_item(
@@ -1390,7 +1392,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Battery Voltage (from detail)
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_battery_voltage"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_voltage"
             battery_voltage = detail.get("batteryVoltage")
             battery_voltage_unit = detail.get("batteryVoltageStr", "V")
             self.dashboard_item(
@@ -1407,7 +1409,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Battery Current (from detail)
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_battery_current"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_current"
             battery_current = detail.get("batteryCurrent")
             battery_current_unit = detail.get("batteryCurrentStr", "A")
             self.dashboard_item(
@@ -1424,7 +1426,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Load Power (from detail)
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_load_power"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_load_power"
             load_power = detail.get("familyLoadPower")
             load_power_unit = detail.get("familyLoadPowerStr", "kW")
             self.dashboard_item(
@@ -1441,7 +1443,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Grid Power (from detail)
-            entity_id = f"sensor.{prefix}_solis_{inverter_sn}_grid_power"
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_grid_power"
             grid_power = detail.get("psum")
             grid_power_unit = detail.get("psumStr", "kW")
             self.dashboard_item(
@@ -1473,7 +1475,7 @@ class SolisAPI(ComponentBase):
                         charge_enable = int(slot_data["charge_enable"])
                     except (ValueError, TypeError):
                         charge_enable = 0
-                    entity_id = f"switch.{prefix}_solis_{inverter_sn}_charge_slot{slot_num}_enable"
+                    entity_id = f"switch.{prefix}_solis_{inverter_sn_lower}_charge_slot{slot_num}_enable"
                     self.dashboard_item(
                         entity_id,
                         state="on" if charge_enable else "off",
@@ -1486,7 +1488,7 @@ class SolisAPI(ComponentBase):
 
                 # Start time selector
                 if "charge_start_time" in slot_data:
-                    entity_id = f"select.{prefix}_solis_{inverter_sn}_charge_slot{slot_num}_start_time"
+                    entity_id = f"select.{prefix}_solis_{inverter_sn_lower}_charge_slot{slot_num}_start_time"
                     start_time = slot_data["charge_start_time"]
                     # Convert HH:MM to HH:MM:00 format
                     if start_time and ":" in start_time and len(start_time.split(":")) == 2:
@@ -1506,7 +1508,7 @@ class SolisAPI(ComponentBase):
 
                 # End time selector
                 if "charge_end_time" in slot_data:
-                    entity_id = f"select.{prefix}_solis_{inverter_sn}_charge_slot{slot_num}_end_time"
+                    entity_id = f"select.{prefix}_solis_{inverter_sn_lower}_charge_slot{slot_num}_end_time"
                     end_time = slot_data["charge_end_time"]
                     # Convert HH:MM to HH:MM:00 format
                     if end_time and ":" in end_time and len(end_time.split(":")) == 2:
@@ -1526,7 +1528,7 @@ class SolisAPI(ComponentBase):
 
                 # SOC target number
                 if "charge_soc" in slot_data:
-                    entity_id = f"number.{prefix}_solis_{inverter_sn}_charge_slot{slot_num}_soc"
+                    entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_charge_slot{slot_num}_soc"
                     try:
                         soc_value = int(slot_data["charge_soc"])
                     except (ValueError, TypeError):
@@ -1547,7 +1549,7 @@ class SolisAPI(ComponentBase):
 
                 # Current limit number (displayed as power in watts)
                 if "charge_current" in slot_data:
-                    entity_id = f"number.{prefix}_solis_{inverter_sn}_charge_slot{slot_num}_power"
+                    entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_charge_slot{slot_num}_power"
                     current_value_amps = slot_data["charge_current"]
 
                     # Convert amps to watts for display
@@ -1586,7 +1588,7 @@ class SolisAPI(ComponentBase):
 
                 # Enable switch
                 if "discharge_enable" in slot_data:
-                    entity_id = f"switch.{prefix}_solis_{inverter_sn}_discharge_slot{slot_num}_enable"
+                    entity_id = f"switch.{prefix}_solis_{inverter_sn_lower}_discharge_slot{slot_num}_enable"
                     try:
                         discharge_enable = int(slot_data["discharge_enable"])
                     except (ValueError, TypeError):
@@ -1603,7 +1605,7 @@ class SolisAPI(ComponentBase):
 
                 # Start time selector
                 if "discharge_start_time" in slot_data:
-                    entity_id = f"select.{prefix}_solis_{inverter_sn}_discharge_slot{slot_num}_start_time"
+                    entity_id = f"select.{prefix}_solis_{inverter_sn_lower}_discharge_slot{slot_num}_start_time"
                     start_time = slot_data["discharge_start_time"]
                     # Convert HH:MM to HH:MM:00 format
                     if start_time and ":" in start_time and len(start_time.split(":")) == 2:
@@ -1623,7 +1625,7 @@ class SolisAPI(ComponentBase):
 
                 # End time selector
                 if "discharge_end_time" in slot_data:
-                    entity_id = f"select.{prefix}_solis_{inverter_sn}_discharge_slot{slot_num}_end_time"
+                    entity_id = f"select.{prefix}_solis_{inverter_sn_lower}_discharge_slot{slot_num}_end_time"
                     end_time = slot_data["discharge_end_time"]
                     # Convert HH:MM to HH:MM:00 format
                     if end_time and ":" in end_time and len(end_time.split(":")) == 2:
@@ -1643,7 +1645,7 @@ class SolisAPI(ComponentBase):
 
                 # SOC target number
                 if "discharge_soc" in slot_data:
-                    entity_id = f"number.{prefix}_solis_{inverter_sn}_discharge_slot{slot_num}_soc"
+                    entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_discharge_slot{slot_num}_soc"
                     try:
                         soc_value = int(slot_data["discharge_soc"])
                     except (ValueError, TypeError):
@@ -1664,7 +1666,7 @@ class SolisAPI(ComponentBase):
 
                 # Current limit number (displayed as power in watts)
                 if "discharge_current" in slot_data:
-                    entity_id = f"number.{prefix}_solis_{inverter_sn}_discharge_slot{slot_num}_power"
+                    entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_discharge_slot{slot_num}_power"
                     current_value_amps = slot_data["discharge_current"]
 
                     # Convert amps to watts for display
@@ -1695,7 +1697,7 @@ class SolisAPI(ComponentBase):
                     )
 
             # Storage mode selector
-            entity_id = f"select.{prefix}_solis_{inverter_sn}_storage_mode"
+            entity_id = f"select.{prefix}_solis_{inverter_sn_lower}_storage_mode"
             mode_value = values.get(SOLIS_CID_STORAGE_MODE, None)
             # Storage mode bit switches
             storage_mode_int = None
@@ -1720,7 +1722,7 @@ class SolisAPI(ComponentBase):
 
 
             # Battery reserve switch
-            entity_id = f"switch.{prefix}_solis_{inverter_sn}_battery_reserve"
+            entity_id = f"switch.{prefix}_solis_{inverter_sn_lower}_battery_reserve"
             reserve_on = (storage_mode_int & (1 << SOLIS_BIT_BACKUP_MODE)) != 0 if storage_mode_int is not None else None
             self.dashboard_item(
                 entity_id,
@@ -1733,7 +1735,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Allow grid charging switch
-            entity_id = f"switch.{prefix}_solis_{inverter_sn}_allow_grid_charging"
+            entity_id = f"switch.{prefix}_solis_{inverter_sn_lower}_allow_grid_charging"
             grid_charging_on = (storage_mode_int & (1 << SOLIS_BIT_GRID_CHARGING)) != 0 if storage_mode_int is not None else None
             self.dashboard_item(
                 entity_id,
@@ -1746,7 +1748,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Time of use switch
-            entity_id = f"switch.{prefix}_solis_{inverter_sn}_time_of_use"
+            entity_id = f"switch.{prefix}_solis_{inverter_sn_lower}_time_of_use"
             tou_on = (storage_mode_int & (1 << SOLIS_BIT_TOU_MODE)) != 0 if storage_mode_int is not None else None
             self.dashboard_item(
                 entity_id,
@@ -1759,7 +1761,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Allow export switch (inverted logic: "0" = allow, "1" = block)
-            entity_id = f"switch.{prefix}_solis_{inverter_sn}_allow_export"
+            entity_id = f"switch.{prefix}_solis_{inverter_sn_lower}_allow_export"
             allow_export_value = values.get(SOLIS_CID_ALLOW_EXPORT, None)
             allow_export_on = (allow_export_value == SOLIS_ALLOW_EXPORT_ON) if allow_export_value is not None else None
             self.dashboard_item(
@@ -1780,7 +1782,7 @@ class SolisAPI(ComponentBase):
                 (SOLIS_CID_BATTERY_RECOVERY_SOC, "recovery_soc", "Battery Recovery SOC", "mdi:battery-50"),
                 (SOLIS_CID_BATTERY_MAX_CHARGE_SOC, "max_charge_soc", "Battery Max Charge SOC", "mdi:battery"),
             ]:
-                entity_id = f"number.{prefix}_solis_{inverter_sn}_{name}"
+                entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_{name}"
                 soc_value = values.get(cid, None)
                 self.dashboard_item(
                     entity_id,
@@ -1798,7 +1800,7 @@ class SolisAPI(ComponentBase):
                 )
 
             # Battery max current numbers (displayed as power in watts)
-            entity_id = f"number.{prefix}_solis_{inverter_sn}_max_charge_power"
+            entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_max_charge_power"
             max_charge_current_amps = values.get(SOLIS_CID_BATTERY_MAX_CHARGE_CURRENT, None)
 
             # Convert amps to watts for display
@@ -1824,7 +1826,7 @@ class SolisAPI(ComponentBase):
                 app="solis"
             )
 
-            entity_id = f"number.{prefix}_solis_{inverter_sn}_max_discharge_power"
+            entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_max_discharge_power"
             max_discharge_current_amps = values.get(SOLIS_CID_BATTERY_MAX_DISCHARGE_CURRENT, None)
 
             # Convert amps to watts for display
@@ -1851,7 +1853,7 @@ class SolisAPI(ComponentBase):
             )
 
             # Power control numbers
-            entity_id = f"number.{prefix}_solis_{inverter_sn}_power_limit"
+            entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_power_limit"
             power_limit_value = values.get(SOLIS_CID_POWER_LIMIT, None)
             self.dashboard_item(
                 entity_id,
@@ -1867,7 +1869,7 @@ class SolisAPI(ComponentBase):
                 app="solis"
             )
 
-            entity_id = f"number.{prefix}_solis_{inverter_sn}_max_output_power"
+            entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_max_output_power"
             max_output_power_value = values.get(SOLIS_CID_MAX_OUTPUT_POWER, None)
             self.dashboard_item(
                 entity_id,
@@ -1883,7 +1885,7 @@ class SolisAPI(ComponentBase):
                 app="solis"
             )
 
-            entity_id = f"number.{prefix}_solis_{inverter_sn}_max_export_power"
+            entity_id = f"number.{prefix}_solis_{inverter_sn_lower}_max_export_power"
             max_export_power_value = values.get(SOLIS_CID_MAX_EXPORT_POWER, None)
             try:
                 max_export_power = float(max_export_power_value)
@@ -1912,7 +1914,7 @@ class SolisAPI(ComponentBase):
                 try:
                     battery_capacity_ah = float(battery_capacity_ah)
                     battery_capacity_kWh = battery_capacity_ah * self.nominal_voltage / 1000.0
-                    entity_id = f"sensor.{prefix}_solis_{inverter_sn}_battery_capacity"
+                    entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_capacity"
                     self.dashboard_item(
                         entity_id,
                         state=round(battery_capacity_kWh, 2),

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -236,11 +236,12 @@ async def test_fetch_entity_data_power_clamping():
         }
     }
 
+    inverter_sn_lower = inverter_sn.lower()
     # Set power values that would exceed max current when converted
     # Charge: 4800W / 48V = 100A, but max is 50A
-    api.dashboard_items[f"number.predbat_solis_{inverter_sn}_charge_slot1_power"] = {"state": "4800", "attributes": {}}
+    api.dashboard_items[f"number.predbat_solis_{inverter_sn_lower}_charge_slot1_power"] = {"state": "4800", "attributes": {}}
     # Discharge: 3000W / 48V = 62.5A, but max is 40A
-    api.dashboard_items[f"number.predbat_solis_{inverter_sn}_discharge_slot1_power"] = {"state": "3000", "attributes": {}}
+    api.dashboard_items[f"number.predbat_solis_{inverter_sn_lower}_discharge_slot1_power"] = {"state": "3000", "attributes": {}}
 
     # Call fetch_entity_data
     await api.fetch_entity_data(inverter_sn)
@@ -278,11 +279,12 @@ async def test_fetch_entity_data_invalid_values():
         }
     }
 
+    inverter_sn_lower = inverter_sn.lower()
     # Set invalid values
-    api.dashboard_items[f"number.predbat_solis_{inverter_sn}_charge_slot1_soc"] = {"state": "not_a_number", "attributes": {}}
-    api.dashboard_items[f"number.predbat_solis_{inverter_sn}_charge_slot1_power"] = {"state": "invalid", "attributes": {}}
-    api.dashboard_items[f"number.predbat_solis_{inverter_sn}_discharge_slot1_soc"] = {"state": None, "attributes": {}}  # None state
-    api.dashboard_items[f"number.predbat_solis_{inverter_sn}_discharge_slot1_power"] = {"state": "", "attributes": {}}  # Empty string
+    api.dashboard_items[f"number.predbat_solis_{inverter_sn_lower}_charge_slot1_soc"] = {"state": "not_a_number", "attributes": {}}
+    api.dashboard_items[f"number.predbat_solis_{inverter_sn_lower}_charge_slot1_power"] = {"state": "invalid", "attributes": {}}
+    api.dashboard_items[f"number.predbat_solis_{inverter_sn_lower}_discharge_slot1_soc"] = {"state": None, "attributes": {}}  # None state
+    api.dashboard_items[f"number.predbat_solis_{inverter_sn_lower}_discharge_slot1_power"] = {"state": "", "attributes": {}}  # Empty string
 
     # Call fetch_entity_data - should not crash
     await api.fetch_entity_data(inverter_sn)
@@ -1726,78 +1728,79 @@ async def test_publish_entities():
 
     # Verify key entities were created
     prefix = api.prefix
+    inverter_sn_lower = inverter_sn.lower()
 
     # Check some sensor entities
-    assert f"sensor.{prefix}_solis_{inverter_sn}_battery_soc" in api.dashboard_items, "Battery SOC sensor should be published"
-    battery_soc_item = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn}_battery_soc"]
+    assert f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_soc" in api.dashboard_items, "Battery SOC sensor should be published"
+    battery_soc_item = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_soc"]
     assert battery_soc_item["state"] == 85, f"Battery SOC should be 85, got {battery_soc_item['state']}"
     assert battery_soc_item["attributes"]["unit_of_measurement"] == "%", "Battery SOC should have % unit"
 
     # Check charge slot 1 controls
-    assert f"switch.{prefix}_solis_{inverter_sn}_charge_slot1_enable" in api.dashboard_items, "Charge slot 1 enable switch should be published"
-    charge_enable = api.dashboard_items[f"switch.{prefix}_solis_{inverter_sn}_charge_slot1_enable"]
+    assert f"switch.{prefix}_solis_{inverter_sn_lower}_charge_slot1_enable" in api.dashboard_items, "Charge slot 1 enable switch should be published"
+    charge_enable = api.dashboard_items[f"switch.{prefix}_solis_{inverter_sn_lower}_charge_slot1_enable"]
     assert charge_enable["state"] == "on", "Charge slot 1 should be enabled"
 
-    assert f"select.{prefix}_solis_{inverter_sn}_charge_slot1_start_time" in api.dashboard_items, "Charge slot 1 start time should be published"
-    charge_start = api.dashboard_items[f"select.{prefix}_solis_{inverter_sn}_charge_slot1_start_time"]
+    assert f"select.{prefix}_solis_{inverter_sn_lower}_charge_slot1_start_time" in api.dashboard_items, "Charge slot 1 start time should be published"
+    charge_start = api.dashboard_items[f"select.{prefix}_solis_{inverter_sn_lower}_charge_slot1_start_time"]
     assert charge_start["state"] == "02:00:00", f"Charge start time should be 02:00:00, got {charge_start['state']}"
 
-    assert f"number.{prefix}_solis_{inverter_sn}_charge_slot1_soc" in api.dashboard_items, "Charge slot 1 SOC should be published"
-    charge_soc = api.dashboard_items[f"number.{prefix}_solis_{inverter_sn}_charge_slot1_soc"]
+    assert f"number.{prefix}_solis_{inverter_sn_lower}_charge_slot1_soc" in api.dashboard_items, "Charge slot 1 SOC should be published"
+    charge_soc = api.dashboard_items[f"number.{prefix}_solis_{inverter_sn_lower}_charge_slot1_soc"]
     assert charge_soc["state"] == 95, f"Charge SOC should be 95, got {charge_soc['state']}"
 
     # Check power conversion (amps to watts)
-    assert f"number.{prefix}_solis_{inverter_sn}_charge_slot1_power" in api.dashboard_items, "Charge slot 1 power should be published"
-    charge_power = api.dashboard_items[f"number.{prefix}_solis_{inverter_sn}_charge_slot1_power"]
+    assert f"number.{prefix}_solis_{inverter_sn_lower}_charge_slot1_power" in api.dashboard_items, "Charge slot 1 power should be published"
+    charge_power = api.dashboard_items[f"number.{prefix}_solis_{inverter_sn_lower}_charge_slot1_power"]
     expected_power = int(50 * api.nominal_voltage)  # 50A * 48.4V = 2420W
     assert charge_power["state"] == expected_power, f"Charge power should be {expected_power}W, got {charge_power['state']}"
     assert charge_power["attributes"]["unit_of_measurement"] == "W", "Charge power should have W unit"
 
     # Check discharge slot 1 controls
-    assert f"switch.{prefix}_solis_{inverter_sn}_discharge_slot1_enable" in api.dashboard_items, "Discharge slot 1 enable switch should be published"
-    discharge_enable = api.dashboard_items[f"switch.{prefix}_solis_{inverter_sn}_discharge_slot1_enable"]
+    assert f"switch.{prefix}_solis_{inverter_sn_lower}_discharge_slot1_enable" in api.dashboard_items, "Discharge slot 1 enable switch should be published"
+    discharge_enable = api.dashboard_items[f"switch.{prefix}_solis_{inverter_sn_lower}_discharge_slot1_enable"]
     assert discharge_enable["state"] == "on", "Discharge slot 1 should be enabled"
 
     # Check storage mode selector
-    assert f"select.{prefix}_solis_{inverter_sn}_storage_mode" in api.dashboard_items, "Storage mode selector should be published"
+    assert f"select.{prefix}_solis_{inverter_sn_lower}_storage_mode" in api.dashboard_items, "Storage mode selector should be published"
 
     # Check switches (battery reserve, grid charging, TOU, export)
-    assert f"switch.{prefix}_solis_{inverter_sn}_battery_reserve" in api.dashboard_items, "Battery reserve switch should be published"
-    assert f"switch.{prefix}_solis_{inverter_sn}_allow_grid_charging" in api.dashboard_items, "Grid charging switch should be published"
-    assert f"switch.{prefix}_solis_{inverter_sn}_time_of_use" in api.dashboard_items, "TOU switch should be published"
-    assert f"switch.{prefix}_solis_{inverter_sn}_allow_export" in api.dashboard_items, "Export switch should be published"
+    assert f"switch.{prefix}_solis_{inverter_sn_lower}_battery_reserve" in api.dashboard_items, "Battery reserve switch should be published"
+    assert f"switch.{prefix}_solis_{inverter_sn_lower}_allow_grid_charging" in api.dashboard_items, "Grid charging switch should be published"
+    assert f"switch.{prefix}_solis_{inverter_sn_lower}_time_of_use" in api.dashboard_items, "TOU switch should be published"
+    assert f"switch.{prefix}_solis_{inverter_sn_lower}_allow_export" in api.dashboard_items, "Export switch should be published"
 
     # Check SOC limit numbers
-    assert f"number.{prefix}_solis_{inverter_sn}_reserve_soc" in api.dashboard_items, "Reserve SOC should be published"
-    reserve_soc = api.dashboard_items[f"number.{prefix}_solis_{inverter_sn}_reserve_soc"]
+    assert f"number.{prefix}_solis_{inverter_sn_lower}_reserve_soc" in api.dashboard_items, "Reserve SOC should be published"
+    reserve_soc = api.dashboard_items[f"number.{prefix}_solis_{inverter_sn_lower}_reserve_soc"]
     assert reserve_soc["state"] == "10", f"Reserve SOC should be 10, got {reserve_soc['state']}"
 
     # Check max power numbers (converted from amps)
-    assert f"number.{prefix}_solis_{inverter_sn}_max_charge_power" in api.dashboard_items, "Max charge power should be published"
-    max_charge = api.dashboard_items[f"number.{prefix}_solis_{inverter_sn}_max_charge_power"]
+    assert f"number.{prefix}_solis_{inverter_sn_lower}_max_charge_power" in api.dashboard_items, "Max charge power should be published"
+    max_charge = api.dashboard_items[f"number.{prefix}_solis_{inverter_sn_lower}_max_charge_power"]
     expected_max_power = int(50 * api.nominal_voltage)  # 50A * 48.4V
     assert max_charge["state"] == expected_max_power, f"Max charge power should be {expected_max_power}W, got {max_charge['state']}"
 
     # Check battery capacity calculation (Ah to kWh)
-    assert f"sensor.{prefix}_solis_{inverter_sn}_battery_capacity" in api.dashboard_items, "Battery capacity should be published"
-    battery_cap = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn}_battery_capacity"]
+    assert f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_capacity" in api.dashboard_items, "Battery capacity should be published"
+    battery_cap = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_capacity"]
     expected_kwh = round(100 * api.nominal_voltage / 1000.0, 2)  # 100Ah * 48.4V / 1000 = 4.84 kWh
     assert battery_cap["state"] == expected_kwh, f"Battery capacity should be {expected_kwh}kWh, got {battery_cap['state']}"
     assert battery_cap["attributes"]["unit_of_measurement"] == "kWh", "Battery capacity should have kWh unit"
 
     # Check that slot 2 entities are also published (even if disabled)
-    assert f"switch.{prefix}_solis_{inverter_sn}_charge_slot2_enable" in api.dashboard_items, "Charge slot 2 should be published"
-    charge2_enable = api.dashboard_items[f"switch.{prefix}_solis_{inverter_sn}_charge_slot2_enable"]
+    assert f"switch.{prefix}_solis_{inverter_sn_lower}_charge_slot2_enable" in api.dashboard_items, "Charge slot 2 should be published"
+    charge2_enable = api.dashboard_items[f"switch.{prefix}_solis_{inverter_sn_lower}_charge_slot2_enable"]
     assert charge2_enable["state"] == "off", "Charge slot 2 should be disabled"
 
     # Check detail API sensors
-    assert f"sensor.{prefix}_solis_{inverter_sn}_pv_power" in api.dashboard_items, "PV power should be published"
-    pv_power = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn}_pv_power"]
+    assert f"sensor.{prefix}_solis_{inverter_sn_lower}_pv_power" in api.dashboard_items, "PV power should be published"
+    pv_power = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn_lower}_pv_power"]
     assert pv_power["state"] == 2.5, f"PV power should be 2.5, got {pv_power['state']}"
 
-    assert f"sensor.{prefix}_solis_{inverter_sn}_battery_power" in api.dashboard_items, "Battery power should be published"
-    assert f"sensor.{prefix}_solis_{inverter_sn}_load_power" in api.dashboard_items, "Load power should be published"
-    assert f"sensor.{prefix}_solis_{inverter_sn}_grid_power" in api.dashboard_items, "Grid power should be published"
+    assert f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_power" in api.dashboard_items, "Battery power should be published"
+    assert f"sensor.{prefix}_solis_{inverter_sn_lower}_load_power" in api.dashboard_items, "Load power should be published"
+    assert f"sensor.{prefix}_solis_{inverter_sn_lower}_grid_power" in api.dashboard_items, "Grid power should be published"
 
     print(f"PASSED: publish_entities created {len(api.dashboard_items)} entities correctly")
     return False


### PR DESCRIPTION
## Problem

Fixes #3433

If a Solis inverter serial number contained uppercase characters (e.g. `ABC123XYZ`), the code was using the serial number directly when constructing Home Assistant entity IDs — resulting in entity IDs like `sensor.predbat_solis_ABC123XYZ_battery_soc` which HA doesn't support (entity IDs must be lowercase).

## Root Cause

Two functions in `solis.py` were building HA entity IDs without lowercasing the serial number:

- `publish_entities()` — writes entities to HA
- `fetch_entity_data()` — reads entities back from HA

Note: `automatic_config()` already correctly used `.lower()` when configuring Predbat args.

## Fix

- Added `inverter_sn_lower = inverter_sn.lower()` in `publish_entities()` and used it for all entity ID construction (sensors, switches, selects, numbers — ~30 entity IDs)
- Added `sn_lower = sn.lower()` in `fetch_entity_data()` and used it for all entity ID lookups
- Updated tests in `test_solis.py` to use lowercase entity IDs matching the fix
- Bumped version to `v8.33.9`