### PR TITLE
Fix issue with multiple IOG cars

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -966,45 +966,7 @@ class Fetch:
                 self.rate_import_cost_threshold = highest
 
         # Work out car plan?
-        # Determine which cars are configured with Octopus Intelligent to avoid calling plan_car_charging for them
-        iog_entity_id_config = self.get_arg("octopus_intelligent_slot", indirect=False)
-        if iog_entity_id_config and not isinstance(iog_entity_id_config, list):
-            iog_entity_ids = [iog_entity_id_config]
-        elif iog_entity_id_config:
-            iog_entity_ids = iog_entity_id_config
-        else:
-            iog_entity_ids = []
-
-        for car_n in range(self.num_cars):
-            if self.octopus_intelligent_charging and car_n < len(iog_entity_ids) and iog_entity_ids[car_n]:
-                if self.car_charging_planned[car_n]:
-                    self.log("Car {} on Octopus Intelligent, active plan for charge".format(car_n))
-                else:
-                    self.log("Car {} on Octopus Intelligent, no active plan".format(car_n))
-            elif self.car_charging_planned[car_n] or self.car_charging_now[car_n]:
-                self.log(
-                    "Car {} plan charging from {} to {}, with slots {} from SoC {}% to {}%, ready by {}".format(
-                        car_n,
-                        self.car_charging_soc[car_n],
-                        self.car_charging_limit[car_n],
-                        self.low_rates,
-                        self.car_charging_soc[car_n],
-                        self.car_charging_limit[car_n],
-                        self.car_charging_plan_time[car_n],
-                    )
-                )
-                self.car_charging_slots[car_n] = self.plan_car_charging(car_n, self.low_rates)
-            else:
-                self.log("Car {} charging is not planned as it is not plugged in".format(car_n))
-
-            # Log the charging plan
-            if self.car_charging_slots[car_n]:
-                self.log("Car {} charging plan is: {}".format(car_n, self.car_charging_slots[car_n]))
-
-            if self.car_charging_planned[car_n] and self.car_charging_exclusive[car_n]:
-                self.log("Car {} charging is exclusive, will not plan other cars".format(car_n))
-                break
-
+        self.fetch_sensor_data_car_planning()
         # Publish the car plan
         self.publish_car_plan()
 
@@ -1060,6 +1022,47 @@ class Fetch:
             self.log("Axle sessions changed from {} to {}".format(prev_axle_sessions, self.axle_sessions))
             force_replan = True
         return force_replan
+
+    def fetch_sensor_data_car_planning(self):
+        # Work out car plan?
+        # Determine which cars are configured with Octopus Intelligent to avoid calling plan_car_charging for them
+        iog_entity_id_config = self.get_arg("octopus_intelligent_slot", indirect=False)
+        if iog_entity_id_config and not isinstance(iog_entity_id_config, list):
+            iog_entity_ids = [iog_entity_id_config]
+        elif iog_entity_id_config:
+            iog_entity_ids = iog_entity_id_config
+        else:
+            iog_entity_ids = []
+
+        for car_n in range(self.num_cars):
+            if self.octopus_intelligent_charging and car_n < len(iog_entity_ids) and iog_entity_ids[car_n]:
+                if self.car_charging_planned[car_n]:
+                    self.log("Car {} on Octopus Intelligent, active plan for charge".format(car_n))
+                else:
+                    self.log("Car {} on Octopus Intelligent, no active plan".format(car_n))
+            elif self.car_charging_planned[car_n] or self.car_charging_now[car_n]:
+                self.log(
+                    "Car {} plan charging from {} to {}, with slots {} from SoC {}% to {}%, ready by {}".format(
+                        car_n,
+                        self.car_charging_soc[car_n],
+                        self.car_charging_limit[car_n],
+                        self.low_rates,
+                        self.car_charging_soc[car_n],
+                        self.car_charging_limit[car_n],
+                        self.car_charging_plan_time[car_n],
+                    )
+                )
+                self.car_charging_slots[car_n] = self.plan_car_charging(car_n, self.low_rates)
+            else:
+                self.log("Car {} charging is not planned as it is not plugged in".format(car_n))
+
+            # Log the charging plan
+            if self.car_charging_slots[car_n]:
+                self.log("Car {} charging plan is: {}".format(car_n, self.car_charging_slots[car_n]))
+
+            if self.car_charging_planned[car_n] and self.car_charging_exclusive[car_n]:
+                self.log("Car {} charging is exclusive, will not plan other cars".format(car_n))
+                break
 
     def fetch_sensor_data_cars(self):
         """

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -966,12 +966,21 @@ class Fetch:
                 self.rate_import_cost_threshold = highest
 
         # Work out car plan?
+        # Determine which cars are configured with Octopus Intelligent to avoid calling plan_car_charging for them
+        iog_entity_id_config = self.get_arg("octopus_intelligent_slot", indirect=False)
+        if iog_entity_id_config and not isinstance(iog_entity_id_config, list):
+            iog_entity_ids = [iog_entity_id_config]
+        elif iog_entity_id_config:
+            iog_entity_ids = iog_entity_id_config
+        else:
+            iog_entity_ids = []
+
         for car_n in range(self.num_cars):
-            if self.octopus_intelligent_charging and car_n == 0:
+            if self.octopus_intelligent_charging and car_n < len(iog_entity_ids) and iog_entity_ids[car_n]:
                 if self.car_charging_planned[car_n]:
-                    self.log("Car 0 on Octopus Intelligent, active plan for charge")
+                    self.log("Car {} on Octopus Intelligent, active plan for charge".format(car_n))
                 else:
-                    self.log("Car 0 on Octopus Intelligent, no active plan")
+                    self.log("Car {} on Octopus Intelligent, no active plan".format(car_n))
             elif self.car_charging_planned[car_n] or self.car_charging_now[car_n]:
                 self.log(
                     "Car {} plan charging from {} to {}, with slots {} from SoC {}% to {}%, ready by {}".format(

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -36,7 +36,7 @@ import pytz
 import requests
 import asyncio
 
-THIS_VERSION = "v8.34.8"
+THIS_VERSION = "v8.34.9"
 
 # fmt: off
 PREDBAT_FILES = ["predbat.py", "const.py", "hass.py", "config.py", "prediction.py", "gecloud.py", "utils.py", "inverter.py", "ha.py", "download.py", "web.py", "web_helper.py", "predheat.py", "futurerate.py", "octopus.py", "solcast.py", "execute.py", "plan.py", "fetch.py", "output.py", "userinterface.py", "energydataservice.py", "alertfeed.py", "compare.py", "db_manager.py", "db_engine.py", "plugin_system.py", "ohme.py", "components.py", "fox.py", "carbon.py", "temperature.py", "web_mcp.py", "component_base.py", "axle.py", "solax.py", "solis.py", "unit_test.py", "load_ml_component.py", "load_predictor.py", "oauth_mixin.py", "predbat_metrics.py", "web_metrics_dashboard.py"]

--- a/apps/predbat/tests/test_multi_car_iog.py
+++ b/apps/predbat/tests/test_multi_car_iog.py
@@ -263,6 +263,146 @@ def run_multi_car_iog_load_slots_test(testname, my_predbat):
     return failed
 
 
+def run_multi_car_iog_unplugged_car_test(testname, my_predbat):
+    """
+    Regression test for issue #3592: When car 1 is NOT physically plugged in but still has
+    stale planned dispatch data from the Octopus Intelligent sensor, the car plan loop was
+    incorrectly calling plan_car_charging() for car 1 (because the `car_n == 0` guard only
+    protected car 0). This caused car 1's charging slots to expand from a small set of IOG
+    dispatch windows to ALL low-rate windows - 'charging slots all the time'.
+
+    The fix changes `car_n == 0` to check whether the car is configured with an IOG entity,
+    which prevents plan_car_charging() from being called for any IOG-configured car.
+    """
+    failed = False
+    print("**** Running Test: multi_car_iog {} ****".format(testname))
+
+    # Set up 2 cars, both on IOG
+    my_predbat.num_cars = 2
+    my_predbat.car_charging_planned = [True, False]  # Car 0 plugged in, car 1 NOT plugged in
+    my_predbat.car_charging_now = [False, False]
+    my_predbat.car_charging_plan_smart = [False, False]
+    my_predbat.car_charging_plan_max_price = [0, 0]
+    my_predbat.car_charging_plan_time = ["07:00:00", "07:00:00"]
+    my_predbat.car_charging_battery_size = [100.0, 80.0]
+    my_predbat.car_charging_limit = [100.0, 80.0]
+    my_predbat.car_charging_rate = [7.4, 7.4]
+    my_predbat.car_charging_soc = [50.0, 40.0]
+    my_predbat.car_charging_soc_next = [None, None]
+    my_predbat.car_charging_slots = [[], []]
+    my_predbat.car_charging_exclusive = [False, False]
+    my_predbat.car_charging_loss = 1.0
+    my_predbat.octopus_intelligent_charging = True
+    my_predbat.octopus_intelligent_ignore_unplugged = False  # default: don't ignore
+
+    # Both cars have IOG entities configured - the scenario from issue #3592
+    my_predbat.args["octopus_intelligent_slot"] = [
+        "binary_sensor.octopus_energy_intelligent_dispatching_car1",
+        "binary_sensor.octopus_energy_intelligent_dispatching_car2",
+    ]
+
+    # Car 0: valid dispatch slot (1 hour)
+    slot0_start = (my_predbat.now_utc + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S%z")
+    slot0_end = (my_predbat.now_utc + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S%z")
+
+    # Car 1: stale dispatch slot (should be ignored due to car not being plugged in,
+    # but with octopus_intelligent_ignore_unplugged=False it gets included by the IOG path)
+    slot1_start = (my_predbat.now_utc + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S%z")
+    slot1_end = (my_predbat.now_utc + timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%S%z")
+
+    my_predbat.ha_interface.set_state(
+        "binary_sensor.octopus_energy_intelligent_dispatching_car1",
+        "on",
+        attributes={
+            "completed_dispatches": [],
+            "planned_dispatches": [{"start": slot0_start, "end": slot0_end, "charge_in_kwh": 10.0, "source": "smart-charge", "location": "AT_HOME"}],
+            "vehicle_battery_size_in_kwh": 100.0,
+            "charge_point_power_in_kw": 7.4,
+        },
+    )
+    my_predbat.ha_interface.set_state(
+        "binary_sensor.octopus_energy_intelligent_dispatching_car2",
+        "on",
+        attributes={
+            "completed_dispatches": [],
+            "planned_dispatches": [{"start": slot1_start, "end": slot1_end, "charge_in_kwh": 8.0, "source": "smart-charge", "location": "AT_HOME"}],
+            "vehicle_battery_size_in_kwh": 80.0,
+            "charge_point_power_in_kw": 7.4,
+        },
+    )
+
+    # Simulate the state after fetch_sensor_data_cars runs - car 1 gets IOG slots because
+    # octopus_intelligent_ignore_unplugged=False includes them, and car_charging_planned[1] is
+    # set to True by the IOG path even though car 1 is not physically plugged in.
+    # The key test: after this, the car plan loop should NOT call plan_car_charging() for car 1.
+    my_predbat.octopus_slots = [[] for _ in range(my_predbat.num_cars)]
+    my_predbat.car_charging_manual_soc = [False, False]
+    my_predbat.args["car_charging_loss"] = 0.0
+    my_predbat.args["car_charging_soc"] = [50.0, 50.0]
+    my_predbat.minutes_now = 0
+
+    try:
+        my_predbat.fetch_sensor_data_cars()
+    except Exception as exc:
+        print("ERROR: fetch_sensor_data_cars raised exception: {}".format(exc))
+        failed = True
+        if failed:
+            print("Test: {} FAILED".format(testname))
+        return failed
+
+    # After fetch_sensor_data_cars, car 1 has IOG slots (stale but included because
+    # octopus_intelligent_ignore_unplugged=False). Verify car_charging_planned[1] is True.
+    if not my_predbat.car_charging_planned[1]:
+        print("SKIP CHECK: car_charging_planned[1] is False - stale slots were filtered. This is acceptable if IOG ignore logic is working.")
+    else:
+        # car_charging_planned[1] is True (stale slots included).
+        # The regression: with the old code, the car plan loop would call plan_car_charging(1, low_rates)
+        # which would OVERWRITE car_charging_slots[1] with ALL low-rate windows.
+        # Verify that car_charging_slots[1] contains only the IOG dispatch slots (at most 1 slot from
+        # the stale dispatch data, not all low-rate windows).
+        iog_windows_car1 = len(my_predbat.car_charging_slots[1])
+        # The stale dispatch data has exactly 1 slot. Even with some expansion, should be very limited.
+        # The old plan_car_charging would create many slots (one per low-rate window = many hours).
+        # We verify it is bounded - if the car plan loop fixed works, the IOG path limits slots.
+        if iog_windows_car1 > 5:
+            print("ERROR: car_charging_slots[1] has {} windows - looks like plan_car_charging was called (old bug). Expected at most a few IOG slots.".format(iog_windows_car1))
+            failed = True
+        else:
+            print("OK: car_charging_slots[1] has {} IOG-derived windows (bounded, not plan_car_charging explosion)".format(iog_windows_car1))
+
+    # Now simulate what the car plan loop in fetch_sensor_data does.
+    # The fix: the condition should treat both car 0 and car 1 as IOG cars (since both have entities).
+    # Test that the condition correctly identifies car 1 as an IOG car.
+    iog_entity_id_config = my_predbat.get_arg("octopus_intelligent_slot", indirect=False)
+    if iog_entity_id_config and not isinstance(iog_entity_id_config, list):
+        iog_entity_ids = [iog_entity_id_config]
+    elif iog_entity_id_config:
+        iog_entity_ids = iog_entity_id_config
+    else:
+        iog_entity_ids = []
+
+    # car 0: should be identified as IOG car
+    car0_is_iog = my_predbat.octopus_intelligent_charging and 0 < len(iog_entity_ids) and bool(iog_entity_ids[0])
+    if not car0_is_iog:
+        print("ERROR: Car 0 should be identified as IOG car in car plan loop")
+        failed = True
+
+    # car 1: should ALSO be identified as IOG car (this was the bug - only car 0 was checked)
+    car1_is_iog = my_predbat.octopus_intelligent_charging and 1 < len(iog_entity_ids) and bool(iog_entity_ids[1])
+    if not car1_is_iog:
+        print("ERROR: Car 1 should be identified as IOG car in car plan loop (fix for issue #3592)")
+        failed = True
+    else:
+        print("OK: Car 1 correctly identified as IOG car - plan_car_charging will not be called for it")
+
+    if failed:
+        print("Test: {} FAILED".format(testname))
+    else:
+        print("Test: {} PASSED".format(testname))
+
+    return failed
+
+
 def run_multi_car_iog_tests(my_predbat):
     """
     Run all multi-car IOG tests
@@ -270,4 +410,5 @@ def run_multi_car_iog_tests(my_predbat):
     failed = False
     failed |= run_multi_car_iog_test("multi_car_iog_basic", my_predbat)
     failed |= run_multi_car_iog_load_slots_test("multi_car_iog_load_slots_regression", my_predbat)
+    failed |= run_multi_car_iog_unplugged_car_test("multi_car_iog_unplugged_car_3592", my_predbat)
     return failed

--- a/apps/predbat/tests/test_multi_car_iog.py
+++ b/apps/predbat/tests/test_multi_car_iog.py
@@ -265,135 +265,82 @@ def run_multi_car_iog_load_slots_test(testname, my_predbat):
 
 def run_multi_car_iog_unplugged_car_test(testname, my_predbat):
     """
-    Regression test for issue #3592: When car 1 is NOT physically plugged in but still has
-    stale planned dispatch data from the Octopus Intelligent sensor, the car plan loop was
-    incorrectly calling plan_car_charging() for car 1 (because the `car_n == 0` guard only
-    protected car 0). This caused car 1's charging slots to expand from a small set of IOG
-    dispatch windows to ALL low-rate windows - 'charging slots all the time'.
+    Regression test for issue #3592: When car 1 has an IOG entity configured but the old code
+    only guarded car_n == 0, plan_car_charging() was incorrectly called for car 1 whenever
+    car_charging_planned[1] was True (e.g. from stale dispatch slots). This caused car 1's
+    charging plan to expand from the small set of IOG dispatch windows to ALL low-rate windows
+    - 'charging slots all the time'.
 
     The fix changes `car_n == 0` to check whether the car is configured with an IOG entity,
     which prevents plan_car_charging() from being called for any IOG-configured car.
+
+    This test exercises fetch_sensor_data_car_planning() directly - the extracted function
+    that contains the fixed conditional.
     """
     failed = False
     print("**** Running Test: multi_car_iog {} ****".format(testname))
 
     # Set up 2 cars, both on IOG
     my_predbat.num_cars = 2
-    my_predbat.car_charging_planned = [True, False]  # Car 0 plugged in, car 1 NOT plugged in
     my_predbat.car_charging_now = [False, False]
     my_predbat.car_charging_plan_smart = [False, False]
     my_predbat.car_charging_plan_max_price = [0, 0]
-    my_predbat.car_charging_plan_time = ["07:00:00", "07:00:00"]
+    my_predbat.car_charging_plan_time = ["23:59:00", "23:59:00"]  # ready at end of day - catches all low_rates windows
     my_predbat.car_charging_battery_size = [100.0, 80.0]
     my_predbat.car_charging_limit = [100.0, 80.0]
     my_predbat.car_charging_rate = [7.4, 7.4]
     my_predbat.car_charging_soc = [50.0, 40.0]
     my_predbat.car_charging_soc_next = [None, None]
-    my_predbat.car_charging_slots = [[], []]
     my_predbat.car_charging_exclusive = [False, False]
     my_predbat.car_charging_loss = 1.0
     my_predbat.octopus_intelligent_charging = True
-    my_predbat.octopus_intelligent_ignore_unplugged = False  # default: don't ignore
+    my_predbat.octopus_intelligent_ignore_unplugged = False
 
-    # Both cars have IOG entities configured - the scenario from issue #3592
+    # Both cars have IOG entities - the scenario from issue #3592
     my_predbat.args["octopus_intelligent_slot"] = [
         "binary_sensor.octopus_energy_intelligent_dispatching_car1",
         "binary_sensor.octopus_energy_intelligent_dispatching_car2",
     ]
 
-    # Car 0: valid dispatch slot (1 hour)
-    slot0_start = (my_predbat.now_utc + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S%z")
-    slot0_end = (my_predbat.now_utc + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S%z")
+    # Simulate state after fetch_sensor_data_cars() ran:
+    # - Both cars have car_charging_planned = True (IOG path sets this when slots are present)
+    # - car_charging_slots contains just the IOG-sourced slots (1 per car)
+    iog_slot_car0 = [{"start": 60, "end": 120, "kwh": 7.4, "average": 7.0, "cost": 51.8, "soc": 57.4}]
+    iog_slot_car1 = [{"start": 120, "end": 180, "kwh": 5.92, "average": 7.0, "cost": 41.44, "soc": 47.4}]
+    my_predbat.car_charging_planned = [True, True]
+    my_predbat.car_charging_slots = [list(iog_slot_car0), list(iog_slot_car1)]
 
-    # Car 1: stale dispatch slot (should be ignored due to car not being plugged in,
-    # but with octopus_intelligent_ignore_unplugged=False it gets included by the IOG path)
-    slot1_start = (my_predbat.now_utc + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S%z")
-    slot1_end = (my_predbat.now_utc + timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%S%z")
+    # Set up multiple low_rates windows so plan_car_charging would produce many slots if called
+    my_predbat.low_rates = [
+        {"start": 0, "end": 30, "average": 5.0},
+        {"start": 60, "end": 90, "average": 5.0},
+        {"start": 120, "end": 150, "average": 5.0},
+        {"start": 180, "end": 210, "average": 5.0},
+        {"start": 240, "end": 270, "average": 5.0},
+        {"start": 1440, "end": 1470, "average": 5.0},
+        {"start": 1500, "end": 1530, "average": 5.0},
+    ]
 
-    my_predbat.ha_interface.set_state(
-        "binary_sensor.octopus_energy_intelligent_dispatching_car1",
-        "on",
-        attributes={
-            "completed_dispatches": [],
-            "planned_dispatches": [{"start": slot0_start, "end": slot0_end, "charge_in_kwh": 10.0, "source": "smart-charge", "location": "AT_HOME"}],
-            "vehicle_battery_size_in_kwh": 100.0,
-            "charge_point_power_in_kw": 7.4,
-        },
-    )
-    my_predbat.ha_interface.set_state(
-        "binary_sensor.octopus_energy_intelligent_dispatching_car2",
-        "on",
-        attributes={
-            "completed_dispatches": [],
-            "planned_dispatches": [{"start": slot1_start, "end": slot1_end, "charge_in_kwh": 8.0, "source": "smart-charge", "location": "AT_HOME"}],
-            "vehicle_battery_size_in_kwh": 80.0,
-            "charge_point_power_in_kw": 7.4,
-        },
-    )
+    # Call the real function under test
+    my_predbat.fetch_sensor_data_car_planning()
 
-    # Simulate the state after fetch_sensor_data_cars runs - car 1 gets IOG slots because
-    # octopus_intelligent_ignore_unplugged=False includes them, and car_charging_planned[1] is
-    # set to True by the IOG path even though car 1 is not physically plugged in.
-    # The key test: after this, the car plan loop should NOT call plan_car_charging() for car 1.
-    my_predbat.octopus_slots = [[] for _ in range(my_predbat.num_cars)]
-    my_predbat.car_charging_manual_soc = [False, False]
-    my_predbat.args["car_charging_loss"] = 0.0
-    my_predbat.args["car_charging_soc"] = [50.0, 50.0]
-    my_predbat.minutes_now = 0
-
-    try:
-        my_predbat.fetch_sensor_data_cars()
-    except Exception as exc:
-        print("ERROR: fetch_sensor_data_cars raised exception: {}".format(exc))
-        failed = True
-        if failed:
-            print("Test: {} FAILED".format(testname))
-        return failed
-
-    # After fetch_sensor_data_cars, car 1 has IOG slots (stale but included because
-    # octopus_intelligent_ignore_unplugged=False). Verify car_charging_planned[1] is True.
-    if not my_predbat.car_charging_planned[1]:
-        print("SKIP CHECK: car_charging_planned[1] is False - stale slots were filtered. This is acceptable if IOG ignore logic is working.")
-    else:
-        # car_charging_planned[1] is True (stale slots included).
-        # The regression: with the old code, the car plan loop would call plan_car_charging(1, low_rates)
-        # which would OVERWRITE car_charging_slots[1] with ALL low-rate windows.
-        # Verify that car_charging_slots[1] contains only the IOG dispatch slots (at most 1 slot from
-        # the stale dispatch data, not all low-rate windows).
-        iog_windows_car1 = len(my_predbat.car_charging_slots[1])
-        # The stale dispatch data has exactly 1 slot. Even with some expansion, should be very limited.
-        # The old plan_car_charging would create many slots (one per low-rate window = many hours).
-        # We verify it is bounded - if the car plan loop fixed works, the IOG path limits slots.
-        if iog_windows_car1 > 5:
-            print("ERROR: car_charging_slots[1] has {} windows - looks like plan_car_charging was called (old bug). Expected at most a few IOG slots.".format(iog_windows_car1))
-            failed = True
-        else:
-            print("OK: car_charging_slots[1] has {} IOG-derived windows (bounded, not plan_car_charging explosion)".format(iog_windows_car1))
-
-    # Now simulate what the car plan loop in fetch_sensor_data does.
-    # The fix: the condition should treat both car 0 and car 1 as IOG cars (since both have entities).
-    # Test that the condition correctly identifies car 1 as an IOG car.
-    iog_entity_id_config = my_predbat.get_arg("octopus_intelligent_slot", indirect=False)
-    if iog_entity_id_config and not isinstance(iog_entity_id_config, list):
-        iog_entity_ids = [iog_entity_id_config]
-    elif iog_entity_id_config:
-        iog_entity_ids = iog_entity_id_config
-    else:
-        iog_entity_ids = []
-
-    # car 0: should be identified as IOG car
-    car0_is_iog = my_predbat.octopus_intelligent_charging and 0 < len(iog_entity_ids) and bool(iog_entity_ids[0])
-    if not car0_is_iog:
-        print("ERROR: Car 0 should be identified as IOG car in car plan loop")
-        failed = True
-
-    # car 1: should ALSO be identified as IOG car (this was the bug - only car 0 was checked)
-    car1_is_iog = my_predbat.octopus_intelligent_charging and 1 < len(iog_entity_ids) and bool(iog_entity_ids[1])
-    if not car1_is_iog:
-        print("ERROR: Car 1 should be identified as IOG car in car plan loop (fix for issue #3592)")
+    # car 0: IOG car, slots must be unchanged (plan_car_charging must NOT have been called)
+    if my_predbat.car_charging_slots[0] != iog_slot_car0:
+        print("ERROR: car_charging_slots[0] was mutated - plan_car_charging should not have been called for an IOG car")
+        print("  Expected: {}".format(iog_slot_car0))
+        print("  Got:      {}".format(my_predbat.car_charging_slots[0]))
         failed = True
     else:
-        print("OK: Car 1 correctly identified as IOG car - plan_car_charging will not be called for it")
+        print("OK: car_charging_slots[0] unchanged - plan_car_charging correctly skipped for IOG car 0")
+
+    # car 1: IOG car, slots must be unchanged (this is the regression from issue #3592)
+    if my_predbat.car_charging_slots[1] != iog_slot_car1:
+        print("ERROR: car_charging_slots[1] was mutated - plan_car_charging should not have been called for an IOG car (issue #3592)")
+        print("  Expected: {}".format(iog_slot_car1))
+        print("  Got {} slots: {}".format(len(my_predbat.car_charging_slots[1]), my_predbat.car_charging_slots[1]))
+        failed = True
+    else:
+        print("OK: car_charging_slots[1] unchanged - plan_car_charging correctly skipped for IOG car 1 (fix for issue #3592)")
 
     if failed:
         print("Test: {} FAILED".format(testname))


### PR DESCRIPTION
Issue #3592: Multiple Cars on Intelligent Go Plan - ttps://github.com/springfall2008/batpred/issues/3592
Root Cause — a hardcoded car_n == 0 guard in the car plan loop in fetch.py:970.

Bug chain:

User has 2 cars on Octopus Intelligent Go, each with their own dispatch entity
Car 1 is unplugged, but its dispatch sensor still has stale planned slots (Octopus doesn't always clear these)
fetch_sensor_data_cars() loads those stale slots into car_charging_slots[1] and sets car_charging_planned[1] = True (because octopus_intelligent_ignore_unplugged defaults to False)
In the car plan loop, the guard if self.octopus_intelligent_charging and car_n == 0: only protects car 0 — car 1 falls through to elif car_charging_planned[1] → plan_car_charging(1, self.low_rates) is called
plan_car_charging expands car 1's charging windows to cover all low-rate periods (the entire cheap overnight window), not just the actual IOG dispatch slots → "charging slots all the time"
Fix (fetch.py:968): Changed the condition from the hardcoded car_n == 0 to check whether the car actually has an Octopus Intelligent entity configured. This prevents plan_car_charging from being called for any IOG-configured car (not just car 0):

Edited
test_multi_car_iog.py+141-0
A regression test run_multi_car_iog_unplugged_car_test was added to tests/test_multi_car_iog.py covering the exact scenario from this issue.