### PR TITLE
[feat] Add Data Logger Timestamp Sensor to Solis Cloud

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1982,6 +1982,24 @@ class SolisAPI(ComponentBase):
                 except (ValueError, TypeError):
                     self.log("Warn: Failed to convert battery capacity for {}: {}".format(inverter_sn, battery_capacity_ah))  # Debug log
 
+            # Data logger timestamp from inverterDetail API (shows when the data logger last reported to SolisCloud)
+            data_timestamp_ms = detail.get("dataTimestamp")
+            if data_timestamp_ms is not None:
+                try:
+                    data_timestamp_dt = datetime.fromtimestamp(int(data_timestamp_ms) / 1000, tz=UTC)
+                    self.dashboard_item(
+                        f"sensor.{prefix}_solis_{inverter_sn_lower}_data_timestamp",
+                        state=data_timestamp_dt.isoformat(),
+                        attributes={
+                            "friendly_name": f"Solis {inverter_name} Data Logger Timestamp",
+                            "device_class": "timestamp",
+                            "icon": "mdi:clock-check-outline",
+                        },
+                        app="solis"
+                    )
+                except (ValueError, TypeError, OSError):
+                    self.log(f"Warn: Failed to parse dataTimestamp for {inverter_sn}: {data_timestamp_ms}")
+
     # ==================== Control Methods ====================
 
     async def set_storage_mode_if_needed(self, inverter_sn, mode):


### PR DESCRIPTION
# Add Data Logger Timestamp Sensor to Solis Cloud

## Problem

When monitoring the Solis Cloud integration, there was no way to tell how fresh the data being displayed actually was. The Solis datalogger only reports to SolisCloud periodically (typically every ~5 minutes), and API throttling or datalogger connectivity issues can cause the data to become stale. Without visibility into the data's age, it's difficult to distinguish between genuinely stable readings and stale/outdated values. In addition, a successful poll by predbat may still retreive stale data from SolisCloud if your datalogger hasn't been able to post its data to SolisCloud.

## Changes

- Added a new sensor in `publish_entities()` in `solis.py`:
  - `sensor.{prefix}_solis_{sn}_data_timestamp` — the timestamp when the datalogger last reported data to SolisCloud, exposed as a HA `timestamp` device class entity.
- The `dataTimestamp` field from the API is provided as epoch milliseconds and is converted to an ISO 8601 datetime string.

## Data Source

This value comes from the `dataTimestamp` field in the Solis `inverterDetail` API response (already polled by `fetch_inverter_details()`), so no additional API calls are needed. This is the same field used by the [solis-sensor](https://github.com/hultenvp/solis-sensor) integration to track data freshness.

## Screenshot

Here's a screenshot of using the entity in a header badge:
<img width="245" height="42" alt="image" src="https://github.com/user-attachments/assets/2c894351-f92a-47f2-8c98-fabb01361d8a" />
