### PR TITLE
 Move car_charging_soc initialization BEFORE the IOG processing loop.

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -940,6 +940,19 @@ class Fetch:
             if self.rate_import:
                 self.rate_scan(self.rate_import, print=False)
 
+            # Work out car SoC and reset next BEFORE processing IOG slots
+            # This must be done before load_octopus_slots is called to avoid IndexError
+            self.car_charging_soc = [0.0 for car_n in range(self.num_cars)]
+            self.car_charging_soc_next = [None for car_n in range(self.num_cars)]
+            for car_n in range(self.num_cars):
+                if car_n < len(self.car_charging_manual_soc) and self.car_charging_manual_soc[car_n]:
+                    car_postfix = "" if car_n == 0 else "_" + str(car_n)
+                    self.car_charging_soc[car_n] = self.get_arg("car_charging_manual_soc_kwh" + car_postfix, 0.0)
+                else:
+                    self.car_charging_soc[car_n] = (self.get_arg("car_charging_soc", 0.0, index=car_n) * self.car_charging_battery_size[car_n]) / 100.0
+            if self.num_cars:
+                self.log("Cars: SoC: {}kWh, Charge limit {}%, plan time {}, battery size {}kWh".format(self.car_charging_soc, self.car_charging_limit, self.car_charging_plan_time, self.car_charging_battery_size))
+
             # Use octopus slots for charging - process for each car
             if self.octopus_intelligent_charging:
                 for car_n in range(min(len(entity_id_list), self.num_cars)):
@@ -964,18 +977,6 @@ class Fetch:
         else:
             # Disable octopus charging if we don't have the slot sensor
             self.octopus_intelligent_charging = False
-
-        # Work out car SoC and reset next
-        self.car_charging_soc = [0.0 for car_n in range(self.num_cars)]
-        self.car_charging_soc_next = [None for car_n in range(self.num_cars)]
-        for car_n in range(self.num_cars):
-            if car_n < len(self.car_charging_manual_soc) and self.car_charging_manual_soc[car_n]:
-                car_postfix = "" if car_n == 0 else "_" + str(car_n)
-                self.car_charging_soc[car_n] = self.get_arg("car_charging_manual_soc_kwh" + car_postfix, 0.0)
-            else:
-                self.car_charging_soc[car_n] = (self.get_arg("car_charging_soc", 0.0, index=car_n) * self.car_charging_battery_size[car_n]) / 100.0
-        if self.num_cars:
-            self.log("Cars: SoC: {}kWh, Charge limit {}%, plan time {}, battery size {}kWh".format(self.car_charging_soc, self.car_charging_limit, self.car_charging_plan_time, self.car_charging_battery_size))
 
         if "rates_export_octopus_url" in self.args:
             # Fixed URL for rate export

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2165,6 +2165,12 @@ class Octopus:
         if car_n >= self.num_cars:
             # Car not configured, just return the slots as they are (for export or other non-car use)
             return new_slots
+
+        if car_n >= len(self.car_charging_soc):
+            # Defensive check: ensure car_charging_soc is properly initialized
+            self.log("Warn: car_n {} is out of range for car_charging_soc (length {})".format(car_n, len(self.car_charging_soc)))
+            return new_slots
+
         octopus_slot_low_rate = self.get_arg("octopus_slot_low_rate", True)
         car_soc = self.car_charging_soc[car_n]
         limit = self.car_charging_limit[car_n]


### PR DESCRIPTION
The fix moves car_charging_soc initialization BEFORE the IOG processing loop.

car_charging_soc was being initialized after being accessed in load_octopus_slots(), causing an IndexError when processing multiple cars

Add a bounds check in load_octopus_slots() to gracefully handle any future initialization issues

Fixes #3515 