### PR TITLE
Fix inverter test bugs: non-deterministic failure, silent assertions, state leak

### DIFF
--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -933,6 +933,7 @@ def test_inverter_update(
 def test_auto_restart(test_name, my_predbat, ha, inv, dummy_items, service, expected, active=False, set_system_notify=None, expect_notify=False):
     print("**** Running Test: {} ****".format(test_name))
     failed = 0
+    prev_service_store_enable = ha.service_store_enable
     ha.service_store_enable = True
     ha.service_store = []
     my_predbat.restart_active = active
@@ -974,6 +975,7 @@ def test_auto_restart(test_name, my_predbat, ha, inv, dummy_items, service, expe
     if json.dumps(expected) != json.dumps(result_filtered):
         print("ERROR: Auto-restart service should be {} got {}".format(expected, result_filtered))
         failed = 1
+    ha.service_store_enable = prev_service_store_enable
     return failed
 
 


### PR DESCRIPTION
## Summary

I've been using Predbat with a SIG inverter and working on some control
improvements for it. While developing tests for that work I ran into
these three bugs in the existing inverter test suite.

- **Non-deterministic rest1 failure**: The test resolves hardcoded charge
  window times (23:30-05:30) relative to the system clock. It passes after
  05:30 but fails before 05:30, since `compute_window_minutes` flips which
  branch handles the midnight-spanning window. Fixed by pinning `minutes_now`
  to noon. (Perhaps this is the test suite's way of telling me not to be
  coding at 1am.)
- **Silent assertion failures**: `test_disable_charge_window` and
  `test_adjust_charge_window` printed ERROR for inverter button press checks
  but never set `failed = True`. Additionally, `test_adjust_charge_window`
  set the wrong attribute (`has_inverter_time_button_press` instead of
  `inv_time_button_press`), so button press behavior was never tested.
- **State leak**: `test_auto_restart` sets `service_store_enable = True`
  but never restores the previous value, potentially leaking state into
  subsequent tests.

SIG inverter control PR to follow — watch this space!

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `python3 unit_test.py --quick` passes (including at 01:00 when it
  previously failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)