### PR TITLE
Add .venv/ and venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ coverage/predbat_standalone_ha/
 coverage/supabase/
 coverage/octopus/
 coverage/venv/
+.venv/
+venv/
 coverage/temp_octopus/
 .coverage
 .pytest_cache/

--- a/apps/predbat/load_predictor.py
+++ b/apps/predbat/load_predictor.py
@@ -1558,7 +1558,7 @@ class LoadPredictor:
             progress = step_idx / PREDICT_HORIZON
             model_weight = 1.0 - progress * (1.0 - blend_floor)
             energy_value = model_weight * model_pred + (1.0 - model_weight) * hist_value
-        
+
             # Cap final value to 5x the maximum historical energy seen for this day-of-week
             energy_value = min(energy_value, 5 * max_energy_by_dow[day_of_week])
 


### PR DESCRIPTION
The existing `.gitignore` only covered `coverage/venv/` but not root-level `.venv/` or `venv/` directories. This caused PR #3485 to accidentally include the contributor's virtual environment files.\n\nThis PR adds `.venv/` and `venv/` to the root `.gitignore` to prevent this from happening again.