### PR TITLE
feat: add kraken_base_url config for GraphQL proxy

### DIFF
--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -271,6 +271,10 @@ COMPONENT_LIST = {
                 "required": False,
                 "config": "kraken_export_mpan",
             },
+            "base_url": {
+                "required": False,
+                "config": "kraken_base_url",
+            },
         },
         "phase": 1,
     },

--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -104,10 +104,11 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
         mpan=None,
         export_account_id=None,
         export_mpan=None,
+        base_url=None,
     ):
         """Initialise the Kraken API component with provider, account, and auth config."""
         self.provider = provider
-        self.base_url = KRAKEN_BASE_URLS.get(provider)
+        self.base_url = base_url or KRAKEN_BASE_URLS.get(provider)
         if not self.base_url:
             self.log(f"Warn: Kraken: Unknown provider '{provider}', expected 'edf' or 'eon'")
             self.base_url = KRAKEN_BASE_URLS["edf"]


### PR DESCRIPTION
## Summary
- Adds optional `kraken_base_url` config key to `KrakenAPI.initialize()`
- When set, overrides the hardcoded `KRAKEN_BASE_URLS` for GraphQL queries
- Allows SaaS pods to route Kraken GraphQL calls through an edge function proxy

## Context
E.ON/Kraken's CloudFront WAF blocks requests from datacenter IPs (e.g. Hetzner). Token refresh works via Supabase edge functions, but direct GraphQL queries from pods get HTTP 403. This change lets us configure a proxy URL per-provider so pods route through our edge function instead.

OSS users are unaffected — without the config key, the existing hardcoded provider URLs are used.

## Test plan
- [ ] Verify OSS behaviour: no `kraken_base_url` in config → uses hardcoded URLs as before
- [ ] Verify SaaS behaviour: `kraken_base_url` set → pod uses proxy URL for GraphQL queries
- [ ] Confirm `find-tariffs` succeeds via proxy from Hetzner pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)