### PR TITLE
fix: Kraken E.ON email/password auth fails with 'No access token'

### DIFF
--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -130,8 +130,12 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
         if export_account_id or export_mpan:
             self.log(f"Kraken: Export account configured — {export_account_id or 'same account'} MPAN {export_mpan or 'auto'}")
 
-        # Init auth — OAuthMixin or KrakenAuthMixin depending on import
-        if hasattr(self, "_init_oauth") and hasattr(_AUTH_BASE, "_init_oauth") and not hasattr(_AUTH_BASE, "_init_kraken_auth"):
+        # Init auth — prefer KrakenAuthMixin for local email/password or API key auth,
+        # use OAuthMixin only for SaaS OAuth mode (where tokens come from edge functions).
+        use_local_auth = auth_method in ("email", "api_key") and hasattr(self, "_init_kraken_auth")
+        if use_local_auth:
+            self._init_kraken_auth(auth_method, key=key, email=email, password=password)
+        elif hasattr(self, "_init_oauth"):
             self._init_oauth(auth_method, key, token_expires_at, "kraken")
             self.token_hash = token_hash or ""
         elif hasattr(self, "_init_kraken_auth"):


### PR DESCRIPTION
## Summary

Fixes #3681 — E.ON users with email/password auth get "Warn: Kraken: No access token for find-tariffs" and the component fails to start.

## Root cause

Both `oauth_mixin.py` and `kraken_auth_mixin.py` ship in the release. The auth init logic at `kraken.py:134` unconditionally preferred OAuthMixin when it was importable. But OAuthMixin has no email/password support — it sets `access_token = None` and `check_and_refresh_oauth_token()` returns `True` without obtaining a token (line 79: `if self.auth_method != "oauth": return True`).

The user's token is never obtained, so every GraphQL call hits "No access token".

## Fix

Prefer `KrakenAuthMixin` when `auth_method` is `"email"` or `"api_key"`, falling back to `OAuthMixin` only for SaaS OAuth mode. This is a 4-line change in the init logic.

## Test plan

- All `kraken_auth` and `kraken` tests pass
- `run_all --test kraken_auth --test kraken` — 28/28 OK