### PR TITLE
cleanup: Fix battery discharge diagram to go the right direction

### DIFF
--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -421,7 +421,7 @@ class WebInterface(ComponentBase):
             """.format(
                 dp0(pv_power)
             )
-        if battery_charging:
+        if battery_discharging:
             # Calculate animation speed based on power flow - faster for higher power
             battery_speed = max(0.5, min(3.0, 2.0 - (abs(battery_power) / 3000)))
 


### PR DESCRIPTION
When my battery is charging up on a solar day, the diagram is going the wrong way? Would attach a diagram but i think github is preventing me from adding it?

Any case from the comments itself should be clear. Line 346-347 states battery is charging, battery is discharging. If it is charging why is it going from the battery to the house?
