### PR TITLE
feat: Add PV1 and PV2 Voltage Sensors to Solis Cloud

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1363,6 +1363,40 @@ class SolisAPI(ComponentBase):
                 app="solis"
             )
 
+            # PV Voltage (from detail)
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_pv1_voltage"
+            pv_voltage = detail.get("uPv1")
+            pv_voltage_unit = detail.get("pvVoltageStr", "V")
+            self.dashboard_item(
+                entity_id,
+                state=pv_voltage,
+                attributes={
+                    "friendly_name": f"Solis {inverter_name} PV1 Voltage",
+                    "unit_of_measurement": pv_voltage_unit,
+                    "device_class": "voltage",
+                    "state_class": "measurement",
+                    "icon": "mdi:lightning-bolt",
+                },
+                app="solis"
+            )
+
+            # PV Voltage (from detail)
+            entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_pv2_voltage"
+            pv_voltage = detail.get("uPv2")
+            pv_voltage_unit = detail.get("pvVoltageStr", "V")
+            self.dashboard_item(
+                entity_id,
+                state=pv_voltage,
+                attributes={
+                    "friendly_name": f"Solis {inverter_name} PV2 Voltage",
+                    "unit_of_measurement": pv_voltage_unit,
+                    "device_class": "voltage",
+                    "state_class": "measurement",
+                    "icon": "mdi:lightning-bolt",
+                },
+                app="solis"
+            )
+
             # Product Model
             entity_id = f"sensor.{prefix}_solis_{inverter_sn_lower}_product_model"
             product_model = detail.get("productModel")

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -1660,6 +1660,9 @@ async def test_publish_entities():
         "familyLoadPowerStr": "kW",
         "psum": -1.2,
         "psumStr": "kW",
+        "uPv1": 285.3,
+        "uPv2": 272.1,
+        "pvVoltageStr": "V",
     }
 
     # Setup cached CID values
@@ -1814,6 +1817,17 @@ async def test_publish_entities():
     assert f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_energy_discharged_today" in api.dashboard_items, "Battery energy discharged today should be published"
     discharged_today = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn_lower}_battery_energy_discharged_today"]
     assert discharged_today["state"] == 3.8, f"Battery energy discharged today should be 3.8, got {discharged_today['state']}"
+
+    # Check PV voltage sensors
+    assert f"sensor.{prefix}_solis_{inverter_sn_lower}_pv1_voltage" in api.dashboard_items, "PV1 voltage should be published"
+    pv1_voltage = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn_lower}_pv1_voltage"]
+    assert pv1_voltage["state"] == 285.3, f"PV1 voltage should be 285.3, got {pv1_voltage['state']}"
+    assert pv1_voltage["attributes"]["unit_of_measurement"] == "V", "PV1 voltage should have V unit"
+
+    assert f"sensor.{prefix}_solis_{inverter_sn_lower}_pv2_voltage" in api.dashboard_items, "PV2 voltage should be published"
+    pv2_voltage = api.dashboard_items[f"sensor.{prefix}_solis_{inverter_sn_lower}_pv2_voltage"]
+    assert pv2_voltage["state"] == 272.1, f"PV2 voltage should be 272.1, got {pv2_voltage['state']}"
+    assert pv2_voltage["attributes"]["unit_of_measurement"] == "V", "PV2 voltage should have V unit"
 
     print(f"PASSED: publish_entities created {len(api.dashboard_items)} entities correctly")
     return False


### PR DESCRIPTION
# Add PV1 and PV2 Voltage Sensors to Solis Cloud

## Problem

When removing the [solis-sensor](https://github.com/hultenvp/solis-sensor) HACS integration and relying solely on Predbat's Solis Cloud component, there were no entities available for the voltage on the PV strings. I have some automations around this to help detect when a panel is bad.

## Changes

- Added two new sensors in `publish_entities()` in `solis.py`:
  - `sensor.{prefix}_solis_{sn}_pv1_voltage` — current value of voltage from the first PV string.
  - `sensor.{prefix}_solis_{sn}_pv2_voltage` — current value of voltage from the second PV string.
- Updated tests in `tests/test_solis.py`:
  - Added `uPv1` and `uPv2` fields to the `test_publish_entities` mock data
  - Added assertions verifying both sensors are published with correct values

## Data Source

These values come from the Solis inverter detail API (already polled by `fetch_inverter_details()`), so no additional API calls are needed.