### PR TITLE
fix: re-run automatic_config when tariff structure changes

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -596,6 +596,7 @@ class OctopusAPI(ComponentBase):
             return self.tariffs
 
         now = datetime.now()
+        old_tariff_keys = set(self.tariffs.keys())
 
         tariffs = {}
         gas = self.account_data.get("account", {}).get("gasAgreements", [])
@@ -653,6 +654,13 @@ class OctopusAPI(ComponentBase):
                     tariffs["gas"]["data"] = self.tariffs.get("gas", {}).get("data", None)
                     tariffs["gas"]["standing"] = self.tariffs.get("gas", {}).get("standing", None)
         self.tariffs = tariffs
+
+        # Re-run automatic config if tariff structure changed (e.g. export agreement became active)
+        new_tariff_keys = set(self.tariffs.keys())
+        if old_tariff_keys and new_tariff_keys != old_tariff_keys and self.automatic:
+            self.log("Octopus API: Tariff structure changed from {} to {}, reconfiguring".format(old_tariff_keys, new_tariff_keys))
+            self.automatic_config(self.tariffs)
+
         return self.tariffs
 
     async def async_update_intelligent_device(self, account_id):


### PR DESCRIPTION
## Summary

- Fixes export rates stuck at 0.0 when a PredBat pod starts before an Octopus export tariff agreement becomes active
- `automatic_config()` only runs on `first=True` and never re-runs when `async_find_tariffs()` discovers the export tariff later
- Captures tariff keys before/after discovery and re-runs `automatic_config()` if the key set changed (e.g. "export" appeared)

## Details

When `async_find_tariffs()` runs every 30 minutes and discovers a newly-active export agreement, the tariff keys change (e.g. `{"import"}` → `{"import", "export"}`). This triggers `automatic_config()` to set the `metric_octopus_export` entity name arg, which was previously never set because the export tariff didn't exist at startup.

The fix is safe because:
- `set_arg()` is idempotent (simple dict assignment)
- `automatic_config()` only sets sensor entity names — no side effects
- First-run path unchanged (`first=True` at line 429-430 still works)
- Only triggers when tariff keys actually change, not every 30-min cycle
- Skips the very first run (when `self.tariffs` is empty `{}`) since `first=True` already handles that

Fixes #3486

## Test plan

- [ ] Verify existing tariff discovery works unchanged (import-only account)
- [ ] Verify export tariff appearing after startup triggers reconfiguration log message
- [ ] Verify `metric_octopus_export` gets set correctly after reconfiguration
- [ ] Verify no reconfiguration on subsequent cycles when tariffs haven't changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)