### PR TITLE
Fix IndexError when octopus_intelligent_ignore_unplugged=True and num_cars=0

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -879,7 +879,7 @@ class Fetch:
             # Completed and planned slots
             if completed:
                 self.octopus_slots += completed
-            if planned and (not self.octopus_intelligent_ignore_unplugged or self.car_charging_planned[0]):
+            if planned and (not self.octopus_intelligent_ignore_unplugged or (self.num_cars >= 1 and self.car_charging_planned[0])):
                 # We only count planned slots if the car is plugged in or we are ignoring unplugged cars
                 self.octopus_slots += planned
 


### PR DESCRIPTION
## Summary

Fixes #3465

When `octopus_intelligent_ignore_unplugged` is `True` and there are planned IOG slots present, the code at [fetch.py line 882](https://github.com/springfall2008/batpred/blob/main/apps/predbat/fetch.py#L882) accesses `self.car_charging_planned[0]` without first checking that `num_cars >= 1`.

If `num_cars` is 0 (Octopus Intelligent used for house rates with no EV configured), `car_charging_planned` is an empty list `[]` and indexing it with `[0]` raises `IndexError: list index out of range`.

## Root Cause

```python
# Before fix - IndexError if num_cars == 0
if planned and (not self.octopus_intelligent_ignore_unplugged or self.car_charging_planned[0]):
```

The condition uses short-circuit evaluation but only skips the `car_charging_planned[0]` access when `octopus_intelligent_ignore_unplugged` is `False`. When it is `True`, Python must evaluate the RHS (`car_charging_planned[0]`), which crashes on an empty list.

Note: The analogous check at line 931 is already safely guarded inside an `if self.num_cars >= 1:` block.

## Fix

```python
# After fix - safe when num_cars == 0
if planned and (not self.octopus_intelligent_ignore_unplugged or (self.num_cars >= 1 and self.car_charging_planned[0])):
```

This ensures that when `num_cars == 0`, the condition correctly evaluates to `False` (don't include planned slots when ignoring unplugged cars and there are no cars configured).

## Testing

- All existing unit tests pass (`./run_all --quick`)
- All pre-commit checks pass (ruff, black, trailing whitespace, cspell, etc.)