### PR TITLE
Add per-month shading factors from Google Solar API

### DIFF
--- a/apps/predbat/solcast.py
+++ b/apps/predbat/solcast.py
@@ -317,6 +317,10 @@ class SolarAPI(ComponentBase):
             az = self.convert_azimuth(az)
             kwp = config.get("kwp", 3.0)
             system_loss = config.get("system_loss", 0)
+            shading_factors = config.get("shading_factors", None)
+
+            if shading_factors and len(shading_factors) == 12:
+                self.log("Open-Meteo: Using per-month shading factors for lat {} lon {}".format(lat, lon))
 
             max_kwh += kwp * (1.0 - system_loss)
 
@@ -375,6 +379,12 @@ class SolarAPI(ComponentBase):
                     period_start_stamp = period_start_stamp.replace(tzinfo=pytz.utc)
                 except (ValueError, TypeError):
                     continue
+
+                # Apply per-month site shading correction from Google Solar API if available
+                if shading_factors and len(shading_factors) == 12:
+                    shading_month = shading_factors[period_start_stamp.month - 1]
+                    pv50 = dp4(pv50 * shading_month)
+                    pv10 = dp4(pv10 * shading_month)
 
                 data_item = {"period_start": period_start_stamp.strftime(TIME_FORMAT), "pv_estimate": pv50, "pv_estimate10": pv10}
                 if period_start_stamp in period_data:


### PR DESCRIPTION
## Summary

- Apply per-month site shading correction when `shading_factors` array is present in `open_meteo_forecast` config
- Multiplies both pv50 and pv10 estimates by the month's factor (0-1)
- Backwards compatible — no effect if shading_factors is absent

## Context

Targets your `feat/solar-forecast` branch (PR #3796). The SaaS onboarding (Predictive-Cloud-Ltd/predbat-saas#961) extracts these factors from Google Solar API's monthly flux GeoTIFF during the Solar Wizard — 12 values per roof segment capturing shading from trees, buildings, chimneys that weather forecasts can't know about.

Config example:
```yaml
open_meteo_forecast:
  - latitude: 55.09
    longitude: -3.58
    tilt: 35
    azimuth: 180
    kwp: 4.8
    shading_factors: [0.65, 0.72, 0.85, 0.92, 0.98, 1.0, 1.0, 0.97, 0.90, 0.82, 0.70, 0.62]
```

More detail in Predictive-Cloud-Ltd/predbat-saas#964.

## Test plan

- [x] Pre-commit hooks pass (ruff, black, cspell)
- [ ] Existing open_meteo tests still pass (no shading_factors = no change)
- [ ] Verify shading correction applied correctly with mock data

🤖 Generated with [Claude Code](https://claude.ai/code)