### PR TITLE
Replace Forecast.Solar with Open-Meteo solar forecast provider

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -281,6 +281,7 @@ Predheat
 psum
 pvbat
 pvenergytotal
+PVGIS
 pvlib
 pvpower
 pwindow

--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -332,6 +332,7 @@ sofar
 SolarEdge
 solarman
 solarnet
+solarposition
 Solax
 solaxcloud
 solaxmodbus

--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -281,6 +281,7 @@ Predheat
 psum
 pvbat
 pvenergytotal
+pvlib
 pvpower
 pwindow
 pyjwt

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -100,13 +100,15 @@ COMPONENT_LIST = {
             "solcast_poll_hours": {"required": False, "config": "solcast_poll_hours", "default": 8},
             "forecast_solar": {"required": False, "config": "forecast_solar", "default": False},
             "forecast_solar_max_age": {"required": False, "config": "forecast_solar_max_age", "default": 8},
+            "open_meteo": {"required": False, "config": "open_meteo", "default": False},
+            "open_meteo_max_age": {"required": False, "config": "open_meteo_max_age", "default": 1},
             "pv_forecast_today": {"required": False, "config": "pv_forecast_today"},
             "pv_forecast_tomorrow": {"required": False, "config": "pv_forecast_tomorrow"},
             "pv_forecast_d3": {"required": False, "config": "pv_forecast_d3"},
             "pv_forecast_d4": {"required": False, "config": "pv_forecast_d4"},
             "pv_scaling": {"required": False, "config": "pv_scaling", "default": 1.0},
         },
-        "required_or": ["solcast_api_key", "forecast_solar", "pv_forecast_today"],
+        "required_or": ["solcast_api_key", "forecast_solar", "open_meteo", "pv_forecast_today"],
         "phase": 2,  # Solar component moved to phase 2 so that any Predbat cloud components (such as GEcloud) have been started and initialised pv_today, etc
     },
     "gecloud": {

--- a/apps/predbat/solcast.py
+++ b/apps/predbat/solcast.py
@@ -94,6 +94,7 @@ class SolarAPI(ComponentBase):
         # Check if this is a Solcast API call for metrics tracking
         is_solcast_api = "solcast.com" in url.lower() or "api.solcast" in url.lower()
         is_forecast_solar_api = "forecast.solar" in url.lower()
+        is_open_meteo_api = "open-meteo.com" in url.lower()
 
         # Increment request counter for Solcast API calls
         if is_solcast_api:
@@ -102,6 +103,10 @@ class SolarAPI(ComponentBase):
         # Increment request counter for forecast.solar API calls
         if is_forecast_solar_api:
             self.forecast_solar_requests_total += 1
+
+        # Increment request counter for Open-Meteo API calls
+        if is_open_meteo_api:
+            self.open_meteo_requests_total += 1
 
         # Get data from cache
         age_minutes = 0
@@ -146,6 +151,9 @@ class SolarAPI(ComponentBase):
                         if is_forecast_solar_api:
                             self.forecast_solar_failures_total += 1
                             record_api_call("forecast_solar", False, "server_error")
+                        if is_open_meteo_api:
+                            self.open_meteo_failures_total += 1
+                            record_api_call("open_meteo", False, "server_error")
                         return data
 
                     try:
@@ -156,6 +164,9 @@ class SolarAPI(ComponentBase):
                         if is_forecast_solar_api:
                             self.forecast_solar_last_success_timestamp = datetime.now(timezone.utc)
                             record_api_call("forecast_solar")
+                        if is_open_meteo_api:
+                            self.open_meteo_last_success_timestamp = datetime.now(timezone.utc)
+                            record_api_call("open_meteo")
                     except (aiohttp.ContentTypeError, Exception) as e:
                         self.log("Warn: Error downloading data from URL {}, error {} code {}".format(url, e, status_code))
                         if is_solcast_api:
@@ -164,6 +175,9 @@ class SolarAPI(ComponentBase):
                         if is_forecast_solar_api:
                             self.forecast_solar_failures_total += 1
                             record_api_call("forecast_solar", False, "decode_error")
+                        if is_open_meteo_api:
+                            self.open_meteo_failures_total += 1
+                            record_api_call("open_meteo", False, "decode_error")
                         if data:
                             self.log("Warn: Error downloading data from URL {}, using cached data age {} minutes".format(url, dp1(age_minutes)))
                         else:
@@ -176,6 +190,9 @@ class SolarAPI(ComponentBase):
             if is_forecast_solar_api:
                 self.forecast_solar_failures_total += 1
                 record_api_call("forecast_solar", False, "connection_error")
+            if is_open_meteo_api:
+                self.open_meteo_failures_total += 1
+                record_api_call("open_meteo", False, "connection_error")
             return data
 
         # Store data in cache

--- a/apps/predbat/solcast.py
+++ b/apps/predbat/solcast.py
@@ -47,7 +47,7 @@ class SolarAPI(ComponentBase):
     for system optimisation and decision-making.
     """
 
-    def initialize(self, solcast_host, solcast_api_key, solcast_sites, solcast_poll_hours, forecast_solar, forecast_solar_max_age, pv_forecast_today, pv_forecast_tomorrow, pv_forecast_d3, pv_forecast_d4, pv_scaling):
+    def initialize(self, solcast_host, solcast_api_key, solcast_sites, solcast_poll_hours, forecast_solar, forecast_solar_max_age, open_meteo, open_meteo_max_age, pv_forecast_today, pv_forecast_tomorrow, pv_forecast_d3, pv_forecast_d4, pv_scaling):
         """Initialise the Solar API component"""
         self.solcast_host = solcast_host
         self.solcast_api_key = solcast_api_key
@@ -55,6 +55,8 @@ class SolarAPI(ComponentBase):
         self.solcast_poll_hours = solcast_poll_hours
         self.forecast_solar = forecast_solar
         self.forecast_solar_max_age = forecast_solar_max_age
+        self.open_meteo = open_meteo
+        self.open_meteo_max_age = open_meteo_max_age
         self.pv_forecast_today = pv_forecast_today
         self.pv_forecast_tomorrow = pv_forecast_tomorrow
         self.pv_forecast_d3 = pv_forecast_d3
@@ -64,8 +66,11 @@ class SolarAPI(ComponentBase):
         self.solcast_failures_total = 0
         self.forecast_solar_requests_total = 0
         self.forecast_solar_failures_total = 0
+        self.open_meteo_requests_total = 0
+        self.open_meteo_failures_total = 0
         self.solcast_last_success_timestamp = None
         self.forecast_solar_last_success_timestamp = None
+        self.open_meteo_last_success_timestamp = None
         self.last_fetched_timestamp = None
         self.forecast_days = 4
 
@@ -1056,7 +1061,12 @@ class SolarAPI(ComponentBase):
         create_pv10 = False
         max_kwh = 9999
 
-        if self.forecast_solar:
+        if self.open_meteo:
+            self.log("Obtaining solar forecast from Open-Meteo API")
+            pv_forecast_data, max_kwh = await self.download_open_meteo_data()
+            divide_by = 30.0
+            create_pv10 = True
+        elif self.forecast_solar:
             self.log("Obtaining solar forecast from Forecast Solar API")
             pv_forecast_data, max_kwh = await self.download_forecast_solar_data()
             divide_by = 30.0
@@ -1116,7 +1126,7 @@ class SolarAPI(ComponentBase):
             # For the HA sensor path the divide_by was computed assuming 30-minute periods;
             # recalculate it using the actual detected period so that the per-minute kWh
             # values are correctly scaled regardless of the forecast resolution.
-            if not self.forecast_solar and not (self.solcast_host and self.solcast_api_key):
+            if not self.open_meteo and not self.forecast_solar and not (self.solcast_host and self.solcast_api_key):
                 factor = divide_by / 30.0
                 divide_by = dp2(period * factor)
 

--- a/apps/predbat/solcast.py
+++ b/apps/predbat/solcast.py
@@ -254,6 +254,9 @@ class SolarAPI(ComponentBase):
                 days_data = config.get("days", 2)
 
             data = await self.cache_get_url(url, params={}, max_age=self.forecast_solar_max_age * 60)
+            if not data:
+                self.log("Warn: Forecast Solar API returned no data for lat {} lon {}, location may not be covered by PVGIS database".format(lat, lon))
+                continue
             watts = data.get("result", {}).get("watts", {})
             info = data.get("message", {}).get("info", {})
             if not watts or not info:

--- a/apps/predbat/solcast.py
+++ b/apps/predbat/solcast.py
@@ -21,6 +21,8 @@ import json
 import os
 import aiohttp
 import traceback
+import pandas as pd
+import pvlib
 import pytz
 from datetime import datetime, timedelta, timezone
 from const import TIME_FORMAT, TIME_FORMAT_SOLCAST
@@ -446,6 +448,142 @@ class SolarAPI(ComponentBase):
 
         self.log("Solcast returned {} data points".format(len(sorted_data)))
         return sorted_data
+
+    OPEN_METEO_URL = "https://api.open-meteo.com/v1/forecast"
+
+    async def download_open_meteo_data(self):
+        """Download solar irradiance from Open-Meteo and convert to PV output using pvlib."""
+        cache_path = self.config_root + "/cache"
+
+        self.open_meteo_data = {}
+        cache_file = cache_path + "/open_meteo.json"
+
+        if os.path.exists(cache_file):
+            try:
+                with open(cache_file) as f:
+                    self.open_meteo_data = json.load(f)
+            except Exception as e:
+                self.log("Warn: Error loading Open-Meteo cache file {}, error {}".format(cache_file, e))
+                self.log("Warn: " + traceback.format_exc())
+                os.remove(cache_file)
+
+        configs = self.open_meteo
+        if configs is None:
+            raise ValueError("SolarAPI: No Open-Meteo configurations found")
+
+        if not isinstance(configs, list):
+            configs = [configs]
+
+        period_data = {}
+        max_kwh = 0
+        for config in configs:
+            lat = config.get("latitude", 51.5072)
+            lon = config.get("longitude", -0.1276)
+            tilt = config.get("tilt", 35.0)
+            azimuth = config.get("azimuth", 180.0)
+            kwp = config.get("kwp", 3.0)
+            efficiency = config.get("efficiency", 0.95)
+            days_data = config.get("days", 2)
+
+            max_kwh += kwp * efficiency
+
+            params = {
+                "latitude": lat,
+                "longitude": lon,
+                "hourly": "shortwave_radiation,direct_radiation,diffuse_radiation,direct_normal_irradiance",
+                "forecast_days": days_data,
+                "timezone": "UTC",
+            }
+            url = self.OPEN_METEO_URL
+            param_str = "&".join("{}={}".format(k, v) for k, v in sorted(params.items()))
+            full_url = "{}?{}".format(url, param_str)
+
+            data = await self.cache_get_url(full_url, params={}, max_age=self.open_meteo_max_age * 60)
+            if not data:
+                self.log("Warn: Open-Meteo API returned no data for lat {} lon {}".format(lat, lon))
+                continue
+
+            hourly = data.get("hourly", {})
+            times = hourly.get("time", [])
+            ghi_values = hourly.get("shortwave_radiation", [])
+            dni_values = hourly.get("direct_normal_irradiance", [])
+            dhi_values = hourly.get("diffuse_radiation", [])
+
+            if not times or not ghi_values:
+                self.log("Warn: Open-Meteo returned empty data for lat {} lon {}".format(lat, lon))
+                continue
+
+            # Convert times to pandas DatetimeIndex for pvlib
+            time_index = pd.DatetimeIndex(pd.to_datetime(times, utc=True))
+
+            # Calculate solar position
+            solar_position = pvlib.solarposition.get_solarposition(time_index, lat, lon)
+            solar_zenith = solar_position["apparent_zenith"]
+            solar_azimuth = solar_position["azimuth"]
+
+            # Transpose irradiance to plane-of-array
+            poa = pvlib.irradiance.get_total_irradiance(
+                surface_tilt=tilt,
+                surface_azimuth=azimuth,
+                solar_zenith=solar_zenith,
+                solar_azimuth=solar_azimuth,
+                dni=pd.Series(dni_values, index=time_index).fillna(0),
+                ghi=pd.Series(ghi_values, index=time_index).fillna(0),
+                dhi=pd.Series(dhi_values, index=time_index).fillna(0),
+                model="isotropic",
+            )
+
+            poa_global = poa["poa_global"].fillna(0).clip(lower=0)
+
+            # Convert POA irradiance (W/m²) to PV output (kW)
+            # Standard test conditions: 1000 W/m² = kwp output
+            pv_watts = poa_global * (kwp / 1000.0) * efficiency
+
+            # Build forecast data in predbat standard format
+            for i, time_val in enumerate(time_index):
+                pv_kw = float(pv_watts.iloc[i])
+                # Convert kW to kWh per interval (matching predbat's expected divide_by=30 format)
+                pv_estimate = dp4(pv_kw / 60.0 * self.plan_interval_minutes)
+
+                if time_val in period_data:
+                    period_data[time_val]["pv_estimate"] += pv_estimate
+                else:
+                    period_data[time_val] = {
+                        "period_start": time_val.strftime(TIME_FORMAT),
+                        "pv_estimate": pv_estimate,
+                    }
+
+        # Merge new data into cached data
+        for key in period_data:
+            self.open_meteo_data[key.strftime(TIME_FORMAT)] = period_data[key]
+
+        # Prune old data
+        new_data = {}
+        for key_txt in self.open_meteo_data:
+            key = datetime.strptime(key_txt, TIME_FORMAT)
+            if key >= self.midnight_utc:
+                new_data[key_txt] = self.open_meteo_data[key_txt]
+        self.open_meteo_data = new_data
+
+        # Save to cache file
+        with open(cache_file, "w") as f:
+            json.dump(self.open_meteo_data, f)
+
+        # Fetch the final cached data as timestamps
+        period_data = {}
+        for key_txt in self.open_meteo_data:
+            key = datetime.strptime(key_txt, TIME_FORMAT)
+            period_data[key] = self.open_meteo_data[key_txt]
+
+        # Sort data and return
+        sorted_data = []
+        if period_data:
+            period_keys = sorted(period_data.keys())
+            for key in period_keys:
+                sorted_data.append(period_data[key])
+
+        self.log("Open-Meteo returned {} data points".format(len(sorted_data)))
+        return sorted_data, max_kwh
 
     def fetch_pv_datapoints(self, argname, entity_id):
         """

--- a/apps/predbat/tests/test_solcast.py
+++ b/apps/predbat/tests/test_solcast.py
@@ -2380,6 +2380,274 @@ def test_forecast_solar_null_response(my_predbat):
 
 
 # ============================================================================
+# Open-Meteo Data Download Tests
+# ============================================================================
+
+
+def _build_open_meteo_response(lat=51.5, lon=-0.1, hours=24):
+    """Build a mock Open-Meteo API response with synthetic irradiance data."""
+    from datetime import timezone as tz
+
+    base_time = datetime(2025, 6, 15, 0, 0, 0, tzinfo=tz.utc)
+    times = [(base_time + timedelta(hours=h)).strftime("%Y-%m-%dT%H:%M") for h in range(hours)]
+
+    # Simulate a simple irradiance curve - peak at midday (hour 12)
+    ghi = []
+    dni = []
+    dhi = []
+    shortwave = []
+    for h in range(hours):
+        if 6 <= h <= 18:
+            factor = 1.0 - abs(h - 12) / 6.0
+            ghi.append(round(800 * factor, 1))
+            dni.append(round(700 * factor, 1))
+            dhi.append(round(100 * factor, 1))
+            shortwave.append(round(800 * factor, 1))
+        else:
+            ghi.append(0.0)
+            dni.append(0.0)
+            dhi.append(0.0)
+            shortwave.append(0.0)
+
+    return {
+        "latitude": lat,
+        "longitude": lon,
+        "hourly": {
+            "time": times,
+            "shortwave_radiation": shortwave,
+            "direct_radiation": ghi,
+            "diffuse_radiation": dhi,
+            "direct_normal_irradiance": dni,
+        },
+    }
+
+
+def _setup_open_meteo_solar_api(test_api, configs=None):
+    """Set up SolarAPI instance with open_meteo attributes for testing."""
+    if configs is None:
+        configs = [
+            {
+                "latitude": 51.5,
+                "longitude": -0.1,
+                "tilt": 35.0,
+                "azimuth": 180.0,
+                "kwp": 3.0,
+                "efficiency": 0.95,
+                "days": 2,
+            }
+        ]
+    test_api.solar.open_meteo = configs
+    test_api.solar.open_meteo_max_age = 4
+    # midnight_utc is a property on ComponentBase that reads from self.base — already set in MockBase
+
+
+def test_open_meteo_basic(my_predbat):
+    """
+    Test download_open_meteo_data with a mock Open-Meteo response.
+    Verifies that PV output is calculated from irradiance and that the
+    data structure is correct.
+    """
+    print("  - test_open_meteo_basic")
+    failed = False
+
+    test_api = create_test_solar_api()
+    try:
+        _setup_open_meteo_solar_api(test_api)
+
+        mock_response = _build_open_meteo_response()
+        test_api.set_mock_response("open-meteo.com", mock_response, 200)
+
+        def create_mock_session(*args, **kwargs):
+            return test_api.mock_aiohttp_session()
+
+        with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session):
+            result, max_kwh = run_async(test_api.solar.download_open_meteo_data())
+
+        # Verify we got data back
+        if result is None or len(result) == 0:
+            print("ERROR: Expected forecast data, got {}".format(result))
+            failed = True
+
+        if result:
+            # Each entry must have period_start and pv_estimate
+            first = result[0]
+            if "period_start" not in first:
+                print("ERROR: Expected 'period_start' in result, got {}".format(list(first.keys())))
+                failed = True
+            if "pv_estimate" not in first:
+                print("ERROR: Expected 'pv_estimate' in result")
+                failed = True
+
+            # Daytime entries should have positive pv_estimate
+            positive_entries = [e for e in result if e.get("pv_estimate", 0) > 0]
+            if len(positive_entries) == 0:
+                print("ERROR: Expected some positive pv_estimate values (daytime irradiance present)")
+                failed = True
+
+            # All pv_estimate values must be non-negative
+            negative_entries = [e for e in result if e.get("pv_estimate", 0) < 0]
+            if len(negative_entries) > 0:
+                print("ERROR: Found {} entries with negative pv_estimate".format(len(negative_entries)))
+                failed = True
+
+        # max_kwh = kwp * efficiency = 3.0 * 0.95 = 2.85
+        expected_max_kwh = 3.0 * 0.95
+        if abs(max_kwh - expected_max_kwh) > 0.01:
+            print("ERROR: Expected max_kwh {}, got {}".format(expected_max_kwh, max_kwh))
+            failed = True
+
+    finally:
+        test_api.cleanup()
+
+    return failed
+
+
+def test_open_meteo_null_response(my_predbat):
+    """
+    Test download_open_meteo_data handles None from cache_get_url gracefully.
+    Should return empty data without crashing.
+    """
+    print("  - test_open_meteo_null_response")
+    failed = False
+
+    test_api = create_test_solar_api()
+    try:
+        _setup_open_meteo_solar_api(test_api)
+
+        # Ensure cache directory exists (normally created by cache_get_url, but we're mocking it)
+        cache_path = test_api.mock_base.config_root + "/cache"
+        os.makedirs(cache_path, exist_ok=True)
+
+        # Mock cache_get_url to return None
+        async def mock_cache_get_url_none(url, params, max_age=None):
+            """Simulate API returning no data."""
+            return None
+
+        test_api.solar.cache_get_url = mock_cache_get_url_none
+
+        result, max_kwh = run_async(test_api.solar.download_open_meteo_data())
+
+        # Should return empty list, not crash
+        if result is None:
+            print("ERROR: Expected empty list, got None")
+            failed = True
+        elif len(result) != 0:
+            print("ERROR: Expected empty list when API returns None, got {} items".format(len(result)))
+            failed = True
+
+        # max_kwh should still be computed from config (kwp * efficiency)
+        expected_max_kwh = 3.0 * 0.95
+        if abs(max_kwh - expected_max_kwh) > 0.01:
+            print("ERROR: Expected max_kwh {} even with null response, got {}".format(expected_max_kwh, max_kwh))
+            failed = True
+
+    finally:
+        test_api.cleanup()
+
+    return failed
+
+
+def test_open_meteo_multi_array(my_predbat):
+    """
+    Test that download_open_meteo_data aggregates PV output across multiple panel arrays.
+    With two identical arrays, the combined output should be double a single array.
+    """
+    print("  - test_open_meteo_multi_array")
+    failed = False
+
+    # --- single-array run ---
+    test_single = create_test_solar_api()
+    try:
+        single_config = [
+            {
+                "latitude": 51.5,
+                "longitude": -0.1,
+                "tilt": 35.0,
+                "azimuth": 180.0,
+                "kwp": 3.0,
+                "efficiency": 0.95,
+                "days": 2,
+            }
+        ]
+        _setup_open_meteo_solar_api(test_single, configs=single_config)
+
+        mock_response = _build_open_meteo_response()
+        test_single.set_mock_response("open-meteo.com", mock_response, 200)
+
+        def create_mock_session_single(*args, **kwargs):
+            return test_single.mock_aiohttp_session()
+
+        with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session_single):
+            single_result, single_max_kwh = run_async(test_single.solar.download_open_meteo_data())
+    finally:
+        test_single.cleanup()
+
+    # --- dual-array run (same config × 2) ---
+    test_dual = create_test_solar_api()
+    try:
+        dual_config = [
+            {
+                "latitude": 51.5,
+                "longitude": -0.1,
+                "tilt": 35.0,
+                "azimuth": 180.0,
+                "kwp": 3.0,
+                "efficiency": 0.95,
+                "days": 2,
+            },
+            {
+                "latitude": 51.5,
+                "longitude": -0.1,
+                "tilt": 35.0,
+                "azimuth": 180.0,
+                "kwp": 3.0,
+                "efficiency": 0.95,
+                "days": 2,
+            },
+        ]
+        _setup_open_meteo_solar_api(test_dual, configs=dual_config)
+
+        mock_response = _build_open_meteo_response()
+        test_dual.set_mock_response("open-meteo.com", mock_response, 200)
+
+        def create_mock_session_dual(*args, **kwargs):
+            return test_dual.mock_aiohttp_session()
+
+        with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session_dual):
+            dual_result, dual_max_kwh = run_async(test_dual.solar.download_open_meteo_data())
+    finally:
+        test_dual.cleanup()
+
+    # max_kwh should be doubled
+    expected_dual_max_kwh = single_max_kwh * 2
+    if abs(dual_max_kwh - expected_dual_max_kwh) > 0.01:
+        print("ERROR: Expected dual max_kwh {}, got {}".format(expected_dual_max_kwh, dual_max_kwh))
+        failed = True
+
+    # Both runs should return the same number of time slots
+    if single_result and dual_result:
+        if len(single_result) != len(dual_result):
+            print("ERROR: Single ({}) and dual ({}) should have same number of time slots".format(len(single_result), len(dual_result)))
+            failed = True
+
+        # Dual pv_estimate should be approximately double single for each slot
+        for i, (s, d) in enumerate(zip(single_result, dual_result)):
+            sv = s.get("pv_estimate", 0)
+            dv = d.get("pv_estimate", 0)
+            if sv == 0 and dv == 0:
+                continue
+            if abs(dv - 2 * sv) > 0.001:
+                print("ERROR: slot {}: dual ({}) should be ~2x single ({})".format(i, dv, sv))
+                failed = True
+                break  # Only report first failure
+    else:
+        print("ERROR: single_result={}, dual_result={}".format(single_result, dual_result))
+        failed = True
+
+    return failed
+
+
+# ============================================================================
 # Main Test Runner
 # ============================================================================
 
@@ -2410,6 +2678,11 @@ def run_solcast_tests(my_predbat):
     failed |= test_download_forecast_solar_data_with_postcode(my_predbat)
     failed |= test_download_forecast_solar_data_personal_api(my_predbat)
     failed |= test_forecast_solar_null_response(my_predbat)
+
+    # Open-Meteo download tests
+    failed |= test_open_meteo_basic(my_predbat)
+    failed |= test_open_meteo_null_response(my_predbat)
+    failed |= test_open_meteo_multi_array(my_predbat)
 
     # HA sensor tests
     failed |= test_fetch_pv_datapoints_detailed_forecast(my_predbat)

--- a/apps/predbat/tests/test_solcast.py
+++ b/apps/predbat/tests/test_solcast.py
@@ -146,6 +146,8 @@ class TestSolarAPI:
             solcast_poll_hours=4,
             forecast_solar=None,
             forecast_solar_max_age=4,
+            open_meteo=None,
+            open_meteo_max_age=1,
             pv_forecast_today=None,
             pv_forecast_tomorrow=None,
             pv_forecast_d3=None,
@@ -2647,6 +2649,48 @@ def test_open_meteo_multi_array(my_predbat):
     return failed
 
 
+def test_fetch_pv_forecast_open_meteo(my_predbat):
+    """
+    Integration test: fetch_pv_forecast routes to Open-Meteo when open_meteo is configured.
+    Verifies that the full pipeline runs and dashboard items are published.
+    """
+    print("  - test_fetch_pv_forecast_open_meteo")
+    failed = False
+
+    test_api = create_test_solar_api()
+    try:
+        # Configure for Open-Meteo: disable all other providers
+        test_api.solar.solcast_host = None
+        test_api.solar.solcast_api_key = None
+        test_api.solar.forecast_solar = None
+        _setup_open_meteo_solar_api(test_api)
+
+        mock_response = _build_open_meteo_response()
+        test_api.set_mock_response("open-meteo.com", mock_response, 200)
+
+        def create_mock_session(*args, **kwargs):
+            return test_api.mock_aiohttp_session()
+
+        with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session):
+            run_async(test_api.solar.fetch_pv_forecast())
+
+        # Verify Open-Meteo API was called
+        open_meteo_calls = [r for r in test_api.request_log if "open-meteo.com" in r["url"]]
+        if len(open_meteo_calls) == 0:
+            print("ERROR: Expected Open-Meteo API call, got none")
+            failed = True
+
+        # Verify dashboard items were published (proves the full pipeline ran)
+        if "sensor.{}_pv_today".format(test_api.mock_base.prefix) not in test_api.dashboard_items:
+            print("ERROR: Expected pv_today entity to be published, got {}".format(list(test_api.dashboard_items.keys())))
+            failed = True
+
+    finally:
+        test_api.cleanup()
+
+    return failed
+
+
 # ============================================================================
 # Main Test Runner
 # ============================================================================
@@ -2706,6 +2750,7 @@ def run_solcast_tests(my_predbat):
     # Integration tests (one per mode)
     failed |= test_fetch_pv_forecast_solcast_direct(my_predbat)
     failed |= test_fetch_pv_forecast_forecast_solar(my_predbat)
+    failed |= test_fetch_pv_forecast_open_meteo(my_predbat)
     failed |= test_fetch_pv_forecast_ha_sensors(my_predbat)
 
     # 15-minute resolution tests

--- a/apps/predbat/tests/test_solcast.py
+++ b/apps/predbat/tests/test_solcast.py
@@ -2325,6 +2325,61 @@ def test_pv_calibration_synthetic_values(my_predbat):
 
 
 # ============================================================================
+# Forecast.Solar null response tests
+# ============================================================================
+
+
+def test_forecast_solar_null_response(my_predbat):
+    """
+    Test that download_forecast_solar_data handles None from cache_get_url without crashing.
+    Regression test for AttributeError: 'NoneType' object has no attribute 'get' when
+    Forecast.Solar returns HTTP 422 for unsupported locations.
+    """
+    print("  - test_forecast_solar_null_response")
+    failed = False
+
+    test_api = create_test_solar_api()
+    try:
+        test_api.solar.forecast_solar = [
+            {
+                "latitude": 89.9,  # Near North Pole - not covered by PVGIS
+                "longitude": 0.0,
+                "declination": 30,
+                "azimuth": 0,
+                "kwp": 3.0,
+                "efficiency": 0.9,
+            }
+        ]
+
+        # Ensure cache directory exists (normally created by cache_get_url, but we're mocking it)
+        cache_path = test_api.mock_base.config_root + "/cache"
+        os.makedirs(cache_path, exist_ok=True)
+
+        # Mock cache_get_url to return None (simulating HTTP 422 or connection failure)
+        async def mock_cache_get_url_none(url, params, max_age=None):
+            """Return None to simulate an unsupported location response."""
+            return None
+
+        test_api.solar.cache_get_url = mock_cache_get_url_none
+
+        # This should NOT raise AttributeError - the null guard must handle it gracefully
+        result, max_kwh = run_async(test_api.solar.download_forecast_solar_data())
+
+        # Result should be empty (no data), not a crash
+        if result is None:
+            print("ERROR: Expected empty list, got None")
+            failed = True
+        elif len(result) != 0:
+            print("ERROR: Expected empty list when API returns None, got {} items".format(len(result)))
+            failed = True
+
+    finally:
+        test_api.cleanup()
+
+    return failed
+
+
+# ============================================================================
 # Main Test Runner
 # ============================================================================
 
@@ -2354,6 +2409,7 @@ def run_solcast_tests(my_predbat):
     failed |= test_download_forecast_solar_data(my_predbat)
     failed |= test_download_forecast_solar_data_with_postcode(my_predbat)
     failed |= test_download_forecast_solar_data_personal_api(my_predbat)
+    failed |= test_forecast_solar_null_response(my_predbat)
 
     # HA sensor tests
     failed |= test_fetch_pv_datapoints_detailed_forecast(my_predbat)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ numpy==2.3.5
 pre-commit
 prometheus-client
 protobuf
+pvlib
 pyjwt
 pytz
 requests


### PR DESCRIPTION
## Summary

- Add Open-Meteo as a new solar forecast provider using pvlib for irradiance-to-PV conversion
- Fix null crash in `download_forecast_solar_data` when API returns no data (e.g. PVGIS coverage gaps)
- Wire Open-Meteo into `fetch_pv_forecast()` and component config
- Add Open-Meteo API metrics tracking

## Why

Forecast.Solar's PVGIS database doesn't cover parts of northern Scotland and Germany. A customer in Dumfries (55°N) gets HTTP 422 errors. Open-Meteo provides free, global-coverage solar irradiance forecasts with hourly resolution.

## How it works

1. Fetches GHI/DNI/DHI irradiance from Open-Meteo API
2. Uses pvlib to compute solar position and plane-of-array transposition
3. Converts to PV output using customer's tilt/azimuth/kWp/efficiency
4. Returns data in predbat's standard format (same as Forecast.Solar/Solcast)
5. Predbat's existing calibration handles accuracy tuning

## New dependency

`pvlib` added to requirements.txt (pulls in scipy + pandas, numpy already present)

## Test plan

- [x] Unit tests for null crash fix
- [x] Unit tests for Open-Meteo basic conversion
- [x] Unit tests for null response handling
- [x] Unit tests for multi-array aggregation
- [x] Integration test for full fetch_pv_forecast pipeline
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)