### PR TITLE
fix: return capabilities.tools as object in MCP initialize response

### DIFF
--- a/apps/predbat/web_mcp.py
+++ b/apps/predbat/web_mcp.py
@@ -1191,8 +1191,7 @@ class MCPServerWrapper:
 
     async def _handle_initialize(self, params):
         """Handle MCP initialize request"""
-        tools = await self._handle_tools_list(params)
-        return {"protocolVersion": "2024-11-05", "capabilities": {"tools": tools["tools"]}, "serverInfo": {"name": "Predbat MCP Server", "version": "1.0.1"}}
+        return {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "Predbat MCP Server", "version": "1.0.1"}}
 
     async def _handle_tools_list(self, params):
         """Handle MCP tools/list request"""


### PR DESCRIPTION
## Summary

Fixes #3496

The MCP `initialize` response was returning `capabilities.tools` as an array of tool objects (the result of `tools/list`) instead of an empty object `{}` as required by the [MCP specification](https://spec.modelcontextprotocol.io/specification/server/utilities/capabilities/).

Strict MCP clients (e.g. Claude Desktop via `mcp-remote` using `@modelcontextprotocol/sdk`) validate against the spec and fail immediately with:

```
Connection error: $ZodError: [
  {
    "expected": "object",
    "code": "invalid_type",
    "path": ["capabilities", "tools"],
    "message": "Invalid input: expected object, received array"
  }
]
```

## Fix

In `_handle_initialize`, removed the call to `_handle_tools_list()` and changed `capabilities.tools` to an empty object `{}`:

```python
# Before
async def _handle_initialize(self, params):
    tools = await self._handle_tools_list(params)
    return {"protocolVersion": "2024-11-05", "capabilities": {"tools": tools["tools"]}, ...}

# After
async def _handle_initialize(self, params):
    return {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, ...}
```

The tool list is correctly returned in response to `tools/list` requests — it does not belong in the `initialize` capabilities field.