### PR TITLE
fix: handle 24:00:00 time string from GivEnergy Cloud

### DIFF
--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -769,6 +769,10 @@ def time_string_to_stamp(time_string):
     if isinstance(time_string, str) and len(time_string) == 5:
         time_string += ":00"
 
+    # Some inverters (e.g. GivEnergy) use "24:00:00" for midnight end-of-day
+    if isinstance(time_string, str) and time_string.startswith("24:"):
+        time_string = "00:" + time_string[3:]
+
     return datetime.strptime(time_string, "%H:%M:%S")
 
 


### PR DESCRIPTION
## Summary

- Fix `time_string_to_stamp()` crash when GivEnergy Cloud returns `24:00:00` for discharge end time
- Normalise `24:xx:xx` to `00:xx:xx` before `strptime` parsing
- Fixes #3651

## Test plan

- [ ] Verify `time_string_to_stamp("24:00:00")` returns `datetime(1900, 1, 1, 0, 0)`
- [ ] Verify normal time strings still parse correctly
- [ ] Verify GivEnergy users with discharge end = midnight no longer crash