### PR TITLE
feat: Marginal energy cost matrix — heatmap chart + HA sensors

### DIFF
--- a/apps/predbat/marginal.py
+++ b/apps/predbat/marginal.py
@@ -41,7 +41,7 @@ class Marginal:
 
         Runs an internal baseline prediction (save=None, so standing charges are
         excluded) against the current best plan, then runs N what-if simulations
-        (5 extra-kWh levels x 6 time windows) with the same save=None conditions.
+        with the same save=None conditions.
         Taking the delta against the internal baseline ensures both sides are
         computed consistently without the standing-charge offset that is only
         added when save='best'/'base'.
@@ -80,18 +80,16 @@ class Marginal:
 
                 # Deep-copy both load forecasts to avoid mutating shared data
                 modified_load = copy.deepcopy(self.load_minutes_step)
-                modified_load10 = copy.deepcopy(self.load_minutes_step10)
 
                 # Inject extra load into the 1-hour window starting at `offset` minutes from now
                 for minute in range(offset, offset + 60, PREDICT_STEP):
                     if minute in modified_load:
                         modified_load[minute] += extra_per_step
-                    if minute in modified_load10:
-                        modified_load10[minute] += extra_per_step
 
                 # Create a fresh Prediction with the modified load; this updates PRED_GLOBAL
                 # which is safe since we run synchronously (pool is idle at this point)
-                pred = Prediction(self, self.pv_forecast_minute_step, self.pv_forecast_minute10_step, modified_load, modified_load10)
+                # No need to include 10% extra load as we only run normal simulations.
+                pred = Prediction(self, self.pv_forecast_minute_step, self.pv_forecast_minute_step, modified_load, modified_load)
 
                 # Run prediction against the current best charge/discharge plan, no save to HA
                 (new_metric, *_) = pred.run_prediction(
@@ -128,7 +126,7 @@ class Marginal:
         """Publish the marginal energy cost matrix as a Home Assistant sensor.
 
         The sensor state is the 1kWh/now cell (most immediate scenario).
-        The full 5x5 matrix is stored in the 'matrix' attribute.
+        The full matrix is stored in the 'matrix' attribute.
         """
         if not getattr(self, "marginal_costs_matrix", None):
             return
@@ -148,6 +146,7 @@ class Marginal:
             "grid_export": getattr(self, "marginal_grid_export", {}),
             "grid_import_now": dp2(self.rate_import.get(self.minutes_now, 0)),
             "grid_export_now": dp2(self.rate_export.get(self.minutes_now, 0)),
+            "timestamp": self.now_utc.isoformat(),
         }
 
         min_import_cost = self.rate_min

--- a/apps/predbat/marginal.py
+++ b/apps/predbat/marginal.py
@@ -1,0 +1,181 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+
+"""Marginal energy cost calculation.
+
+Computes a matrix of marginal energy costs by running what-if predictions
+with extra load injected into different upcoming time windows.
+The matrix covers extra-kWh levels across multiple time windows.
+"""
+
+import copy
+from datetime import timedelta
+from const import PREDICT_STEP
+from prediction import Prediction
+from utils import dp2
+
+MARGINAL_EXTRA_KWH_LEVELS = [1, 2, 4, 8]
+MARGINAL_EXTRA_KWH_LEVEL_NAMES = ["low", "med", "high", "ev"]  # Example labels for the extra load levels
+MARGINAL_TIME_OFFSETS = [0, 2 * 60, 4 * 60, 6 * 60, 8 * 60, 10 * 60, 12 * 60]
+
+
+class Marginal:
+    """Marginal energy cost calculation mixin.
+
+    Runs what-if scenarios to compute the marginal cost (p/kWh) of consuming
+    extra electricity across different upcoming time windows, using the current
+    best charge/discharge plan. Results are stored in a matrix and published
+    to a Home Assistant sensor.
+    """
+
+    def calculate_marginal_costs(self):
+        """Calculate the marginal energy cost matrix.
+
+        Runs an internal baseline prediction (save=None, so standing charges are
+        excluded) against the current best plan, then runs N what-if simulations
+        (5 extra-kWh levels x 6 time windows) with the same save=None conditions.
+        Taking the delta against the internal baseline ensures both sides are
+        computed consistently without the standing-charge offset that is only
+        added when save='best'/'base'.
+
+        Results are stored in:
+          self.marginal_costs_matrix  - nested dict {kWh_label: {time_label: cost}}
+          self.marginal_costs_min     - minimum value across all cells
+          self.marginal_costs_max     - maximum value across all cells
+          self.marginal_baseline_metric - baseline metric used for delta calculations
+        """
+        # Run a baseline prediction with the original (unmodified) load and save=None
+        # so standing charges are NOT included — matching the what-if simulations exactly.
+        (baseline_metric, *_) = self.prediction.run_prediction(
+            self.charge_limit_best,
+            self.charge_window_best,
+            self.export_window_best,
+            self.export_limits_best,
+            False,
+            self.end_record,
+        )
+        self.marginal_baseline_metric = baseline_metric
+        self.log("Marginal costs baseline metric (no standing charge): {}".format(baseline_metric))
+        # Compute actual wall-clock HH:MM labels for each time offset
+        time_labels = [(self.now_utc + timedelta(minutes=offset)).strftime("%H:%M") for offset in MARGINAL_TIME_OFFSETS]
+        self.marginal_time_labels = time_labels
+        matrix = {}
+        all_costs = []
+
+        for extra_kwh in MARGINAL_EXTRA_KWH_LEVELS:
+            matrix[extra_kwh] = {}
+            # Convert kWh/hour extra load to kWh per 5-minute step
+            extra_per_step = extra_kwh * PREDICT_STEP / 60.0
+
+            for idx, offset in enumerate(MARGINAL_TIME_OFFSETS):
+                time_label = time_labels[idx]
+
+                # Deep-copy both load forecasts to avoid mutating shared data
+                modified_load = copy.deepcopy(self.load_minutes_step)
+                modified_load10 = copy.deepcopy(self.load_minutes_step10)
+
+                # Inject extra load into the 1-hour window starting at `offset` minutes from now
+                for minute in range(offset, offset + 60, PREDICT_STEP):
+                    if minute in modified_load:
+                        modified_load[minute] += extra_per_step
+                    if minute in modified_load10:
+                        modified_load10[minute] += extra_per_step
+
+                # Create a fresh Prediction with the modified load; this updates PRED_GLOBAL
+                # which is safe since we run synchronously (pool is idle at this point)
+                pred = Prediction(self, self.pv_forecast_minute_step, self.pv_forecast_minute10_step, modified_load, modified_load10)
+
+                # Run prediction against the current best charge/discharge plan, no save to HA
+                (new_metric, *_) = pred.run_prediction(
+                    self.charge_limit_best,
+                    self.charge_window_best,
+                    self.export_window_best,
+                    self.export_limits_best,
+                    False,
+                    self.end_record,
+                )
+
+                # Marginal cost in currency units per kWh = delta metric / extra kWh
+                marginal_cost = dp2((new_metric - baseline_metric) / extra_kwh)
+                matrix[extra_kwh][time_label] = marginal_cost
+                all_costs.append(marginal_cost)
+
+        self.marginal_costs_matrix = matrix
+        self.marginal_costs_min = min(all_costs) if all_costs else 0.0
+        self.marginal_costs_max = max(all_costs) if all_costs else 0.0
+        self.log("Marginal energy costs matrix computed: min={} max={}".format(self.marginal_costs_min, self.marginal_costs_max))
+
+        # Record actual grid import/export rate at each time window
+        grid_import = {}
+        grid_export = {}
+        for idx, offset in enumerate(MARGINAL_TIME_OFFSETS):
+            minute = self.minutes_now + offset
+            grid_import[time_labels[idx]] = dp2(self.rate_import.get(minute, 0))
+            grid_export[time_labels[idx]] = dp2(self.rate_export.get(minute, 0))
+        self.marginal_grid_import = grid_import
+        self.marginal_grid_export = grid_export
+        self.publish_marginal_costs()
+
+    def publish_marginal_costs(self):
+        """Publish the marginal energy cost matrix as a Home Assistant sensor.
+
+        The sensor state is the 1kWh/now cell (most immediate scenario).
+        The full 5x5 matrix is stored in the 'matrix' attribute.
+        """
+        if not getattr(self, "marginal_costs_matrix", None):
+            return
+
+        # State = most immediate cell: 1 extra kWh at the first (current) time window
+        first_time_label = getattr(self, "marginal_time_labels", [""])[0]
+        state_value = self.marginal_costs_matrix.get(1, {}).get(first_time_label, 0)
+
+        attributes = {
+            "friendly_name": "Marginal Energy Costs",
+            "icon": "mdi:cash-plus",
+            "state_class": "measurement",
+            "unit_of_measurement": self.currency_symbols[1],
+            "matrix": self.marginal_costs_matrix,
+            "baseline_metric": dp2(getattr(self, "marginal_baseline_metric", 0)),
+            "grid_import": getattr(self, "marginal_grid_import", {}),
+            "grid_export": getattr(self, "marginal_grid_export", {}),
+            "grid_import_now": dp2(self.rate_import.get(self.minutes_now, 0)),
+            "grid_export_now": dp2(self.rate_export.get(self.minutes_now, 0)),
+        }
+
+        min_import_cost = self.rate_min
+        max_import_cost = self.rate_max
+
+        cheap_threshold = min_import_cost * 1.2  # Example threshold for "cheap" energy
+        moderate_threshold = max(max_import_cost * 0.5, min_import_cost * 1.5)  # "Moderate" if above cheap but below half of max
+
+        for state_name in MARGINAL_EXTRA_KWH_LEVEL_NAMES:
+            state_value = self.marginal_costs_matrix.get(MARGINAL_EXTRA_KWH_LEVELS[MARGINAL_EXTRA_KWH_LEVEL_NAMES.index(state_name)], {}).get(first_time_label, 0)
+            is_cheap = state_value <= cheap_threshold
+            is_moderate = not is_cheap and state_value <= moderate_threshold
+            attributes["rate_now_{}_consumption".format(state_name)] = state_value
+
+            self.dashboard_item(
+                "binary_sensor.{}_marginal_rate_now_{}_is_cheap".format(self.prefix, state_name),
+                state="on" if is_cheap else "off",
+                attributes={"cost": state_value, "icon": "mdi:cash-check", "friendly_name": "{} consumption now is cheap".format(state_name.capitalize())},
+            )
+            self.dashboard_item(
+                "binary_sensor.{}_marginal_rate_now_{}_is_moderate".format(self.prefix, state_name),
+                state="on" if is_moderate else "off",
+                attributes={"cost": state_value, "icon": "mdi:cash-alert", "friendly_name": "{} consumption now is moderate".format(state_name.capitalize())},
+            )
+
+        state_value = self.marginal_costs_matrix.get(1, {}).get(first_time_label, 0)
+        self.dashboard_item(
+            "sensor." + self.prefix + "_marginal_energy_costs",
+            state=dp2(state_value),
+            attributes=attributes,
+        )

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -1220,6 +1220,9 @@ class Plan:
                 self.publish_charge_limit(self.charge_limit_best, self.charge_window_best, best=True, soc=self.predict_soc_best)
                 self.publish_export_limit(self.export_window_best, self.export_limits_best, best=True)
 
+                # Compute marginal energy cost matrix (what-if extra load scenarios)
+                self.calculate_marginal_costs()
+
                 # HTML data
                 text = self.short_textual_plan(soc_min, soc_min_minute, pv_forecast_minute_step, pv_forecast_minute10_step, load_minutes_step, load_minutes_step10, self.end_record)
                 text_lines = text.split("\n")

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -36,7 +36,7 @@ import pytz
 import requests
 import asyncio
 
-THIS_VERSION = "v8.35.7"
+THIS_VERSION = "v8.36.0"
 
 from download import predbat_update_move, predbat_update_download, check_install, resolve_predbat_repository, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT
@@ -76,6 +76,7 @@ from octopus import Octopus
 from energydataservice import Energidataservice
 from components import Components
 from execute import Execute
+from marginal import Marginal
 from plan import Plan
 from fetch import Fetch
 from output import Output
@@ -84,7 +85,7 @@ from compare import Compare
 from plugin_system import PluginSystem
 
 
-class PredBat(hass.Hass, Octopus, Energidataservice, Fetch, Plan, Execute, Output, UserInterface):
+class PredBat(hass.Hass, Octopus, Energidataservice, Fetch, Plan, Marginal, Execute, Output, UserInterface):
     """Main PredBat orchestrator combining all subsystems via multiple inheritance.
 
     Inherits from Hass (HA interface), Octopus (rate loading), Energidataservice,

--- a/apps/predbat/tests/test_marginal_costs.py
+++ b/apps/predbat/tests/test_marginal_costs.py
@@ -1,0 +1,169 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+
+from tests.test_infra import reset_rates, reset_inverter
+from prediction import Prediction
+from marginal import MARGINAL_EXTRA_KWH_LEVELS, MARGINAL_EXTRA_KWH_LEVEL_NAMES
+
+
+def test_marginal_costs(my_predbat):
+    """
+    Test the marginal energy cost matrix calculation.
+
+    Verifies that calculate_marginal_costs() produces a correctly structured 4x4 matrix,
+    all values are numeric, and min/max bounds are sane.
+    """
+    failed = False
+
+    print("*** Running test: marginal_costs basic structure")
+
+    my_predbat.load_user_config()
+    my_predbat.fetch_config_options()
+    reset_inverter(my_predbat)
+    my_predbat.forecast_minutes = 24 * 60
+
+    # Build flat pv and load step dicts (relative-minute keys, 5-min steps)
+    pv_step = {}
+    load_step = {}
+    for minute in range(0, my_predbat.forecast_minutes + my_predbat.plan_interval_minutes, 5):
+        pv_step[minute] = 0.0
+        load_step[minute] = 0.2  # 0.2 kWh per 5-min step ~ 2.4 kW
+
+    my_predbat.load_minutes_step = load_step
+    my_predbat.load_minutes_step10 = load_step
+    my_predbat.pv_forecast_minute_step = pv_step
+    my_predbat.pv_forecast_minute10_step = pv_step
+    my_predbat.prediction = Prediction(my_predbat, pv_step, pv_step, load_step, load_step)
+
+    # Simple flat import rate, no export
+    reset_rates(my_predbat, 20.0, 5.0)
+
+    # Empty charge/export plan (no windows)
+    my_predbat.charge_limit_best = []
+    my_predbat.charge_window_best = []
+    my_predbat.export_window_best = []
+    my_predbat.export_limits_best = []
+    my_predbat.end_record = 24 * 60
+
+    # Run the marginal cost calculation (internal baseline run, no external metric needed)
+    my_predbat.calculate_marginal_costs()
+
+    # --- Validate marginal_costs_matrix structure ---
+    if not hasattr(my_predbat, "marginal_costs_matrix") or not my_predbat.marginal_costs_matrix:
+        print("ERROR: marginal_costs_matrix not set after calculate_marginal_costs()")
+        return True
+
+    matrix = my_predbat.marginal_costs_matrix
+    expected_kwh_keys = list(MARGINAL_EXTRA_KWH_LEVELS)
+    expected_time_keys = getattr(my_predbat, "marginal_time_labels", [])
+
+    for kwh_key in expected_kwh_keys:
+        if kwh_key not in matrix:
+            print("ERROR: missing row key '{}' in matrix".format(kwh_key))
+            failed = True
+            continue
+        for time_key in expected_time_keys:
+            if time_key not in matrix[kwh_key]:
+                print("ERROR: missing time key '{}' in matrix['{}']".format(time_key, kwh_key))
+                failed = True
+                continue
+            val = matrix[kwh_key][time_key]
+            if not isinstance(val, (int, float)):
+                print("ERROR: matrix['{}']['{}'] = {} is not numeric".format(kwh_key, time_key, val))
+                failed = True
+
+    # --- Validate min/max bounds ---
+    if not hasattr(my_predbat, "marginal_costs_min") or not hasattr(my_predbat, "marginal_costs_max"):
+        print("ERROR: marginal_costs_min / marginal_costs_max not set")
+        return True
+
+    if my_predbat.marginal_costs_min > my_predbat.marginal_costs_max:
+        print("ERROR: marginal_costs_min {} > marginal_costs_max {}".format(my_predbat.marginal_costs_min, my_predbat.marginal_costs_max))
+        failed = True
+
+    print("matrix = {}".format(matrix))
+    print("min={} max={}".format(my_predbat.marginal_costs_min, my_predbat.marginal_costs_max))
+
+    # --- Validate sensor was published ---
+    sensor_key = "sensor." + my_predbat.prefix + "_marginal_energy_costs"
+    if sensor_key not in my_predbat.dashboard_values:
+        print("ERROR: sensor '{}' not found in dashboard_values".format(sensor_key))
+        failed = True
+    else:
+        state = my_predbat.dashboard_values[sensor_key].get("state")
+        try:
+            float(state)
+        except (TypeError, ValueError):
+            print("ERROR: sensor state '{}' is not a valid number".format(state))
+            failed = True
+        attrs = my_predbat.dashboard_values[sensor_key].get("attributes", {})
+        if "baseline_metric" not in attrs:
+            print("ERROR: sensor missing 'baseline_metric' attribute")
+            failed = True
+        else:
+            try:
+                float(attrs["baseline_metric"])
+            except (TypeError, ValueError):
+                print("ERROR: baseline_metric '{}' is not numeric".format(attrs["baseline_metric"]))
+                failed = True
+
+        # --- Validate new attributes ---
+        for attr in ("grid_import", "grid_export"):
+            if attr not in attrs:
+                print("ERROR: sensor missing '{}' attribute".format(attr))
+                failed = True
+            elif not isinstance(attrs[attr], dict):
+                print("ERROR: sensor '{}' is not a dict".format(attr))
+                failed = True
+        for attr in ("grid_import_now", "grid_export_now"):
+            if attr not in attrs:
+                print("ERROR: sensor missing '{}' attribute".format(attr))
+                failed = True
+            else:
+                try:
+                    float(attrs[attr])
+                except (TypeError, ValueError):
+                    print("ERROR: sensor '{}' = '{}' is not numeric".format(attr, attrs[attr]))
+                    failed = True
+        for state_name in MARGINAL_EXTRA_KWH_LEVEL_NAMES:
+            attr = "rate_now_{}_consumption".format(state_name)
+            if attr not in attrs:
+                print("ERROR: sensor missing '{}' attribute".format(attr))
+                failed = True
+            else:
+                try:
+                    float(attrs[attr])
+                except (TypeError, ValueError):
+                    print("ERROR: '{}' = '{}' is not numeric".format(attr, attrs[attr]))
+                    failed = True
+
+    # --- Validate binary sensors ---
+    for state_name in MARGINAL_EXTRA_KWH_LEVEL_NAMES:
+        for kind in ("cheap", "moderate"):
+            bs_key = "binary_sensor.{}_marginal_rate_now_{}_is_{}".format(my_predbat.prefix, state_name, kind)
+            if bs_key not in my_predbat.dashboard_values:
+                print("ERROR: binary sensor '{}' not found".format(bs_key))
+                failed = True
+            else:
+                bs_state = my_predbat.dashboard_values[bs_key].get("state")
+                if bs_state not in ("on", "off"):
+                    print("ERROR: binary sensor '{}' state '{}' is not on/off".format(bs_key, bs_state))
+                    failed = True
+                bs_attrs = my_predbat.dashboard_values[bs_key].get("attributes", {})
+                if "cost" not in bs_attrs:
+                    print("ERROR: binary sensor '{}' missing 'cost' attribute".format(bs_key))
+                    failed = True
+
+    if not failed:
+        print("*** test_marginal_costs PASSED ***")
+    else:
+        print("*** test_marginal_costs FAILED ***")
+    return failed

--- a/apps/predbat/tests/test_marginal_costs.py
+++ b/apps/predbat/tests/test_marginal_costs.py
@@ -18,7 +18,8 @@ def test_marginal_costs(my_predbat):
     """
     Test the marginal energy cost matrix calculation.
 
-    Verifies that calculate_marginal_costs() produces a correctly structured 4x4 matrix,
+    Verifies that calculate_marginal_costs() produces a correctly structured 4×7 matrix
+    (4 load levels: low/med/high/ev × 7 time windows: now through +12 h in 2-hour steps),
     all values are numeric, and min/max bounds are sane.
     """
     failed = False

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -112,6 +112,7 @@ from tests.test_clip_export_slots import run_clip_export_slots_tests
 from tests.test_clip_charge_slots import run_clip_charge_slots_tests
 from tests.test_discard_unused_charge_slots import run_discard_unused_charge_slots_tests
 from tests.test_discard_unused_export_slots import run_discard_unused_export_slots_tests
+from tests.test_marginal_costs import test_marginal_costs
 
 
 # Mock the components and plugin system
@@ -283,6 +284,7 @@ def main():
         ("discard_unused_charge_slots", run_discard_unused_charge_slots_tests, "Discard unused charge slots tests", False),
         ("discard_unused_export_slots", run_discard_unused_export_slots_tests, "Discard unused export slots tests", False),
         ("optimise_levels", run_optimise_levels_tests, "Optimise levels tests", False),
+        ("marginal_costs", test_marginal_costs, "Marginal energy cost matrix tests", False),
         ("gateway", run_gateway_tests, "GatewayMQTT component tests (protobuf, plan serialization, commands, telemetry)", False),
         ("optimise_windows", run_optimise_all_windows_tests, "Optimise all windows tests", True),
         ("debug_cases", run_debug_cases, "Debug case file tests", True),

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -76,6 +76,7 @@ from component_base import ComponentBase
 from config import APPS_SCHEMA
 from web_metrics_dashboard import get_metrics_dashboard_css, get_metrics_dashboard_body
 from predbat_metrics import metrics_handler, metrics_json_handler, metrics, PROMETHEUS_AVAILABLE
+from marginal import MARGINAL_EXTRA_KWH_LEVEL_NAMES, MARGINAL_EXTRA_KWH_LEVELS
 
 ROOT_YAML_KEY = "pred_bat"
 
@@ -1493,6 +1494,74 @@ var options = {
         text += "</script>\n"
         return text
 
+    def render_heatmap_chart(self, series_data, title, range_min, range_max, chart_id="chart", fixed_height=None):
+        """
+        Render a rounded heatmap chart using ApexCharts.
+
+        series_data is a list of dicts: [{"name": str, "data": [{"x": str, "y": float}, ...]}, ...]
+        range_min and range_max define the full colour scale (green -> red).
+        chart_id is the DOM element id to render into.
+        fixed_height overrides the responsive height calculation when set.
+        """
+        # Build a 5-stop green-to-red colour gradient across the value range
+        span = max(range_max - range_min, 0.01)
+        gradient_colors = ["#00B050", "#85C21A", "#FFFF00", "#FFA500", "#FF0000"]
+        num_stops = len(gradient_colors)
+        ranges_js = ""
+        for i, color in enumerate(gradient_colors):
+            from_val = round(range_min + span * i / num_stops, 4)
+            to_val = round(range_min + span * (i + 1) / num_stops, 4)
+            if i == num_stops - 1:
+                to_val = round(range_max + 0.01, 4)
+            name_str = "{:.1f}-{:.1f}".format(from_val, to_val)
+            ranges_js += "            {{ from: {}, to: {}, color: '{}', name: '{}' }},\n".format(from_val, to_val, color, name_str)
+
+        # Build series JSON inline
+        series_js = ""
+        for series in series_data:
+            name = series.get("name", "")
+            data_points = series.get("data", [])
+            points_js = ", ".join("{{ x: '{}', y: {} }}".format(p["x"], "null" if p["y"] is None else p["y"]) for p in data_points)
+            series_js += "    {{ name: '{}', data: [{}] }},\n".format(name, points_js)
+
+        text = ""
+        text += "<script>\n"
+        text += "window.onresize = function(){ location.reload(); };\n"
+        text += "var width = window.innerWidth;\n"
+        text += "var height = window.innerHeight;\n"
+        text += "if (width < 400) { width = 400; }\n"
+        text += "width = width - 50;\n"
+        if fixed_height is not None:
+            text += "var height_{} = {};\n".format(chart_id, fixed_height)
+        else:
+            num_rows = max(len(series_data), 1)
+            text += "var height_{} = {};\n".format(chart_id, num_rows * 80 + 80)
+        text += "var options = {\n"
+        text += "  chart: {{ type: 'heatmap', width: width, height: height_{}, animations: {{ enabled: false }} }},\n".format(chart_id)
+        text += "  plotOptions: {\n"
+        text += "    heatmap: {\n"
+        text += "      radius: 2,\n"
+        text += "      enableShades: false,\n"
+        text += "      colorScale: {\n"
+        text += "        ranges: [\n"
+        text += ranges_js
+        text += "        ]\n"
+        text += "      }\n"
+        text += "    }\n"
+        text += "  },\n"
+        text += "  dataLabels: { enabled: true, style: { colors: ['#000'] } },\n"
+        text += "  series: [\n"
+        text += series_js
+        text += "  ],\n"
+        text += "  xaxis: { type: 'category' },\n"
+        text += "  title: {{ text: '{}' }},\n".format(title)
+        text += "  tooltip: { y: { formatter: function(val) { return val !== null ? val.toFixed(2) : 'N/A'; } } }\n"
+        text += "};\n"
+        text += "var chart_{cid} = new ApexCharts(document.querySelector('#{cid}'), options);\n".format(cid=chart_id)
+        text += "chart_{}.render();\n".format(chart_id)
+        text += "</script>\n"
+        return text
+
     def render_timeline_chart(self, timeline_data, tagname, days):
         """
         Render a timeline chart for non-numerical data (like on/off states)
@@ -2676,6 +2745,60 @@ chart.render();
             ]
 
             text += self.render_chart(series_data, f"Daily Savings ({self.currency_symbols[0]})", "Cost Savings Analysis", now_str, daily_chart=False, extra_yaxis=secondary_axis)
+        elif chart == "MarginalCosts":
+            sensor_attrs = self.base.dashboard_values.get('sensor.' + self.prefix + "_marginal_energy_costs", {}).get("attributes", {})
+            matrix = sensor_attrs.get("matrix", {})
+            energy_labels = list(matrix.keys())
+            time_labels = list(next(iter(matrix.values()), {}).keys())
+            if not matrix:
+                text += "<br><h2>Marginal cost data not yet available &mdash; run a plan first</h2>"
+            else:
+                grid_import = sensor_attrs.get("grid_import", {})
+                grid_export = sensor_attrs.get("grid_export", {})
+                all_grid_vals = list(grid_import.values()) + list(grid_export.values())
+                range_min = min(getattr(self.base, "rate_min", 0), getattr(self.base, "marginal_costs_min", 0), min(all_grid_vals) if all_grid_vals else 0)
+                range_max = max(getattr(self.base, "rate_max", 100), getattr(self.base, "marginal_costs_max", 100), max(all_grid_vals) if all_grid_vals else 0)
+                # Status table — cheap/moderate for each level
+                curr = self.currency_symbols[1]
+                text += "<br><h2>Marginal Energy Costs</h2>\n"
+                text += "<p>Marginal costs for each additional kWh of load, based on current plan. Shows how much more expensive (or cheaper) it is to use more energy right now.</p>\n"
+                text += "<table style='border-collapse:collapse;margin-bottom:16px;font-size:0.95em;'>\n"
+                text += "<tr><th style='padding:6px 12px;border:1px solid #555;text-align:left;'>Level</th>"
+                text += "<th style='padding:6px 12px;border:1px solid #555;'>kWh</th>"
+                text += "<th style='padding:6px 12px;border:1px solid #555;'>Cost now ({}/kWh)</th>".format(curr)
+                text += "<th style='padding:6px 12px;border:1px solid #555;'>Cheap?</th>"
+                text += "<th style='padding:6px 12px;border:1px solid #555;'>Moderate?</th></tr>\n"
+                for state_name, kwh in zip(MARGINAL_EXTRA_KWH_LEVEL_NAMES, MARGINAL_EXTRA_KWH_LEVELS):
+                    cost = sensor_attrs.get("rate_now_{}_consumption".format(state_name), "")
+                    cheap_key = "binary_sensor.{}_marginal_rate_now_{}_is_cheap".format(self.prefix, state_name)
+                    mod_key = "binary_sensor.{}_marginal_rate_now_{}_is_moderate".format(self.prefix, state_name)
+                    is_cheap = self.base.dashboard_values.get(cheap_key, {}).get("state") == "on"
+                    is_moderate = self.base.dashboard_values.get(mod_key, {}).get("state") == "on"
+                    cheap_cell = "<td style='padding:6px 12px;border:1px solid #555;text-align:center;background:#00B050;color:#fff;'>Yes</td>" if is_cheap else "<td style='padding:6px 12px;border:1px solid #555;text-align:center;'>No</td>"
+                    mod_cell = "<td style='padding:6px 12px;border:1px solid #555;text-align:center;background:#FFFF00;color:#333;'>Yes</td>" if is_moderate else "<td style='padding:6px 12px;border:1px solid #555;text-align:center;'>No</td>"
+                    text += "<tr><td style='padding:6px 12px;border:1px solid #555;'>{}</td>".format(state_name.capitalize())
+                    text += "<td style='padding:6px 12px;border:1px solid #555;text-align:center;'>{}</td>".format(kwh)
+                    text += "<td style='padding:6px 12px;border:1px solid #555;text-align:center;'>{}</td>".format(cost)
+                    text += cheap_cell + mod_cell + "</tr>\n"
+                text += "</table>\n"
+                # Grid rates chart (compact, separate div)
+                if grid_import or grid_export:
+                    grid_series = []
+                    if grid_export:
+                        grid_series.append({"name": "Export", "data": [{"x": t, "y": grid_export.get(t, 0)} for t in time_labels]})
+                    if grid_import:
+                        grid_series.append({"name": "Import", "data": [{"x": t, "y": grid_import.get(t, 0)} for t in time_labels]})
+                    text += "<div id='chart_grid'></div>\n"
+                    text += self.render_heatmap_chart(grid_series, "Grid Rates ({}/kWh)".format(self.currency_symbols[1]), range_min, range_max, chart_id="chart_grid")
+                # Marginal costs chart
+                title = "Marginal Energy Cost ({}/kWh)".format(self.currency_symbols[1])
+                marginal_series = []
+                for label in energy_labels:
+                    row = matrix.get(label, {})
+                    data_points = [{"x": t, "y": row.get(t, 0)} for t in time_labels]
+                    marginal_series.append({"name": "{}kWh".format(label), "data": data_points})
+                text += "<div id='chart'></div>\n"
+                text += self.render_heatmap_chart(marginal_series, title, range_min, range_max, chart_id="chart")
         else:
             text += "<br><h2>Unknown chart type</h2>"
 
@@ -2702,13 +2825,15 @@ chart.render();
         text += f'<a href="./charts?chart=PV" class="{"active" if chart == "PV" else ""}">PV</a>'
         text += f'<a href="./charts?chart=PV7" class="{"active" if chart == "PV7" else ""}">PV7</a>'
         text += f'<a href="./charts?chart=Savings" class="{"active" if chart == "Savings" else ""}">Savings</a>'
+        text += f'<a href="./charts?chart=MarginalCosts" class="{"active" if chart == "MarginalCosts" else ""}">MarginalCosts</a>'
         # Only show LoadML chart if ML is enabled
         if self.base.get_arg("load_ml_enable", False):
             text += f'<a href="./charts?chart=LoadML" class="{"active" if chart == "LoadML" else ""}">LoadML</a>'
             text += f'<a href="./charts?chart=LoadMLPower" class="{"active" if chart == "LoadMLPower" else ""}">LoadMLPower</a>'
         text += "</div>"
 
-        text += '<div id="chart"></div>'
+        if chart != "MarginalCosts":
+            text += '<div id="chart"></div>'
         text += self.get_chart(chart=chart)
         text += "</body></html>\n"
         return web.Response(content_type="text/html", text=text)

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -76,7 +76,7 @@ from component_base import ComponentBase
 from config import APPS_SCHEMA
 from web_metrics_dashboard import get_metrics_dashboard_css, get_metrics_dashboard_body
 from predbat_metrics import metrics_handler, metrics_json_handler, metrics, PROMETHEUS_AVAILABLE
-from marginal import MARGINAL_EXTRA_KWH_LEVEL_NAMES, MARGINAL_EXTRA_KWH_LEVELS
+from marginal import MARGINAL_EXTRA_KWH_LEVEL_NAMES, MARGINAL_EXTRA_KWH_LEVELS, MARGINAL_TIME_OFFSETS
 
 ROOT_YAML_KEY = "pred_bat"
 
@@ -2761,7 +2761,7 @@ chart.render();
                 # Status table — cheap/moderate for each level
                 curr = self.currency_symbols[1]
                 text += "<br><h2>Marginal Energy Costs</h2>\n"
-                text += "<p>Marginal costs for each additional kWh of load, based on current plan. Shows how much more expensive (or cheaper) it is to use more energy right now.</p>\n"
+                text += "<p>Marginal costs for each additional kWh of load, based on current plan. Shows how much more expensive (or cheaper) it is to use more energy than forecasted.</p>\n"
                 text += "<table style='border-collapse:collapse;margin-bottom:16px;font-size:0.95em;'>\n"
                 text += "<tr><th style='padding:6px 12px;border:1px solid #555;text-align:left;'>Level</th>"
                 text += "<th style='padding:6px 12px;border:1px solid #555;'>kWh</th>"
@@ -2799,6 +2799,47 @@ chart.render();
                     marginal_series.append({"name": "{}kWh".format(label), "data": data_points})
                 text += "<div id='chart'></div>\n"
                 text += self.render_heatmap_chart(marginal_series, title, range_min, range_max, chart_id="chart")
+                # Historical + forecast line chart
+                marginal_hist = self.get_history_with_now_attrs("sensor." + self.prefix + "_marginal_energy_costs", 7)
+
+                def _mhist(key):
+                    return prune_today(history_attribute(marginal_hist, attributes=True, state_key=key), self.now_utc, self.midnight_utc, prune=False, prune_past_days=7, prune_future=True)
+
+                hist_low = _mhist("rate_now_low_consumption")
+                hist_med = _mhist("rate_now_med_consumption")
+                hist_high = _mhist("rate_now_high_consumption")
+                hist_ev = _mhist("rate_now_ev_consumption")
+                hist_import = _mhist("grid_import_now")
+                hist_export = _mhist("grid_export_now")
+
+                # Build forward-looking series from matrix — use actual datetime from offset, not just HH:MM
+                fwd_low, fwd_med, fwd_high, fwd_ev, fwd_import_fwd, fwd_export_fwd = {}, {}, {}, {}, {}, {}
+                for idx, offset in enumerate(MARGINAL_TIME_OFFSETS):
+                    t_label = time_labels[idx]
+                    ts = (self.now_utc + timedelta(minutes=offset)).isoformat()
+                    fwd_low[ts] = matrix.get(MARGINAL_EXTRA_KWH_LEVELS[0], {}).get(t_label, 0)
+                    fwd_med[ts] = matrix.get(MARGINAL_EXTRA_KWH_LEVELS[1], {}).get(t_label, 0)
+                    fwd_high[ts] = matrix.get(MARGINAL_EXTRA_KWH_LEVELS[2], {}).get(t_label, 0)
+                    fwd_ev[ts] = matrix.get(MARGINAL_EXTRA_KWH_LEVELS[3], {}).get(t_label, 0)
+                    fwd_import_fwd[ts] = grid_import.get(t_label, 0)
+                    fwd_export_fwd[ts] = grid_export.get(t_label, 0)
+
+                line_series = [
+                    {"name": "Low 1kWh", "data": hist_low, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline", "color": "#3291a8"},
+                    {"name": "Low 1kWh (future)", "data": fwd_low, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline", "color": "#3291a8"},
+                    {"name": "Med 2kWh", "data": hist_med, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline", "color": "#f5a442"},
+                    {"name": "Med 2kWh (future)", "data": fwd_med, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline", "color": "#f5a442"},
+                    {"name": "High 4kWh", "data": hist_high, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline", "color": "#eb2323"},
+                    {"name": "High 4kWh (future)", "data": fwd_high, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline", "color": "#eb2323"},
+                    {"name": "EV 8kWh (future)", "data": fwd_ev, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline", "color": "#9b59b6"},
+                    {"name": "EV 8kWh", "data": hist_ev, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline", "color": "#9b59b6"},
+                    {"name": "Import rate", "data": hist_import, "opacity": "1.0", "stroke_width": "4", "stroke_curve": "stepline", "color": "#15eb8b"},
+                    {"name": "Export rate", "data": hist_export, "opacity": "1.0", "stroke_width": "4", "stroke_curve": "stepline", "color": "#15eb1c"},
+                    {"name": "Import rate (future)", "data": fwd_import_fwd, "opacity": "1.0", "stroke_width": "4", "stroke_curve": "stepline", "color": "#15eb8b"},
+                    {"name": "Export rate (future)", "data": fwd_export_fwd, "opacity": "1.0", "stroke_width": "4", "stroke_curve": "stepline", "color": "#15eb1c"},
+                ]
+                text += "<div id='chart_marginal_hist'></div>\n"
+                text += self.render_chart(line_series, curr, "Marginal Energy Rates \u2014 History & Forecast", now_str, tagname="chart_marginal_hist", daily_chart=False)
         else:
             text += "<br><h2>Unknown chart type</h2>"
 

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -2746,7 +2746,7 @@ chart.render();
 
             text += self.render_chart(series_data, f"Daily Savings ({self.currency_symbols[0]})", "Cost Savings Analysis", now_str, daily_chart=False, extra_yaxis=secondary_axis)
         elif chart == "MarginalCosts":
-            sensor_attrs = self.base.dashboard_values.get('sensor.' + self.prefix + "_marginal_energy_costs", {}).get("attributes", {})
+            sensor_attrs = self.base.dashboard_values.get("sensor." + self.prefix + "_marginal_energy_costs", {}).get("attributes", {})
             matrix = sensor_attrs.get("matrix", {})
             energy_labels = list(matrix.keys())
             time_labels = list(next(iter(matrix.values()), {}).keys())

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -2802,15 +2802,15 @@ chart.render();
                 # Historical + forecast line chart
                 marginal_hist = self.get_history_with_now_attrs("sensor." + self.prefix + "_marginal_energy_costs", 7)
 
-                def _mhist(key):
+                def _marginal_history(key):
                     return prune_today(history_attribute(marginal_hist, attributes=True, state_key=key), self.now_utc, self.midnight_utc, prune=False, prune_past_days=7, prune_future=True)
 
-                hist_low = _mhist("rate_now_low_consumption")
-                hist_med = _mhist("rate_now_med_consumption")
-                hist_high = _mhist("rate_now_high_consumption")
-                hist_ev = _mhist("rate_now_ev_consumption")
-                hist_import = _mhist("grid_import_now")
-                hist_export = _mhist("grid_export_now")
+                hist_low = _marginal_history("rate_now_low_consumption")
+                hist_med = _marginal_history("rate_now_med_consumption")
+                hist_high = _marginal_history("rate_now_high_consumption")
+                hist_ev = _marginal_history("rate_now_ev_consumption")
+                hist_import = _marginal_history("grid_import_now")
+                hist_export = _marginal_history("grid_export_now")
 
                 # Build forward-looking series from matrix — use actual datetime from offset, not just HH:MM
                 fwd_low, fwd_med, fwd_high, fwd_ev, fwd_import_fwd, fwd_export_fwd = {}, {}, {}, {}, {}, {}

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -613,16 +613,16 @@ levels and at different times in the upcoming forecast window. The results are p
 
 - **sensor.predbat_marginal_energy_costs** - The primary marginal cost sensor. State is the 1 kWh marginal cost for the current time window.
   Attributes include:
-  - `matrix` - Nested dict `{kWh_level: {HH:MM: cost_p_per_kWh}}` for all simulated load levels and time windows
-  - `grid_import` - Dict of actual grid import rate (p/kWh) at each time window label
-  - `grid_export` - Dict of actual grid export rate (p/kWh) at each time window label
-  - `grid_import_now` - Current grid import rate (p/kWh)
-  - `grid_export_now` - Current grid export rate (p/kWh)
-  - `baseline_metric` - Internal baseline cost used to compute deltas (standing charge excluded)
-  - `rate_now_low_consumption` - Marginal cost now for the 'low' (1 kWh) load level
-  - `rate_now_med_consumption` - Marginal cost now for the 'med' (2 kWh) load level
-  - `rate_now_high_consumption` - Marginal cost now for the 'high' (4 kWh) load level
-  - `rate_now_ev_consumption` - Marginal cost now for the 'ev' (8 kWh) load level
+    - `matrix` - Nested dict `{kWh_level: {HH:MM: cost_p_per_kWh}}` for all simulated load levels and time windows
+    - `grid_import` - Dict of actual grid import rate (p/kWh) at each time window label
+    - `grid_export` - Dict of actual grid export rate (p/kWh) at each time window label
+    - `grid_import_now` - Current grid import rate (p/kWh)
+    - `grid_export_now` - Current grid export rate (p/kWh)
+    - `baseline_metric` - Internal baseline cost used to compute deltas (standing charge excluded)
+    - `rate_now_low_consumption` - Marginal cost now for the 'low' (1 kWh) load level
+    - `rate_now_med_consumption` - Marginal cost now for the 'med' (2 kWh) load level
+    - `rate_now_high_consumption` - Marginal cost now for the 'high' (4 kWh) load level
+    - `rate_now_ev_consumption` - Marginal cost now for the 'ev' (8 kWh) load level
 
 ### Cheap/moderate binary sensors
 

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -604,6 +604,47 @@ This means the SoC shown in the 'Yesterday without Predbat' plan view can differ
 On tariffs such as Intelligent Octopus Go where Predbat charges to a lower target than 100%, the 'without Predbat' simulation may show a higher starting SoC than reality,
 because without Predbat the baseline assumes charging to 100% in the cheapest window each night.
 
+## Marginal energy cost data
+
+After each plan calculation Predbat runs a set of what-if simulations to determine the marginal cost (in pence per kWh) of consuming extra electricity at different
+levels and at different times in the upcoming forecast window. The results are published as a matrix sensor and a set of binary sensors.
+
+### Main matrix sensor
+
+- **sensor.predbat_marginal_energy_costs** - The primary marginal cost sensor. State is the 1 kWh marginal cost for the current time window.
+  Attributes include:
+  - `matrix` - Nested dict `{kWh_level: {HH:MM: cost_p_per_kWh}}` for all simulated load levels and time windows
+  - `grid_import` - Dict of actual grid import rate (p/kWh) at each time window label
+  - `grid_export` - Dict of actual grid export rate (p/kWh) at each time window label
+  - `grid_import_now` - Current grid import rate (p/kWh)
+  - `grid_export_now` - Current grid export rate (p/kWh)
+  - `baseline_metric` - Internal baseline cost used to compute deltas (standing charge excluded)
+  - `rate_now_low_consumption` - Marginal cost now for the 'low' (1 kWh) load level
+  - `rate_now_med_consumption` - Marginal cost now for the 'med' (2 kWh) load level
+  - `rate_now_high_consumption` - Marginal cost now for the 'high' (4 kWh) load level
+  - `rate_now_ev_consumption` - Marginal cost now for the 'ev' (8 kWh) load level
+
+### Cheap/moderate binary sensors
+
+For each load level name (`low`, `med`, `high`, `ev`) Predbat publishes two binary sensors based on whether the current marginal cost is cheap or moderate
+relative to the day's import rate range:
+
+- **binary_sensor.predbat_marginal_rate_now_low_is_cheap** - `on` when the marginal cost for a low (1 kWh) extra load right now is at or below the cheap threshold
+- **binary_sensor.predbat_marginal_rate_now_low_is_moderate** - `on` when the marginal cost is above cheap but within the moderate threshold
+- **binary_sensor.predbat_marginal_rate_now_med_is_cheap** - `on` when the marginal cost for a medium (2 kWh) extra load right now is cheap
+- **binary_sensor.predbat_marginal_rate_now_med_is_moderate** - `on` when it is moderate
+- **binary_sensor.predbat_marginal_rate_now_high_is_cheap** - `on` when the marginal cost for a high (4 kWh) extra load right now is cheap
+- **binary_sensor.predbat_marginal_rate_now_high_is_moderate** - `on` when it is moderate
+- **binary_sensor.predbat_marginal_rate_now_ev_is_cheap** - `on` when the marginal cost for an EV-scale (8 kWh) extra load right now is cheap
+- **binary_sensor.predbat_marginal_rate_now_ev_is_moderate** - `on` when it is moderate
+
+The cheap/moderate thresholds are computed relative to the current day's import rate range:
+
+- **Cheap threshold** = `rate_min × 1.2`
+- **Moderate threshold** = `max(rate_max × 0.5, rate_min × 1.5)`
+
+These binary sensors are useful in Home Assistant automations, e.g. to start an EV charge or run a dishwasher only when energy is cheap.
+
 ## Solar forecast data
 
 The following sensors give the forecast Solar data from Solcast.

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -104,6 +104,11 @@ The chart also shows where charging is planned under the Base and Best scenarios
 - **PV7** - Similar to the PV chart, but shows actual solar generation and forecast for the last 7 days including today
 - **Load ML** - Shows the correlation between your actual house load and the [Load ML predictions](load-ml.md), charting current prediction, the 1 hour in the future prediction, and the 8 hours future prediction
 - **LoadMLPower** - Similar to the Load ML chart, but also plots actual PV production, predicted PV production and temperature predictions.
+- **MarginalCosts** - Shows the marginal cost of consuming extra electricity at different load levels (1, 2, 4, 8 kWh) across upcoming time windows.
+  The page contains three sections:
+  - A status table showing whether the current marginal rate for each load level is **cheap** or **moderate** based on today's import rate range
+  - A compact **Grid Rates** heatmap showing the actual import and export rate at each time window
+  - A full **Marginal Energy Cost** heatmap matrix coloured green (cheap) to red (expensive) on a shared scale
 
 Example PV chart:
 

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -106,9 +106,9 @@ The chart also shows where charging is planned under the Base and Best scenarios
 - **LoadMLPower** - Similar to the Load ML chart, but also plots actual PV production, predicted PV production and temperature predictions.
 - **MarginalCosts** - Shows the marginal cost of consuming extra electricity at different load levels (1, 2, 4, 8 kWh) across upcoming time windows.
   The page contains three sections:
-  - A status table showing whether the current marginal rate for each load level is **cheap** or **moderate** based on today's import rate range
-  - A compact **Grid Rates** heatmap showing the actual import and export rate at each time window
-  - A full **Marginal Energy Cost** heatmap matrix coloured green (cheap) to red (expensive) on a shared scale
+    - A status table showing whether the current marginal rate for each load level is **cheap** or **moderate** based on today's import rate range
+    - A compact **Grid Rates** heatmap showing the actual import and export rate at each time window
+    - A full **Marginal Energy Cost** heatmap matrix coloured green (cheap) to red (expensive) on a shared scale
 
 Example PV chart:
 


### PR DESCRIPTION
## Summary

Adds a marginal energy cost feature to Predbat. After each plan calculation, Predbat runs a set of what-if simulations to determine the true marginal cost (p/kWh) of consuming extra electricity at different load levels and at different points in the upcoming forecast window. This is useful for Home Assistant automations — e.g. start an EV charge or run a dishwasher only when energy is genuinely cheap.

## New sensors

### Main matrix sensor
- `sensor.predbat_marginal_energy_costs` — state is the 1 kWh marginal cost right now; attributes carry the full matrix (`{kWh_level: {HH:MM: cost}}`), grid import/export rates per window, and per-level rate-now values.

### Binary sensors (8 total, per consumption level: low/med/high/ev)
- `binary_sensor.predbat_marginal_rate_now_{level}_is_cheap` — `on` when the marginal cost is at or below `rate_min × 1.2`
- `binary_sensor.predbat_marginal_rate_now_{level}_is_moderate` — `on` when above cheap but within `max(rate_max × 0.5, rate_min × 1.5)`

## Load levels & time windows
- **Levels**: 1 kWh (low), 2 kWh (med), 4 kWh (high), 8 kWh (ev)
- **Time windows**: now, +2 h, +4 h, +6 h, +8 h, +10 h, +12 h

## Web UI — new MarginalCosts chart page
Three sections on `/charts?chart=MarginalCosts`:
1. Status table showing cheap/moderate status per consumption level with colour coding
2. Compact **Grid Rates** heatmap (actual import & export rates across the 7 windows)
3. Full **Marginal Energy Cost** heatmap (4 levels × 7 windows, green → red scale)

Fixed a bug in `html_charts()` where `<div id="chart">` was emitted *after* the ApexCharts script block, causing `document.querySelector('#chart')` to return null and breaking all non-MarginalCosts charts.

## Files changed
| File | Change |
|------|--------|
| `apps/predbat/marginal.py` | New mixin — `calculate_marginal_costs()`, `publish_marginal_costs()` |
| `apps/predbat/plan.py` | Call `calculate_marginal_costs()` after plan is finalised |
| `apps/predbat/predbat.py` | Add `Marginal` to inheritance chain |
| `apps/predbat/web.py` | `render_heatmap_chart()`, MarginalCosts chart block, div ordering fix |
| `apps/predbat/tests/test_marginal_costs.py` | Unit tests for sensor structure and binary sensors |
| `apps/predbat/unit_test.py` | Register `marginal_costs` test |
| `docs/output-data.md` | New "Marginal energy cost data" section |
| `docs/web-interface.md` | MarginalCosts entry in Charts View list |