### PR TITLE
Improve rate coloring and text descriptions

### DIFF
--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -567,11 +567,6 @@ class Output:
         import_cost_threshold = self.rate_import_cost_threshold
         export_cost_threshold = self.rate_export_cost_threshold
 
-        if self.rate_best_cost_threshold_charge:
-            import_cost_threshold = self.rate_best_cost_threshold_charge
-        if self.rate_best_cost_threshold_export:
-            export_cost_threshold = self.rate_best_cost_threshold_export
-
         rate = dp2(rate)
 
         if not export:
@@ -581,14 +576,18 @@ class Output:
                 text = "free"
             elif rate < 0:
                 text = "negative"
-            elif rate <= import_cost_threshold * 0.5:
-                text = "very cheap"
-            elif rate <= import_cost_threshold:
-                text = "cheap"
-            elif rate <= (import_cost_threshold * 1.5):
-                text = "expensive"
+            elif self.rate_max <= self.rate_min:
+                text = "fixed"
             else:
-                text = "very expensive"
+                rate_frac = (rate - self.rate_min) / (self.rate_max - self.rate_min)
+                if rate_frac <= 0.1:
+                    text = "very cheap"
+                elif rate_frac <= 0.5:
+                    text = "cheap"
+                elif rate_frac <= 0.8:
+                    text = "expensive"
+                else:
+                    text = "very expensive"
         else:
             if self.rate_export_min == self.rate_export_max:
                 text = "fixed"
@@ -1209,12 +1208,23 @@ class Output:
             if plan_debug and load_forecast10 > 0.0:
                 load_forecast += " (%s)" % (str(load_forecast10))
 
-            if rate_value_import <= 0:  # colour the import rate, blue for negative, then green, yellow and red
+            if rate_value_import <= 0:  # colour the import rate based on position in min-max range
                 rate_color_import = "#74C1FF"
-            elif rate_value_import <= import_cost_threshold:
-                rate_color_import = "#3AEE85"
-            elif rate_value_import > (import_cost_threshold * 1.5):
-                rate_color_import = "#F18261"
+            elif self.rate_min >= self.rate_max:
+                rate_color_import = "#FFFFAA"
+            else:
+                rate_frac = (rate_value_import - self.rate_min) / (self.rate_max - self.rate_min)
+                rate_frac = max(0.0, min(1.0, rate_frac))
+                if rate_frac <= 0.1:
+                    rate_color_import = "#3AEE85"
+                elif rate_frac <= 0.35:
+                    rate_color_import = "#AAEE85"
+                elif rate_frac <= 0.65:
+                    rate_color_import = "#FFFFAA"
+                elif rate_frac <= 0.9:
+                    rate_color_import = "#F1A861"
+                else:
+                    rate_color_import = "#F18261"
 
             if rate_value_export >= (1.5 * export_cost_threshold):
                 rate_color_export = "#F18261"


### PR DESCRIPTION
## Summary
- Rate colors in the plan table now use proportional position within the min-max rate range instead of fixed charge threshold multiples, giving distinct colors for each rate tier (e.g. Cosy Octopus 4p/14p/28p/43p all get visually different colors instead of 28p and 43p being identical)
- Rate text descriptions ("very cheap", "cheap", "expensive", "very expensive") also use the min-max range, so they reflect the user's actual tariff structure rather than internal battery charging thresholds
- Previously, the charge threshold override caused most rates to appear "expensive" or "very expensive" on multi-tier tariffs like Cosy Octopus

## Test plan
- [ ] Verify Cosy Octopus shows 4 distinct colors for 4p/14p/28p/43p rates
- [ ] Verify Agile tariff shows reasonable gradient across its rate range
- [ ] Verify flat-rate tariff shows "fixed" text
- [ ] Verify negative rates still show blue
- [ ] Check status text descriptions match expected bands

🤖 Generated with [Claude Code](https://claude.com/claude-code)