### PR TITLE
Fix Solis case-insensitive SN matching in event handlers (#3433)

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -234,6 +234,17 @@ class SolisAPI(ComponentBase):
 
         self.log(f"Solis API: Initialized with inverter_sn={self.inverter_sn} automatic={automatic}")
 
+    # ==================== Helper Methods ====================
+
+    def find_inverter_by_sn(self, sn_from_entity_id):
+        """Return the original-case serial number that matches sn_from_entity_id case-insensitively.
+
+        HA normalises entity IDs to lowercase, so serial numbers containing uppercase hex digits
+        (A-F) would never match self.inverter_sn via a plain 'in' check.  This method does a
+        case-insensitive search and returns the canonical (API-casing) SN, or None if not found.
+        """
+        return next((sn for sn in self.inverter_sn if sn.lower() == sn_from_entity_id.lower()), None)
+
     # ==================== Authentication Methods ====================
 
     def _digest(self, body):
@@ -2004,9 +2015,11 @@ class SolisAPI(ComponentBase):
             inverter_sn = parts[0]
             field = "_".join(parts[1:])
 
-            # Validate inverter exists
-            if inverter_sn not in self.inverter_sn:
-                self.log(f"Warn: Solis API: Unknown inverter {inverter_sn} in select_event")
+            # Validate inverter exists (case-insensitive: HA normalises entity IDs to lowercase,
+            # so SNs containing uppercase hex digits A-F would never match otherwise)
+            inverter_sn = self.find_inverter_by_sn(inverter_sn)
+            if inverter_sn is None:
+                self.log(f"Warn: Solis API: Unknown inverter {parts[0]} in select_event")
                 return
 
             # Handle storage mode
@@ -2123,9 +2136,11 @@ class SolisAPI(ComponentBase):
             inverter_sn = parts[0]
             field = "_".join(parts[1:])
 
-            # Validate inverter exists
-            if inverter_sn not in self.inverter_sn:
-                self.log(f"Warn: Solis API: Unknown inverter {inverter_sn} in number_event")
+            # Validate inverter exists (case-insensitive: HA normalises entity IDs to lowercase,
+            # so SNs containing uppercase hex digits A-F would never match otherwise)
+            inverter_sn = self.find_inverter_by_sn(inverter_sn)
+            if inverter_sn is None:
+                self.log(f"Warn: Solis API: Unknown inverter {parts[0]} in number_event")
                 return
 
             # Convert value to string for API
@@ -2324,9 +2339,11 @@ class SolisAPI(ComponentBase):
             inverter_sn = parts[0]
             field = "_".join(parts[1:])
 
-            # Validate inverter exists
-            if inverter_sn not in self.inverter_sn:
-                self.log(f"Warn: Solis API: Unknown inverter {inverter_sn} in switch_event")
+            # Validate inverter exists (case-insensitive: HA normalises entity IDs to lowercase,
+            # so SNs containing uppercase hex digits A-F would never match otherwise)
+            inverter_sn = self.find_inverter_by_sn(inverter_sn)
+            if inverter_sn is None:
+                self.log(f"Warn: Solis API: Unknown inverter {parts[0]} in switch_event")
                 return
 
             # Handle charge slot enables


### PR DESCRIPTION
## Summary

Fixes #3433 — `solis.py` event handlers still ignoring writes for inverters with uppercase hex digits in their serial number.

## Root cause

HA normalises entity IDs to lowercase, so when `number_event`, `select_event`, or `switch_event` extract the serial number from the entity ID it arrives in lowercase (e.g. `111f33333333333`).  The previous fix (PR #3457) lowercased the SN when *building* entity IDs, but the event handlers still validated with a plain `sn in self.inverter_sn` check against `self.inverter_sn` which retains the original API casing (e.g. `111F33333333333`).  The comparison therefore failed for every write, producing the repeated warning:

```
Warn: Solis API: Unknown inverter 111f33333333333 in number_event
```

## Fix

Add a `find_inverter_by_sn()` helper that performs a **case-insensitive** lookup and returns the **canonical (API-casing) SN**:

```python
def find_inverter_by_sn(self, sn_from_entity_id):
    return next((sn for sn in self.inverter_sn if sn.lower() == sn_from_entity_id.lower()), None)
```

All three event handlers now call this helper.  The returned SN is then used for Solis API payloads and internal dict keys (`cached_values`, `charge_discharge_time_windows`, etc.) so original casing is preserved where the API requires it.

## Testing

Unit tests pass (`./run_all --quick`).