### PR TITLE
Catch missing history data in compare chart

### DIFF
--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -3161,8 +3161,8 @@ chart.render();
                 compare_hist[id] = {}
                 result = self.base.comparison.get_comparison(id)
                 if result:
-                    compare_hist[id]["cost"] = history_attribute(self.get_history_wrapper(result["entity_id"], 28), daily=True, pounds=True)
-                    compare_hist[id]["metric"] = history_attribute(self.get_history_wrapper(result["entity_id"], 28), state_key="metric", attributes=True, daily=True, pounds=True)
+                    compare_hist[id]["cost"] = history_attribute(self.get_history_wrapper(result["entity_id"], 28, required=False), daily=True, pounds=True)
+                    compare_hist[id]["metric"] = history_attribute(self.get_history_wrapper(result["entity_id"], 28, required=False), state_key="metric", attributes=True, daily=True, pounds=True)
 
         compare_list = self.get_arg("compare_list", [])
 


### PR DESCRIPTION
Fixes #3568

When the compare tab is loaded, `get_history_wrapper` is called for each compare tariff entity. If history isn't available yet (new entity, HA not tracking it, etc.) the call raises `ValueError` (since `required` defaults to `True`), which bubbles up as a 500 server error.

Fix: pass `required=False` to both `get_history_wrapper` calls in `html_compare`, matching the same pattern already used for `cost_yesterday` on the line above. `history_attribute()` already handles `None` input gracefully.