### PR TITLE
feat(components): support provider injection via value key in args

### DIFF
--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -444,7 +444,11 @@ class Components:
                 default = arg_info.get("default", None)
                 indirect = arg_info.get("indirect", False)
                 config_late_resolve = arg_info.get("config_late_resolve", False)
-                if config_late_resolve:
+                if "value" in arg_info:
+                    # Pre-computed provider object injected directly — no config lookup needed.
+                    arg_dict[arg] = arg_info["value"]
+                    continue
+                elif config_late_resolve:
                     # Defer resolution of config value until later
                     arg_dict[arg] = arg_info["config"]
                     continue


### PR DESCRIPTION
## Summary

- Adds a `"value"` key to the component arg spec in `components.py`
- When present, the pre-built object is used directly and config lookup is skipped
- No impact on existing components — the check is a new early-exit before the existing `config_late_resolve` path

## Use case

Allows SaaS overlay code to inject a pre-constructed `StorageComponent` backend (e.g. a Redis client) without subclassing or monkey-patching the component system. The value is resolved once in `hass.py` before `PredBat` is constructed and passed straight through.

## Test plan

- [ ] Existing component tests pass (no behaviour change for args without `"value"`)
- [ ] Manual verify: component with `{"value": <obj>}` arg receives the object in `initialize()`

🤖 Generated with [Claude Code](https://claude.ai/code)