### PR TITLE
Fix Fox inverter_limit_charge not honoured (issue #3610)

### DIFF
--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -663,6 +663,7 @@ class FoxAPI(ComponentBase, OAuthMixin):
         battery_times = self.device_battery_charging_time.get(deviceSN, {})
         scheduler_times = self.device_scheduler.get(deviceSN, {}).get("groups", [])
         device_scheduler_enabled = self.device_scheduler.get(deviceSN, {}).get("enable", False)
+        fdPwr_max = self.fdpwr_max.get(deviceSN, 8000)
 
         # First convert battery times into the same format as scheduler times
         # Create an array of 0 - 2 slots containing the battery charge times
@@ -683,7 +684,7 @@ class FoxAPI(ComponentBase, OAuthMixin):
                         "endHour": 0,
                         "endMinute": 0,
                         "enable": 0,
-                        "fdPwr": self.fdpwr_max.get(deviceSN, 8000),
+                        "fdPwr": fdPwr_max,
                         "workMode": "SelfUse",
                         "fdSoc": 100,
                         "minSocOnGrid": reserve,
@@ -703,7 +704,7 @@ class FoxAPI(ComponentBase, OAuthMixin):
                         "endHour": end_time.get("hour", 0),
                         "endMinute": end_time.get("minute", 0),
                         "enable": 1,
-                        "fdPwr": 0,
+                        "fdPwr": fdPwr_max,
                         "workMode": "ForceCharge",
                         "fdSoc": 100,
                         "minSocOnGrid": reserve,
@@ -739,7 +740,7 @@ class FoxAPI(ComponentBase, OAuthMixin):
             self.local_schedule[deviceSN]["charge"]["start_time"] = "{:02d}:{:02d}:00".format(charge_group.get("startHour", 0), charge_group.get("startMinute", 0))
             self.local_schedule[deviceSN]["charge"]["end_time"] = "{:02d}:{:02d}:00".format(end_hour, end_minute)
             self.local_schedule[deviceSN]["charge"]["soc"] = charge_group.get("maxSoc", 100)
-            self.local_schedule[deviceSN]["charge"]["power"] = self.fdpwr_max[deviceSN]
+            self.local_schedule[deviceSN]["charge"]["power"] = int(charge_group.get("fdPwr", fdPwr_max))
             self.local_schedule[deviceSN]["charge"]["enable"] = 1 if charge_group.get("enable", 0) else 0
         if discharge_group:
             end_hour = discharge_group.get("endHour", 0)
@@ -749,7 +750,7 @@ class FoxAPI(ComponentBase, OAuthMixin):
             self.local_schedule[deviceSN]["discharge"]["start_time"] = "{:02d}:{:02d}:00".format(discharge_group.get("startHour", 0), discharge_group.get("startMinute", 0))
             self.local_schedule[deviceSN]["discharge"]["end_time"] = "{:02d}:{:02d}:00".format(end_hour, end_minute)
             self.local_schedule[deviceSN]["discharge"]["soc"] = discharge_group.get("fdSoc", 100)
-            self.local_schedule[deviceSN]["discharge"]["power"] = int(discharge_group.get("fdPwr", 0))
+            self.local_schedule[deviceSN]["discharge"]["power"] = int(discharge_group.get("fdPwr", fdPwr_max))
             self.local_schedule[deviceSN]["discharge"]["enable"] = 1 if discharge_group.get("enable", 0) else 0
         return self.local_schedule
 
@@ -1610,7 +1611,7 @@ class FoxAPI(ComponentBase, OAuthMixin):
                             "workMode": "ForceCharge",
                             "fdSoc": 100,
                             "maxSoc": soc,
-                            "fdPwr": fdPwr_max,
+                            "fdPwr": power,
                             "minSocOnGrid": soc,
                         }
                     )

--- a/apps/predbat/tests/test_fox_api.py
+++ b/apps/predbat/tests/test_fox_api.py
@@ -5233,6 +5233,122 @@ def test_fox_rate_limiting_variable_pattern(my_predbat):
     return False
 
 
+def test_compute_schedule_charge_power_reads_slot_fdpwr(my_predbat):
+    """
+    Regression test for #3610: compute_schedule must read fdPwr from the active charge slot,
+    not always substitute fdPwr_max.  When inverter_limit_charge restricts charge power below
+    the hardware maximum, that lower value should appear in local_schedule["charge"]["power"].
+    """
+    print("  - test_compute_schedule_charge_power_reads_slot_fdpwr")
+
+    fox = MockFoxAPI()
+    deviceSN = "TEST123"
+
+    limited_power = 3000  # simulates inverter_limit_charge being set below fdPwr_max
+
+    fox.device_scheduler[deviceSN] = {
+        "enable": True,
+        "groups": [
+            {
+                "startHour": 1,
+                "startMinute": 0,
+                "endHour": 4,
+                "endMinute": 59,
+                "enable": 1,
+                "fdPwr": limited_power,  # slot has the limited power value
+                "workMode": "ForceCharge",
+                "fdSoc": 100,
+                "maxSoc": 80,
+                "minSocOnGrid": 10,
+            }
+        ],
+    }
+    fox.device_settings[deviceSN] = {"MinSocOnGrid": {"value": 10}}
+    fox.fdpwr_max[deviceSN] = 8000  # hardware maximum is higher than the limit
+    fox.local_schedule[deviceSN] = {"reserve": 10}
+
+    asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
+
+    charge = fox.local_schedule[deviceSN]["charge"]
+    assert charge["power"] == limited_power, f"charge power should be {limited_power} (from slot fdPwr), got {charge['power']} — " "fdPwr_max must not overwrite the slot value (issue #3610)"
+
+    return False
+
+
+def test_compute_schedule_discharge_missing_fdpwr_defaults_to_max(my_predbat):
+    """
+    Regression test for #3610: when a ForceDischarge slot has no fdPwr key,
+    compute_schedule should default to fdPwr_max (not 0).
+    """
+    print("  - test_compute_schedule_discharge_missing_fdpwr_defaults_to_max")
+
+    fox = MockFoxAPI()
+    deviceSN = "TEST123"
+
+    fox.device_scheduler[deviceSN] = {
+        "enable": True,
+        "groups": [
+            {
+                "startHour": 16,
+                "startMinute": 0,
+                "endHour": 18,
+                "endMinute": 59,
+                "enable": 1,
+                # fdPwr intentionally omitted to test the default
+                "workMode": "ForceDischarge",
+                "fdSoc": 10,
+                "maxSoc": 90,
+                "minSocOnGrid": 10,
+            }
+        ],
+    }
+    fox.device_settings[deviceSN] = {"MinSocOnGrid": {"value": 10}}
+    fox.fdpwr_max[deviceSN] = 8000
+    fox.local_schedule[deviceSN] = {"reserve": 10}
+
+    asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
+
+    discharge = fox.local_schedule[deviceSN]["discharge"]
+    assert discharge["power"] == 8000, f"discharge power should default to fdPwr_max (8000) when fdPwr is missing, got {discharge['power']}"
+
+    return False
+
+
+def test_apply_battery_schedule_limited_charge_power_sent_to_api(my_predbat):
+    """
+    Regression test for #3610: apply_battery_schedule must send the charge power stored in
+    local_schedule (which reflects inverter_limit_charge) as fdPwr in the ForceCharge slot —
+    not the hardware maximum fdPwr_max.
+    """
+    print("  - test_apply_battery_schedule_limited_charge_power_sent_to_api")
+
+    fox = MockFoxAPIWithSchedulerTracking()
+    deviceSN = "TEST123456"
+
+    limited_power = 3000  # simulates inverter_limit_charge
+
+    fox.device_detail[deviceSN] = {"hasBattery": True}
+    fox.device_settings[deviceSN] = {"MinSocOnGrid": {"value": 10}}
+    fox.fdpwr_max[deviceSN] = 8000
+    fox.fdsoc_min[deviceSN] = 10
+    fox.local_schedule[deviceSN] = {
+        "reserve": 10,
+        "charge": {"enable": 1, "start_time": "01:00:00", "end_time": "05:00:00", "soc": 100, "power": limited_power},
+        "discharge": {"enable": 0, "start_time": "00:00:00", "end_time": "00:00:00", "soc": 10, "power": 5000},
+    }
+
+    run_async(fox.apply_battery_schedule(deviceSN))
+
+    assert len(fox.set_scheduler_calls) == 1
+    groups = fox.set_scheduler_calls[0]["groups"]
+
+    charge_group = next((g for g in groups if g.get("workMode") == "ForceCharge"), None)
+    assert charge_group is not None, "ForceCharge group not found in schedule sent to API"
+    assert charge_group["fdPwr"] == limited_power, f"fdPwr sent to API should be {limited_power} (from local_schedule power), " f"got {charge_group['fdPwr']} — fdPwr_max must not override inverter_limit_charge (issue #3610)"
+
+    return False
+
+
 def run_fox_api_tests(my_predbat):
     """
     Run all Fox API tests
@@ -5403,6 +5519,11 @@ def run_fox_api_tests(my_predbat):
         failed |= test_apply_battery_schedule_discharge_only(my_predbat)
         failed |= test_apply_battery_schedule_both_enabled(my_predbat)
         failed |= test_apply_battery_schedule_neither_enabled(my_predbat)
+        failed |= test_apply_battery_schedule_limited_charge_power_sent_to_api(my_predbat)
+
+        # compute_schedule charge-rate power fix tests (issue #3610)
+        failed |= test_compute_schedule_charge_power_reads_slot_fdpwr(my_predbat)
+        failed |= test_compute_schedule_discharge_missing_fdpwr_defaults_to_max(my_predbat)
 
         # automatic_config tests
         failed |= test_automatic_config_single_battery(my_predbat)


### PR DESCRIPTION
## Summary

Fixes #3610 — `inverter_limit_charge` was silently ignored for FoxCloud inverters.

## Root cause

Two separate bugs combined to break the charge-power round-trip:

**1. `apply_battery_schedule` always sent `fdPwr_max` to the Fox API**

When writing a ForceCharge slot, the code hardcoded `"fdPwr": fdPwr_max` regardless of whatever power was stored in `local_schedule["charge"]["power"]`. This meant the hardware maximum was always sent, overriding any lower value supplied by `inverter_limit_charge`.

**2. `compute_schedule` always overwrote charge power with `fdPwr_max`**

When reading back the current schedule, the code set `local_schedule["charge"]["power"] = self.fdpwr_max[deviceSN]` (a plain dict access, which could also `KeyError`) instead of reading the `fdPwr` field from the active ForceCharge slot. This reset the stored value every cycle.

## Changes

- **`compute_schedule`**: reads `fdPwr` from the active charge slot (defaulting to `fdPwr_max` only when absent) — change 3
- **`compute_schedule`**: missing `fdPwr` on a ForceDischarge slot now defaults to `fdPwr_max` rather than `0` — change 4
- **`apply_battery_schedule`**: sends `"fdPwr": power` (from `local_schedule`) instead of `"fdPwr": fdPwr_max` — change 5
- **`compute_schedule`**: extracts `fdPwr_max` to a local variable early to avoid repeated dict lookups and remove a potential `KeyError` — changes 1 & 2

## Tests

Three regression tests added to `tests/test_fox_api.py`:

- `test_compute_schedule_charge_power_reads_slot_fdpwr` — asserts the slot's `fdPwr` is preserved in `local_schedule`
- `test_compute_schedule_discharge_missing_fdpwr_defaults_to_max` — asserts missing `fdPwr` defaults to `fdPwr_max`, not `0`
- `test_apply_battery_schedule_limited_charge_power_sent_to_api` — asserts the limited power is what gets sent to the Fox API