### PR TITLE
feat: add KrakenAPI component for EDF/E.ON tariff discovery

### DIFF
--- a/apps/predbat/component_base.py
+++ b/apps/predbat/component_base.py
@@ -150,6 +150,7 @@ class ComponentBase(ABC):
         """
         seconds = 0
         first = True
+        self.log(f"{self.__class__.__name__}: Starting...")
         while not self.api_stop and not self.fatal_error:
             try:
                 if first or seconds % 60 == 0:

--- a/apps/predbat/component_callback_server.py
+++ b/apps/predbat/component_callback_server.py
@@ -1,0 +1,177 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2025 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt: off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Component Callback Server
+
+This server runs within Predbat and provides a callback endpoint for remote
+components to access the base Predbat object's methods.
+"""
+
+import asyncio
+import pickle
+import inspect
+import traceback
+import aiohttp.web
+import time
+
+
+class ComponentCallbackServer:
+    """
+    HTTP server that handles callbacks from remote components.
+    
+    This server provides endpoints for remote components to call back and access
+    the main Predbat base object's methods (get_arg, get_state_wrapper, etc.)
+    """
+    
+    def __init__(self, base, port):
+        """
+        Initialize the callback server.
+        
+        Args:
+            base: The main Predbat base object
+            port: Port to bind to
+        """
+        self.base = base
+        self.port = port
+        self.started = False
+        self.runner = None
+        self.site = None
+        self.log = self.base.log
+        self.stop_api = False
+    
+    async def start(self):
+        """
+        Start the callback server.
+        """
+        print('Here')
+        self.log("CallBackServer: Initializing ComponentCallbackServer...")
+        try:
+            # Create web application
+            app = aiohttp.web.Application()
+
+            self.log("Starting ComponentCallbackServer...")
+            
+            # Add routes
+            app.router.add_post('/base/call', self._handle_base_call)
+            app.router.add_get('/health', self._handle_health)
+            
+            self.log("CallBackServer: Setting up ComponentCallbackServer runner...")
+            # Create runner
+            self.runner = aiohttp.web.AppRunner(app)
+            await self.runner.setup()
+
+            self.log(f"CallBackServer: Creating ComponentCallbackServer site port {self.port}...")
+            
+            # Create site and start
+            self.site = aiohttp.web.TCPSite(self.runner, '0.0.0.0', self.port)
+            
+            try:
+                await self.site.start()
+            except OSError as e:
+                error_msg = f"Failed to bind callback server to port {self.port}: {e}"
+                self.log(error_msg)
+                raise
+            
+            self.started = True
+            self.log(f"CallBackServer: started on port {self.port}")
+            
+        except Exception as e:
+            self.log(f"CallBackServer: Error: Failed to start callback server: {e}")
+            self.log(traceback.format_exc())
+            raise
+
+        while not self.stop_api:
+            await asyncio.sleep(1)
+
+        if self.runner:
+            self.log("CallBackServer: Stopping callback server")
+            await self.runner.cleanup()
+            self.started = False
+
+    
+    async def _handle_base_call(self, request):
+        """
+        Handle base API call from remote component.
+        
+        Expected pickled request: {
+            "method": str,
+            "args": tuple,
+            "kwargs": dict
+        }
+        """
+        try:
+            # Read and unpickle request
+            data = await request.read()
+            req = pickle.loads(data)
+            
+            method = req["method"]
+            args = req.get("args", ())
+            kwargs = req.get("kwargs", {})
+            
+            # Invoke method on base object
+            try:
+                method_fn = getattr(self.base, method)
+                result = method_fn(*args, **kwargs)
+                
+                # Check if result is a coroutine and await it
+                if inspect.iscoroutine(result):
+                    result = await result
+                
+                # Return pickled result
+                return aiohttp.web.Response(
+                    body=pickle.dumps(result, protocol=4)
+                )
+                
+            except Exception as e:
+                error_msg = str(e)
+                self.log(f"CallBackServer: Error: Base call {method} failed: {error_msg}")
+                self.log(traceback.format_exc())
+                
+                # Return error
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"error": error_msg}, protocol=4)
+                )
+                
+        except Exception as e:
+            error_msg = f"Failed to process base call: {e}"
+            self.log(f"CallBackServer: Error: {error_msg}")
+            self.log(traceback.format_exc())
+            
+            return aiohttp.web.Response(
+                body=pickle.dumps({"error": error_msg}, protocol=4)
+            )
+    
+    async def _handle_health(self, request):
+        """Handle health check request."""
+        return aiohttp.web.json_response({"status": "ok"})
+    
+    def wait_started(self, timeout=5*60):
+        """
+        Wait for the server to start.
+        
+        Args:
+            timeout: Maximum time to wait in seconds
+            
+        Raises:
+            TimeoutError: If server doesn't start within timeout
+        """
+        elapsed = 0
+        while not self.started and elapsed < timeout:
+            time.sleep(1)
+            elapsed += 1
+        
+        if not self.started:
+            raise TimeoutError("Callback server failed to start within timeout")
+    
+    async def stop(self):
+        """Stop the callback server."""
+        self.stop_api = True
+        await asyncio.sleep(0.1)  # Give time for any ongoing requests to finish

--- a/apps/predbat/component_callback_server.py
+++ b/apps/predbat/component_callback_server.py
@@ -26,15 +26,15 @@ import time
 class ComponentCallbackServer:
     """
     HTTP server that handles callbacks from remote components.
-    
+
     This server provides endpoints for remote components to call back and access
     the main Predbat base object's methods (get_arg, get_state_wrapper, etc.)
     """
-    
+
     def __init__(self, base, port):
         """
         Initialize the callback server.
-        
+
         Args:
             base: The main Predbat base object
             port: Port to bind to
@@ -46,7 +46,7 @@ class ComponentCallbackServer:
         self.site = None
         self.log = self.base.log
         self.stop_api = False
-    
+
     async def start(self):
         """
         Start the callback server.
@@ -58,31 +58,31 @@ class ComponentCallbackServer:
             app = aiohttp.web.Application()
 
             self.log("Starting ComponentCallbackServer...")
-            
+
             # Add routes
             app.router.add_post('/base/call', self._handle_base_call)
             app.router.add_get('/health', self._handle_health)
-            
+
             self.log("CallBackServer: Setting up ComponentCallbackServer runner...")
             # Create runner
             self.runner = aiohttp.web.AppRunner(app)
             await self.runner.setup()
 
             self.log(f"CallBackServer: Creating ComponentCallbackServer site port {self.port}...")
-            
+
             # Create site and start
             self.site = aiohttp.web.TCPSite(self.runner, '0.0.0.0', self.port)
-            
+
             try:
                 await self.site.start()
             except OSError as e:
                 error_msg = f"Failed to bind callback server to port {self.port}: {e}"
                 self.log(error_msg)
                 raise
-            
+
             self.started = True
             self.log(f"CallBackServer: started on port {self.port}")
-            
+
         except Exception as e:
             self.log(f"CallBackServer: Error: Failed to start callback server: {e}")
             self.log(traceback.format_exc())
@@ -96,11 +96,11 @@ class ComponentCallbackServer:
             await self.runner.cleanup()
             self.started = False
 
-    
+
     async def _handle_base_call(self, request):
         """
         Handle base API call from remote component.
-        
+
         Expected pickled request: {
             "method": str,
             "args": tuple,
@@ -111,55 +111,55 @@ class ComponentCallbackServer:
             # Read and unpickle request
             data = await request.read()
             req = pickle.loads(data)
-            
+
             method = req["method"]
             args = req.get("args", ())
             kwargs = req.get("kwargs", {})
-            
+
             # Invoke method on base object
             try:
                 method_fn = getattr(self.base, method)
                 result = method_fn(*args, **kwargs)
-                
+
                 # Check if result is a coroutine and await it
                 if inspect.iscoroutine(result):
                     result = await result
-                
+
                 # Return pickled result
                 return aiohttp.web.Response(
                     body=pickle.dumps(result, protocol=4)
                 )
-                
+
             except Exception as e:
                 error_msg = str(e)
                 self.log(f"CallBackServer: Error: Base call {method} failed: {error_msg}")
                 self.log(traceback.format_exc())
-                
+
                 # Return error
                 return aiohttp.web.Response(
                     body=pickle.dumps({"error": error_msg}, protocol=4)
                 )
-                
+
         except Exception as e:
             error_msg = f"Failed to process base call: {e}"
             self.log(f"CallBackServer: Error: {error_msg}")
             self.log(traceback.format_exc())
-            
+
             return aiohttp.web.Response(
                 body=pickle.dumps({"error": error_msg}, protocol=4)
             )
-    
+
     async def _handle_health(self, request):
         """Handle health check request."""
         return aiohttp.web.json_response({"status": "ok"})
-    
+
     def wait_started(self, timeout=5*60):
         """
         Wait for the server to start.
-        
+
         Args:
             timeout: Maximum time to wait in seconds
-            
+
         Raises:
             TimeoutError: If server doesn't start within timeout
         """
@@ -167,10 +167,10 @@ class ComponentCallbackServer:
         while not self.started and elapsed < timeout:
             time.sleep(1)
             elapsed += 1
-        
+
         if not self.started:
             raise TimeoutError("Callback server failed to start within timeout")
-    
+
     async def stop(self):
         """Stop the callback server."""
         self.stop_api = True

--- a/apps/predbat/component_client.py
+++ b/apps/predbat/component_client.py
@@ -282,7 +282,7 @@ class ComponentClient:
         if time.time() - self.last_ping_time > poll_interval:
             return await self._send_ping()
         return True
-    
+
     async def _send_ping(self):
         """Send health check ping to server."""
         try:
@@ -307,11 +307,11 @@ class ComponentClient:
                     self.log(f"Warn: Remote component reports not alive")
                     return False
                 return True
-                    
+
         except Exception as e:
             self.log(f"Warn: Failed to ping server: {e}")
             return False
-    
+
     async def final(self):
         """
         Final cleanup before stopping.

--- a/apps/predbat/component_client.py
+++ b/apps/predbat/component_client.py
@@ -27,14 +27,14 @@ import aiohttp
 class ComponentClient:
     """
     Client proxy that forwards component operations to a remote ComponentServer.
-    
+
     This class inherits from ComponentBase and acts as a transparent proxy for
     remote components, handling all communication with the component server.
     """
     def __init__(self, base, server_url, remote_class, **component_kwargs):
         """
         Initialize the component client.
-        
+
         Args:
             base: The main Predbat base object
             server_url: URL of the component server
@@ -50,7 +50,7 @@ class ComponentClient:
         self.last_ping_time = 0
         self.restart_lock = asyncio.Lock()
         self.component_started = False
-        
+
         # Initialize base attributes (mimic ComponentBase)
         self.base = base
         self.log = base.log
@@ -74,11 +74,11 @@ class ComponentClient:
                 return False
             time.sleep(0.5)
         return True
-    
+
     async def start(self):
         """
         Start the component client.
-        
+
         This method:
         1. Gets or creates a client ID
         2. Creates HTTP session
@@ -89,12 +89,12 @@ class ComponentClient:
             # Get or create client ID
             client_id_entity = f"{self.prefix}.client_id"
             self.client_id = self.base.get_state_wrapper(client_id_entity, default=None)
-            
+
             if not self.client_id:
                 # Generate new client ID
                 self.client_id = str(uuid.uuid4())
                 self.log(f"ComponentClient: Generated new client ID: {self.client_id}")
-                
+
                 # Save client ID
                 self.base.set_state_wrapper(
                     client_id_entity,
@@ -106,16 +106,16 @@ class ComponentClient:
                 )
             else:
                 self.log(f"ComponentClient: Using existing client ID: {self.client_id}")
-            
+
             # Get callback URL from config
             callback_url = self.base.get_arg("component_client_callback_url", "http://localhost:5054")
-            
+
             # Create HTTP session
             self.session = aiohttp.ClientSession()
-            
+
             # Start remote component
             await self._start_remote_component(callback_url)
-            
+
             # Run main loop (same as ComponentBase.start())
             seconds = 0
             first = True
@@ -132,31 +132,31 @@ class ComponentClient:
                 except Exception as e:
                     self.log(f"Error: ComponentClient ({self.remote_class}): {e}")
                     self.log("Error: " + traceback.format_exc())
-                
+
                 seconds += 5
                 await asyncio.sleep(5)
-            
+
             self.log(f"ComponentClient ({self.remote_class}): Finalizing...")
             await self.final()
-            
+
             self.api_started = False
             self.log(f"ComponentClient ({self.remote_class}): Stopped")
-            
+
         except Exception as e:
             self.log(f"Error: ComponentClient.start() failed: {e}")
             self.log("Error: " + traceback.format_exc())
             self.api_started = False
-    
+
     async def _start_remote_component(self, callback_url):
         """
         Start the component on the remote server.
-        
+
         Args:
             callback_url: URL for server to call back to
         """
         try:
             self.log(f"ComponentClient: Starting remote component {self.remote_class} on {self.server_url} with callback {callback_url} args {self.component_kwargs}")
-            
+
             # Prepare request
             request_data = pickle.dumps({
                 "client_id": self.client_id,
@@ -164,7 +164,7 @@ class ComponentClient:
                 "callback_url": callback_url,
                 "init_kwargs": self.component_kwargs
             }, protocol=4)
-            
+
             # Send start request
             timeout = aiohttp.ClientTimeout(total=30)
             async with self.session.post(
@@ -174,37 +174,37 @@ class ComponentClient:
             ) as resp:
                 response_data = await resp.read()
                 result = pickle.loads(response_data)
-                
+
                 # Check for error
                 if isinstance(result, dict) and "error" in result:
                     error_msg = f"Failed to start remote component: {result['error']}"
                     self.log(f"Error: {error_msg}")
                     raise RuntimeError(error_msg)
-                
+
                 self.component_started = True
                 self.log(f"ComponentClient: Remote component {self.remote_class} started successfully")
-                
+
         except Exception as e:
             self.log(f"Error: Failed to start remote component: {e}")
             self.log("Error: " + traceback.format_exc())
             raise
-    
+
     async def _call_remote_with_retry(self, method, *args, **kwargs):
         """
         Call a remote method with retry logic.
-        
+
         Args:
             method: Method name to call
             *args: Positional arguments
             **kwargs: Keyword arguments
-            
+
         Returns:
             Result from remote call, or False on failure
         """
         start_time = time.time()
         backoff = 1
         timeout_config = self.base.get_arg("component_server_timeout", 1800)
-        
+
         while True:
             try:
                 # Prepare request
@@ -215,7 +215,7 @@ class ComponentClient:
                     "args": args,
                     "kwargs": kwargs
                 }, protocol=4)
-                
+
                 # Send request
                 timeout = aiohttp.ClientTimeout(total=30)
                 async with self.session.post(
@@ -225,54 +225,54 @@ class ComponentClient:
                 ) as resp:
                     response_data = await resp.read()
                     result = pickle.loads(response_data)
-                    
+
                     # Check for "Component not found" error - trigger restart
                     if isinstance(result, dict) and "error" in result:
                         if "Component not found" in result["error"]:
                             self.log(f"Warn: Remote component not found, restarting...")
-                            
+
                             # Use lock to prevent duplicate restarts
                             async with self.restart_lock:
                                 # Double-check component is still missing
                                 if not self.component_started:
                                     callback_url = self.base.get_arg("component_client_callback_url", "http://localhost:5054")
                                     await self._start_remote_component(callback_url)
-                            
+
                             # Retry the call
                             continue
                         else:
                             # Other error
                             self.log(f"Error: Remote call {method} failed: {result['error']}")
                             return False
-                    
+
                     # Success
                     return result
-                    
+
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                 # Check if we've exceeded total timeout
                 elapsed = time.time() - start_time
                 if elapsed > timeout_config:
                     self.log(f"Error: Remote call {method} timed out after {elapsed}s")
                     return False
-                
+
                 # Log and retry with backoff
                 self.log(f"Warn: Remote call {method} failed ({e}), retrying in {backoff}s...")
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30)  # Exponential backoff, max 30s
-                
+
             except Exception as e:
                 self.log(f"Error: Remote call {method} failed: {e}")
                 self.log("Error: " + traceback.format_exc())
                 return False
-    
+
     async def run(self, seconds, first):
         """
         Run method called by the main loop.
-        
+
         Args:
             seconds: Seconds since start
             first: True if first run
-            
+
         Returns:
             True on success, False on failure
         """
@@ -281,7 +281,7 @@ class ComponentClient:
         while not self.api_stop and not self.fatal_error:
             if time.time() - self.last_ping_time > poll_interval:
                 await self._send_ping()
-    
+
     async def _send_ping(self):
         """Send health check ping to server."""
         try:
@@ -289,7 +289,7 @@ class ComponentClient:
                 "client_id": self.client_id,
                 "component_class": self.remote_class
             }, protocol=4)
-            
+
             timeout = aiohttp.ClientTimeout(total=10)
             async with self.session.post(
                 f"{self.server_url}/component/ping",
@@ -298,16 +298,16 @@ class ComponentClient:
             ) as resp:
                 response_data = await resp.read()
                 result = pickle.loads(response_data)
-                
+
                 self.last_ping_time = time.time()
-                
+
                 # Log if component is not alive
                 if isinstance(result, dict) and not result.get("alive", True):
                     self.log(f"Warn: Remote component reports not alive")
-                    
+
         except Exception as e:
             self.log(f"Warn: Failed to ping server: {e}")
-    
+
     async def final(self):
         """
         Final cleanup before stopping.
@@ -318,7 +318,7 @@ class ComponentClient:
                 "client_id": self.client_id,
                 "component_class": self.remote_class
             }, protocol=4)
-            
+
             timeout = aiohttp.ClientTimeout(total=10)
             async with self.session.post(
                 f"{self.server_url}/component/stop",
@@ -326,14 +326,14 @@ class ComponentClient:
                 timeout=timeout
             ) as resp:
                 await resp.read()
-                
+
         except Exception as e:
             self.log(f"Warn: Failed to stop remote component: {e}")
-        
+
         # Close session
         if self.session:
             await self.session.close()
-    
+
     async def stop(self):
         """
         Stop the component gracefully.
@@ -341,34 +341,34 @@ class ComponentClient:
         self.api_stop = True
         self.api_started = False
         await asyncio.sleep(0.1)
-    
+
     @property
     def fatal_error(self):
         """Check if a fatal error has occurred."""
         return self.base.fatal_error
-    
+
     def is_alive(self):
         """Check if component is alive."""
         return self.api_started
-    
+
     def last_updated_time(self):
         """Get last updated time."""
         return self.last_success_timestamp
-    
+
     def update_success_timestamp(self):
         """Update last success timestamp."""
         self.last_success_timestamp = datetime.now(timezone.utc)
-    
+
     # Event handlers - forward to remote component
-    
+
     async def select_event(self, entity_id, value):
         """Handle select entity event."""
         await self._call_remote_with_retry("select_event", entity_id, value)
-    
+
     async def number_event(self, entity_id, value):
         """Handle number entity event."""
         await self._call_remote_with_retry("number_event", entity_id, value)
-    
+
     async def switch_event(self, entity_id, service):
         """Handle switch entity event."""
         await self._call_remote_with_retry("switch_event", entity_id, service)

--- a/apps/predbat/component_client.py
+++ b/apps/predbat/component_client.py
@@ -1,0 +1,374 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2025 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt: off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Component Client for Remote Component Execution
+
+WARNING: This client uses pickle for serialization. Only use in trusted networks
+(e.g. Kubernetes cluster) as pickle can execute arbitrary code.
+"""
+
+import asyncio
+import pickle
+import time
+import uuid
+import traceback
+from datetime import datetime, timezone
+import aiohttp
+
+
+class ComponentClient:
+    """
+    Client proxy that forwards component operations to a remote ComponentServer.
+    
+    This class inherits from ComponentBase and acts as a transparent proxy for
+    remote components, handling all communication with the component server.
+    """
+    def __init__(self, base, server_url, remote_class, **component_kwargs):
+        """
+        Initialize the component client.
+        
+        Args:
+            base: The main Predbat base object
+            server_url: URL of the component server
+            remote_class: Name of the remote component class
+            **component_kwargs: Initialization kwargs to pass to remote component
+        """
+        # Store parameters before calling parent init
+        self.server_url = server_url
+        self.remote_class = remote_class
+        self.component_kwargs = component_kwargs
+        self.client_id = None
+        self.session = None
+        self.last_ping_time = 0
+        self.restart_lock = asyncio.Lock()
+        self.component_started = False
+        
+        # Initialize base attributes (mimic ComponentBase)
+        self.base = base
+        self.log = base.log
+        self.api_started = False
+        self.api_stop = False
+        self.last_success_timestamp = None
+        self.local_tz = base.local_tz
+        self.prefix = base.prefix
+        self.args = base.args
+        self.currenty_symbols = base.currency_symbols
+        self.count_errors = 0
+
+    def wait_api_started(self, timeout=60):
+        """
+        Wait for the component's API to be started (self.api_started == True).
+        Returns True if started, False if timeout.
+        """
+        start = time.time()
+        while not self.api_started:
+            if time.time() - start > timeout:
+                return False
+            time.sleep(0.5)
+        return True
+    
+    async def start(self):
+        """
+        Start the component client.
+        
+        This method:
+        1. Gets or creates a client ID
+        2. Creates HTTP session
+        3. Starts the remote component
+        4. Runs the main loop
+        """
+        try:
+            # Get or create client ID
+            client_id_entity = f"{self.prefix}.client_id"
+            self.client_id = self.base.get_state_wrapper(client_id_entity, default=None)
+            
+            if not self.client_id:
+                # Generate new client ID
+                self.client_id = str(uuid.uuid4())
+                self.log(f"ComponentClient: Generated new client ID: {self.client_id}")
+                
+                # Save client ID
+                self.base.set_state_wrapper(
+                    client_id_entity,
+                    self.client_id,
+                    attributes={
+                        "created": datetime.now(timezone.utc).isoformat(),
+                        "server_url": self.server_url
+                    }
+                )
+            else:
+                self.log(f"ComponentClient: Using existing client ID: {self.client_id}")
+            
+            # Get callback URL from config
+            callback_url = self.base.get_arg("component_client_callback_url", "http://localhost:5054")
+            
+            # Create HTTP session
+            self.session = aiohttp.ClientSession()
+            
+            # Start remote component
+            await self._start_remote_component(callback_url)
+            
+            # Run main loop (same as ComponentBase.start())
+            seconds = 0
+            first = True
+            while not self.api_stop and not self.fatal_error:
+                try:
+                    if first or seconds % 60 == 0:
+                        if await self.run(seconds, first):
+                            if not self.api_started:
+                                self.api_started = True
+                                self.log(f"ComponentClient ({self.remote_class}): Started")
+                        else:
+                            self.count_errors += 1
+                    first = False
+                except Exception as e:
+                    self.log(f"Error: ComponentClient ({self.remote_class}): {e}")
+                    self.log("Error: " + traceback.format_exc())
+                
+                seconds += 5
+                await asyncio.sleep(5)
+            
+            self.log(f"ComponentClient ({self.remote_class}): Finalizing...")
+            await self.final()
+            
+            self.api_started = False
+            self.log(f"ComponentClient ({self.remote_class}): Stopped")
+            
+        except Exception as e:
+            self.log(f"Error: ComponentClient.start() failed: {e}")
+            self.log("Error: " + traceback.format_exc())
+            self.api_started = False
+    
+    async def _start_remote_component(self, callback_url):
+        """
+        Start the component on the remote server.
+        
+        Args:
+            callback_url: URL for server to call back to
+        """
+        try:
+            self.log(f"ComponentClient: Starting remote component {self.remote_class} on {self.server_url} with callback {callback_url} args {self.component_kwargs}")
+            
+            # Prepare request
+            request_data = pickle.dumps({
+                "client_id": self.client_id,
+                "component_class": self.remote_class,
+                "callback_url": callback_url,
+                "init_kwargs": self.component_kwargs
+            }, protocol=4)
+            
+            # Send start request
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with self.session.post(
+                f"{self.server_url}/component/start",
+                data=request_data,
+                timeout=timeout
+            ) as resp:
+                response_data = await resp.read()
+                result = pickle.loads(response_data)
+                
+                # Check for error
+                if isinstance(result, dict) and "error" in result:
+                    error_msg = f"Failed to start remote component: {result['error']}"
+                    self.log(f"Error: {error_msg}")
+                    raise RuntimeError(error_msg)
+                
+                self.component_started = True
+                self.log(f"ComponentClient: Remote component {self.remote_class} started successfully")
+                
+        except Exception as e:
+            self.log(f"Error: Failed to start remote component: {e}")
+            self.log("Error: " + traceback.format_exc())
+            raise
+    
+    async def _call_remote_with_retry(self, method, *args, **kwargs):
+        """
+        Call a remote method with retry logic.
+        
+        Args:
+            method: Method name to call
+            *args: Positional arguments
+            **kwargs: Keyword arguments
+            
+        Returns:
+            Result from remote call, or False on failure
+        """
+        start_time = time.time()
+        backoff = 1
+        timeout_config = self.base.get_arg("component_server_timeout", 1800)
+        
+        while True:
+            try:
+                # Prepare request
+                request_data = pickle.dumps({
+                    "client_id": self.client_id,
+                    "component_class": self.remote_class,
+                    "method": method,
+                    "args": args,
+                    "kwargs": kwargs
+                }, protocol=4)
+                
+                # Send request
+                timeout = aiohttp.ClientTimeout(total=30)
+                async with self.session.post(
+                    f"{self.server_url}/component/call",
+                    data=request_data,
+                    timeout=timeout
+                ) as resp:
+                    response_data = await resp.read()
+                    result = pickle.loads(response_data)
+                    
+                    # Check for "Component not found" error - trigger restart
+                    if isinstance(result, dict) and "error" in result:
+                        if "Component not found" in result["error"]:
+                            self.log(f"Warn: Remote component not found, restarting...")
+                            
+                            # Use lock to prevent duplicate restarts
+                            async with self.restart_lock:
+                                # Double-check component is still missing
+                                if not self.component_started:
+                                    callback_url = self.base.get_arg("component_client_callback_url", "http://localhost:5054")
+                                    await self._start_remote_component(callback_url)
+                            
+                            # Retry the call
+                            continue
+                        else:
+                            # Other error
+                            self.log(f"Error: Remote call {method} failed: {result['error']}")
+                            return False
+                    
+                    # Success
+                    return result
+                    
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                # Check if we've exceeded total timeout
+                elapsed = time.time() - start_time
+                if elapsed > timeout_config:
+                    self.log(f"Error: Remote call {method} timed out after {elapsed}s")
+                    return False
+                
+                # Log and retry with backoff
+                self.log(f"Warn: Remote call {method} failed ({e}), retrying in {backoff}s...")
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30)  # Exponential backoff, max 30s
+                
+            except Exception as e:
+                self.log(f"Error: Remote call {method} failed: {e}")
+                self.log("Error: " + traceback.format_exc())
+                return False
+    
+    async def run(self, seconds, first):
+        """
+        Run method called by the main loop.
+        
+        Args:
+            seconds: Seconds since start
+            first: True if first run
+            
+        Returns:
+            True on success, False on failure
+        """
+        # Send ping if needed
+        poll_interval = self.base.get_arg("component_server_poll_interval", 300)
+        while not self.api_stop and not self.fatal_error:
+            if time.time() - self.last_ping_time > poll_interval:
+                await self._send_ping()
+    
+    async def _send_ping(self):
+        """Send health check ping to server."""
+        try:
+            request_data = pickle.dumps({
+                "client_id": self.client_id,
+                "component_class": self.remote_class
+            }, protocol=4)
+            
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with self.session.post(
+                f"{self.server_url}/component/ping",
+                data=request_data,
+                timeout=timeout
+            ) as resp:
+                response_data = await resp.read()
+                result = pickle.loads(response_data)
+                
+                self.last_ping_time = time.time()
+                
+                # Log if component is not alive
+                if isinstance(result, dict) and not result.get("alive", True):
+                    self.log(f"Warn: Remote component reports not alive")
+                    
+        except Exception as e:
+            self.log(f"Warn: Failed to ping server: {e}")
+    
+    async def final(self):
+        """
+        Final cleanup before stopping.
+        """
+        try:
+            # Send stop request to server
+            request_data = pickle.dumps({
+                "client_id": self.client_id,
+                "component_class": self.remote_class
+            }, protocol=4)
+            
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with self.session.post(
+                f"{self.server_url}/component/stop",
+                data=request_data,
+                timeout=timeout
+            ) as resp:
+                await resp.read()
+                
+        except Exception as e:
+            self.log(f"Warn: Failed to stop remote component: {e}")
+        
+        # Close session
+        if self.session:
+            await self.session.close()
+    
+    async def stop(self):
+        """
+        Stop the component gracefully.
+        """
+        self.api_stop = True
+        self.api_started = False
+        await asyncio.sleep(0.1)
+    
+    @property
+    def fatal_error(self):
+        """Check if a fatal error has occurred."""
+        return self.base.fatal_error
+    
+    def is_alive(self):
+        """Check if component is alive."""
+        return self.api_started
+    
+    def last_updated_time(self):
+        """Get last updated time."""
+        return self.last_success_timestamp
+    
+    def update_success_timestamp(self):
+        """Update last success timestamp."""
+        self.last_success_timestamp = datetime.now(timezone.utc)
+    
+    # Event handlers - forward to remote component
+    
+    async def select_event(self, entity_id, value):
+        """Handle select entity event."""
+        await self._call_remote_with_retry("select_event", entity_id, value)
+    
+    async def number_event(self, entity_id, value):
+        """Handle number entity event."""
+        await self._call_remote_with_retry("number_event", entity_id, value)
+    
+    async def switch_event(self, entity_id, service):
+        """Handle switch entity event."""
+        await self._call_remote_with_retry("switch_event", entity_id, service)

--- a/apps/predbat/component_server.py
+++ b/apps/predbat/component_server.py
@@ -28,15 +28,15 @@ import aiohttp.web
 class BaseMock:
     """
     Mock base object that forwards all calls back to the client's Predbat instance.
-    
+
     This class mimics the PredBat base object interface but implements it by making
     HTTP callbacks to the client for all operations.
     """
-    
+
     def __init__(self, callback_url, component_name, client_id):
         """
         Initialize BaseMock with callback URL.
-        
+
         Args:
             callback_url: URL of the client's callback server
         """
@@ -55,16 +55,16 @@ class BaseMock:
         self.config_root = await self._remote_call("get_local_attr", "config_root")
         self.num_cars = await self._remote_call("get_local_attr", "num_cars")
         self.plan_interval_minutes = await self._remote_call("get_local_attr", "plan_interval_minutes")
-    
+
     async def _remote_call(self, method, *args, **kwargs):
         """
         Make a remote call to the client's base object.
-        
+
         Args:
             method: Method name to call
             *args: Positional arguments
             **kwargs: Keyword arguments
-            
+
         Returns:
             Result from the remote call
         """
@@ -74,7 +74,7 @@ class BaseMock:
                 "args": args,
                 "kwargs": kwargs
             }, protocol=4)
-            
+
             async with self.session.post(
                 f"{self.callback_url}/base/call",
                 data=request_data,
@@ -82,20 +82,20 @@ class BaseMock:
             ) as resp:
                 response_data = await resp.read()
                 result = pickle.loads(response_data)
-                
+
                 # Check if error was returned
                 if isinstance(result, dict) and "error" in result:
                     raise RuntimeError(f"Remote call failed: {result['error']}")
-                
+
                 return result
         except Exception as e:
             logging.error(f"BaseMock._remote_call({method}) failed: {e}")
             raise
-    
+
     # Base API methods - all forward to client
     def log(self, msg):
         logging.info(f"{self.component_name} ({self.client_id}): {msg}")
-    
+
     async def async_get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
         """Get configuration argument from client (async)."""
         return await self._remote_call(
@@ -210,7 +210,7 @@ class BaseMock:
     @property
     def arg_errors(self):
         return self._run_async(self.async_arg_errors)
-    
+
     async def cleanup(self):
         """Cleanup session"""
         await self.session.close()
@@ -221,11 +221,11 @@ class ComponentServer:
     HTTP server that hosts remote components and forwards their base API calls
     back to the client Predbat instance.
     """
-    
+
     def __init__(self, timeout, component_loader):
         """
         Initialize the component server.
-        
+
         Args:
             timeout: Timeout in seconds for component inactivity
             component_classes: Dict mapping class names to class objects
@@ -240,11 +240,11 @@ class ComponentServer:
         self.logger = logging.getLogger("ComponentServer")
         self.app = None
         self.timeout_task = None
-    
+
     async def handle_component_start(self, request):
         """
         Handle component start request.
-        
+
         Expected pickled request: {
             "client_id": str,
             "component_class": str,
@@ -256,12 +256,12 @@ class ComponentServer:
             return aiohttp.web.Response(
                 body=pickle.dumps({"error": "Server is shutting down"}, protocol=4)
             )
-        
+
         try:
             # Unpickle request
             data = await request.read()
             req = pickle.loads(data)
-            
+
             client_id = req["client_id"]
             component_class = req["component_class"]
             callback_url = req["callback_url"]
@@ -273,9 +273,9 @@ class ComponentServer:
                 return aiohttp.web.Response(
                     body=pickle.dumps({"error": "Component already started"}, protocol=4)
                 )
-            
+
             self.logger.info(f"Starting component {component_class} for client {client_id} class {component_class} with callback {callback_url} args {init_kwargs}")
-            
+
             # Validate callback URL is reachable
             try:
                 async with aiohttp.ClientSession() as session:
@@ -292,25 +292,25 @@ class ComponentServer:
                 return aiohttp.web.Response(
                     body=pickle.dumps({"error": error_msg}, protocol=4)
                 )
-            
+
             # Import and instantiate component
             try:
                 # Get component class from registry or lazy loader
-                cls = self.component_loader(component_class)                
+                cls = self.component_loader(component_class)
                 if not cls:
                     raise ValueError(f"Component class {component_class} not registered")
                 self.logger.info(f"Loaded component class {component_class}")
-                
+
                 # Create BaseMock
                 base_mock = BaseMock(callback_url, component_class, client_id)
                 self.logger.info(f"Initializing BaseMock for component {component_class}")
                 await base_mock.initialize()
                 self.logger.info(f"BaseMock initialized for component {component_class}")
-                
+
                 # Instantiate component
                 component = cls(base_mock, **component_args)
                 self.logger.info(f"Instantiated component {component_class}")
-                
+
                 # Store component metadata
                 self.components[instance_key] = {
                     "component": component,
@@ -319,13 +319,13 @@ class ComponentServer:
                     "last_ping": datetime.now(timezone.utc),
                     "task": asyncio.create_task(component.start())
                 }
-                
+
                 self.logger.info(f"Component {instance_key} started successfully")
-                
+
                 return aiohttp.web.Response(
                     body=pickle.dumps({"success": True}, protocol=4)
                 )
-                
+
             except Exception as e:
                 error_msg = f"Failed to start component: {e}"
                 self.logger.error(error_msg)
@@ -333,7 +333,7 @@ class ComponentServer:
                 return aiohttp.web.Response(
                     body=pickle.dumps({"error": error_msg}, protocol=4)
                 )
-                
+
         except Exception as e:
             error_msg = f"Failed to process start request: {e}"
             self.logger.error(error_msg)
@@ -341,11 +341,11 @@ class ComponentServer:
             return aiohttp.web.Response(
                 body=pickle.dumps({"error": error_msg}, protocol=4)
             )
-    
+
     async def handle_component_call(self, request):
         """
         Handle component method call.
-        
+
         Expected pickled request: {
             "client_id": str,
             "component_class": str,
@@ -358,49 +358,49 @@ class ComponentServer:
             return aiohttp.web.Response(
                 body=pickle.dumps({"error": "Server is shutting down"}, protocol=4)
             )
-        
+
         # Increment active calls counter
         async with self.active_calls_lock:
             self.active_calls += 1
-        
+
         try:
             # Unpickle request
             data = await request.read()
             req = pickle.loads(data)
-            
+
             client_id = req["client_id"]
             component_class = req["component_class"]
             method = req["method"]
             args = req.get("args", ())
             kwargs = req.get("kwargs", {})
-            
+
             instance_key = f"{client_id}_{component_class}"
 
             self.logger.info(f"ComponentServer: Handling call to {method} for component {instance_key} class {component_class} args {args} kwargs {kwargs}")
-            
+
             # Check if component exists
             if instance_key not in self.components:
                 return aiohttp.web.Response(
                     body=pickle.dumps({"error": "Component not found"}, protocol=4)
                 )
-            
+
             component_meta = self.components[instance_key]
             component = component_meta["component"]
-            
+
             # Invoke method
             try:
                 method_fn = getattr(component, method)
-                
+
                 # Check if method is a coroutine function
                 if asyncio.iscoroutinefunction(method_fn):
                     result = await method_fn(*args, **kwargs)
                 else:
                     result = method_fn(*args, **kwargs)
-                
+
                 return aiohttp.web.Response(
                     body=pickle.dumps(result, protocol=4)
                 )
-                
+
             except Exception as e:
                 error_msg = str(e)
                 self.logger.error(f"Component method {method} failed: {error_msg}")
@@ -408,7 +408,7 @@ class ComponentServer:
                 return aiohttp.web.Response(
                     body=pickle.dumps({"error": error_msg}, protocol=4)
                 )
-                
+
         except Exception as e:
             error_msg = f"Failed to process call request: {e}"
             self.logger.error(error_msg)
@@ -420,11 +420,11 @@ class ComponentServer:
             # Decrement active calls counter
             async with self.active_calls_lock:
                 self.active_calls -= 1
-    
+
     async def handle_component_ping(self, request):
         """
         Handle component ping (health check).
-        
+
         Expected pickled request: {
             "client_id": str,
             "component_class": str
@@ -433,19 +433,19 @@ class ComponentServer:
         try:
             data = await request.read()
             req = pickle.loads(data)
-            
+
             client_id = req["client_id"]
             component_class = req["component_class"]
             instance_key = f"{client_id}_{component_class}"
-            
+
             if instance_key in self.components:
                 # Update last ping time
                 self.components[instance_key]["last_ping"] = datetime.now(timezone.utc)
-                
+
                 # Check if component is alive
                 component = self.components[instance_key]["component"]
                 alive = component.is_alive()
-                
+
                 return aiohttp.web.Response(
                     body=pickle.dumps({"alive": alive}, protocol=4)
                 )
@@ -453,18 +453,18 @@ class ComponentServer:
                 return aiohttp.web.Response(
                     body=pickle.dumps({"error": "Component not found"}, protocol=4)
                 )
-                
+
         except Exception as e:
             error_msg = f"Failed to process ping request: {e}"
             self.logger.error(error_msg)
             return aiohttp.web.Response(
                 body=pickle.dumps({"error": error_msg}, protocol=4)
             )
-    
+
     async def handle_component_stop(self, request):
         """
         Handle component stop request.
-        
+
         Expected pickled request: {
             "client_id": str,
             "component_class": str
@@ -473,14 +473,14 @@ class ComponentServer:
         try:
             data = await request.read()
             req = pickle.loads(data)
-            
+
             client_id = req["client_id"]
             component_class = req["component_class"]
             instance_key = f"{client_id}_{component_class}"
-            
+
             if instance_key in self.components:
                 await self._stop_component(instance_key)
-                
+
                 return aiohttp.web.Response(
                     body=pickle.dumps({"success": True}, protocol=4)
                 )
@@ -488,32 +488,32 @@ class ComponentServer:
                 return aiohttp.web.Response(
                     body=pickle.dumps({"error": "Component not found"}, protocol=4)
                 )
-                
+
         except Exception as e:
             error_msg = f"Failed to process stop request: {e}"
             self.logger.error(error_msg)
             return aiohttp.web.Response(
                 body=pickle.dumps({"error": error_msg}, protocol=4)
             )
-    
+
     async def _stop_component(self, instance_key):
         """Stop a component and clean up."""
         if instance_key not in self.components:
             return
-        
+
         self.logger.info(f"Stopping component {instance_key}")
-        
+
         component_meta = self.components[instance_key]
         component = component_meta["component"]
         task = component_meta["task"]
         base_mock = component_meta["base_mock"]
-        
+
         # Stop component
         try:
             await component.stop()
         except Exception as e:
             self.logger.error(f"Error stopping component: {e}")
-        
+
         # Cancel task
         if task and not task.done():
             task.cancel()
@@ -521,72 +521,72 @@ class ComponentServer:
                 await task
             except asyncio.CancelledError:
                 pass
-        
+
         # Cleanup base mock
         try:
             await base_mock.cleanup()
         except Exception as e:
             self.logger.error(f"Error cleaning up base mock: {e}")
-        
+
         # Remove from dict
         del self.components[instance_key]
-        
+
         self.logger.info(f"Component {instance_key} stopped")
-    
+
     async def _timeout_checker(self):
         """Background task to check for timed out components."""
         self.logger.info("Timeout checker started")
-        
+
         while not self.shutdown_flag:
             try:
                 await asyncio.sleep(60)  # Check every 60 seconds
-                
+
                 now = datetime.now(timezone.utc)
                 timed_out = []
-                
+
                 for instance_key, meta in self.components.items():
                     last_ping = meta["last_ping"]
                     elapsed = (now - last_ping).total_seconds()
-                    
+
                     if elapsed > self.timeout:
                         timed_out.append(instance_key)
                         self.logger.warning(f"Component {instance_key} timed out (no ping for {elapsed}s)")
-                
+
                 # Stop timed out components
                 for instance_key in timed_out:
                     await self._stop_component(instance_key)
-                    
+
             except Exception as e:
                 self.logger.error(f"Error in timeout checker: {e}")
                 self.logger.error(traceback.format_exc())
-        
+
         self.logger.info("Timeout checker stopped")
-    
+
     async def shutdown(self):
         """Graceful shutdown of the server."""
         self.logger.info("Shutdown initiated")
-        
+
         # Set shutdown flag to reject new calls
         self.shutdown_flag = True
-        
+
         # Wait for active calls to complete (max 30 seconds)
         wait_time = 0
         while wait_time < 30:
             async with self.active_calls_lock:
                 if self.active_calls == 0:
                     break
-            
+
             await asyncio.sleep(1)
             wait_time += 1
-        
+
         if self.active_calls > 0:
             self.logger.warning(f"Forcing shutdown with {self.active_calls} active calls")
-        
+
         # Stop all components
         instance_keys = list(self.components.keys())
         for instance_key in instance_keys:
             await self._stop_component(instance_key)
-        
+
         # Cancel timeout checker
         if self.timeout_task and not self.timeout_task.done():
             self.timeout_task.cancel()
@@ -594,30 +594,30 @@ class ComponentServer:
                 await self.timeout_task
             except asyncio.CancelledError:
                 pass
-        
+
         self.logger.info("Shutdown complete")
-    
+
     async def run(self, host, port):
         """
         Run the component server.
-        
+
         Args:
             host: Host to bind to
             port: Port to bind to
         """
         # Create web application
         self.app = aiohttp.web.Application()
-        
+
         # Add routes
         self.app.router.add_post('/component/start', self.handle_component_start)
         self.app.router.add_post('/component/call', self.handle_component_call)
         self.app.router.add_post('/component/ping', self.handle_component_ping)
         self.app.router.add_post('/component/stop', self.handle_component_stop)
-        
+
         # Start timeout checker
         self.timeout_task = asyncio.create_task(self._timeout_checker())
-        
+
         self.logger.info(f"Component server starting on {host}:{port}")
-        
+
         # Run web server
         await aiohttp.web._run_app(self.app, host=host, port=port)

--- a/apps/predbat/component_server.py
+++ b/apps/predbat/component_server.py
@@ -58,7 +58,7 @@ class BaseMock:
         # Config root
         self.config_root = self.component_name + "_" + self.client_id
         os.makedirs(self.config_root, exist_ok=True)
-    
+
     async def _remote_call(self, method, *args, **kwargs):
         """
         Make a remote call to the client's base object.
@@ -77,7 +77,7 @@ class BaseMock:
                 "args": args,
                 "kwargs": kwargs
             }, protocol=4)
-            
+
             # Get or create session for current event loop
             try:
                 loop = asyncio.get_running_loop()
@@ -89,7 +89,7 @@ class BaseMock:
             except RuntimeError:
                 # No running loop, use default session
                 session = self.session
-            
+
             async with session.post(
                 f"{self.callback_url}/base/call",
                 data=request_data,
@@ -171,10 +171,10 @@ class BaseMock:
             # Use a new thread to run asyncio.run to avoid blocking the event loop
             import threading
             import queue
-            
+
             result_queue = queue.Queue()
             exception_queue = queue.Queue()
-            
+
             def run_in_thread():
                 try:
                     # Create a new event loop in this thread
@@ -187,17 +187,17 @@ class BaseMock:
                         new_loop.close()
                 except Exception as e:
                     exception_queue.put(e)
-            
+
             thread = threading.Thread(target=run_in_thread, daemon=True)
             thread.start()
             thread.join(timeout=2*60)  # 2 minute timeout
-            
+
             if not exception_queue.empty():
                 raise exception_queue.get()
-            
+
             if not result_queue.empty():
                 return result_queue.get()
-            
+
             raise TimeoutError("Async operation timed out after 30 seconds")
 
     def get_arg(self, *args, **kwargs):
@@ -354,7 +354,7 @@ class ComponentServer:
 
                 self.logger.info(f"Component {instance_key} started successfully")
                 component.api_started = True
-                
+
                 return aiohttp.web.Response(
                     body=pickle.dumps({"success": True}, protocol=4)
                 )

--- a/apps/predbat/component_server.py
+++ b/apps/predbat/component_server.py
@@ -1,0 +1,623 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2025 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt: off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Component Server for Remote Component Execution
+
+WARNING: This server uses pickle for serialization. Only use in trusted networks
+(e.g. Kubernetes cluster) as pickle can execute arbitrary code. Do not expose
+this server to untrusted networks or the internet.
+"""
+
+import asyncio
+import pickle
+import logging
+import importlib
+import traceback
+from datetime import datetime, timezone
+import aiohttp
+import aiohttp.web
+
+class BaseMock:
+    """
+    Mock base object that forwards all calls back to the client's Predbat instance.
+    
+    This class mimics the PredBat base object interface but implements it by making
+    HTTP callbacks to the client for all operations.
+    """
+    
+    def __init__(self, callback_url, component_name, client_id):
+        """
+        Initialize BaseMock with callback URL.
+        
+        Args:
+            callback_url: URL of the client's callback server
+        """
+        self.callback_url = callback_url
+        self.session = aiohttp.ClientSession()
+        self.fatal_error = False
+        self.component_name = component_name
+        self.client_id = client_id
+
+    async def initialize(self):
+        # Cache immutable attributes on initialization
+        self.local_tz = await self._remote_call("get_local_attr", "local_tz")
+        self.prefix = await self._remote_call("get_local_attr", "prefix")
+        self.args = await self._remote_call("get_local_attr", "args")
+        self.currency_symbols = await self._remote_call("get_local_attr", "currency_symbols")
+        self.config_root = await self._remote_call("get_local_attr", "config_root")
+        self.num_cars = await self._remote_call("get_local_attr", "num_cars")
+        self.plan_interval_minutes = await self._remote_call("get_local_attr", "plan_interval_minutes")
+    
+    async def _remote_call(self, method, *args, **kwargs):
+        """
+        Make a remote call to the client's base object.
+        
+        Args:
+            method: Method name to call
+            *args: Positional arguments
+            **kwargs: Keyword arguments
+            
+        Returns:
+            Result from the remote call
+        """
+        try:
+            request_data = pickle.dumps({
+                "method": method,
+                "args": args,
+                "kwargs": kwargs
+            }, protocol=4)
+            
+            async with self.session.post(
+                f"{self.callback_url}/base/call",
+                data=request_data,
+                timeout=aiohttp.ClientTimeout(total=30)
+            ) as resp:
+                response_data = await resp.read()
+                result = pickle.loads(response_data)
+                
+                # Check if error was returned
+                if isinstance(result, dict) and "error" in result:
+                    raise RuntimeError(f"Remote call failed: {result['error']}")
+                
+                return result
+        except Exception as e:
+            logging.error(f"BaseMock._remote_call({method}) failed: {e}")
+            raise
+    
+    # Base API methods - all forward to client
+    def log(self, msg):
+        logging.info(f"{self.component_name} ({self.client_id}): {msg}")
+    
+    async def async_get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
+        """Get configuration argument from client (async)."""
+        return await self._remote_call(
+            "get_arg", arg, default=default, indirect=indirect, combine=combine,
+            attribute=attribute, index=index, domain=domain, can_override=can_override, required_unit=required_unit
+        )
+
+
+    # Async versions
+    async def async_get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
+        return await self._remote_call(
+            "get_arg", arg, default=default, indirect=indirect, combine=combine,
+            attribute=attribute, index=index, domain=domain, can_override=can_override, required_unit=required_unit
+        )
+    async def async_set_arg(self, arg, value):
+        return await self._remote_call("set_arg", arg, value)
+
+    async def async_get_state_wrapper(self, entity_id=None, default=None, attribute=None, refresh=False, required_unit=None):
+        return await self._remote_call("get_state_wrapper", entity_id, default=default, attribute=attribute, refresh=refresh, required_unit=required_unit)
+
+    async def async_set_state_wrapper(self, entity_id, state, attributes={}, required_unit=None):
+        return await self._remote_call("set_state_wrapper", entity_id, state, attributes=attributes, required_unit=required_unit)
+
+    async def async_get_history_wrapper(self, entity_id, days=30, required=True, tracked=True):
+        return await self._remote_call("get_history_wrapper", entity_id, days=days, required=required, tracked=tracked)
+
+    async def async_get_ha_config(self, name, default):
+        return await self._remote_call("get_ha_config", name, default)
+
+    async def async_dashboard_item(self, entity, state, attributes, app=None):
+        return await self._remote_call("dashboard_item", entity, state, attributes, app=app)
+
+    @property
+    async def async_now_utc(self):
+        return await self._remote_call("now_utc")
+
+    @property
+    async def async_midnight_utc(self):
+        return await self._remote_call("midnight_utc")
+
+    @property
+    async def async_minutes_now(self):
+        return await self._remote_call("minutes_now")
+
+    @property
+    async def async_arg_errors(self):
+        return await self._remote_call("arg_errors")
+
+    # Sync wrappers (for non-async contexts only)
+    def _run_async(self, coro):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop, safe to use asyncio.run
+            return asyncio.run(coro)
+        else:
+            # Already in an event loop
+            # If called from async context, we must be inside a coroutine, so we must await
+            # But since this is a sync wrapper, we must detect and run a nested task and wait for it
+            # This is a hack, but works for most cases
+            import threading
+            if threading.current_thread() is threading.main_thread() and asyncio.current_task(loop=loop):
+                # Called from async context, so we must block until done
+                fut = loop.create_task(coro)
+                import concurrent.futures
+                # Block until result is ready
+                done = concurrent.futures.Future()
+                def _set_result(f):
+                    try:
+                        done.set_result(f.result())
+                    except Exception as e:
+                        done.set_exception(e)
+                fut.add_done_callback(_set_result)
+                return done.result()
+            else:
+                # Called from sync context in a running loop (rare), fallback
+                return loop.run_until_complete(coro)
+
+    def get_arg(self, *args, **kwargs):
+        return self._run_async(self.async_get_arg(*args, **kwargs))
+
+    def set_arg(self, *args, **kwargs):
+        return self._run_async(self.async_set_arg(*args, **kwargs))
+
+    def get_state_wrapper(self, *args, **kwargs):
+        return self._run_async(self.async_get_state_wrapper(*args, **kwargs))
+
+    def set_state_wrapper(self, *args, **kwargs):
+        return self._run_async(self.async_set_state_wrapper(*args, **kwargs))
+
+    def get_history_wrapper(self, *args, **kwargs):
+        return self._run_async(self.async_get_history_wrapper(*args, **kwargs))
+
+    def get_ha_config(self, *args, **kwargs):
+        return self._run_async(self.async_get_ha_config(*args, **kwargs))
+
+    def dashboard_item(self, *args, **kwargs):
+        return self._run_async(self.async_dashboard_item(*args, **kwargs))
+
+    @property
+    def now_utc(self):
+        return self._run_async(self.async_now_utc)
+
+    @property
+    def midnight_utc(self):
+        return self._run_async(self.async_midnight_utc)
+
+    @property
+    def minutes_now(self):
+        return self._run_async(self.async_minutes_now)
+
+    @property
+    def arg_errors(self):
+        return self._run_async(self.async_arg_errors)
+    
+    async def cleanup(self):
+        """Cleanup session"""
+        await self.session.close()
+
+
+class ComponentServer:
+    """
+    HTTP server that hosts remote components and forwards their base API calls
+    back to the client Predbat instance.
+    """
+    
+    def __init__(self, timeout, component_loader):
+        """
+        Initialize the component server.
+        
+        Args:
+            timeout: Timeout in seconds for component inactivity
+            component_classes: Dict mapping class names to class objects
+            component_loader: Optional function(class_name) -> class for lazy loading
+        """
+        self.timeout = timeout
+        self.component_loader = component_loader
+        self.components = {}  # Key: client_id_component_class, Value: metadata dict
+        self.shutdown_flag = False
+        self.active_calls = 0
+        self.active_calls_lock = asyncio.Lock()
+        self.logger = logging.getLogger("ComponentServer")
+        self.app = None
+        self.timeout_task = None
+    
+    async def handle_component_start(self, request):
+        """
+        Handle component start request.
+        
+        Expected pickled request: {
+            "client_id": str,
+            "component_class": str,
+            "callback_url": str,
+            "init_kwargs": dict
+        }
+        """
+        if self.shutdown_flag:
+            return aiohttp.web.Response(
+                body=pickle.dumps({"error": "Server is shutting down"}, protocol=4)
+            )
+        
+        try:
+            # Unpickle request
+            data = await request.read()
+            req = pickle.loads(data)
+            
+            client_id = req["client_id"]
+            component_class = req["component_class"]
+            callback_url = req["callback_url"]
+            init_kwargs = req["init_kwargs"]
+            component_args = init_kwargs.get("component_args", {})
+            instance_key = f"{client_id}_{component_class}"
+
+            if instance_key in self.components:
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"error": "Component already started"}, protocol=4)
+                )
+            
+            self.logger.info(f"Starting component {component_class} for client {client_id} class {component_class} with callback {callback_url} args {init_kwargs}")
+            
+            # Validate callback URL is reachable
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(
+                        f"{callback_url}/health",
+                        timeout=aiohttp.ClientTimeout(total=5)
+                    ) as resp:
+                        if resp.status != 200:
+                            raise Exception(f"Health check returned {resp.status}")
+            except Exception as e:
+                error_msg = f"Callback URL {callback_url} not reachable: {e}"
+                error_msg += traceback.format_exc()
+                self.logger.error(error_msg)
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"error": error_msg}, protocol=4)
+                )
+            
+            # Import and instantiate component
+            try:
+                # Get component class from registry or lazy loader
+                cls = self.component_loader(component_class)                
+                if not cls:
+                    raise ValueError(f"Component class {component_class} not registered")
+                self.logger.info(f"Loaded component class {component_class}")
+                
+                # Create BaseMock
+                base_mock = BaseMock(callback_url, component_class, client_id)
+                self.logger.info(f"Initializing BaseMock for component {component_class}")
+                await base_mock.initialize()
+                self.logger.info(f"BaseMock initialized for component {component_class}")
+                
+                # Instantiate component
+                component = cls(base_mock, **component_args)
+                self.logger.info(f"Instantiated component {component_class}")
+                
+                # Store component metadata
+                self.components[instance_key] = {
+                    "component": component,
+                    "base_mock": base_mock,
+                    "callback_url": callback_url,
+                    "last_ping": datetime.now(timezone.utc),
+                    "task": asyncio.create_task(component.start())
+                }
+                
+                self.logger.info(f"Component {instance_key} started successfully")
+                
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"success": True}, protocol=4)
+                )
+                
+            except Exception as e:
+                error_msg = f"Failed to start component: {e}"
+                self.logger.error(error_msg)
+                self.logger.error(traceback.format_exc())
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"error": error_msg}, protocol=4)
+                )
+                
+        except Exception as e:
+            error_msg = f"Failed to process start request: {e}"
+            self.logger.error(error_msg)
+            self.logger.error(traceback.format_exc())
+            return aiohttp.web.Response(
+                body=pickle.dumps({"error": error_msg}, protocol=4)
+            )
+    
+    async def handle_component_call(self, request):
+        """
+        Handle component method call.
+        
+        Expected pickled request: {
+            "client_id": str,
+            "component_class": str,
+            "method": str,
+            "args": tuple,
+            "kwargs": dict
+        }
+        """
+        if self.shutdown_flag:
+            return aiohttp.web.Response(
+                body=pickle.dumps({"error": "Server is shutting down"}, protocol=4)
+            )
+        
+        # Increment active calls counter
+        async with self.active_calls_lock:
+            self.active_calls += 1
+        
+        try:
+            # Unpickle request
+            data = await request.read()
+            req = pickle.loads(data)
+            
+            client_id = req["client_id"]
+            component_class = req["component_class"]
+            method = req["method"]
+            args = req.get("args", ())
+            kwargs = req.get("kwargs", {})
+            
+            instance_key = f"{client_id}_{component_class}"
+
+            self.logger.info(f"ComponentServer: Handling call to {method} for component {instance_key} class {component_class} args {args} kwargs {kwargs}")
+            
+            # Check if component exists
+            if instance_key not in self.components:
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"error": "Component not found"}, protocol=4)
+                )
+            
+            component_meta = self.components[instance_key]
+            component = component_meta["component"]
+            
+            # Invoke method
+            try:
+                method_fn = getattr(component, method)
+                
+                # Check if method is a coroutine function
+                if asyncio.iscoroutinefunction(method_fn):
+                    result = await method_fn(*args, **kwargs)
+                else:
+                    result = method_fn(*args, **kwargs)
+                
+                return aiohttp.web.Response(
+                    body=pickle.dumps(result, protocol=4)
+                )
+                
+            except Exception as e:
+                error_msg = str(e)
+                self.logger.error(f"Component method {method} failed: {error_msg}")
+                self.logger.error(traceback.format_exc())
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"error": error_msg}, protocol=4)
+                )
+                
+        except Exception as e:
+            error_msg = f"Failed to process call request: {e}"
+            self.logger.error(error_msg)
+            self.logger.error(traceback.format_exc())
+            return aiohttp.web.Response(
+                body=pickle.dumps({"error": error_msg}, protocol=4)
+            )
+        finally:
+            # Decrement active calls counter
+            async with self.active_calls_lock:
+                self.active_calls -= 1
+    
+    async def handle_component_ping(self, request):
+        """
+        Handle component ping (health check).
+        
+        Expected pickled request: {
+            "client_id": str,
+            "component_class": str
+        }
+        """
+        try:
+            data = await request.read()
+            req = pickle.loads(data)
+            
+            client_id = req["client_id"]
+            component_class = req["component_class"]
+            instance_key = f"{client_id}_{component_class}"
+            
+            if instance_key in self.components:
+                # Update last ping time
+                self.components[instance_key]["last_ping"] = datetime.now(timezone.utc)
+                
+                # Check if component is alive
+                component = self.components[instance_key]["component"]
+                alive = component.is_alive()
+                
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"alive": alive}, protocol=4)
+                )
+            else:
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"error": "Component not found"}, protocol=4)
+                )
+                
+        except Exception as e:
+            error_msg = f"Failed to process ping request: {e}"
+            self.logger.error(error_msg)
+            return aiohttp.web.Response(
+                body=pickle.dumps({"error": error_msg}, protocol=4)
+            )
+    
+    async def handle_component_stop(self, request):
+        """
+        Handle component stop request.
+        
+        Expected pickled request: {
+            "client_id": str,
+            "component_class": str
+        }
+        """
+        try:
+            data = await request.read()
+            req = pickle.loads(data)
+            
+            client_id = req["client_id"]
+            component_class = req["component_class"]
+            instance_key = f"{client_id}_{component_class}"
+            
+            if instance_key in self.components:
+                await self._stop_component(instance_key)
+                
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"success": True}, protocol=4)
+                )
+            else:
+                return aiohttp.web.Response(
+                    body=pickle.dumps({"error": "Component not found"}, protocol=4)
+                )
+                
+        except Exception as e:
+            error_msg = f"Failed to process stop request: {e}"
+            self.logger.error(error_msg)
+            return aiohttp.web.Response(
+                body=pickle.dumps({"error": error_msg}, protocol=4)
+            )
+    
+    async def _stop_component(self, instance_key):
+        """Stop a component and clean up."""
+        if instance_key not in self.components:
+            return
+        
+        self.logger.info(f"Stopping component {instance_key}")
+        
+        component_meta = self.components[instance_key]
+        component = component_meta["component"]
+        task = component_meta["task"]
+        base_mock = component_meta["base_mock"]
+        
+        # Stop component
+        try:
+            await component.stop()
+        except Exception as e:
+            self.logger.error(f"Error stopping component: {e}")
+        
+        # Cancel task
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        
+        # Cleanup base mock
+        try:
+            await base_mock.cleanup()
+        except Exception as e:
+            self.logger.error(f"Error cleaning up base mock: {e}")
+        
+        # Remove from dict
+        del self.components[instance_key]
+        
+        self.logger.info(f"Component {instance_key} stopped")
+    
+    async def _timeout_checker(self):
+        """Background task to check for timed out components."""
+        self.logger.info("Timeout checker started")
+        
+        while not self.shutdown_flag:
+            try:
+                await asyncio.sleep(60)  # Check every 60 seconds
+                
+                now = datetime.now(timezone.utc)
+                timed_out = []
+                
+                for instance_key, meta in self.components.items():
+                    last_ping = meta["last_ping"]
+                    elapsed = (now - last_ping).total_seconds()
+                    
+                    if elapsed > self.timeout:
+                        timed_out.append(instance_key)
+                        self.logger.warning(f"Component {instance_key} timed out (no ping for {elapsed}s)")
+                
+                # Stop timed out components
+                for instance_key in timed_out:
+                    await self._stop_component(instance_key)
+                    
+            except Exception as e:
+                self.logger.error(f"Error in timeout checker: {e}")
+                self.logger.error(traceback.format_exc())
+        
+        self.logger.info("Timeout checker stopped")
+    
+    async def shutdown(self):
+        """Graceful shutdown of the server."""
+        self.logger.info("Shutdown initiated")
+        
+        # Set shutdown flag to reject new calls
+        self.shutdown_flag = True
+        
+        # Wait for active calls to complete (max 30 seconds)
+        wait_time = 0
+        while wait_time < 30:
+            async with self.active_calls_lock:
+                if self.active_calls == 0:
+                    break
+            
+            await asyncio.sleep(1)
+            wait_time += 1
+        
+        if self.active_calls > 0:
+            self.logger.warning(f"Forcing shutdown with {self.active_calls} active calls")
+        
+        # Stop all components
+        instance_keys = list(self.components.keys())
+        for instance_key in instance_keys:
+            await self._stop_component(instance_key)
+        
+        # Cancel timeout checker
+        if self.timeout_task and not self.timeout_task.done():
+            self.timeout_task.cancel()
+            try:
+                await self.timeout_task
+            except asyncio.CancelledError:
+                pass
+        
+        self.logger.info("Shutdown complete")
+    
+    async def run(self, host, port):
+        """
+        Run the component server.
+        
+        Args:
+            host: Host to bind to
+            port: Port to bind to
+        """
+        # Create web application
+        self.app = aiohttp.web.Application()
+        
+        # Add routes
+        self.app.router.add_post('/component/start', self.handle_component_start)
+        self.app.router.add_post('/component/call', self.handle_component_call)
+        self.app.router.add_post('/component/ping', self.handle_component_ping)
+        self.app.router.add_post('/component/stop', self.handle_component_stop)
+        
+        # Start timeout checker
+        self.timeout_task = asyncio.create_task(self._timeout_checker())
+        
+        self.logger.info(f"Component server starting on {host}:{port}")
+        
+        # Run web server
+        await aiohttp.web._run_app(self.app, host=host, port=port)

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -228,13 +228,13 @@ class Components:
 
     def initialize(self, only=None, phase=0):
         """Initialize components without starting them"""
-        
+
         # Initialize callback server for remote components (phase 0 only)
         if phase == 0 and only is None:
             # Get component_server config from args (apps.yaml)
             component_server_config = self.base.args.get("component_server", {})
             component_server_components = component_server_config.get("components", [])
-            
+
             if component_server_components:
                 server_url = component_server_config.get("url", "")
                 if not server_url:
@@ -255,7 +255,7 @@ class Components:
                         self.log(f"Components: Error: Failed to start callback server: {e}")
                         self.callback_server = None
                         component_server_components = []
-        
+
         for component_name, component_info in COMPONENT_LIST.items():
             if only and component_name != only:
                 continue
@@ -291,11 +291,11 @@ class Components:
                     have_all_args = False
             if have_all_args:
                 self.log(f"Initializing {component_info['name']} interface")
-                
+
                 # Check if this component should run remotely
                 component_server_config = self.base.args.get("component_server", {})
                 component_server_components = component_server_config.get("components", [])
-                
+
                 if component_name in component_server_components and self.callback_server:
                     # Create remote component client
                     server_url = component_server_config.get("url", "")
@@ -305,7 +305,7 @@ class Components:
                     timeout = component_server_config.get("timeout", 1800)
 
                     args_data = {"callback_url": callback_url, "callback_port": callback_port, "poll_interval": poll_interval, "timeout": timeout, "component_args": arg_dict}
-                    
+
                     self.log(f"Creating remote component client for {component_name} at {server_url}")
                     self.components[component_name] = ComponentClient(
                         self.base,
@@ -348,7 +348,7 @@ class Components:
             self.log("Stopping component callback server")
             await self.callback_server.stop()
             self.callback_server = None
-        
+
         for component_name, component_info in reversed(list(self.components.items())):
             if only and component_name != only:
                 continue

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -19,6 +19,7 @@ from web import WebInterface
 from ha import HAInterface, HAHistory
 from db_manager import DatabaseManager
 from fox import FoxAPI
+from kraken import KrakenAPI
 from web_mcp import PredbatMCPServer
 from component_client import ComponentClient
 from component_callback_server import ComponentCallbackServer
@@ -189,6 +190,43 @@ COMPONENT_LIST = {
                 "required": False,
                 "default": False,
                 "config": "fox_automatic",
+            },
+        },
+        "phase": 1,
+    },
+    "kraken": {
+        "class": KrakenAPI,
+        "name": "Kraken Energy (EDF/E.ON)",
+        "event_filter": "predbat_kraken_",
+        "args": {
+            "provider": {
+                "required": True,
+                "config": "kraken_provider",
+            },
+            "account_id": {
+                "required": True,
+                "config": "kraken_account_id",
+            },
+            "key": {
+                "required": False,
+                "config": "kraken_key",
+            },
+            "email": {
+                "required": False,
+                "config": "kraken_email",
+            },
+            "password": {
+                "required": False,
+                "config": "kraken_password",
+            },
+            "auth_method": {
+                "required": False,
+                "default": "oauth",
+                "config": "kraken_auth_method",
+            },
+            "token_expires_at": {
+                "required": False,
+                "config": "kraken_token_expires_at",
             },
         },
         "phase": 1,

--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -341,6 +341,7 @@ class FoxAPI(ComponentBase):
         result = await self.request_get(GET_DEVICE_INFO, post=False, datain=query)
         if result is not None:
             self.device_detail[deviceSN] = result
+        return result
 
     async def get_device_settings(self, deviceSN):
         """
@@ -1258,8 +1259,11 @@ class FoxAPI(ComponentBase):
 class MockBase:
     """Mock base class for testing"""
 
+
     def __init__(self):
         self.local_tz = datetime.now().astimezone().tzinfo
+        self.prefix = "predbat"
+        self.args = {}
 
     def log(self, message):
         print(f"LOG: {message}")
@@ -1277,29 +1281,36 @@ async def test_fox_api(api_key):
     # Create a mock base object
     mock_base = MockBase()
 
-    sn = "609H50204BPM048"
+    sn = "603J303046YP036"
 
     # Create FoxAPI instance with a lambda that returns the API key
-    fox_api = FoxAPI(api_key, False, mock_base)
-    # device_List = await fox_api.get_device_list()
-    # print(f"Device List: {device_List}")
+    args = {
+        "key": api_key,
+        "automatic": False,
+    }
+    fox_api = FoxAPI(mock_base, **args)
+    device_List = await fox_api.get_device_list()
+    print(f"Device List: {device_List}")
+    #return(1)
     # await fox_api.start()
-    # res = await fox_api.get_device_settings(sn)
-    # print(res)
-    # res = await fox_api.get_battery_charging_time(sn)
-    # print(res)
-    res = await fox_api.get_device_detail(sn)
-    print(res)
-    res = await fox_api.get_scheduler(sn, checkBattery=False)
-    print(res)
-    return 1
+    #res = await fox_api.get_device_settings(sn)
+    #print(res)
+    #res = await fox_api.get_battery_charging_time(sn)
+    #print("Battery Charging Time:")
+    #print(res)
+    #return 1
+    #res = await fox_api.get_device_detail(sn)
+    #print(res)
+    #res = await fox_api.get_scheduler(sn, checkBattery=False)
+    #print(res)
     # res = await fox_api.compute_schedule(sn)
     # res = await fox_api.publish_data()
     # res = await fox_api.set_device_setting(sn, "dummy", 42)
     # print(res)
 
-    # res = await fox_api.get_scheduler(sn)
-    # groups = res.get('groups', [])
+    res = await fox_api.get_scheduler(sn, checkBattery=False)
+    print(res)
+    groups = res.get('groups', [])
     # {'endHour': 0, 'fdPwr': 0, 'minSocOnGrid': 10, 'workMode': 'Invalid', 'fdSoc': 10, 'enable': 0, 'startHour': 0, 'maxSoc': 100, 'startMinute': 0, 'endMinute': 0},
     # new_slot = groups[0].copy()
     new_slot = {}
@@ -1310,7 +1321,7 @@ async def test_fox_api(api_key):
     new_slot["endHour"] = 12
     new_slot["endMinute"] = 00
     new_slot["fdSoc"] = 10
-    new_slot["fdPwr"] = 5000
+    new_slot["fdPwr"] = 8000
     new_slot["minSocOnGrid"] = 10
     new_slot2 = {}
     new_slot2["enable"] = 1

--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -1259,7 +1259,6 @@ class FoxAPI(ComponentBase):
 class MockBase:
     """Mock base class for testing"""
 
-
     def __init__(self):
         self.local_tz = datetime.now().astimezone().tzinfo
         self.prefix = "predbat"
@@ -1291,18 +1290,18 @@ async def test_fox_api(api_key):
     fox_api = FoxAPI(mock_base, **args)
     device_List = await fox_api.get_device_list()
     print(f"Device List: {device_List}")
-    #return(1)
+    # return(1)
     # await fox_api.start()
-    #res = await fox_api.get_device_settings(sn)
-    #print(res)
-    #res = await fox_api.get_battery_charging_time(sn)
-    #print("Battery Charging Time:")
-    #print(res)
-    #return 1
-    #res = await fox_api.get_device_detail(sn)
-    #print(res)
-    #res = await fox_api.get_scheduler(sn, checkBattery=False)
-    #print(res)
+    # res = await fox_api.get_device_settings(sn)
+    # print(res)
+    # res = await fox_api.get_battery_charging_time(sn)
+    # print("Battery Charging Time:")
+    # print(res)
+    # return 1
+    # res = await fox_api.get_device_detail(sn)
+    # print(res)
+    # res = await fox_api.get_scheduler(sn, checkBattery=False)
+    # print(res)
     # res = await fox_api.compute_schedule(sn)
     # res = await fox_api.publish_data()
     # res = await fox_api.set_device_setting(sn, "dummy", 42)
@@ -1310,7 +1309,7 @@ async def test_fox_api(api_key):
 
     res = await fox_api.get_scheduler(sn, checkBattery=False)
     print(res)
-    groups = res.get('groups', [])
+    groups = res.get("groups", [])
     # {'endHour': 0, 'fdPwr': 0, 'minSocOnGrid': 10, 'workMode': 'Invalid', 'fdSoc': 10, 'enable': 0, 'startHour': 0, 'maxSoc': 100, 'startMinute': 0, 'endMinute': 0},
     # new_slot = groups[0].copy()
     new_slot = {}

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -5,11 +5,14 @@
 # -----------------------------------------------------------------------------
 
 import requests
-from datetime import timedelta, datetime, timezone
+from datetime import timedelta, datetime
 from utils import str2time, dp1
 import asyncio
 import random
 import time
+import yaml
+import os
+from component_base import ComponentBase
 
 """
 GE Cloud data download
@@ -28,7 +31,7 @@ GE_API_SMART_DEVICE = "smart-device/{uuid}"
 GE_API_SMART_DEVICE_DATA = "smart-device/{uuid}/data"
 GE_API_EVC_DEVICES = "ev-charger"
 GE_API_EVC_DEVICE = "ev-charger/{uuid}"
-GE_API_EVC_DEVICE_DATA = "ev-charger/{uuid}/meter-data?start_time={start_time}&end_time={end_time}&meter_ids[]={meter_ids}"
+GE_API_EVC_DEVICE_DATA = "ev-charger/{uuid}/meter-data?start_time={start_time}&end_time={end_time}&meter_ids[]={meter_ids}&page=1"
 GE_API_EVC_COMMANDS = "ev-charger/{uuid}/commands"
 GE_API_EVC_COMMAND_DATA = "ev-charger/{uuid}/commands/{command}"
 GE_API_EVC_SEND_COMMAND = "ev-charger/{uuid}/commands/{command}"
@@ -152,8 +155,10 @@ EVC_SELECT_VALUE_KEY = {
 EVC_BLACKLIST_COMMANDS = ["installation-mode", "perform-factory-reset", "rename-id-tag", "delete-id-tags", "change-randomised-delay-duration"]
 
 TIMEOUT = 240
-RETRIES = 5
+RETRIES = 10
+RETRY_FACTOR = 1
 MAX_THREADS = 2
+MAX_START_TIME = 10 * 60
 
 attribute_table = {
     "time": {"friendly_name": "Time", "icon": "mdi:clock", "unit_of_measurement": "Time", "state_class": "timestamp"},
@@ -167,18 +172,18 @@ attribute_table = {
     "grid_voltage": {"friendly_name": "Grid Voltage", "icon": "mdi:transmission-tower", "unit_of_measurement": "V", "device_class": "voltage"},
     "grid_current": {"friendly_name": "Grid Current", "icon": "mdi:transmission-tower", "unit_of_measurement": "A", "device_class": "current"},
     "grid_frequency": {"friendly_name": "Grid Frequency", "icon": "mdi:transmission-tower", "unit_of_measurement": "Hz", "device_class": "frequency"},
-    "solar_today": {"friendly_name": "Solar Today", "icon": "mdi:solar-power", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "consumption_today": {"friendly_name": "Consumption Today", "icon": "mdi:flash", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "battery_charge_today": {"friendly_name": "Battery Charge Today", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "battery_discharge_today": {"friendly_name": "Battery Discharge Today", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "grid_import_today": {"friendly_name": "Grid Import Today", "icon": "mdi:transmission-tower", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "grid_export_today": {"friendly_name": "Grid Export Today", "icon": "mdi:transmission-tower", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "solar_total": {"friendly_name": "Solar Total", "icon": "mdi:solar-power", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "consumption_total": {"friendly_name": "Consumption Total", "icon": "mdi:flash", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "battery_charge_total": {"friendly_name": "Battery Charge Total", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "battery_discharge_total": {"friendly_name": "Battery Discharge Total", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "grid_import_total": {"friendly_name": "Grid Import Total", "icon": "mdi:transmission-tower", "unit_of_measurement": "kWh", "device_class": "energy"},
-    "grid_export_total": {"friendly_name": "Grid Export Total", "icon": "mdi:transmission-tower", "unit_of_measurement": "kWh", "device_class": "energy"},
+    "solar_today": {"friendly_name": "Solar Today", "icon": "mdi:solar-power", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "consumption_today": {"friendly_name": "Consumption Today", "icon": "mdi:flash", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "battery_charge_today": {"friendly_name": "Battery Charge Today", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "battery_discharge_today": {"friendly_name": "Battery Discharge Today", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "grid_import_today": {"friendly_name": "Grid Import Today", "icon": "mdi:transmission-tower", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "grid_export_today": {"friendly_name": "Grid Export Today", "icon": "mdi:transmission-tower", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "solar_total": {"friendly_name": "Solar Total", "icon": "mdi:solar-power", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "consumption_total": {"friendly_name": "Consumption Total", "icon": "mdi:flash", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "battery_charge_total": {"friendly_name": "Battery Charge Total", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "battery_discharge_total": {"friendly_name": "Battery Discharge Total", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "grid_import_total": {"friendly_name": "Grid Import Total", "icon": "mdi:transmission-tower", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
+    "grid_export_total": {"friendly_name": "Grid Export Total", "icon": "mdi:transmission-tower", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
     "max_charge_rate": {"friendly_name": "Max Charge Rate", "icon": "mdi:battery", "unit_of_measurement": "W", "device_class": "power"},
     "battery_size": {"friendly_name": "Battery Size", "icon": "mdi:battery", "unit_of_measurement": "kWh", "device_class": "energy"},
     "battery_dod": {"friendly_name": "Battery Depth of Discharge", "icon": "mdi:battery", "unit_of_measurement": "*", "device_class": "battery"},
@@ -189,13 +194,21 @@ OPTIONS_TIME = [((BASE_TIME + timedelta(seconds=minute * 60)).strftime("%H:%M"))
 OPTIONS_TIME_FULL = [((BASE_TIME + timedelta(seconds=minute * 60)).strftime("%H:%M") + ":00") for minute in range(0, 24 * 60, 1)]
 
 
-class GECloudDirect:
-    def __init__(self, api_key, automatic, base):
-        """
-        Setup client
-        """
-        self.base = base
-        self.log = base.log
+def regname_to_ha(name):
+    """
+    Convert register name to HA style
+    """
+    name = name.lower().replace(" ", "_").replace("%", "percent").replace("-", "_")
+    return name
+
+
+class GECloudDirect(ComponentBase):
+    """
+    GivEnergy Cloud Direct API interface
+    """
+
+    def initialize(self, ge_cloud_direct, api_key, automatic):
+        """Initialize the GE Cloud Direct component"""
         self.api_key = api_key
         self.automatic = automatic
         self.register_list = {}
@@ -203,39 +216,23 @@ class GECloudDirect:
         self.status = {}
         self.meter = {}
         self.info = {}
-        self.stop_cloud = False
-        self.api_started = False
         self.register_entity_map = {}
         self.long_poll_active = False
         self.pending_writes = {}
         self.evc_device = {}
         self.evc_data = {}
         self.evc_sessions = {}
+        self.api_fatal = False
+        self.devices_dict = {}
+        self.device_list = []
+        self.ems_device = None
+        self.gateway_device = None
+        self.evc_devices_dict = {}
+        self.evc_device_list = []
 
         # API request metrics for monitoring
         self.requests_total = 0
         self.failures_total = 0
-        self.last_success_timestamp = None
-
-    def wait_api_started(self):
-        """
-        Return if the API has started
-        """
-        self.log("GECloud: Waiting for API to start")
-        count = 0
-        while not self.api_started and count < 120:
-            time.sleep(1)
-            count += 1
-        if not self.api_started:
-            self.log("Warn: GECloud: API failed to start in required time")
-            return False
-        return True
-
-    def is_alive(self):
-        """
-        Check if the API is alive
-        """
-        return self.api_started
 
     async def switch_event(self, entity_id, service):
         """
@@ -371,6 +368,7 @@ class GECloudDirect:
             attributes = {}
             if key == "info":
                 info = device_info[key]
+                last_updated = device_info.get("last_updated", None)
                 cap = info.get("battery", {}).get("nominal_capacity", None)
                 volt = info.get("battery", {}).get("nominal_voltage", None)
                 dod = info.get("battery", {}).get("depth_of_discharge", None)
@@ -383,17 +381,17 @@ class GECloudDirect:
                         pass
 
                 max_charge_rate = info.get("max_charge_rate", 0)
-                self.log("GECloud: Device {} battery capacity {} max charge rate {}".format(device, capacity, max_charge_rate))
+                self.log("GECloud: Update data for device {} battery capacity {} max charge rate {}".format(device, capacity, max_charge_rate))
 
-                self.base.dashboard_item(entity_name + "_battery_size", capacity, attributes=attribute_table.get("battery_size", {}), app="gecloud")
-                self.base.dashboard_item(entity_name + "_max_charge_rate", max_charge_rate, attributes=attribute_table.get("max_charge_rate", {}), app="gecloud")
-                self.base.dashboard_item(entity_name + "_battery_dod", dod, attributes=attribute_table.get("_battery_dod", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_battery_size", capacity, attributes=attribute_table.get("battery_size", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_max_charge_rate", max_charge_rate, attributes=attribute_table.get("max_charge_rate", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_battery_dod", dod, attributes=attribute_table.get("_battery_dod", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_last_updated", last_updated, attributes=attribute_table.get("time", {}), app="gecloud")
 
     async def publish_evc_data(self, serial, evc_data):
         """
         Data passed in is a dictionary of measurands according to EVC_DATA_POINTS
         """
-
         for key in evc_data:
             entity_name = "sensor.predbat_gecloud_" + serial
             entity_name = entity_name.lower()
@@ -401,37 +399,37 @@ class GECloudDirect:
             if measurand:
                 state = evc_data[key]
                 if measurand == "Current.Export":
-                    self.base.dashboard_item(entity_name + "_evc_current_export", state=state, attributes={"friendly_name": "EV Charger Current Export", "icon": "mdi:ev-station", "unit_of_measurement": "A", "device_class": "current"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_current_export", state=state, attributes={"friendly_name": "EV Charger Current Export", "icon": "mdi:ev-station", "unit_of_measurement": "A", "device_class": "current"}, app="gecloud")
                 elif measurand == "Current.Import":
-                    self.base.dashboard_item(entity_name + "_evc_current_import", state=state, attributes={"friendly_name": "EV Charger Current Import", "icon": "mdi:ev-station", "unit_of_measurement": "A", "device_class": "current"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_current_import", state=state, attributes={"friendly_name": "EV Charger Current Import", "icon": "mdi:ev-station", "unit_of_measurement": "A", "device_class": "current"}, app="gecloud")
                 elif measurand == "Current.Offered":
-                    self.base.dashboard_item(entity_name + "_evc_current_offered", state=state, attributes={"friendly_name": "EV Charger Current Offered", "icon": "mdi:ev-station", "unit_of_measurement": "A", "device_class": "current"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_current_offered", state=state, attributes={"friendly_name": "EV Charger Current Offered", "icon": "mdi:ev-station", "unit_of_measurement": "A", "device_class": "current"}, app="gecloud")
                 elif measurand == "Energy.Active.Export.Register":
-                    self.base.dashboard_item(
+                    self.dashboard_item(
                         entity_name + "_evc_energy_active_export_register", state=state, attributes={"friendly_name": "EV Charger Total Export", "icon": "mdi:ev-station", "unit_of_measurement": "kWh", "device_class": "energy"}, app="gecloud"
                     )
                 elif measurand == "Energy.Active.Import.Register":
-                    self.base.dashboard_item(
+                    self.dashboard_item(
                         entity_name + "_evc_energy_active_import_register", state=state, attributes={"friendly_name": "EV Charger Total Import", "icon": "mdi:ev-station", "unit_of_measurement": "kWh", "device_class": "energy"}, app="gecloud"
                     )
                 elif measurand == "Frequency":
-                    self.base.dashboard_item(entity_name + "_evc_frequency", state=state, attributes={"friendly_name": "EV Charger Frequency", "icon": "mdi:ev-station", "unit_of_measurement": "Hz", "device_class": "frequency"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_frequency", state=state, attributes={"friendly_name": "EV Charger Frequency", "icon": "mdi:ev-station", "unit_of_measurement": "Hz", "device_class": "frequency"}, app="gecloud")
                 elif measurand == "Power.Active.Export":
-                    self.base.dashboard_item(entity_name + "_evc_power_active_export", state=state, attributes={"friendly_name": "EV Charger Export Power", "icon": "mdi:ev-station", "unit_of_measurement": "W", "device_class": "power"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_power_active_export", state=state, attributes={"friendly_name": "EV Charger Export Power", "icon": "mdi:ev-station", "unit_of_measurement": "W", "device_class": "power"}, app="gecloud")
                 elif measurand == "Power.Active.Import":
-                    self.base.dashboard_item(entity_name + "_evc_power_active_import", state=state, attributes={"friendly_name": "EV Charger Import Power", "icon": "mdi:ev-station", "unit_of_measurement": "W", "device_class": "power"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_power_active_import", state=state, attributes={"friendly_name": "EV Charger Import Power", "icon": "mdi:ev-station", "unit_of_measurement": "W", "device_class": "power"}, app="gecloud")
                 elif measurand == "Power.Factor":
-                    self.base.dashboard_item(entity_name + "_evc_power_factor", state=state, attributes={"friendly_name": "EV Charger Power Factor", "icon": "mdi:ev-station", "unit_of_measurement": "*", "device_class": "power_factor"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_power_factor", state=state, attributes={"friendly_name": "EV Charger Power Factor", "icon": "mdi:ev-station", "unit_of_measurement": "*", "device_class": "power_factor"}, app="gecloud")
                 elif measurand == "Power.Offered":
-                    self.base.dashboard_item(entity_name + "_evc_power_offered", state=state, attributes={"friendly_name": "EV Charger Power Offered", "icon": "mdi:ev-station", "unit_of_measurement": "W", "device_class": "power"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_power_offered", state=state, attributes={"friendly_name": "EV Charger Power Offered", "icon": "mdi:ev-station", "unit_of_measurement": "W", "device_class": "power"}, app="gecloud")
                 elif measurand == "SoC":
-                    self.base.dashboard_item(entity_name + "_evc_soc", state=state, attributes={"friendly_name": "EV Charger State of Charge", "icon": "mdi:ev-station", "unit_of_measurement": "%", "device_class": "battery"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_soc", state=state, attributes={"friendly_name": "EV Charger State of Charge", "icon": "mdi:ev-station", "unit_of_measurement": "%", "device_class": "battery"}, app="gecloud")
                 elif measurand == "Temperature":
-                    self.base.dashboard_item(entity_name + "_evc_temperature", state=state, attributes={"friendly_name": "EV Charger Temperature", "icon": "mdi:ev-station", "unit_of_measurement": "°C", "device_class": "temperature"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_temperature", state=state, attributes={"friendly_name": "EV Charger Temperature", "icon": "mdi:ev-station", "unit_of_measurement": "°C", "device_class": "temperature"}, app="gecloud")
                 elif measurand == "Voltage":
-                    self.base.dashboard_item(entity_name + "_evc_voltage", state=state, attributes={"friendly_name": "EV Charger Voltage", "icon": "mdi:ev-station", "unit_of_measurement": "V", "device_class": "voltage"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_voltage", state=state, attributes={"friendly_name": "EV Charger Voltage", "icon": "mdi:ev-station", "unit_of_measurement": "V", "device_class": "voltage"}, app="gecloud")
                 elif measurand == "RPM":
-                    self.base.dashboard_item(entity_name + "_evc_rpm", state=state, attributes={"friendly_name": "EV Charger Fan Speed", "icon": "mdi:ev-station", "unit_of_measurement": "RPM"}, app="gecloud")
+                    self.dashboard_item(entity_name + "_evc_rpm", state=state, attributes={"friendly_name": "EV Charger Fan Speed", "icon": "mdi:ev-station", "unit_of_measurement": "RPM"}, app="gecloud")
 
     async def publish_status(self, device, status):
         """
@@ -451,22 +449,22 @@ class GECloudDirect:
             entity_name = entity_name.lower()
             attributes = {}
             if key == "time":
-                self.base.dashboard_item(entity_name + "_time", state=status[key], attributes=attribute_table.get("time", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_time", state=status[key], attributes=attribute_table.get("time", {}), app="gecloud")
             elif key == "status":
-                self.base.dashboard_item(entity_name + "_status", state=status[key], attributes=attribute_table.get("status", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_status", state=status[key], attributes=attribute_table.get("status", {}), app="gecloud")
             elif key == "solar":
-                self.base.dashboard_item(entity_name + "_solar_power", state=status[key].get("power", 0), attributes=attribute_table.get("solar_power", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_solar_power", state=status[key].get("power", 0), attributes=attribute_table.get("solar_power", {}), app="gecloud")
             elif key == "consumption":
-                self.base.dashboard_item(entity_name + "_consumption_power", state=status[key], attributes=attribute_table.get("consumption_power", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_consumption_power", state=status[key], attributes=attribute_table.get("consumption_power", {}), app="gecloud")
             elif key == "battery":
-                self.base.dashboard_item(entity_name + "_battery_power", state=status[key].get("power", 0), attributes=attribute_table.get("battery_power", {}), app="gecloud")
-                self.base.dashboard_item(entity_name + "_battery_percent", state=status[key].get("percent", 0), attributes=attribute_table.get("battery_percent", {}), app="gecloud")
-                self.base.dashboard_item(entity_name + "_battery_temperature", state=status[key].get("temperature", 0), attributes=attribute_table.get("battery_temperature", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_battery_power", state=status[key].get("power", 0), attributes=attribute_table.get("battery_power", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_battery_percent", state=status[key].get("percent", 0), attributes=attribute_table.get("battery_percent", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_battery_temperature", state=status[key].get("temperature", 0), attributes=attribute_table.get("battery_temperature", {}), app="gecloud")
             elif key == "grid":
-                self.base.dashboard_item(entity_name + "_grid_power", state=status[key].get("power", 0), attributes=attribute_table.get("grid_power", {}), app="gecloud")
-                self.base.dashboard_item(entity_name + "_grid_voltage", state=status[key].get("voltage", 0), attributes=attribute_table.get("grid_voltage", {}), app="gecloud")
-                self.base.dashboard_item(entity_name + "_grid_current", state=status[key].get("current", 0), attributes=attribute_table.get("grid_current", {}), app="gecloud")
-                self.base.dashboard_item(entity_name + "_grid_frequency", state=status[key].get("frequency", 0), attributes=attribute_table.get("grid_frequency", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_grid_power", state=status[key].get("power", 0), attributes=attribute_table.get("grid_power", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_grid_voltage", state=status[key].get("voltage", 0), attributes=attribute_table.get("grid_voltage", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_grid_current", state=status[key].get("current", 0), attributes=attribute_table.get("grid_current", {}), app="gecloud")
+                self.dashboard_item(entity_name + "_grid_frequency", state=status[key].get("frequency", 0), attributes=attribute_table.get("grid_frequency", {}), app="gecloud")
 
     async def publish_meter(self, device, meter):
         """
@@ -496,30 +494,63 @@ class GECloudDirect:
                     entity_name = entity_name.lower()
                     attributes = {}
                     if subkey == "solar":
-                        self.base.dashboard_item(entity_name + "_solar_today", state=meter[key][subkey], attributes=attribute_table.get("solar_today", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_solar_today", state=meter[key][subkey], attributes=attribute_table.get("solar_today", {}), app="gecloud")
                     elif subkey == "consumption":
-                        self.base.dashboard_item(entity_name + "_consumption_today", state=meter[key][subkey], attributes=attribute_table.get("consumption_today", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_consumption_today", state=meter[key][subkey], attributes=attribute_table.get("consumption_today", {}), app="gecloud")
                     elif subkey == "battery":
-                        self.base.dashboard_item(entity_name + "_battery_charge_today", state=meter[key][subkey].get("charge", 0), attributes=attribute_table.get("battery_charge_today", {}), app="gecloud")
-                        self.base.dashboard_item(entity_name + "_battery_discharge_today", state=meter[key][subkey].get("discharge", 0), attributes=attribute_table.get("battery_discharge_today", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_battery_charge_today", state=meter[key][subkey].get("charge", 0), attributes=attribute_table.get("battery_charge_today", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_battery_discharge_today", state=meter[key][subkey].get("discharge", 0), attributes=attribute_table.get("battery_discharge_today", {}), app="gecloud")
                     elif subkey == "grid":
-                        self.base.dashboard_item(entity_name + "_grid_import_today", state=meter[key][subkey].get("import", 0), attributes=attribute_table.get("grid_import_today", {}), app="gecloud")
-                        self.base.dashboard_item(entity_name + "_grid_export_today", state=meter[key][subkey].get("export", 0), attributes=attribute_table.get("grid_export_today", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_grid_import_today", state=meter[key][subkey].get("import", 0), attributes=attribute_table.get("grid_import_today", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_grid_export_today", state=meter[key][subkey].get("export", 0), attributes=attribute_table.get("grid_export_today", {}), app="gecloud")
             elif key == "total":
                 for subkey in meter[key]:
                     entity_name = "sensor.predbat_gecloud_" + device
                     entity_name = entity_name.lower()
                     attributes = {}
                     if subkey == "solar":
-                        self.base.dashboard_item(entity_name + "_solar_total", state=meter[key][subkey], attributes=attribute_table.get("solar_total", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_solar_total", state=meter[key][subkey], attributes=attribute_table.get("solar_total", {}), app="gecloud")
                     elif subkey == "consumption":
-                        self.base.dashboard_item(entity_name + "_consumption_total", state=meter[key][subkey], attributes=attribute_table.get("consumption_total", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_consumption_total", state=meter[key][subkey], attributes=attribute_table.get("consumption_total", {}), app="gecloud")
                     elif subkey == "battery":
-                        self.base.dashboard_item(entity_name + "_battery_charge_total", state=meter[key][subkey].get("charge", 0), attributes=attribute_table.get("battery_charge_total", {}), app="gecloud")
-                        self.base.dashboard_item(entity_name + "_battery_discharge_total", state=meter[key][subkey].get("discharge", 0), attributes=attribute_table.get("battery_discharge_total", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_battery_charge_total", state=meter[key][subkey].get("charge", 0), attributes=attribute_table.get("battery_charge_total", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_battery_discharge_total", state=meter[key][subkey].get("discharge", 0), attributes=attribute_table.get("battery_discharge_total", {}), app="gecloud")
                     elif subkey == "grid":
-                        self.base.dashboard_item(entity_name + "_grid_import_total", state=meter[key][subkey].get("import", 0), attributes=attribute_table.get("grid_import_total", {}), app="gecloud")
-                        self.base.dashboard_item(entity_name + "_grid_export_total", state=meter[key][subkey].get("export", 0), attributes=attribute_table.get("grid_export_total", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_grid_import_total", state=meter[key][subkey].get("import", 0), attributes=attribute_table.get("grid_import_total", {}), app="gecloud")
+                        self.dashboard_item(entity_name + "_grid_export_total", state=meter[key][subkey].get("export", 0), attributes=attribute_table.get("grid_export_total", {}), app="gecloud")
+
+    async def enable_default_options(self, device, registers):
+        for key in registers:
+            reg_name = registers[key].get("name", "")
+            value = registers[key].get("value", None)
+            ha_name = regname_to_ha(reg_name)
+            if "inverter_max_output_active_power_percent" in ha_name:
+                if value and value != 100:
+                    self.log("GECloud: Setting inverter max output active power percent to 100 for {} was {}".format(device, value))
+                    result = await self.async_write_inverter_setting(device, key, 100)
+                    if result and ("value" in result):
+                        registers[key]["value"] = result["value"]
+                        await self.publish_registers(device, self.settings[device], select_key=key)
+                        return True
+                    else:
+                        self.log("GECloud: Failed to set inverter max output active power percent for {}".format(device))
+                        return False
+
+            if "real_time_control" in ha_name:
+                if value:
+                    self.log("GECloud: Real-time control already enabled for {}".format(device))
+                    return True
+                else:
+                    self.log("GECloud: Enabling real-time control for {} as current value is {}".format(device, value))
+                result = await self.async_write_inverter_setting(device, key, True)
+                if result and ("value" in result):
+                    registers[key]["value"] = result["value"]
+                    await self.publish_registers(device, self.settings[device], select_key=key)
+                    return True
+                else:
+                    self.log("GECloud: Failed to enable real-time control for {}".format(device))
+                    return False
+        return False
 
     async def publish_registers(self, device, registers, select_key=None):
         """
@@ -532,7 +563,7 @@ class GECloudDirect:
             validation_rules = registers[key].get("validation_rules", None)
             validation = registers[key].get("validation", None)
             value = registers[key].get("value", None)
-            ha_name = reg_name.lower().replace(" ", "_").replace("%", "percent")
+            ha_name = regname_to_ha(reg_name)
             attributes = {}
             attributes["friendly_name"] = reg_name
 
@@ -588,13 +619,13 @@ class GECloudDirect:
                 entity_id = entity_name + "_" + ha_name
                 entity_id = entity_id.lower()
                 attributes["options"] = options_text
-                self.base.dashboard_item(entity_id, state=value, attributes=attributes, app="gecloud")
+                self.dashboard_item(entity_id, state=value, attributes=attributes, app="gecloud")
                 self.register_entity_map[entity_id] = {"device": device, "key": key, "time": is_select_time}
             elif is_number:
                 entity_name = "number.predbat_gecloud_" + device
                 entity_id = entity_name + "_" + ha_name
                 entity_id = entity_id.lower()
-                self.base.dashboard_item(entity_id, state=value, attributes=attributes, app="gecloud")
+                self.dashboard_item(entity_id, state=value, attributes=attributes, app="gecloud")
                 self.register_entity_map[entity_id] = {"device": device, "key": key}
             elif is_switch:
                 entity_name = "switch.predbat_gecloud_" + device
@@ -606,247 +637,213 @@ class GECloudDirect:
                         state = True
                 elif isinstance(value, bool):
                     state = value
-                self.base.dashboard_item(entity_id, state="on" if state else "off", attributes=attributes, app="gecloud")
+                self.dashboard_item(entity_id, state="on" if state else "off", attributes=attributes, app="gecloud")
                 self.register_entity_map[entity_id] = {"device": device, "key": key}
 
-    async def async_automatic_config(self, devices, evc_devices=None):
+    async def async_automatic_config(self, devices):
         """
         Automatically configure predbat using GE Cloud auto-detected devices.
         'devices' is a dict with keys:
           - "ems": the EMS device serial
+          - "gateway": the gateway serial
           - "battery": list of battery inverter serials (for battery-specific sensors)
-        'evc_devices' is a list of EV charger device dicts
         """
         if not devices or not devices["battery"]:
             self.log("GECloud: No battery devices found, cannot configure")
             return
 
         batteries = devices["battery"]
+        batteries_real = devices["battery"]
         num_inverters = len(batteries)
 
-        self.base.args["inverter_type"] = ["GEC" for _ in range(num_inverters)]
-        self.base.args["num_inverters"] = num_inverters
-        self.base.args["load_today"] = ["sensor.predbat_gecloud_" + device + "_consumption_today" for device in batteries]
-        self.base.args["import_today"] = ["sensor.predbat_gecloud_" + device + "_grid_import_today" for device in batteries]
-        self.base.args["export_today"] = ["sensor.predbat_gecloud_" + device + "_grid_export_today" for device in batteries]
-        self.base.args["pv_today"] = ["sensor.predbat_gecloud_" + device + "_solar_today" for device in batteries]
-        self.base.args["charge_rate"] = ["number.predbat_gecloud_" + device + "_battery_charge_power" for device in batteries]
-        self.base.args["battery_rate_max"] = ["sensor.predbat_gecloud_" + device + "_max_charge_rate" for device in batteries]
-        self.base.args["discharge_rate"] = ["number.predbat_gecloud_" + device + "_battery_discharge_power" for device in batteries]
-        self.base.args["battery_power"] = ["sensor.predbat_gecloud_" + device + "_battery_power" for device in batteries]
-        self.base.args["pv_power"] = ["sensor.predbat_gecloud_" + device + "_solar_power" for device in batteries]
-        self.base.args["load_power"] = ["sensor.predbat_gecloud_" + device + "_consumption_power" for device in batteries]
-        self.base.args["grid_power"] = ["sensor.predbat_gecloud_" + device + "_grid_power" for device in batteries]
-        self.base.args["soc_percent"] = ["sensor.predbat_gecloud_" + device + "_battery_percent" for device in batteries]
-        self.base.args["soc_max"] = ["sensor.predbat_gecloud_" + device + "_battery_size" for device in batteries]
-        self.base.args["reserve"] = ["number.predbat_gecloud_" + device + "_battery_reserve_percent_limit" for device in batteries]
-        self.base.args["inverter_time"] = ["sensor.predbat_gecloud_" + device + "_time" for device in batteries]
-        self.base.args["charge_start_time"] = ["select.predbat_gecloud_" + device + "_ac_charge_1_start_time" for device in batteries]
-        self.base.args["charge_end_time"] = ["select.predbat_gecloud_" + device + "_ac_charge_1_end_time" for device in batteries]
-        self.base.args["charge_limit"] = ["number.predbat_gecloud_" + device + "_ac_charge_upper_percent_limit" for device in batteries]
-        self.base.args["discharge_start_time"] = ["select.predbat_gecloud_" + device + "_dc_discharge_1_start_time" for device in batteries]
-        self.base.args["discharge_end_time"] = ["select.predbat_gecloud_" + device + "_dc_discharge_1_end_time" for device in batteries]
-        self.base.args["scheduled_charge_enable"] = ["switch.predbat_gecloud_" + device + "_ac_charge_enable" for device in batteries]
-        self.base.args["scheduled_discharge_enable"] = ["switch.predbat_gecloud_" + device + "_enable_dc_discharge" for device in batteries]
-        self.base.args["pause_mode"] = ["select.predbat_gecloud_" + device + "_pause_battery" for device in batteries]
-        self.base.args["pause_start_time"] = ["select.predbat_gecloud_" + device + "_pause_battery_start_time" for device in batteries]
-        self.base.args["pause_end_time"] = ["select.predbat_gecloud_" + device + "_pause_battery_end_time" for device in batteries]
-        if "givtcp_rest" in self.base.args:
-            del self.base.args["givtcp_rest"]
-        self.base.args["ge_cloud_serial"] = batteries[0]
+        if not devices["ems"] and devices["gateway"] and len(batteries) > 1:
+            # Only use gateway as main control if we have multiple batteries
+            num_inverters = 1
+            batteries = [devices["gateway"]]
+
+        # Do we have a charge power percentage setting?
+        has_charge_power_percent = False
+        has_pause_start_time = False
+        has_discharge_target_soc = False
+        has_pause_battery = False
+        for device in batteries:
+            registers = self.settings.get(device, {})
+            for key in registers:
+                reg_name = registers[key].get("name", "")
+                ha_name = regname_to_ha(reg_name)
+                if "inverter_charge_power_percentage" in ha_name:
+                    has_charge_power_percent = True
+                if "pause_battery_start_time" in ha_name:
+                    has_pause_start_time = True
+                if "dc_discharge_1_lower_soc_percent_limit" in ha_name:
+                    has_discharge_target_soc = True
+                if "pause_battery" in ha_name:
+                    has_pause_battery = True
+
+        self.log("GECloud: Auto-config detected features - charge power percent: {}, pause battery: {}, pause start time: {}, discharge target soc: {}".format(has_charge_power_percent, has_pause_battery, has_pause_start_time, has_discharge_target_soc))
+
+        self.set_arg("inverter_type", ["GEC" for _ in range(num_inverters)])
+        self.set_arg("num_inverters", num_inverters)
+        self.set_arg("load_today", ["sensor.predbat_gecloud_" + device + "_consumption_today" for device in batteries])
+        self.set_arg("import_today", ["sensor.predbat_gecloud_" + device + "_grid_import_today" for device in batteries])
+        self.set_arg("export_today", ["sensor.predbat_gecloud_" + device + "_grid_export_today" for device in batteries])
+        self.set_arg("pv_today", ["sensor.predbat_gecloud_" + device + "_solar_today" for device in batteries])
+        self.set_arg("charge_rate", ["number.predbat_gecloud_" + device + "_battery_charge_power" for device in batteries])
+        self.set_arg("battery_rate_max", ["sensor.predbat_gecloud_" + device + "_max_charge_rate" for device in batteries])
+        self.set_arg("discharge_rate", ["number.predbat_gecloud_" + device + "_battery_discharge_power" for device in batteries])
+        self.set_arg("battery_power", ["sensor.predbat_gecloud_" + device + "_battery_power" for device in batteries])
+        self.set_arg("pv_power", ["sensor.predbat_gecloud_" + device + "_solar_power" for device in batteries])
+        self.set_arg("load_power", ["sensor.predbat_gecloud_" + device + "_consumption_power" for device in batteries])
+        self.set_arg("grid_power", ["sensor.predbat_gecloud_" + device + "_grid_power" for device in batteries])
+        self.set_arg("soc_percent", ["sensor.predbat_gecloud_" + device + "_battery_percent" for device in batteries])
+        self.set_arg("soc_max", ["sensor.predbat_gecloud_" + device + "_battery_size" for device in batteries])
+        self.set_arg("reserve", ["number.predbat_gecloud_" + device + "_battery_reserve_percent_limit" for device in batteries])
+        self.set_arg("inverter_time", ["sensor.predbat_gecloud_" + device + "_time" for device in batteries])
+        self.set_arg("charge_start_time", ["select.predbat_gecloud_" + device + "_ac_charge_1_start_time" for device in batteries])
+        self.set_arg("charge_end_time", ["select.predbat_gecloud_" + device + "_ac_charge_1_end_time" for device in batteries])
+        self.set_arg("charge_limit", ["number.predbat_gecloud_" + device + "_ac_charge_upper_percent_limit" for device in batteries])
+        self.set_arg("discharge_start_time", ["select.predbat_gecloud_" + device + "_dc_discharge_1_start_time" for device in batteries])
+        self.set_arg("discharge_end_time", ["select.predbat_gecloud_" + device + "_dc_discharge_1_end_time" for device in batteries])
+        self.set_arg("scheduled_charge_enable", ["switch.predbat_gecloud_" + device + "_ac_charge_enable" for device in batteries])
+        self.set_arg("scheduled_discharge_enable", ["switch.predbat_gecloud_" + device + "_enable_dc_discharge" for device in batteries])
+        self.set_arg("battery_temperature", ["sensor.predbat_gecloud_" + device + "_battery_temperature" for device in batteries])
+        self.set_arg("battery_scaling", ["sensor.predbat_gecloud_" + device + "_battery_dod" for device in batteries])
+
+        if len(batteries):
+            self.set_arg("battery_temperature_history", "sensor.predbat_gecloud_" + batteries[0] + "_battery_temperature")
+
+        if has_pause_battery:
+            self.set_arg("pause_mode", ["select.predbat_gecloud_" + device + "_pause_battery" for device in batteries])
+            if has_pause_start_time:
+                self.set_arg("pause_start_time", ["select.predbat_gecloud_" + device + "_pause_battery_start_time" for device in batteries])
+                self.set_arg("pause_end_time", ["select.predbat_gecloud_" + device + "_pause_battery_end_time" for device in batteries])
+        else:
+            self.set_arg("pause_mode", None)
+            self.set_arg("pause_start_time", None)
+            self.set_arg("pause_end_time", None)
+
+        if has_discharge_target_soc:
+            self.set_arg("discharge_target_soc", ["number.predbat_gecloud_" + device + "_dc_discharge_1_lower_soc_percent_limit" for device in batteries])
+        else:
+            self.set_arg("discharge_target_soc", None)
+
+        if has_charge_power_percent:
+            self.set_arg("charge_rate_percent", ["number.predbat_gecloud_" + device + "_inverter_charge_power_percentage" for device in batteries])
+            self.set_arg("discharge_rate_percent", ["number.predbat_gecloud_" + device + "_inverter_discharge_power_percentage" for device in batteries])
+        else:
+            self.set_arg("charge_rate_percent", None)
+            self.set_arg("discharge_rate_percent", None)
+
+        self.set_arg("givtcp_rest", None)
+
+        # Use the first battery serial for the ge_cloud_serial (for status)
+        self.set_arg("ge_cloud_serial", devices["battery"][0])
 
         # reconfigure for EMS
         if devices["ems"]:
-            self.log("GECloud: EMS detected")
+            self.log("GECloud: EMS detected, using this for control")
             ems = devices["ems"]
-            self.base.args["inverter_type"] = ["GEE" for _ in range(num_inverters)]
-            self.base.args["ge_cloud_serial"] = ems
-            self.base.args["load_today"] = ["sensor.predbat_gecloud_" + ems + "_consumption_today"]
-            self.base.args["import_today"] = ["sensor.predbat_gecloud_" + ems + "_grid_import_today"]
-            self.base.args["export_today"] = ["sensor.predbat_gecloud_" + ems + "_grid_export_today"]
-            self.base.args["pv_today"] = ["sensor.predbat_gecloud_" + ems + "_solar_today"]
-            self.base.args["charge_start_time"] = ["select.predbat_gecloud_" + ems + "_charge_start_time_slot_1" for _ in range(num_inverters)]
-            self.base.args["charge_end_time"] = ["select.predbat_gecloud_" + ems + "_charge_end_time_slot_1" for _ in range(num_inverters)]
-            self.base.args["idle_start_time"] = ["select.predbat_gecloud_" + ems + "_discharge_start_time_slot_1" for _ in range(num_inverters)]
-            self.base.args["idle_end_time"] = ["select.predbat_gecloud_" + ems + "_discharge_end_time_slot_1" for _ in range(num_inverters)]
-            self.base.args["charge_limit"] = ["number.predbat_gecloud_" + ems + "_charge_soc_percent_limit_1" for _ in range(num_inverters)]
-            self.base.args["discharge_start_time"] = ["select.predbat_gecloud_" + ems + "_export_start_time_slot_1" for _ in range(num_inverters)]
-            self.base.args["discharge_end_time"] = ["select.predbat_gecloud_" + ems + "_export_end_time_slot_1" for _ in range(num_inverters)]
+            self.set_arg("inverter_type", ["GEE" for _ in range(num_inverters)])
+            self.set_arg("ge_cloud_serial", ems)
+            self.set_arg("load_today", ["sensor.predbat_gecloud_" + ems + "_consumption_today"])
+            self.set_arg("import_today", ["sensor.predbat_gecloud_" + ems + "_grid_import_today"])
+            self.set_arg("export_today", ["sensor.predbat_gecloud_" + ems + "_grid_export_today"])
+            self.set_arg("pv_today", ["sensor.predbat_gecloud_" + ems + "_solar_today"])
+            self.set_arg("charge_start_time", ["select.predbat_gecloud_" + ems + "_charge_start_time_slot_1" for _ in range(num_inverters)])
+            self.set_arg("charge_end_time", ["select.predbat_gecloud_" + ems + "_charge_end_time_slot_1" for _ in range(num_inverters)])
+            self.set_arg("idle_start_time", ["select.predbat_gecloud_" + ems + "_discharge_start_time_slot_1" for _ in range(num_inverters)])
+            self.set_arg("idle_end_time", ["select.predbat_gecloud_" + ems + "_discharge_end_time_slot_1" for _ in range(num_inverters)])
+            self.set_arg("charge_limit", ["number.predbat_gecloud_" + ems + "_charge_soc_percent_limit_1" for _ in range(num_inverters)])
+            self.set_arg("discharge_start_time", ["select.predbat_gecloud_" + ems + "_export_start_time_slot_1" for _ in range(num_inverters)])
+            self.set_arg("discharge_end_time", ["select.predbat_gecloud_" + ems + "_export_end_time_slot_1" for _ in range(num_inverters)])
 
             # EMS Produces the data for all inverters
-            self.base.args["battery_power"] = ["sensor.predbat_gecloud_" + ems + "_battery_power"] + [0 for _ in range(num_inverters - 1)]
-            self.base.args["pv_power"] = ["sensor.predbat_gecloud_" + ems + "_solar_power"] + [0 for _ in range(num_inverters - 1)]
-            self.base.args["load_power"] = ["sensor.predbat_gecloud_" + ems + "_consumption_power"] + [0 for _ in range(num_inverters - 1)]
-            self.base.args["grid_power"] = ["sensor.predbat_gecloud_" + ems + "_grid_power"] + [0 for _ in range(num_inverters - 1)]
-
-        # Auto-configure EV chargers if any are detected
-        if evc_devices:
-            evc_serials = []
-            self.log(f"GECloud: Processing {len(evc_devices)} EV charger devices for auto-configuration")
-            for device_data in evc_devices:
-                uuid = device_data.get("uuid")
-                self.log(f"GECloud: Processing EV charger UUID: {uuid}")
-                if uuid:
-                    try:
-                        # Get full device details to extract serial number
-                        full_device = await self.async_get_evc_device(uuid)
-                        self.log(f"GECloud: Retrieved device details: {full_device}")
-                        serial = full_device.get("serial_number")
-                        self.log(f"GECloud: Extracted serial number: {serial}")
-                        if serial:
-                            evc_serials.append(serial)
-                    except Exception as e:
-                        self.log(f"GECloud: Error getting device details for {uuid}: {e}")
-                        # Fallback to UUID if serial fetch fails
-                        evc_serials.append(uuid)
-
-            if evc_serials:
-                # Store charger info for later use by Enode plugin
-                self.evc_chargers = evc_serials
-
-                # Get current car_charging_planned array or create empty list
-                current_planned = self.base.args.get("car_charging_planned", [])
-                if not isinstance(current_planned, list):
-                    current_planned = []
-
-                # Append EVC status sensors to car_charging_planned
-                for serial in evc_serials:
-                    evc_sensor = "sensor.predbat_gecloud_" + serial + "_evc_status"
-                    if evc_sensor not in current_planned:
-                        current_planned.append(evc_sensor)
-
-                self.base.args["car_charging_planned"] = current_planned
-
-                # Increment num_cars for each charger
-                # The Enode plugin will manage the actual car arrays and try to match vehicles to chargers
-                current_num_cars = self.base.args.get("num_cars", 0)
-                self.base.args["num_cars"] = current_num_cars + len(evc_serials)
-
-                self.log(f"GECloud: Found {len(evc_serials)} EV chargers, increased num_cars from {current_num_cars} to {self.base.args['num_cars']}")
-                self.log(f"GECloud: Updated car_charging_planned: {self.base.args['car_charging_planned']}")
+            self.set_arg("battery_power", ["sensor.predbat_gecloud_" + ems + "_battery_power"] + [0 for _ in range(num_inverters - 1)])
+            self.set_arg("pv_power", ["sensor.predbat_gecloud_" + ems + "_solar_power"] + [0 for _ in range(num_inverters - 1)])
+            self.set_arg("load_power", ["sensor.predbat_gecloud_" + ems + "_consumption_power"] + [0 for _ in range(num_inverters - 1)])
+            self.set_arg("grid_power", ["sensor.predbat_gecloud_" + ems + "_grid_power"] + [0 for _ in range(num_inverters - 1)])
 
         self.log("GECloud: Automatic configuration complete")
 
-    async def configure_car_arrays_for_evc(self, serial, entity_name):
-        """
-        Configure car arrays for a newly detected EV charger.
-        This handles cases where EVCs are detected after initial startup.
-        """
-        # Get current car_charging_planned array or create empty list
-        current_planned = self.base.args.get("car_charging_planned", [])
-        if not isinstance(current_planned, list):
-            current_planned = []
-
-        # Add EVC status sensor to car_charging_planned if not already there
-        if entity_name not in current_planned:
-            current_planned.append(entity_name)
-            self.base.args["car_charging_planned"] = current_planned
-
-            # Increment num_cars
-            current_num_cars = self.base.args.get("num_cars", 0)
-            self.base.args["num_cars"] = current_num_cars + 1
-
-            self.log(f"GECloud: Configured car arrays for EVC {serial}, added {entity_name} to car_charging_planned")
-            self.log(f"GECloud: Increased num_cars from {current_num_cars} to {self.base.args['num_cars']}")
-
-    async def start(self):
+    async def run(self, seconds, first):
         """
         Start the client
         """
-        self.log("[GECLOUD DEBUG] start() method called")
-        self.stop_cloud = False
-        self.api_started = False
-        self.polling_mode = True
-        # Get devices using the modified auto-detection (returns dict)
-        self.log("[GECLOUD DEBUG] About to call async_get_devices()")
-        devices_dict = await self.async_get_devices()
-        self.log(f"[GECLOUD DEBUG] async_get_devices() returned: {devices_dict}")
-        evc_devices_dict = await self.async_get_evc_devices()
 
-        # Build a list of devices to poll:
-        # Use all battery inverter serials and also add the EMS device if it's distinct.
-        device_list = devices_dict["battery"][:]
+        if first:
+            self.polling_mode = True
+            # Get devices using the modified auto-detection (returns dict)
+            self.devices_dict = await self.async_get_devices()
+            self.evc_devices_dict = await self.async_get_evc_devices()
 
-        ems_device = None
-        if devices_dict["ems"]:
-            ems_device = devices_dict["ems"]
-            self.polling_mode = False
-            self.log("GECloud: Found EMS device {} and disabled polling on inverters".format(ems_device))
-            if ems_device not in device_list:
-                device_list.append(ems_device)
+            # Build a list of devices to poll:
+            # Use all battery inverter serials and also add the EMS device if it's distinct.
+            self.device_list = self.devices_dict["battery"][:]
 
-        evc_device_list = []
-        for device in evc_devices_dict:
-            uuid = device.get("uuid", None)
-            device_name = device.get("alias", None)
-            evc_device_list.append(uuid)
+            self.ems_device = None
+            if self.devices_dict["ems"]:
+                self.ems_device = self.devices_dict["ems"]
+                self.polling_mode = False
+                self.log("GECloud: Found EMS device {} and disabled polling on inverters".format(self.ems_device))
+                if self.ems_device not in self.device_list:
+                    self.device_list.append(self.ems_device)
 
-        self.log("GECloud: Starting up, found devices {} evc_devices {}".format(device_list, evc_device_list))
-        for device in device_list:
-            self.pending_writes[device] = []
+            self.gateway_device = None
+            if not self.ems_device and self.devices_dict["gateway"] and len(self.device_list) > 1:
+                self.gateway_device = self.devices_dict["gateway"]
+                self.log("GECloud: Found Gateway device {} and multiple batteries, using only this device".format(self.gateway_device))
+                self.device_list = [self.gateway_device]
 
-        if self.automatic:
-            await self.async_automatic_config(devices_dict, evc_devices_dict)
+            self.evc_device_list = []
+            for device in self.evc_devices_dict:
+                uuid = device.get("uuid", None)
+                device_name = device.get("alias", None)
+                self.evc_device_list.append(uuid)
+            self.log("GECloud: Starting up, found devices {} evc_devices {}".format(self.device_list, self.evc_device_list))
+            for device in self.device_list:
+                self.pending_writes[device] = []
 
-        seconds = 0
-        while not self.stop_cloud and not self.base.fatal_error:
-            try:
-                if seconds % 60 == 0:
-                    for device in device_list:
-                        self.status[device] = await self.async_get_inverter_status(device)
-                        await self.publish_status(device, self.status[device])
-                        self.meter[device] = await self.async_get_inverter_meter(device)
-                        await self.publish_meter(device, self.meter[device])
-                        self.info[device] = await self.async_get_device_info(device)
-                        await self.publish_info(device, self.info[device])
-                    for uuid in evc_device_list:
-                        self.evc_device[uuid] = await self.async_get_evc_device(uuid)
-                        serial = self.evc_device[uuid].get("serial_number", "unknown")
+            if not self.device_list and not self.evc_device_list:
+                self.log("Error: GECloud: No devices found, check your GE Cloud credentials")
+                self.api_fatal = True
+                return False
 
-                        # Publish EV charger status as sensor entity
-                        evc_status = self.evc_device[uuid].get("status", "unknown")
-                        entity_name = f"sensor.predbat_gecloud_{serial}_evc_status"
-                        entity_name = entity_name.lower()
-                        self.base.dashboard_item(entity_name, state=evc_status, attributes={"friendly_name": "EV Charger Status", "icon": "mdi:ev-station", "device_class": "enum"}, app="gecloud")
-                        self.log(f"GE Cloud EVC {serial}: Published status sensor with value '{evc_status}'")
+        if first or (seconds % 60 == 0):
+            for device in self.device_list:
+                self.status[device] = await self.async_get_inverter_status(device, self.status.get(device, {}))
+                await self.publish_status(device, self.status[device])
+                self.meter[device] = await self.async_get_inverter_meter(device, self.meter.get(device, {}))
+                await self.publish_meter(device, self.meter[device])
+                self.info[device] = await self.async_get_device_info(device, self.info.get(device, {}))
+                await self.publish_info(device, self.info[device])
+            for uuid in self.evc_device_list:
+                self.evc_device[uuid] = await self.async_get_evc_device(uuid, self.evc_device.get(uuid, {}))
+                serial = self.evc_device[uuid].get("serial_number", "unknown")
+                self.evc_data[uuid] = await self.async_get_evc_device_data(uuid, self.evc_data.get(uuid, {}))
+                self.evc_sessions[uuid] = await self.async_get_evc_sessions(uuid, self.evc_sessions.get(uuid, []))
+                await self.publish_evc_data(serial, self.evc_data[uuid])
 
-                        # Configure car arrays when EV charger is first detected
-                        if uuid not in getattr(self, "configured_evcs", set()):
-                            await self.configure_car_arrays_for_evc(serial, entity_name)
-                            # Mark this EVC as configured
-                            if not hasattr(self, "configured_evcs"):
-                                self.configured_evcs = set()
-                            self.configured_evcs.add(uuid)
+        if first or (seconds % (10 * 60) == 0):
+            # Get All registers every now and again in case user changes them
+            for device in self.device_list:
+                if seconds == 0 or self.polling_mode or (device == self.ems_device) or (device == self.gateway_device):
+                    self.settings[device] = await self.async_get_inverter_settings(device, first=False, previous=self.settings.get(device, {}))
+                    await self.publish_registers(device, self.settings[device])
 
-                        self.evc_data[uuid] = await self.async_get_evc_device_data(uuid)
-                        self.evc_sessions[uuid] = await self.async_get_evc_sessions(uuid)
-                        await self.publish_evc_data(serial, self.evc_data[uuid])
+            # One shot tasks
+            if first:
+                if self.automatic:
+                    await self.async_automatic_config(self.devices_dict)
+                for device in self.device_list:
+                    await self.enable_default_options(device, self.settings[device])
 
-                # Mark API as started after quick status/meter/info fetch
-                # Settings will backfill in background - no need to block startup
-                if not self.api_started:
-                    print("GECloud API Started (settings will backfill)")
-                    self.api_started = True
+        # Clear pending writes
+        for device in self.device_list:
+            if device in self.pending_writes:
+                self.pending_writes[device] = []
 
-                if seconds % 300 == 0:
-                    for device in device_list:
-                        if seconds == 0 or self.polling_mode or (device == ems_device):
-                            self.settings[device] = await self.async_get_inverter_settings(device, first=False, previous=self.settings.get(device, {}))
-                            await self.publish_registers(device, self.settings[device])
-
-            except Exception as e:
-                self.log("Error: GECloud: Exception in main loop {}".format(e))
-
-            # Clear pending writes
-            for device in device_list:
-                if device in self.pending_writes:
-                    self.pending_writes[device] = []
-
-            await asyncio.sleep(5)
-            seconds += 5
-
-    async def stop(self):
-        self.stop_cloud = True
+        self.update_success_timestamp()
+        return True
 
     async def async_send_evc_command(self, uuid, command, params):
         """
@@ -865,7 +862,7 @@ class GECloudDirect:
                     data = None
             if data:
                 break
-            await asyncio.sleep(1 * (retry + 1))
+            await asyncio.sleep(RETRY_FACTOR * (retry + 1))
         if data is None:
             self.log("Error: GECloud: Failed to send EVC command {} params {}".format(command, params))
         return data
@@ -887,7 +884,7 @@ class GECloudDirect:
         if serial in self.pending_writes:
             for pending in self.pending_writes[serial]:
                 if pending["setting_id"] == setting_id:
-                    return {"value": pending["value"]}
+                    return {"value": pending["value"], "context": "predbat"}
 
         for retry in range(RETRIES):
             data = await self.async_get_inverter_data(GE_API_INVERTER_READ_SETTING, serial, setting_id, post=True)
@@ -899,12 +896,12 @@ class GECloudDirect:
             elif data and data_value in [-1, -2, -5, -6]:
                 data = None
                 # Inverter timeout, try to spread requests out
-                await asyncio.sleep(random.random() * 2)
+                await asyncio.sleep(random.random() * (3 + retry))
             if data:
                 break
-            await asyncio.sleep(1 * (retry + 1))
+            await asyncio.sleep(RETRY_FACTOR * (retry + 1))
         if data is None:
-            self.log("Warn: GECloud: Failed to read inverter setting id {}".format(setting_id))
+            self.log("Warn: GECloud: Device {} Failed to read inverter setting id {} got {}".format(serial, setting_id, data))
         return data
 
     async def async_write_inverter_setting(self, serial, setting_id, value):
@@ -917,7 +914,7 @@ class GECloudDirect:
                 serial,
                 setting_id,
                 post=True,
-                datain={"value": str(value), "context": "homeassistant"},
+                datain={"value": str(value), "context": "predbat"},
             )
             if data and "success" in data:
                 if not data["success"]:
@@ -925,7 +922,7 @@ class GECloudDirect:
             if data:
                 self.pending_writes[serial].append({"setting_id": setting_id, "value": value})
                 break
-            await asyncio.sleep(1 * (retry + 1))
+            await asyncio.sleep(RETRY_FACTOR * (retry + 1))
         if data is None:
             self.log("Warn: GECloud: Failed to write setting id {} value {}".format(setting_id, value))
         return data
@@ -1022,11 +1019,11 @@ class GECloudDirect:
             return point
         return {}
 
-    async def async_get_evc_sessions(self, uuid):
+    async def async_get_evc_sessions(self, uuid, previous=[]):
         """
         Get list of EVC sessions
         """
-        now = datetime.now(timezone.utc)
+        now = self.now_utc_exact
         start = now - timedelta(hours=24)
         start_time = start.strftime("%Y-%m-%dT%H:%M:%SZ")
         end_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -1034,31 +1031,38 @@ class GECloudDirect:
         data = await self.async_get_inverter_data_retry(GE_API_EVC_SESSIONS, uuid=uuid, start_time=start_time, end_time=end_time)
         if isinstance(data, list):
             return data
-        return []
+        return previous
 
-    async def async_get_evc_device_data(self, uuid):
+    async def async_get_evc_device_data(self, uuid, previous={}):
         """
         Get smart device data points
         """
-        now = datetime.now(timezone.utc)
+        now = self.now_utc_exact
         start = now - timedelta(minutes=10)
         start_time = start.strftime("%Y-%m-%dT%H:%M:%SZ")
         end_time = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        data = await self.async_get_inverter_data_retry(GE_API_EVC_DEVICE_DATA, uuid=uuid, meter_ids=str(EVC_METER_CHARGER), start_time=start_time, end_time=end_time)
+        # Request all measurands that we want to track
+        measurands = "&".join([f"measurands[]={i}" for i in range(22)])  # All measurands 0-21
+        data = await self.async_get_inverter_data_retry(GE_API_EVC_DEVICE_DATA, uuid=uuid, meter_ids=str(EVC_METER_CHARGER), start_time=start_time, end_time=end_time, measurands=measurands)
         result = {}
         if not data:
-            return result
+            return previous
 
-        for meter in data:
-            meter_id = meter.get("meter_id", -1)
+        # Handle the new API response format
+        data_points = data.get("data", []) if isinstance(data, dict) else data
+
+        # Get the latest measurements from the most recent timestamp
+        if data_points:
+            latest_point = data_points[-1]  # Get most recent data point
+            meter_id = latest_point.get("meter_id", -1)
             if meter_id == EVC_METER_CHARGER:
-                for point in meter.get("measurements", []):
-                    measurand = point.get("measurand", None)
+                for measurement in latest_point.get("measurements", []):
+                    measurand = measurement.get("measurand", None)
                     if (measurand is not None) and measurand in EVC_DATA_POINTS:
-                        value = point.get("value", None)
-                        unit = point.get("unit", None)
-                        result[EVC_DATA_POINTS[measurand]] = value
+                        value = measurement.get("value", None)
+                        unit = measurement.get("unit", None)
+                        result[measurand] = value
         self.log("EVC device point {}".format(result))
         return result
 
@@ -1102,7 +1106,7 @@ class GECloudDirect:
 
         return command_info
 
-    async def async_get_evc_device(self, uuid):
+    async def async_get_evc_device(self, uuid, previous={}):
         """
         Get EVC device
         """
@@ -1117,15 +1121,16 @@ class GECloudDirect:
             status = device.get("status", None)
             type = device.get("type", None)
             return {"uuid": uuid, "alias": alias, "serial_number": serial_number, "status": status, "online": online, "type": type, "went_offline_at": went_offline_at}
-        return {}
+        return previous
 
-    async def async_get_smart_devices(self):
+    async def async_get_smart_devices(self, previous=[]):
         """
         Get list of smart devices
         """
         device_list = await self.async_get_inverter_data_retry(GE_API_SMART_DEVICES)
-        devices = []
+        devices = previous
         if device_list is not None:
+            devices = []
             for device in device_list:
                 uuid = device.get("uuid", None)
                 other_data = device.get("other_data", {})
@@ -1134,13 +1139,14 @@ class GECloudDirect:
                 devices.append({"uuid": uuid, "alias": alias, "local_key": local_key})
         return devices
 
-    async def async_get_evc_devices(self):
+    async def async_get_evc_devices(self, previous=[]):
         """
         Get list of smart devices
         """
         device_list = await self.async_get_inverter_data_retry(GE_API_EVC_DEVICES)
-        devices = []
+        devices = previous
         if device_list is not None:
+            devices = []
             for device in device_list:
                 uuid = device.get("uuid", None)
                 other_data = device.get("other_data", {})
@@ -1148,7 +1154,7 @@ class GECloudDirect:
                 devices.append({"uuid": uuid, "alias": alias})
         return devices
 
-    async def async_get_device_info(self, serial):
+    async def async_get_device_info(self, serial, previous={}):
         """
         Get the device info
         """
@@ -1160,7 +1166,7 @@ class GECloudDirect:
                     this_serial = inverter.get("serial", None)
                     if this_serial and this_serial.lower() == serial.lower():
                         return inverter
-        return {}
+        return previous
 
     async def async_get_devices(self):
         """
@@ -1168,9 +1174,45 @@ class GECloudDirect:
         Returns a dict with:
           "ems": serial (lowercase) of the EMS device (model "Plant EMS") if found
           "battery": list of serials (lowercase) for battery inverters (devices with non-empty batteries)
+
+        {
+            'serial_number': 'xxxx', 'firmware_version': 904, 'type': 'GPRS', 'commission_date': '2025-09-23T00:00:00Z',
+            'inverter':
+                {'serial': 'xxxx', 'status': 'NORMAL', 'last_online': '2025-09-26T18:28:23Z', 'last_updated': '2025-09-26T18:28:23Z',
+                 'commission_date': '2024-08-16T00:00:00Z',
+                 'info': {
+                    'battery_type': 'LITHIUM',
+                    'battery': {'nominal_capacity': 52, 'nominal_voltage': 307.2, 'depth_of_discharge': 0.85},
+                    'model': 'All-In-One', 'max_charge_rate': 6000, 'max_discharge_rate': 6000},
+                    'warranty': {'type': 'Standard', 'expiry_date': '2036-08-16T00:00:00Z'},
+                    'firmware_version': {'ARM': 616, 'DSP': 616},
+                    'connections': {'batteries': [{'module_number': 1, 'serial': '6568', 'firmware_version': 12, 'capacity': {'full': 52, 'design': 52}, 'cell_count': 96, 'has_usb': False, 'nominal_voltage': 307.2}], 'meters': []}, 'flags': ['full-power-discharge-in-eco-mode']}, 'site_id': 61435}
+        {
+            'serial_number': 'xxxx', 'firmware_version': 206, 'type': 'GPRS', 'commission_date': '2024-05-24T00:00:00Z',
+            'inverter':
+                {'serial': 'xxxx', 'status': 'NORMAL', 'last_online': '2025-09-26T18:28:22Z', 'last_updated': '2025-09-26T18:28:22Z', 'commission_date': '2024-05-24T00:00:00Z',
+                 'info':
+                    {'battery_type': 'LITHIUM',
+                     'battery': {'nominal_capacity': 52, 'nominal_voltage': 307.2, 'depth_of_discharge': 0.85},
+                     'model': 'All-In-One', 'max_charge_rate': 6000, 'max_discharge_rate': 6000},
+                     'warranty': {'type': 'Standard', 'expiry_date': '2036-05-29T13:25:55Z'},
+                     'firmware_version': {'ARM': 616, 'DSP': 616},
+                     'connections': {'batteries': [{'module_number': 1, 'serial': '4316', 'firmware_version': 12, 'capacity': {'full': 49.7, 'design': 52}, 'cell_count': 96, 'has_usb': False, 'nominal_voltage': 307.2}], 'meters': []}, 'flags': ['full-power-discharge-in-eco-mode']}, 'site_id': 61435}
+        {
+            'serial_number': 'xxxx', 'firmware_version': 206, 'type': 'GPRS', 'commission_date': '2024-05-24T00:00:00Z',
+            'inverter':
+                {'serial': 'xxxx', 'status': 'NORMAL', 'last_online': '2025-09-26T18:28:07Z', 'last_updated': '2025-09-26T18:28:22Z', 'commission_date': '2024-05-24T00:00:00Z',
+                'info':
+                    {'battery_type': 'LEAD_ACID',
+                     'battery': {'nominal_capacity': 104, 'nominal_voltage': 307.2, 'depth_of_discharge': 0.85},
+                     'model': 'Gateway', 'max_charge_rate': 12000, 'max_discharge_rate': 12000},
+                     'warranty': {'type': 'Standard', 'expiry_date': '2036-05-29T13:25:55Z'},
+                     'firmware_version': {'ARM': 13, 'DSP': 0},
+                     'connections': {'datalog': {'serial_number': 'WK2315G357', 'firmware_version': 206, 'type': 'GPRS', 'commission_date': '2024-05-24T00:00:00Z', 'site_id': 61435}, 'batteries': [{'module_number': 1, 'serial': '4316', 'firmware_version': 12, 'capacity': {'full': 49.7, 'design': 52}, 'cell_count': 96, 'has_usb': False, 'nominal_voltage': 307.2}, {'module_number': 1, 'serial': '6568', 'firmware_version': 12, 'capacity': {'full': 52, 'design': 52}, 'cell_count': 96, 'has_usb': False, 'nominal_voltage': 307.2}], 'meters': [{'address': 1, 'serial_number': 2075078, 'manufacturer_code': '3510960161', 'type_code': 33, 'hardware_version': 256, 'software_version': 517, 'baud_rate': 9600}, {'address': 2, 'serial_number': 2021106, 'manufacturer_code': '960823329', 'type_code': 33, 'hardware_version': 256, 'software_version': 517, 'baud_rate': 9600}]}, 'flags': ['full-power-discharge-in-eco-mode', 'is-controllable']}, 'site_id': 61435}
         """
+
         device_list = await self.async_get_inverter_data_retry(GE_API_DEVICES)
-        result = {"ems": None, "battery": []}
+        result = {"gateway": None, "ems": None, "battery": []}
         if device_list is None:
             return result
 
@@ -1178,43 +1220,55 @@ class GECloudDirect:
             self.log("GECloud: Found device {}".format(device))
             inverter = device.get("inverter", {})
             serial = inverter.get("serial", None)
-            model = inverter.get("info", {}).get("model", "").lower()
+            last_updated = inverter.get("last_updated", None)
+            info = inverter.get("info", {})
+            model = info.get("model", "").lower()
+            battery = info.get("battery_type", {})
             batteries = inverter.get("connections", {}).get("batteries", [])
             if serial:
                 serial = serial.lower()
                 if "plant ems" in model:
                     result["ems"] = serial
+                elif "gateway" in model:
+                    result["gateway"] = serial
                 elif batteries:
                     result["battery"].append(serial)
+            else:
+                self.log("Warn: GECloud: Device without serial found: {}".format(device))
         return result
 
-    async def async_get_inverter_status(self, serial):
+    async def async_get_inverter_status(self, serial, previous={}):
         """
         Get basis status for inverter
         """
-        return await self.async_get_inverter_data_retry(GE_API_INVERTER_STATUS, serial)
+        result = await self.async_get_inverter_data_retry(GE_API_INVERTER_STATUS, serial)
+        if result is None:
+            return previous
+        return result
 
-    async def async_get_inverter_meter(self, serial):
+    async def async_get_inverter_meter(self, serial, previous={}):
         """
         Get meter data for inverter
         """
         meter = await self.async_get_inverter_data_retry(GE_API_INVERTER_METER, serial)
+        if meter is None:
+            return previous
         return meter
 
-    async def async_get_inverter_data_retry(self, endpoint, serial="", setting_id="", post=False, datain=None, uuid="", meter_ids="", start_time="", end_time="", command=""):
+    async def async_get_inverter_data_retry(self, endpoint, serial="", setting_id="", post=False, datain=None, uuid="", meter_ids="", start_time="", end_time="", command="", measurands=""):
         """
         Retry API call
         """
         for retry in range(RETRIES):
-            data = await self.async_get_inverter_data(endpoint, serial, setting_id, post, datain, uuid, meter_ids, start_time=start_time, end_time=end_time, command=command)
+            data = await self.async_get_inverter_data(endpoint, serial, setting_id, post, datain, uuid, meter_ids, start_time=start_time, end_time=end_time, command=command, measurands=measurands)
             if data is not None:
                 break
-            await asyncio.sleep(1 * (retry + 1))
+            await asyncio.sleep(RETRY_FACTOR * (retry + 1))
         if data is None:
             self.log("Warn: GECloud: Failed to get data from {}".format(endpoint))
         return data
 
-    async def async_get_inverter_data(self, endpoint, serial="", setting_id="", post=False, datain=None, uuid="", meter_ids="", start_time="", end_time="", command=""):
+    async def async_get_inverter_data(self, endpoint, serial="", setting_id="", post=False, datain=None, uuid="", meter_ids="", start_time="", end_time="", command="", measurands=""):
         """
         Basic API call to GE Cloud
         """
@@ -1222,6 +1276,10 @@ class GECloudDirect:
         self.requests_total += 1
 
         url = GE_API_URL + endpoint.format(inverter_serial_number=serial, setting_id=setting_id, uuid=uuid, start_time=start_time, end_time=end_time, meter_ids=meter_ids, command=command)
+
+        # Add measurands parameters if provided (for EV charger endpoints)
+        if measurands:
+            url += f"&{measurands}"
         headers = {
             "Authorization": "Bearer " + self.api_key,
             "Content-Type": "application/json",
@@ -1261,11 +1319,12 @@ class GECloudDirect:
         if response.status_code in [200, 201]:
             if data is None:
                 data = {}
-            self.last_success_timestamp = time.time()
+            self.update_success_timestamp()
             return data
         if response.status_code in [401, 403, 404, 422]:
             # Unauthorized
             self.failures_total += 1
+            self.log("Warn: GECloud: Failed to get data from {} code {}".format(endpoint, response.status_code))
             return {}
         if response.status_code == 429:
             # Rate limiting so wait up to 30 seconds
@@ -1274,17 +1333,111 @@ class GECloudDirect:
         return None
 
 
-class GECloud:
-    def clean_url_cache(self, now_utc):
+class GECloudData(ComponentBase):
+    """
+    GivEnergy Cloud Data download and caching
+    """
+
+    def initialize(self, ge_cloud_data, ge_cloud_key, ge_cloud_serial, days_previous):
+        """Initialize the GE Cloud Data component"""
+        self.ge_cloud_key = ge_cloud_key
+        self.ge_cloud_serial_config_item = ge_cloud_serial
+        self.days_previous = days_previous
+        self.ge_cloud_serial = None
+        self.api_fatal = False
+        self.ge_url_cache = {}
+        self.mdata = []
+
+        # API request metrics for monitoring
+        self.requests_total = 0
+        self.failures_total = 0
+        self.oldest_data_time = None
+
+    def wait_api_started(self, timeout=MAX_START_TIME):
+        """
+        Wait for the API to start with custom timeout
+
+        Args:
+            timeout: Maximum time to wait in seconds
+
+        Returns:
+            bool: True if component started successfully, False if timeout
+        """
+        self.log("GECloudData: Waiting for API to start")
+        count = 0
+        while not self.api_started and count < timeout and not self.api_fatal:
+            time.sleep(1)
+            count += 1
+        if not self.api_started:
+            self.log("Warn: GECloudData: API failed to start in required time")
+            return False
+        return True
+
+    async def run(self, seconds, first):
+        """
+        Run the client
+        """
+        if first:
+            self.max_days_previous = max(self.days_previous) + 1
+            # Resolve any templated values
+            self.ge_cloud_serial = self.get_arg(self.ge_cloud_serial_config_item, default="")
+            self.log("GECloudData: Starting up with max_days_previous {} and serial {}".format(self.max_days_previous, self.ge_cloud_serial))
+
+        if seconds % (10 * 60) == 0:
+            now_utc = self.now_utc_exact
+            await self.download_ge_data(now_utc)
+
+        self.update_success_timestamp()
+        return True
+
+    def get_ge_cache_filename(self):
+        cache_path = self.config_root + "/cache"
+        if not os.path.exists(cache_path):
+            os.makedirs(cache_path, exist_ok=True)
+        cache_file = cache_path + "/givenergy_data.yaml"
+        return cache_file
+
+    def load_ge_cache(self):
+        """
+        Load the GE Cloud cache
+        """
+        cache_file = self.get_ge_cache_filename()
+        if os.path.exists(cache_file):
+            try:
+                with open(cache_file, "r") as f:
+                    self.ge_url_cache = yaml.safe_load(f)
+                if not isinstance(self.ge_url_cache, dict):
+                    self.ge_url_cache = {}
+            except (yaml.YAMLError, IOError) as e:
+                self.ge_url_cache = {}
+        else:
+            self.ge_url_cache = {}
+
+    def save_ge_cache(self):
+        """
+        Save the GE Cloud cache
+        """
+        cache_file = self.get_ge_cache_filename()
+        try:
+            with open(cache_file, "w") as f:
+                yaml.safe_dump(self.ge_url_cache, f)
+        except IOError as e:
+            pass
+
+    def clean_ge_url_cache(self, now_utc):
         """
         Clean up the GE Cloud cache
         """
         current_keys = list(self.ge_url_cache.keys())
         for url in current_keys[:]:
-            stamp = self.ge_url_cache[url]["stamp"]
-            age = now_utc - stamp
-            if age.seconds > (24 * 60 * 60):
+            stamp = self.ge_url_cache[url].get("stamp", None)
+            mdata = self.ge_url_cache[url].get("data", None)
+            if stamp is None or mdata is None:
                 del self.ge_url_cache[url]
+            else:
+                age = now_utc - stamp
+                if age.seconds > (24 * 60 * 60):
+                    del self.ge_url_cache[url]
 
     def get_ge_url(self, url, headers, now_utc, max_age_minutes=30):
         """
@@ -1292,44 +1445,87 @@ class GECloud:
         """
         if url in self.ge_url_cache:
             stamp = self.ge_url_cache[url]["stamp"]
-            pdata = self.ge_url_cache[url]["data"]
+            mdata = self.ge_url_cache[url]["data"]
+            url_next = self.ge_url_cache[url]["next"]
             age = now_utc - stamp
             if age.seconds < (max_age_minutes * 60):
                 self.log("Return cached GE data for {} age {} minutes".format(url, dp1(age.seconds / 60)))
-                return pdata
+                return mdata, url_next
 
         self.log("Fetching {}".format(url))
         try:
             r = requests.get(url, headers=headers)
         except (requests.Timeout, requests.exceptions.ReadTimeout, requests.exceptions.RequestException, requests.exceptions.ConnectionError) as e:
-            return {}
+            return {}, None
+
+        if r.status_code not in [200, 201]:
+            self.log("Warn: GeCloud: Failed to get data from {} status code {}".format(url, r.status_code))
+            return {}, None
 
         try:
             data = r.json()
         except requests.exceptions.JSONDecodeError as e:
-            return {}
+            return {}, None
+
+        if not data or "data" not in data:
+            return {}, None
+
+        # Convert to minute data
+        mdata = []
+        darray = data.get("data", None)
+
+        if "links" in data:
+            url_next = data["links"].get("next", None)
+        else:
+            url_next = None
+
+        last_time = None
+        for item in darray:
+            new_data = {}
+            this_time = str2time(item["time"])
+            # Align this_time to 5 minute intervals
+            if this_time:
+                this_time = this_time.replace(second=0, microsecond=0)
+                minute = (this_time.minute // 5) * 5
+                this_time = this_time.replace(minute=minute)
+
+            # Skip duplicate times (aligned to 5 minutes)
+            if this_time == last_time:
+                continue
+            last_time = this_time
+
+            new_data["last_updated"] = item["time"]
+            new_data["consumption"] = item["total"]["consumption"]
+            new_data["import"] = item["total"]["grid"]["import"]
+            new_data["export"] = item["total"]["grid"]["export"]
+            new_data["pv"] = item["total"]["solar"]
+            mdata.append(new_data)
 
         self.ge_url_cache[url] = {}
         self.ge_url_cache[url]["stamp"] = now_utc
-        self.ge_url_cache[url]["data"] = data
-        return data
+        self.ge_url_cache[url]["data"] = mdata
+        self.ge_url_cache[url]["next"] = url_next
+        return mdata, url_next
 
-    def download_ge_data(self, now_utc):
+    async def download_ge_data(self, now_utc):
         """
         Download consumption data from GE Cloud
         """
-        geserial = self.get_arg("ge_cloud_serial")
-        gekey = self.args.get("ge_cloud_key", None)
-        self.clean_url_cache(now_utc)
+        geserial = self.ge_cloud_serial
+        gekey = self.ge_cloud_key
 
         if not geserial:
-            self.log("Error: GE Cloud has been enabled but ge_cloud_serial is not set to your serial")
-            self.record_status("Warn: GE Cloud has been enabled but ge_cloud_serial is not set to your serial", had_errors=True)
+            self.log("Error: GECloudDirect has been enabled but ge_cloud_serial is not set to your serial")
             return False
         if not gekey:
-            self.log("Error: GE Cloud has been enabled but ge_cloud_key is not set to your appkey")
-            self.record_status("Warn: GE Cloud has been enabled but ge_cloud_key is not set to your appkey", had_errors=True)
+            self.log("Error: GECloudDirect has been enabled but ge_cloud_key is not set to your appkey")
             return False
+
+        # Load cache if not already loaded
+        self.load_ge_cache()
+
+        # Clean old cache entries
+        self.clean_ge_url_cache(now_utc)
 
         headers = {"Authorization": "Bearer  " + gekey, "Content-Type": "application/json", "Accept": "application/json"}
         mdata = []
@@ -1338,36 +1534,26 @@ class GECloud:
             days_prev = self.max_days_previous - days_prev_count
             time_value = now_utc - timedelta(days=days_prev)
             datestr = time_value.strftime("%Y-%m-%d")
-            url = "https://api.givenergy.cloud/v1/inverter/{}/data-points/{}?pageSize=4096".format(geserial, datestr)
+            url = "https://api.givenergy.cloud/v1/inverter/{}/data-points/{}".format(geserial, datestr)
             while url:
-                data = self.get_ge_url(url, headers, now_utc, 30 if days_prev == 0 else 8 * 60)
-                darray = data.get("data", None)
+                if "?" in url:
+                    url += "&pageSize=8000"
+                else:
+                    url += "?pageSize=8000"
+                darray, url = self.get_ge_url(url, headers, now_utc, 30 if days_prev == 0 else 18 * 60)
                 if darray is None:
                     # If we are less than 8 hours into today then ignore errors for today as data may not be available yet
                     if days_prev == 0:
-                        self.log("Info: No GE Cloud data available for today yet, continuing")
+                        self.log("Info: GECloudDirect: No GECloudDirect data available for today yet, continuing")
                         days_prev_count += 1
                         break
                     else:
-                        self.log("Warn: Error downloading GE data from URL {}".format(url))
-                        self.record_status("Warn: Error downloading GE data from cloud", debug=url)
+                        self.log("Warn: GECloudDirect: Error downloading GE data from URL {}".format(url))
                         continue
-
-                for item in darray:
-                    timestamp = item["time"]
-                    consumption = item["total"]["consumption"]
-                    dimport = item["total"]["grid"]["import"]
-                    dexport = item["total"]["grid"]["export"]
-                    dpv = item["total"]["solar"]
-
-                    new_data = {}
-                    new_data["last_updated"] = timestamp
-                    new_data["consumption"] = consumption
-                    new_data["import"] = dimport
-                    new_data["export"] = dexport
-                    new_data["pv"] = dpv
-                    mdata.append(new_data)
-                url = data["links"].get("next", None)
+                else:
+                    self.update_success_timestamp()
+                mdata.extend(darray)
+                # self.log("Info: GECloud downloaded {} data points".format(len(darray)))
             days_prev_count += 1
 
         # Find how old the data is
@@ -1378,17 +1564,16 @@ class GECloud:
                 last_updated_time = str2time(item["last_updated"])
             except (ValueError, TypeError):
                 pass
+        self.oldest_data_time = last_updated_time
+        self.mdata = mdata
 
-        age = now_utc - last_updated_time
-        self.load_minutes_age = age.days
-        self.load_minutes = self.minute_data(mdata, self.max_days_previous, now_utc, "consumption", "last_updated", backwards=True, smoothing=True, scale=self.load_scaling, clean_increment=True)
-        self.import_today = self.minute_data(mdata, self.max_days_previous, now_utc, "import", "last_updated", backwards=True, smoothing=True, scale=self.import_export_scaling, clean_increment=True)
-        self.export_today = self.minute_data(mdata, self.max_days_previous, now_utc, "export", "last_updated", backwards=True, smoothing=True, scale=self.import_export_scaling, clean_increment=True)
-        self.pv_today = self.minute_data(mdata, self.max_days_previous, now_utc, "pv", "last_updated", backwards=True, smoothing=True, scale=self.import_export_scaling, clean_increment=True)
-
-        self.load_minutes_now = self.load_minutes.get(0, 0) - self.load_minutes.get(self.minutes_now, 0)
-        self.import_today_now = self.import_today.get(0, 0) - self.import_today.get(self.minutes_now, 0)
-        self.export_today_now = self.export_today.get(0, 0) - self.export_today.get(self.minutes_now, 0)
-        self.pv_today_now = self.pv_today.get(0, 0) - self.pv_today.get(self.minutes_now, 0)
-        self.log("Downloaded {} datapoints from GE going back {} days".format(len(self.load_minutes), self.load_minutes_age))
+        # Save GE URL cache to disk for next time
+        self.save_ge_cache()
+        self.ge_url_cache = {}
         return True
+
+    def get_data(self):
+        """
+        Get the GECloudData data
+        """
+        return self.mdata, self.oldest_data_time

--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -10,6 +10,7 @@ KrakenAuthMixin (local API key / email+password → JWT).
 
 import aiohttp
 import asyncio
+from datetime import datetime
 
 from component_base import ComponentBase
 
@@ -43,6 +44,31 @@ except ImportError:
 
         _AUTH_BASE = _NoAuth
 
+
+# Validated EDF/E.ON Kraken query — uses electricitySupplyPoints (NOT Octopus's
+# electricityAgreements/meterPoint schema). Matches _shared/kraken-graphql.ts.
+# No accountNumber arg needed — JWT scopes to authenticated account.
+KRAKEN_ACCOUNT_QUERY = """{
+  account {
+    number
+    properties {
+      electricitySupplyPoints {
+        mpan
+        agreements {
+          validFrom
+          validTo
+          tariff {
+            ... on StandardTariff { tariffCode displayName productCode }
+            ... on DayNightTariff { tariffCode displayName productCode }
+            ... on ThreeRateTariff { tariffCode displayName productCode }
+            ... on HalfHourlyTariff { tariffCode displayName productCode }
+            ... on PrepayTariff { tariffCode displayName productCode }
+          }
+        }
+      }
+    }
+  }
+}"""
 
 KRAKEN_BASE_URLS = {
     "edf": "https://api.edfgb-kraken.energy",
@@ -133,3 +159,50 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
             self.log(f"Warn: Kraken: Network error for {request_context}: {e}")
             self.failures_total += 1
             return None
+
+    async def async_find_tariffs(self):
+        """Query account to discover current tariff. Returns tariff info if changed, None if same."""
+        data = await self.async_graphql_query(KRAKEN_ACCOUNT_QUERY, "find-tariffs")
+        if not data:
+            return None
+
+        account = data.get("account", {})
+        properties = account.get("properties", [])
+
+        # Find first property with electricity supply points (same as kraken-graphql.ts)
+        for prop in properties:
+            supply_points = prop.get("electricitySupplyPoints", [])
+            for sp in supply_points:
+                agreements = sp.get("agreements", [])
+
+                # Find active agreement (validTo is None or in the future)
+                for agr in agreements:
+                    valid_to = agr.get("validTo")
+                    if valid_to is not None:
+                        try:
+                            vt = datetime.fromisoformat(valid_to.replace("Z", "+00:00"))
+                            if vt < datetime.now(vt.tzinfo):
+                                continue
+                        except (ValueError, AttributeError):
+                            continue
+
+                    tariff = agr.get("tariff", {})
+                    tariff_code = tariff.get("tariffCode")
+                    product_code = tariff.get("productCode")
+
+                    if not tariff_code or not product_code:
+                        continue
+
+                    new_tariff = {"tariff_code": tariff_code, "product_code": product_code}
+
+                    if self.current_tariff == new_tariff:
+                        self.log(f"Kraken: Tariff unchanged — {tariff_code}")
+                        return None
+
+                    old = self.current_tariff
+                    self.current_tariff = new_tariff
+                    self.log(f"Kraken: Tariff {'discovered' if old is None else 'changed'} — {tariff_code} (product {product_code})")
+                    return new_tariff
+
+        self.log("Warn: Kraken: No active electricity agreement found")
+        return None

--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -247,3 +247,77 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
             self.log(f"Warn: Kraken: Network error fetching rates: {e}")
             self.failures_total += 1
             return None
+
+    def get_entity_name(self, root, suffix):
+        """Construct entity name. Same pattern as OctopusAPI.get_entity_name."""
+        entity_name = root + ".predbat_kraken_" + self.account_id.replace("-", "_") + "_" + suffix
+        return entity_name.lower()
+
+    def set_arg(self, key, value):
+        """Set a config arg on the base PredBat instance."""
+        self.base.args[key] = value
+
+    async def run(self, seconds, first):
+        """Component run method — called by ComponentBase.start() every 60s.
+
+        Timing (mirrors OctopusAPI pattern):
+        - First run + every 30 min: discover tariff via GraphQL
+        - Every cycle: fetch rates from REST + publish entities
+        - First run: wire into fetch.py via set_arg
+        """
+        now = datetime.now()
+        count_minutes = now.minute + now.hour * 60
+
+        # Tariff discovery — first run + every 30 minutes
+        if first or (count_minutes % 30) == 0:
+            tariff_change = await self.async_find_tariffs()
+
+            if tariff_change:
+                self.dashboard_item(
+                    self.get_entity_name("sensor", "tariff_code"),
+                    tariff_change["tariff_code"],
+                    attributes={
+                        "friendly_name": "Kraken Tariff Code",
+                        "product_code": tariff_change["product_code"],
+                        "icon": "mdi:lightning-bolt",
+                    },
+                    app="kraken",
+                )
+
+        # Fetch rates — every cycle (rates update throughout the day)
+        if self.current_tariff:
+            rates = await self.async_fetch_rates()
+            if rates:
+                self.dashboard_item(
+                    self.get_entity_name("sensor", "import_rates"),
+                    state=len(rates),
+                    attributes={
+                        "friendly_name": "Kraken Import Rates",
+                        "rates": rates,
+                        "tariff_code": self.current_tariff["tariff_code"],
+                        "product_code": self.current_tariff["product_code"],
+                        "icon": "mdi:currency-gbp",
+                    },
+                    app="kraken",
+                )
+
+        # Wire into fetch.py on first successful run (same as OctopusAPI.automatic_config)
+        if first and self.current_tariff:
+            self.set_arg("metric_octopus_import", self.get_entity_name("sensor", "import_rates"))
+            self.set_arg("metric_standing_charge", self.get_entity_name("sensor", "import_standing"))
+
+        # Publish account status
+        status = "error" if self.oauth_failed else ("connected" if self.current_tariff else "discovering")
+        self.dashboard_item(
+            self.get_entity_name("sensor", "account_status"),
+            state=status,
+            attributes={
+                "friendly_name": "Kraken Account Status",
+                "provider": self.provider,
+                "account_id": self.account_id,
+                "icon": "mdi:account-check" if status == "connected" else "mdi:account-alert",
+            },
+            app="kraken",
+        )
+
+        return True

--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -1,0 +1,135 @@
+"""Kraken API component for EDF/E.ON tariff discovery and rate fetching.
+
+Self-contained — discovers tariffs via Kraken GraphQL, constructs rate URLs
+from provider base URL + tariff code, fetches rates from public REST API.
+No stored URLs, no edge function callbacks.
+
+Auth strategy: SaaS uses OAuthMixin (edge function refresh), OSS uses
+KrakenAuthMixin (local API key / email+password → JWT).
+"""
+
+import aiohttp
+import asyncio
+
+from component_base import ComponentBase
+
+# Auth strategy selection — priority: OAuthMixin > KrakenAuthMixin > no-op
+try:
+    from oauth_mixin import OAuthMixin
+
+    _AUTH_BASE = OAuthMixin
+except ImportError:
+    try:
+        from kraken_auth_mixin import KrakenAuthMixin
+
+        _AUTH_BASE = KrakenAuthMixin
+    except ImportError:
+
+        class _NoAuth:
+            def _init_oauth(self, *args, **kwargs):
+                self.auth_method = None
+                self.oauth_failed = True
+                self.access_token = None
+                self.token_expires_at = None
+
+            def _init_kraken_auth(self, *args, **kwargs):
+                self._init_oauth(*args, **kwargs)
+
+            async def check_and_refresh_oauth_token(self):
+                return False
+
+            async def handle_oauth_401(self):
+                return False
+
+        _AUTH_BASE = _NoAuth
+
+
+KRAKEN_BASE_URLS = {
+    "edf": "https://api.edfgb-kraken.energy",
+    "eon": "https://api.eonnext-kraken.energy",
+}
+
+# Auth error codes that trigger token refresh + retry
+KRAKEN_AUTH_ERROR_CODES = ("KT-CT-1139", "KT-CT-1111", "KT-CT-1143")
+
+
+class KrakenAPI(ComponentBase, _AUTH_BASE):
+    """Kraken GraphQL component for EDF/E.ON tariff discovery and rate fetching."""
+
+    def initialize(self, provider, account_id, key=None, email=None, password=None, auth_method="oauth", token_expires_at=None):
+        """Initialise the Kraken API component with provider, account, and auth config."""
+        self.provider = provider
+        self.base_url = KRAKEN_BASE_URLS.get(provider)
+        if not self.base_url:
+            self.log(f"Warn: Kraken: Unknown provider '{provider}', expected 'edf' or 'eon'")
+            self.base_url = KRAKEN_BASE_URLS["edf"]
+
+        self.account_id = account_id
+        self.current_tariff = None
+        self.requests_total = 0
+        self.failures_total = 0
+
+        # Init auth — OAuthMixin or KrakenAuthMixin depending on import
+        if hasattr(self, "_init_oauth") and _AUTH_BASE.__name__ == "OAuthMixin":
+            self._init_oauth(auth_method, key, token_expires_at, "kraken")
+        elif hasattr(self, "_init_kraken_auth"):
+            self._init_kraken_auth(auth_method, key=key, email=email, password=password)
+
+    async def async_graphql_query(self, query, request_context, _retry_count=0):
+        """Execute a GraphQL query with auth and auto-retry on auth errors."""
+        token_ok = await self.check_and_refresh_oauth_token()
+        if not token_ok:
+            self.log(f"Warn: Kraken: Auth not available for {request_context}")
+            self.failures_total += 1
+            return None
+
+        token = self.access_token
+        if not token:
+            self.log(f"Warn: Kraken: No access token for {request_context}")
+            self.failures_total += 1
+            return None
+
+        url = f"{self.base_url}/v1/graphql/"
+        headers = {
+            "Authorization": f"JWT {token}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            self.requests_total += 1
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(url, json={"query": query}, headers=headers) as response:
+                    if response.status != 200:
+                        self.log(f"Warn: Kraken: GraphQL HTTP {response.status} for {request_context}")
+                        self.failures_total += 1
+                        return None
+                    body = await response.json()
+
+            # Check for auth errors — retry once after token refresh
+            if body and "errors" in body and _retry_count == 0:
+                for error in body.get("errors", []):
+                    error_code = error.get("extensions", {}).get("errorCode", "")
+                    if error_code in KRAKEN_AUTH_ERROR_CODES:
+                        self.log(f"Kraken: Auth error {error_code}, refreshing token and retrying")
+                        refreshed = await self.handle_oauth_401()
+                        if refreshed:
+                            return await self.async_graphql_query(query, request_context, _retry_count=1)
+                        self.log(f"Warn: Kraken: Token refresh failed for {request_context}")
+                        self.failures_total += 1
+                        return None
+
+            if body and "errors" in body:
+                self.log(f"Warn: Kraken: GraphQL errors for {request_context}: {body['errors']}")
+                self.failures_total += 1
+                return None
+
+            if body and "data" in body:
+                return body["data"]
+
+            return None
+
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            self.log(f"Warn: Kraken: Network error for {request_context}: {e}")
+            self.failures_total += 1
+            return None

--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -206,3 +206,44 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
 
         self.log("Warn: Kraken: No active electricity agreement found")
         return None
+
+    def build_rates_url(self, product_code, tariff_code):
+        """Construct public REST rates URL from base URL + tariff info."""
+        return f"{self.base_url}/v1/products/{product_code}/electricity-tariffs/{tariff_code}/standard-unit-rates/"
+
+    def build_standing_charge_url(self, product_code, tariff_code):
+        """Construct public REST standing charge URL."""
+        return f"{self.base_url}/v1/products/{product_code}/electricity-tariffs/{tariff_code}/standing-charges/"
+
+    async def async_fetch_rates(self):
+        """Fetch rates from public REST endpoint. No auth needed. Returns list of rate objects or None."""
+        if not self.current_tariff:
+            return None
+
+        url = self.build_rates_url(
+            self.current_tariff["product_code"],
+            self.current_tariff["tariff_code"],
+        )
+
+        all_results = []
+        try:
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                while url:
+                    async with session.get(url) as response:
+                        if response.status != 200:
+                            self.log(f"Warn: Kraken: Rates HTTP {response.status} for {url}")
+                            self.failures_total += 1
+                            return None
+                        data = await response.json()
+
+                    all_results.extend(data.get("results", []))
+                    url = data.get("next")  # Pagination
+
+            self.log(f"Kraken: Fetched {len(all_results)} rate periods")
+            return all_results
+
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            self.log(f"Warn: Kraken: Network error fetching rates: {e}")
+            self.failures_total += 1
+            return None

--- a/apps/predbat/kraken_auth_mixin.py
+++ b/apps/predbat/kraken_auth_mixin.py
@@ -1,0 +1,125 @@
+"""Local Kraken auth mixin for OSS users.
+
+Handles API key and email/password authentication against the Kraken GraphQL
+API (shared by Octopus, EDF, E.ON). Manages JWT + refresh token lifecycle
+locally — no SaaS edge functions needed.
+
+GraphQL mutation: obtainKrakenToken(input: ObtainJSONWebTokenInput!)
+  - API key mode: input = { APIKey: "..." }
+  - Email mode:   input = { email: "...", password: "..." }
+  - Refresh:      input = { refreshToken: "..." }
+All return: { token, refreshToken, payload { exp } }
+"""
+
+import aiohttp
+import asyncio
+from datetime import datetime, timezone, timedelta
+
+
+class KrakenAuthMixin:
+    """Local Kraken auth — API key or email/password → JWT, with local refresh."""
+
+    def _init_kraken_auth(self, auth_method, key=None, email=None, password=None):
+        """Initialise Kraken auth state. Call from the consuming class __init__."""
+        self.auth_method = auth_method
+        self._api_key = key
+        self._email = email
+        self._password = password
+        self.access_token = None
+        self.refresh_token = None
+        self.token_expires_at = None
+        self.oauth_failed = False
+        self._refresh_in_progress = False
+
+    async def check_and_refresh_oauth_token(self):
+        """Ensure a valid access token is available, refreshing or re-obtaining as needed.
+
+        Returns True if a valid token is available, False on permanent auth failure.
+        """
+        if self.oauth_failed:
+            return False
+        if self._refresh_in_progress:
+            return self.access_token is not None
+
+        now = datetime.now(timezone.utc)
+        if self.access_token and self.token_expires_at:
+            if self.token_expires_at > now + timedelta(minutes=5):
+                return True
+
+        self._refresh_in_progress = True
+        try:
+            if self.refresh_token:
+                result = await self._kraken_token_request({"refreshToken": self.refresh_token})
+            elif self.auth_method == "api_key" and self._api_key:
+                result = await self._kraken_token_request({"APIKey": self._api_key})
+            elif self.auth_method == "email" and self._email and self._password:
+                result = await self._kraken_token_request({"email": self._email, "password": self._password})
+            else:
+                self.oauth_failed = True
+                return False
+
+            if result:
+                self.access_token = result["token"]
+                self.refresh_token = result["refreshToken"]
+                self.token_expires_at = datetime.fromtimestamp(result["exp"], tz=timezone.utc)
+                return True
+            else:
+                if self.refresh_token:
+                    # Refresh token is stale — clear it and retry with primary credentials
+                    self.refresh_token = None
+                    self._refresh_in_progress = False
+                    return await self.check_and_refresh_oauth_token()
+                self.oauth_failed = True
+                return False
+        finally:
+            self._refresh_in_progress = False
+
+    async def handle_oauth_401(self):
+        """Handle a 401 response by discarding all tokens and re-obtaining from scratch.
+
+        Returns True if a fresh token was obtained, False on failure.
+        """
+        self.access_token = None
+        self.refresh_token = None
+        self.token_expires_at = None
+        return await self.check_and_refresh_oauth_token()
+
+    async def _kraken_token_request(self, input_vars):
+        """Execute the obtainKrakenToken GraphQL mutation with the given input variables.
+
+        Returns a dict with token, refreshToken, exp on success, or None on failure.
+        """
+        mutation = """mutation obtainKrakenToken($input: ObtainJSONWebTokenInput!) {
+            obtainKrakenToken(input: $input) {
+                token
+                refreshToken
+                payload { exp }
+            }
+        }"""
+        url = f"{self.base_url}/v1/graphql/"
+        try:
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    url,
+                    json={"query": mutation, "variables": {"input": input_vars}},
+                    headers={"Content-Type": "application/json"},
+                ) as response:
+                    if response.status != 200:
+                        return None
+                    data = await response.json()
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            return None
+
+        if data.get("errors"):
+            return None
+
+        token_data = data.get("data", {}).get("obtainKrakenToken")
+        if not token_data or not token_data.get("token"):
+            return None
+
+        return {
+            "token": token_data["token"],
+            "refreshToken": token_data["refreshToken"],
+            "exp": token_data["payload"]["exp"],
+        }

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -338,6 +338,7 @@ class OctopusAPI(ComponentBase):
         if not os.path.exists(self.cache_path):
             os.makedirs(self.cache_path)
         self.cache_file = self.cache_path + "/octopus.yaml"
+        self.log("Octopus API: Initialized with account ID {} cache {}".format(self.account_id, self.cache_file))
 
     async def select_event(self, entity_id, value):
         if entity_id == self.get_entity_name("select", "intelligent_target_time"):

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -17,6 +17,7 @@ import yaml
 from config import TIME_FORMAT
 import json
 import pytz
+import traceback
 
 user_agent_value = "predbat-octopus-energy"
 integration_context_header = "Ha-Integration-Context"
@@ -364,6 +365,7 @@ class OctopusAPI(ComponentBase):
         """
         Main run loop
         """
+        self.log("Octopus API: enter seconds {} first {}".format(seconds, first))
         if first:
             # Load cached data
             await self.load_octopus_cache()

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2015,10 +2015,6 @@ class Octopus:
         """
         data_all = []
         rate_data = {}
-
-        # DEBUG: Always log octopus rate fetching
-        print(f"*** fetch_octopus_rates CALLED: entity_id={entity_id}, adjust_key={adjust_key} ***")
-
         if entity_id:
             # From 9.0.0 of the Octopus plugin the data is split between previous rate, current rate and next rate
             # and the sensor is replaced with an event - try to support the old settings and find the new events
@@ -2047,16 +2043,12 @@ class Octopus:
             else:
                 current_rate_id = entity_id
 
-            print(f"*** Fetching current rates from: {current_rate_id} ***")
-
             data_import = (
                 self.get_state_wrapper(entity_id=current_rate_id, attribute="rates")
                 or self.get_state_wrapper(entity_id=current_rate_id, attribute="all_rates")
                 or self.get_state_wrapper(entity_id=current_rate_id, attribute="raw_today")
                 or self.get_state_wrapper(entity_id=current_rate_id, attribute="prices")
             )
-
-            print(f"*** data_import result: {type(data_import)}, len={len(data_import) if data_import else 0} ***")
 
             if data_import:
                 data_all += data_import
@@ -2080,10 +2072,7 @@ class Octopus:
                 if data_import:
                     data_all += data_import
 
-        print(f"*** Total data_all accumulated: len={len(data_all)} ***")
-
         if data_all:
-            print(f"*** data_all[0] sample: {data_all[0]} ***")
             rate_key = "rate"
             from_key = "from"
             to_key = "to"

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -17,7 +17,6 @@ import yaml
 from config import TIME_FORMAT
 import json
 import pytz
-import traceback
 
 user_agent_value = "predbat-octopus-energy"
 integration_context_header = "Ha-Integration-Context"
@@ -2017,6 +2016,9 @@ class Octopus:
         data_all = []
         rate_data = {}
 
+        # DEBUG: Always log octopus rate fetching
+        print(f"*** fetch_octopus_rates CALLED: entity_id={entity_id}, adjust_key={adjust_key} ***")
+
         if entity_id:
             # From 9.0.0 of the Octopus plugin the data is split between previous rate, current rate and next rate
             # and the sensor is replaced with an event - try to support the old settings and find the new events
@@ -2045,12 +2047,17 @@ class Octopus:
             else:
                 current_rate_id = entity_id
 
+            print(f"*** Fetching current rates from: {current_rate_id} ***")
+
             data_import = (
                 self.get_state_wrapper(entity_id=current_rate_id, attribute="rates")
                 or self.get_state_wrapper(entity_id=current_rate_id, attribute="all_rates")
                 or self.get_state_wrapper(entity_id=current_rate_id, attribute="raw_today")
                 or self.get_state_wrapper(entity_id=current_rate_id, attribute="prices")
             )
+
+            print(f"*** data_import result: {type(data_import)}, len={len(data_import) if data_import else 0} ***")
+
             if data_import:
                 data_all += data_import
             else:
@@ -2073,7 +2080,10 @@ class Octopus:
                 if data_import:
                     data_all += data_import
 
+        print(f"*** Total data_all accumulated: len={len(data_all)} ***")
+
         if data_all:
+            print(f"*** data_all[0] sample: {data_all[0]} ***")
             rate_key = "rate"
             from_key = "from"
             to_key = "to"

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -30,7 +30,7 @@ import asyncio
 THIS_VERSION = "v8.29.1"
 
 # fmt: off
-PREDBAT_FILES = ["predbat.py", "hass.py", "config.py", "prediction.py", "gecloud.py","utils.py", "inverter.py", "ha.py", "download.py", "web.py", "web_helper.py", "predheat.py", "futurerate.py", "octopus.py", "solcast.py","execute.py", "plan.py", "fetch.py", "output.py", "userinterface.py", "energydataservice.py", "alertfeed.py", "compare.py", "db_manager.py", "db_engine.py", "plugin_system.py", "ohme.py", "components.py", "fox.py", "carbon.py", "web_mcp.py", "component_base.py"]
+PREDBAT_FILES = ["predbat.py", "hass.py", "config.py", "prediction.py", "gecloud.py","utils.py", "inverter.py", "ha.py", "download.py", "web.py", "web_helper.py", "predheat.py", "futurerate.py", "octopus.py", "solcast.py","execute.py", "plan.py", "fetch.py", "output.py", "userinterface.py", "energydataservice.py", "alertfeed.py", "compare.py", "db_manager.py", "db_engine.py", "plugin_system.py", "ohme.py", "components.py", "fox.py", "carbon.py", "web_mcp.py", "component_base.py", "component_server.py", "component_client.py", "component_callback_server.py"]
 # fmt: on
 
 from download import predbat_update_move, predbat_update_download, check_install
@@ -78,6 +78,12 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Fetch, Plan, Execute, Outpu
     """
     The battery prediction class itself
     """
+
+    def get_local_attr(self, attr_name):
+        """
+        Get a local attribute by name
+        """
+        return getattr(self, attr_name, None)
 
     def download_predbat_releases_url(self, url):
         """

--- a/apps/predbat/run_component_server.py
+++ b/apps/predbat/run_component_server.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2025 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+"""
+Component Server Launcher
+
+WARNING: This server uses pickle for serialization. Only use in trusted networks
+(e.g. Kubernetes cluster) as pickle can execute arbitrary code. Do not expose
+this server to untrusted networks or the internet.
+
+This script launches the ComponentServer to host remote Predbat components.
+"""
+
+import sys
+import os
+import argparse
+import asyncio
+import logging
+import signal
+import importlib
+
+# Add apps/predbat to path so we can import modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'apps', 'predbat'))
+
+from predbat import THIS_VERSION
+from component_server import ComponentServer
+from components import COMPONENT_LIST
+
+def get_component_class(component_name):
+    """
+    Lazy-load a component class by name using importlib to avoid circular import issues.
+    
+    Args:
+        class_name: Name of the component class (e.g., "OctopusAPI")
+    
+    Returns:
+        Component class or None if not found
+    """
+
+    component_def = COMPONENT_LIST.get(component_name)
+    if not component_def:
+        return None
+    
+    try:
+        return component_def["class"]
+    except Exception as e:
+        logging.error(f"Failed to load component class {component_def['class']}: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+
+
+def setup_logging(log_level, log_file=None):
+    """
+    Setup logging configuration.
+    
+    Args:
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR)
+        log_file: Optional log file path
+    """
+    handlers = [logging.StreamHandler(sys.stdout)]
+    
+    if log_file:
+        handlers.append(logging.FileHandler(log_file))
+    
+    logging.basicConfig(
+        level=getattr(logging, log_level),
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=handlers
+    )
+
+
+def main():
+    """Main entry point for the component server."""
+    parser = argparse.ArgumentParser(
+        description='Predbat Component Server - Remote component execution host'
+    )
+    parser.add_argument(
+        '--host',
+        default='0.0.0.0',
+        help='Server bind address (default: 0.0.0.0)'
+    )
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=5053,
+        help='Server port (default: 5053)'
+    )
+    parser.add_argument(
+        '--timeout',
+        type=int,
+        default=1800,
+        help='Component inactivity timeout in seconds (default: 1800)'
+    )
+    parser.add_argument(
+        '--log-level',
+        default='INFO',
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+        help='Logging level (default: INFO)'
+    )
+    parser.add_argument(
+        '--log-file',
+        help='Optional log file path'
+    )
+    
+    args = parser.parse_args()
+    
+    # Setup logging
+    setup_logging(args.log_level, args.log_file)
+    logger = logging.getLogger(__name__)
+    
+    logger.info("=" * 80)
+    logger.info(f"Predbat Component Server (Predbat VERSION {THIS_VERSION})")
+    logger.info("=" * 80)
+    logger.info(f"Host: {args.host}")
+    logger.info(f"Port: {args.port}")
+    logger.info(f"Timeout: {args.timeout} seconds")
+    logger.info(f"Log Level: {args.log_level}")
+    if args.log_file:
+        logger.info(f"Log File: {args.log_file}")
+    logger.info(f"Registered Components: OctopusAPI")
+    logger.info("=" * 80)
+    logger.warning("WARNING: Using pickle serialization - only use in trusted networks!")
+    logger.info("=" * 80)
+    
+    # Create server instance with lazy component loader
+    server = ComponentServer(
+        timeout=args.timeout,
+        component_loader=get_component_class  # Lazy loader function
+    )
+    
+    # Setup signal handlers for graceful shutdown
+    shutdown_event = asyncio.Event()
+    
+    def signal_handler(signum, frame):
+        """Handle shutdown signals."""
+        logger.info(f"Received signal {signum}, initiating shutdown...")
+        shutdown_event.set()
+    
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+    
+    # Run server
+    async def run_with_shutdown():
+        """Run server with shutdown handling."""
+        # Start server in background
+        server_task = asyncio.create_task(server.run(host=args.host, port=args.port))
+        
+        # Wait for shutdown signal
+        await shutdown_event.wait()
+        
+        # Trigger graceful shutdown
+        await server.shutdown()
+        
+        # Cancel server task if still running
+        if not server_task.done():
+            server_task.cancel()
+            try:
+                await server_task
+            except asyncio.CancelledError:
+                pass
+    
+    try:
+        asyncio.run(run_with_shutdown())
+    except KeyboardInterrupt:
+        logger.info("Keyboard interrupt received")
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        import traceback
+        logger.error(traceback.format_exc())
+        sys.exit(1)
+    
+    logger.info("Component server stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/predbat/tests/test_kraken.py
+++ b/apps/predbat/tests/test_kraken.py
@@ -120,3 +120,70 @@ def test_graphql_query_oauth_failed_returns_none():
     api.check_and_refresh_oauth_token = AsyncMock(return_value=False)
     result = asyncio.run(api.async_graphql_query("query { test }", "test-context"))
     assert result is None
+
+
+def test_find_tariffs_detects_change():
+    api = make_kraken_api()
+    # Response shape matches validated EDF/E.ON Kraken schema (electricitySupplyPoints)
+    account_data = {
+        "account": {
+            "number": "A-TEST123",
+            "properties": [
+                {
+                    "electricitySupplyPoints": [
+                        {
+                            "mpan": "1234567890123",
+                            "agreements": [
+                                {
+                                    "validFrom": "2026-01-01T00:00:00+00:00",
+                                    "validTo": None,
+                                    "tariff": {
+                                        "productCode": "VAR-22-11-01",
+                                        "tariffCode": "E-1R-VAR-22-11-01-J",
+                                        "displayName": "EDF Variable",
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    api.async_graphql_query = AsyncMock(return_value=account_data)
+    result = asyncio.run(api.async_find_tariffs())
+    assert result is not None
+    assert result["tariff_code"] == "E-1R-VAR-22-11-01-J"
+    assert result["product_code"] == "VAR-22-11-01"
+    assert api.current_tariff == {"tariff_code": "E-1R-VAR-22-11-01-J", "product_code": "VAR-22-11-01"}
+
+
+def test_find_tariffs_no_change():
+    api = make_kraken_api()
+    api.current_tariff = {"tariff_code": "E-1R-VAR-22-11-01-J", "product_code": "VAR-22-11-01"}
+    account_data = {
+        "account": {
+            "number": "A-TEST123",
+            "properties": [
+                {
+                    "electricitySupplyPoints": [
+                        {
+                            "mpan": "1234567890123",
+                            "agreements": [{"validFrom": "2026-01-01T00:00:00+00:00", "validTo": None, "tariff": {"productCode": "VAR-22-11-01", "tariffCode": "E-1R-VAR-22-11-01-J", "displayName": "EDF Variable"}}],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    api.async_graphql_query = AsyncMock(return_value=account_data)
+    result = asyncio.run(api.async_find_tariffs())
+    assert result is None
+
+
+def test_find_tariffs_graphql_failure():
+    api = make_kraken_api()
+    api.async_graphql_query = AsyncMock(return_value=None)
+    result = asyncio.run(api.async_find_tariffs())
+    assert result is None
+    assert api.current_tariff is None

--- a/apps/predbat/tests/test_kraken.py
+++ b/apps/predbat/tests/test_kraken.py
@@ -187,3 +187,57 @@ def test_find_tariffs_graphql_failure():
     result = asyncio.run(api.async_find_tariffs())
     assert result is None
     assert api.current_tariff is None
+
+
+def test_build_rates_url():
+    api = make_kraken_api(provider="edf")
+    url = api.build_rates_url("VAR-22-11-01", "E-1R-VAR-22-11-01-J")
+    assert url == "https://api.edfgb-kraken.energy/v1/products/VAR-22-11-01/electricity-tariffs/E-1R-VAR-22-11-01-J/standard-unit-rates/"
+
+
+def test_build_rates_url_eon():
+    api = make_kraken_api(provider="eon")
+    url = api.build_rates_url("PROD-01", "E-1R-PROD-01-A")
+    assert url == "https://api.eonnext-kraken.energy/v1/products/PROD-01/electricity-tariffs/E-1R-PROD-01-A/standard-unit-rates/"
+
+
+def test_fetch_rates_single_page():
+    api = make_kraken_api()
+    api.current_tariff = {"tariff_code": "E-1R-VAR-22-11-01-J", "product_code": "VAR-22-11-01"}
+
+    rates_response = {
+        "count": 2,
+        "next": None,
+        "results": [
+            {"value_inc_vat": 24.5, "valid_from": "2026-03-23T00:00:00Z", "valid_to": "2026-03-24T00:00:00Z"},
+            {"value_inc_vat": 28.3, "valid_from": "2026-03-24T00:00:00Z", "valid_to": "2026-03-25T00:00:00Z"},
+        ],
+    }
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value=rates_response)
+
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=None),
+        )
+    )
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("aiohttp.ClientSession", return_value=mock_session):
+        result = asyncio.run(api.async_fetch_rates())
+
+    assert result is not None
+    assert len(result) == 2
+    assert result[0]["value_inc_vat"] == 24.5
+
+
+def test_fetch_rates_no_tariff():
+    api = make_kraken_api()
+    assert api.current_tariff is None
+    result = asyncio.run(api.async_fetch_rates())
+    assert result is None

--- a/apps/predbat/tests/test_kraken.py
+++ b/apps/predbat/tests/test_kraken.py
@@ -1,0 +1,122 @@
+# src/batpred/apps/predbat/tests/test_kraken.py
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def make_mock_base():
+    base = MagicMock()
+    base.log = MagicMock()
+    base.prefix = "predbat"
+    base.local_tz = "Europe/London"
+    base.args = {"user_id": "test-instance-123"}
+    return base
+
+
+def make_kraken_api(provider="edf", account_id="A-TEST123", auth_method="api_key", key="test-key"):
+    from kraken import KrakenAPI
+
+    api = KrakenAPI.__new__(KrakenAPI)
+    base = make_mock_base()
+    api.base = base
+    api.log = base.log
+    api.api_started = False
+    api.api_stop = False
+    api.last_success_timestamp = None
+    api.local_tz = base.local_tz
+    api.prefix = base.prefix
+    api.args = base.args
+    api.count_errors = 0
+    api.run_timeout = 3600
+    api.initialize(provider=provider, account_id=account_id, key=key, auth_method=auth_method)
+    return api
+
+
+def test_initialize_sets_base_url_from_provider():
+    api = make_kraken_api(provider="edf")
+    assert api.base_url == "https://api.edfgb-kraken.energy"
+    api2 = make_kraken_api(provider="eon")
+    assert api2.base_url == "https://api.eonnext-kraken.energy"
+
+
+def test_initialize_sets_current_tariff_none():
+    api = make_kraken_api()
+    assert api.current_tariff is None
+
+
+def test_graphql_query_success():
+    api = make_kraken_api()
+    api.access_token = "jwt-token-123"
+    api.check_and_refresh_oauth_token = AsyncMock(return_value=True)
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"data": {"account": {"electricityAgreements": []}}})
+
+    mock_session = AsyncMock()
+    mock_session.post = MagicMock(
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=None),
+        )
+    )
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("aiohttp.ClientSession", return_value=mock_session):
+        result = asyncio.run(api.async_graphql_query("query { test }", "test-context"))
+
+    assert result == {"account": {"electricityAgreements": []}}
+    call_args = mock_session.post.call_args
+    assert call_args[1]["headers"]["Authorization"] == "JWT jwt-token-123"
+
+
+def test_graphql_query_auth_error_retries():
+    api = make_kraken_api()
+    api.access_token = "old-token"
+    api.check_and_refresh_oauth_token = AsyncMock(return_value=True)
+    api.handle_oauth_401 = AsyncMock(return_value=True)
+
+    auth_error_resp = AsyncMock()
+    auth_error_resp.status = 200
+    auth_error_resp.json = AsyncMock(return_value={"errors": [{"extensions": {"errorCode": "KT-CT-1139"}, "message": "Invalid token"}]})
+    success_resp = AsyncMock()
+    success_resp.status = 200
+    success_resp.json = AsyncMock(return_value={"data": {"account": {"electricityAgreements": []}}})
+
+    call_count = [0]
+
+    def make_context(resp):
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=resp)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        return ctx
+
+    def post_side_effect(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return make_context(auth_error_resp)
+        return make_context(success_resp)
+
+    mock_session = AsyncMock()
+    mock_session.post = MagicMock(side_effect=post_side_effect)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("aiohttp.ClientSession", return_value=mock_session):
+        result = asyncio.run(api.async_graphql_query("query { test }", "test-context"))
+
+    assert result == {"account": {"electricityAgreements": []}}
+    api.handle_oauth_401.assert_called_once()
+
+
+def test_graphql_query_oauth_failed_returns_none():
+    api = make_kraken_api()
+    api.oauth_failed = True
+    api.check_and_refresh_oauth_token = AsyncMock(return_value=False)
+    result = asyncio.run(api.async_graphql_query("query { test }", "test-context"))
+    assert result is None

--- a/apps/predbat/tests/test_kraken.py
+++ b/apps/predbat/tests/test_kraken.py
@@ -241,3 +241,49 @@ def test_fetch_rates_no_tariff():
     assert api.current_tariff is None
     result = asyncio.run(api.async_fetch_rates())
     assert result is None
+
+
+def test_get_entity_name():
+    api = make_kraken_api(account_id="A-1234ABCD")
+    name = api.get_entity_name("sensor", "import_rates")
+    assert name == "sensor.predbat_kraken_a_1234abcd_import_rates"
+
+
+def test_run_first_discovers_tariff_and_fetches_rates():
+    api = make_kraken_api()
+    discovered = {"tariff_code": "E-1R-NEW-01", "product_code": "NEW-01"}
+
+    async def find_tariffs_side_effect():
+        api.current_tariff = discovered
+        return discovered
+
+    api.async_find_tariffs = AsyncMock(side_effect=find_tariffs_side_effect)
+    api.async_fetch_rates = AsyncMock(
+        return_value=[
+            {"value_inc_vat": 24.5, "valid_from": "2026-03-23T00:00:00Z", "valid_to": "2026-03-24T00:00:00Z"},
+        ]
+    )
+    api.dashboard_item = MagicMock()
+    api.set_arg = MagicMock()
+
+    result = asyncio.run(api.run(0, True))
+
+    assert result is True
+    api.async_find_tariffs.assert_called_once()
+    api.async_fetch_rates.assert_called_once()
+    api.dashboard_item.assert_called()
+    # On first run, should wire into fetch.py
+    api.set_arg.assert_any_call("metric_octopus_import", api.get_entity_name("sensor", "import_rates"))
+
+
+def test_run_fetches_rates_even_when_tariff_unchanged():
+    api = make_kraken_api()
+    api.current_tariff = {"tariff_code": "E-1R-VAR-01", "product_code": "VAR-01"}
+    api.async_find_tariffs = AsyncMock(return_value=None)
+    api.async_fetch_rates = AsyncMock(return_value=[{"value_inc_vat": 24.5}])
+    api.dashboard_item = MagicMock()
+
+    result = asyncio.run(api.run(0, False))
+
+    assert result is True
+    api.async_fetch_rates.assert_called_once()

--- a/apps/predbat/tests/test_kraken_auth_mixin.py
+++ b/apps/predbat/tests/test_kraken_auth_mixin.py
@@ -1,0 +1,179 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2025 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt: off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime, timezone, timedelta
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def make_token_response(token="jwt-token-123", refresh="refresh-token-456", exp_offset=3600):
+    """Build a mock obtainKrakenToken GraphQL response."""
+    exp = int(time.time()) + exp_offset
+    return {
+        "data": {
+            "obtainKrakenToken": {
+                "token": token,
+                "refreshToken": refresh,
+                "payload": {"exp": exp},
+            }
+        }
+    }
+
+
+def make_error_response(message="Auth failed", error_code=None):
+    """Build a mock GraphQL error response."""
+    error = {"message": message}
+    if error_code:
+        error["extensions"] = {"errorCode": error_code}
+    return {"errors": [error]}
+
+
+def make_mixin(auth_method="api_key", key=None, email=None, password=None):
+    """Create a KrakenAuthMixin instance with mock base."""
+    from kraken_auth_mixin import KrakenAuthMixin
+
+    mixin = KrakenAuthMixin.__new__(KrakenAuthMixin)
+    mixin.base = MagicMock()
+    mixin.base.session = AsyncMock()
+    mixin.base_url = "https://api.edfgb-kraken.energy"
+    mixin.log = MagicMock()
+    mixin._init_kraken_auth(auth_method, key=key, email=email, password=password)
+    return mixin
+
+
+def test_init_api_key_mode():
+    mixin = make_mixin(auth_method="api_key", key="sk_live_test123")
+    assert mixin.auth_method == "api_key"
+    assert mixin._api_key == "sk_live_test123"
+    assert mixin.access_token is None
+    assert mixin.refresh_token is None
+    assert mixin.oauth_failed is False
+
+
+def test_init_email_mode():
+    mixin = make_mixin(auth_method="email", email="user@edf.com", password="secret")
+    assert mixin.auth_method == "email"
+    assert mixin._email == "user@edf.com"
+    assert mixin._password == "secret"
+    assert mixin.access_token is None
+
+
+def test_obtain_token_api_key():
+    mixin = make_mixin(auth_method="api_key", key="sk_live_test123")
+    mixin._kraken_token_request = AsyncMock(return_value={
+        "token": "jwt-token-123",
+        "refreshToken": "refresh-token-456",
+        "exp": int(time.time()) + 3600,
+    })
+    result = asyncio.run(mixin.check_and_refresh_oauth_token())
+    assert result is True
+    assert mixin.access_token == "jwt-token-123"
+    assert mixin.refresh_token == "refresh-token-456"
+    mixin._kraken_token_request.assert_called_once_with({"APIKey": "sk_live_test123"})
+
+
+def test_obtain_token_email():
+    mixin = make_mixin(auth_method="email", email="user@edf.com", password="secret")
+    mixin._kraken_token_request = AsyncMock(return_value={
+        "token": "jwt-email-token",
+        "refreshToken": "refresh-email-token",
+        "exp": int(time.time()) + 3600,
+    })
+    result = asyncio.run(mixin.check_and_refresh_oauth_token())
+    assert result is True
+    assert mixin.access_token == "jwt-email-token"
+    mixin._kraken_token_request.assert_called_once_with({"email": "user@edf.com", "password": "secret"})
+
+
+def test_refresh_uses_refresh_token():
+    mixin = make_mixin(auth_method="api_key", key="sk_live_test123")
+    mixin.access_token = "old-token"
+    mixin.refresh_token = "existing-refresh"
+    mixin.token_expires_at = datetime.now(timezone.utc) + timedelta(minutes=2)
+    mixin._kraken_token_request = AsyncMock(return_value={
+        "token": "new-jwt",
+        "refreshToken": "new-refresh",
+        "exp": int(time.time()) + 3600,
+    })
+    result = asyncio.run(mixin.check_and_refresh_oauth_token())
+    assert result is True
+    assert mixin.access_token == "new-jwt"
+    mixin._kraken_token_request.assert_called_once_with({"refreshToken": "existing-refresh"})
+
+
+def test_valid_token_not_refreshed():
+    mixin = make_mixin(auth_method="api_key", key="sk_live_test123")
+    mixin.access_token = "valid-token"
+    mixin.refresh_token = "valid-refresh"
+    mixin.token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    mixin._kraken_token_request = AsyncMock()
+    result = asyncio.run(mixin.check_and_refresh_oauth_token())
+    assert result is True
+    mixin._kraken_token_request.assert_not_called()
+
+
+def test_refresh_failure_retries_with_credentials():
+    mixin = make_mixin(auth_method="api_key", key="sk_live_test123")
+    mixin.refresh_token = "bad-refresh"
+    mixin.token_expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    call_count = 0
+    async def side_effect(input_vars):
+        nonlocal call_count
+        call_count += 1
+        if "refreshToken" in input_vars:
+            return None
+        return {
+            "token": "recovered-jwt",
+            "refreshToken": "new-refresh",
+            "exp": int(time.time()) + 3600,
+        }
+    mixin._kraken_token_request = AsyncMock(side_effect=side_effect)
+    result = asyncio.run(mixin.check_and_refresh_oauth_token())
+    assert result is True
+    assert mixin.access_token == "recovered-jwt"
+    assert call_count == 2
+
+
+def test_total_auth_failure_sets_oauth_failed():
+    mixin = make_mixin(auth_method="api_key", key="sk_live_test123")
+    mixin._kraken_token_request = AsyncMock(return_value=None)
+    result = asyncio.run(mixin.check_and_refresh_oauth_token())
+    assert result is False
+    assert mixin.oauth_failed is True
+
+
+def test_handle_oauth_401_clears_and_reobtains():
+    mixin = make_mixin(auth_method="api_key", key="sk_live_test123")
+    mixin.access_token = "old"
+    mixin.refresh_token = "old-refresh"
+    mixin.token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    mixin._kraken_token_request = AsyncMock(return_value={
+        "token": "fresh-jwt",
+        "refreshToken": "fresh-refresh",
+        "exp": int(time.time()) + 3600,
+    })
+    result = asyncio.run(mixin.handle_oauth_401())
+    assert result is True
+    assert mixin.access_token == "fresh-jwt"
+    mixin._kraken_token_request.assert_called_once_with({"APIKey": "sk_live_test123"})
+
+
+def test_oauth_failed_short_circuits():
+    mixin = make_mixin(auth_method="api_key", key="sk_live_test123")
+    mixin.oauth_failed = True
+    mixin._kraken_token_request = AsyncMock()
+    result = asyncio.run(mixin.check_and_refresh_oauth_token())
+    assert result is False
+    mixin._kraken_token_request.assert_not_called()

--- a/docs/COMPONENT_SERVER.md
+++ b/docs/COMPONENT_SERVER.md
@@ -1,0 +1,192 @@
+# Distributed Component Server/Client System
+
+This feature allows Predbat components to run on a separate server, useful for Kubernetes deployments or load distribution.
+
+## Architecture
+
+- **Component Server**: Standalone server that hosts remote component instances (e.g., OctopusAPI)
+- **Component Client**: Proxy in main Predbat that forwards operations to the server via REST
+- **Callback Server**: HTTP server in Predbat that handles base API callbacks from remote components
+
+## Security Warning
+
+⚠️ **WARNING**: This system uses pickle for serialization. Only use in trusted networks (e.g., Kubernetes cluster) as pickle can execute arbitrary code. Do not expose to untrusted networks or the internet.
+
+## Configuration
+
+Add this section to your `apps.yaml` under the Predbat app configuration:
+
+```yaml
+predbat:
+  module: predbat
+  class: PredBat
+  # ... other configuration ...
+  
+  # Component server configuration (infrastructure settings)
+  component_server:
+    # URL of the component server
+    url: "http://componentserver:5053"
+    
+    # List of components to run remotely (component names from components.py)
+    components:
+      - octopus
+    
+    # Callback URL where this Predbat instance can be reached by the server
+    # If not specified, server will use X-Forwarded-For or remote IP
+    callback_url: "http://predbat:5054"
+    
+    # Port for callback server (default: 5054)
+    callback_port: 5054
+    
+    # How often client pings server (seconds, default: 300)
+    poll_interval: 300
+    
+    # Component timeout - server stops component after this many seconds of no pings (default: 1800)
+    timeout: 1800
+```
+
+### Configuration Keys
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `url` | string | Yes | - | HTTP URL of component server |
+| `components` | list | Yes | - | Component names to run remotely |
+| `callback_url` | string | No | Auto-detect | URL where Predbat callback server is accessible |
+| `callback_port` | int | No | 5054 | Port for Predbat callback server |
+| `poll_interval` | int | No | 300 | Ping interval in seconds |
+| `timeout` | int | No | 1800 | Component inactivity timeout in seconds |
+
+## Running the Component Server
+
+```bash
+cd apps/predbat
+./run_component_server.py --host 0.0.0.0 --port 5053 --timeout 1800 --log-level INFO
+```
+
+### Command Line Options
+
+- `--host`: Server bind address (default: 0.0.0.0)
+- `--port`: Server port (default: 5053)
+- `--timeout`: Component inactivity timeout in seconds (default: 1800)
+- `--log-level`: Logging level - DEBUG, INFO, WARNING, ERROR (default: INFO)
+- `--log-file`: Optional log file path
+
+## How It Works
+
+1. **Startup**:
+   - Predbat starts callback server on configured port
+   - For components in `component_server_components` list, creates `ComponentClient` instead of actual component
+   - Client connects to component server and requests component start
+
+2. **Operation**:
+   - Client forwards all method calls (run, events, etc.) to server via HTTP POST
+   - Server invokes methods on actual component instance
+   - When component needs base API (get_arg, get_state_wrapper, etc.), server calls back to Predbat
+   - Results are pickled and returned to client
+
+3. **Health Monitoring**:
+   - Client sends ping every `component_server_poll_interval` seconds
+   - Server auto-stops components that haven't pinged in `timeout` seconds
+   - Client auto-restarts components if server reports "Component not found"
+
+4. **Shutdown**:
+   - Client sends stop request to server
+   - Server gracefully stops component and cleans up resources
+
+## Supported Components
+
+Currently registered for remote execution:
+- OctopusAPI
+
+To add more components, edit `COMPONENT_CLASSES` in `run_component_server.py`.
+
+## Kubernetes Deployment Example
+
+### Component Server Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: predbat-component-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: predbat-component-server
+  template:
+    metadata:
+      labels:
+        app: predbat-component-server
+    spec:
+      containers:
+      - name: server
+        image: predbat:latest
+        command: ["python3", "/app/apps/predbat/run_component_server.py"]
+        args: ["--host", "0.0.0.0", "--port", "5053", "--timeout", "1800"]
+        ports:
+        - containerPort: 5053
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: componentserver
+spec:
+  selector:
+    app: predbat-component-server
+  ports:
+  - port: 5053
+    targetPort: 5053
+```
+
+### Predbat Deployment
+
+Ensure Predbat has a Service exposing port 5054 for callbacks:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: predbat
+spec:
+  selector:
+    app: predbat
+  ports:
+  - name: web
+    port: 5052
+    targetPort: 5052
+  - name: callback
+    port: 5054
+    targetPort: 5054
+```
+
+## Troubleshooting
+
+### Component won't start
+
+- Check callback URL is reachable from component server
+- Verify component server URL is correct
+- Check logs for connection errors
+
+### Component keeps restarting
+
+- Check ping interval isn't too long relative to timeout
+- Verify network connectivity between server and client
+- Review server logs for timeout messages
+
+### Performance issues
+
+- Reduce number of remote components (network overhead per call)
+- Increase timeout values if network is slow
+- Check server resources (CPU, memory)
+
+## Testing
+
+The feature is optional - Predbat works normally when `component_server_components` is empty or `component_server_url` is not set.
+
+To test:
+1. Start component server manually
+2. Configure Predbat with server URL and component list
+3. Restart Predbat
+4. Check logs for "Creating remote component client" messages
+5. Verify component functionality (e.g., Octopus rates updating)

--- a/docs/COMPONENT_SERVER.md
+++ b/docs/COMPONENT_SERVER.md
@@ -21,26 +21,26 @@ predbat:
   module: predbat
   class: PredBat
   # ... other configuration ...
-  
+
   # Component server configuration (infrastructure settings)
   component_server:
     # URL of the component server
     url: "http://componentserver:5053"
-    
+
     # List of components to run remotely (component names from components.py)
     components:
       - octopus
-    
+
     # Callback URL where this Predbat instance can be reached by the server
     # If not specified, server will use X-Forwarded-For or remote IP
     callback_url: "http://predbat:5054"
-    
+
     # Port for callback server (default: 5054)
     callback_port: 5054
-    
+
     # How often client pings server (seconds, default: 300)
     poll_interval: 300
-    
+
     # Component timeout - server stops component after this many seconds of no pings (default: 1800)
     timeout: 1800
 ```
@@ -96,6 +96,7 @@ cd apps/predbat
 ## Supported Components
 
 Currently registered for remote execution:
+
 - OctopusAPI
 
 To add more components, edit `COMPONENT_CLASSES` in `run_component_server.py`.
@@ -185,6 +186,7 @@ spec:
 The feature is optional - Predbat works normally when `component_server_components` is empty or `component_server_url` is not set.
 
 To test:
+
 1. Start component server manually
 2. Configure Predbat with server URL and component list
 3. Restart Predbat


### PR DESCRIPTION
## Summary
- Add `KrakenAuthMixin` for OSS local auth (API key or email/password → JWT via `obtainKrakenToken` mutation)
- Add `KrakenAPI` component — discovers tariffs via Kraken GraphQL (`electricitySupplyPoints` schema), fetches rates from public REST API
- Three-level auth import guard: OAuthMixin (SaaS) → KrakenAuthMixin (OSS) → _NoAuth stub
- Register `kraken` in `components.py` COMPONENT_LIST with provider, account_id, key, auth_method args
- Wires into fetch.py via `set_arg("metric_octopus_import", ...)` for rate consumption
- 25 tests (10 auth mixin + 15 component)

## New Files
- `apps/predbat/kraken_auth_mixin.py` — local JWT management
- `apps/predbat/kraken.py` — KrakenAPI component
- `apps/predbat/tests/test_kraken_auth_mixin.py`
- `apps/predbat/tests/test_kraken.py`

## Modified Files
- `apps/predbat/components.py` — add kraken entry

## Test plan
- [ ] All 25 tests pass (`pytest tests/test_kraken.py tests/test_kraken_auth_mixin.py`)
- [ ] Component activates with OSS config (kraken_provider, kraken_account_id, kraken_auth_method, kraken_email, kraken_password)
- [ ] SaaS path: OAuthMixin takes priority when available
- [ ] Rate entities published and consumed by fetch.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)