### PR TITLE
Fix missing float value in LuxPower automation

### DIFF
--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -1430,7 +1430,7 @@ actions:
       entity_id: input_boolean.freeze_charge_guard
     action: input_boolean.turn_off
     - alias: "StartupReset: Wait for battery voltage to be > 0"
-    wait_template: "{{ states('sensor.lux_battery_voltage_live') | float > 0 }}"
+    wait_template: "{{ states('sensor.lux_battery_voltage_live') | float(0) > 0 }}"
     timeout: "00:01:00"
     continue_on_timeout: true
     - alias: "StartupReset: Set discharge current limit from battery_rate_max"


### PR DESCRIPTION
This updates the LuxPower section of inverter-setup.md document by adding a default value to the `wait_template`  in the HA Startup Reset automation.
The change prevents template errors when the sensor state is "unavailable" during startup and improves reliability of the documented automation.
