### PR TITLE
Fix Axle notification timezone for DST/BST

### DIFF
--- a/apps/predbat/axle.py
+++ b/apps/predbat/axle.py
@@ -366,7 +366,9 @@ class AxleAPI(ComponentBase):
                 # send alert if this is a new Axle event
                 if (start_time.strftime(TIME_FORMAT) != current_start_time) or (end_time.strftime(TIME_FORMAT) != current_end_time):
                     if self.get_arg("set_event_notify"):
-                        self.call_notify("Predbat: Scheduled Axle VPP event {}-{}, {} p/kWh".format(start_time.strftime("%a %d/%m %H:%M"), end_time.strftime("%H:%M"), self.pence_per_kwh))
+                        local_start = start_time.astimezone(self.local_tz)
+                        local_end = end_time.astimezone(self.local_tz)
+                        self.call_notify("Predbat: Scheduled Axle VPP event {}-{}, {} p/kWh".format(local_start.strftime("%a %d/%m %H:%M"), local_end.strftime("%H:%M"), self.pence_per_kwh))
 
             self.cleanup_event_history()
             self.publish_axle_event()

--- a/apps/predbat/tests/test_axle.py
+++ b/apps/predbat/tests/test_axle.py
@@ -43,6 +43,7 @@ class MockAxleAPI(AxleAPI):
         self.updated_at = None
         self.history_loaded = False
         self._now_utc = datetime.now(timezone.utc)
+        self.local_tz = timezone.utc
         self._state_store = {}  # Mock state storage
 
         # Managed mode defaults


### PR DESCRIPTION
Convert event start/end times to local timezone before formatting the notification message, so times shown reflect local time (BST in summer) rather than UTC.

Also add local_tz to MockAxleAPI in tests to match the ComponentBase attribute set during real initialisation.

Fixes #3764