### PR TITLE
Take a copy of rates obtained via download_octopus_rates so saving sessions don't repeatedly increment them

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -27,6 +27,7 @@ from axle import fetch_axle_sessions, load_axle_slot, fetch_axle_active
 
 import copy
 
+
 class Fetch:
     """Data fetching mixin for loading energy rates, consumption, and forecasts.
 


### PR DESCRIPTION
When using rates_import_octopus_url/rates_export_octopus_url:

- ```download_octopus_rates``` fetches the current cached import/export rates
- ```load_saving_slot``` increments the rates *as stored in the cache* at the relevant times
- hence these increases accumulate, and reset only when the cache is deemed stale
- repeat until the saving session is over

Solution -- take a copy of the cached import/export rates, so saving sessions affect only a local copy of the rates rather than the cached rates.

(Happy to submit an issue with a log file evidencing the bug, if that's your preferred workflow.)