### PR TITLE
fix: handle null start/end times in basic_rates

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1545,10 +1545,10 @@ class Fetch:
         midnight = time_string_to_stamp("00:00:00")
         for this_rate in info + manual_items:
             if this_rate and isinstance(this_rate, dict):
-                start_str = this_rate.get("start", "00:00:00")
-                start_str = self.resolve_arg("start", start_str, "00:00:00")
-                end_str = this_rate.get("end", "00:00:00")
-                end_str = self.resolve_arg("end", end_str, "00:00:00")
+                start_str = this_rate.get("start") or "00:00:00"
+                start_str = self.resolve_arg("start", start_str, "00:00:00") or "00:00:00"
+                end_str = this_rate.get("end") or "00:00:00"
+                end_str = self.resolve_arg("end", end_str, "00:00:00") or "00:00:00"
                 load_scaling = this_rate.get("load_scaling", None)
 
                 if start_str.count(":") < 2:


### PR DESCRIPTION
## Summary
- `dict.get("start", "00:00:00")` returns `None` when the key exists with an explicit `null` value — the default only applies when the key is missing entirely
- Use `or "00:00:00"` to fall back for both missing and null start/end times in rate entries
- Also guards the return value of `resolve_arg()` which can return `None` in edge cases

## Context
Customer on `manual_v2` energy provider with a flat export rate — the tariff wizard saved `"start": null, "end": null` for the flat rate entry, causing:
```
AttributeError: 'NoneType' object has no attribute 'count'
  File "/addon/fetch.py", line 1554, in basic_rates
    if start_str.count(":") < 2:
```

## Test plan
- [ ] Existing `basic_rates` tests still pass
- [ ] Flat rate with null start/end no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)