### PR TITLE
fix: use self.base.prefix in _execute_get_plan (resolves AttributeError)

### DIFF
--- a/apps/predbat/web_mcp.py
+++ b/apps/predbat/web_mcp.py
@@ -948,7 +948,7 @@ class MCPServerWrapper:
     async def _execute_get_plan(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the get_plan tool"""
         try:
-            raw_plan = self.base.get_state_wrapper(self.prefix + ".plan_html", attribute="raw", default=None)
+            raw_plan = self.base.get_state_wrapper(self.base.prefix + ".plan_html", attribute="raw", default=None)
             # Check if we have plan data available
             if not raw_plan:
                 return {"success": False, "error": "No plan data available", "data": None}


### PR DESCRIPTION
## Summary

- Fixes `AttributeError: 'MCPServerWrapper' object has no attribute 'prefix'` when calling the `get_plan` MCP tool
- `MCPServerWrapper` does not define `prefix` — it belongs to the underlying Predbat base object
- One-line fix: `self.prefix` → `self.base.prefix` in `_execute_get_plan` (`web_mcp.py`)

Fixes #3497