### PR TITLE
Fix: float slot end crash in yesterday_reconstruct_car_slots (issue #3911)

### DIFF
--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -4139,7 +4139,7 @@ class Plan:
                         # Scale down the number of minutes if the value exceeds the max
                         if kwh > iboost_left:
                             percent = iboost_left / kwh
-                            length = min(round(((length * percent) / 5) + 0.5, 0) * 5, end - start)
+                            length = int(min(round(((length * percent) / 5) + 0.5, 0) * 5, end - start))
                             end = start + length
                             hours = length / 60
                             kwh = min(iboost_power * hours, iboost_left)
@@ -4239,7 +4239,7 @@ class Plan:
             # Clamp length to required amount (shorten the window)
             if kwh_add > kwh_left:
                 percent = kwh_left / kwh_add
-                length = min(round(((length * percent) / 5) + 0.5, 0) * 5, end - start)
+                length = int(min(round(((length * percent) / 5) + 0.5, 0) * 5, end - start))
                 end = start + length
                 hours = length / 60
                 kwh = self.car_charging_rate[car_n] * hours

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -36,7 +36,7 @@ import pytz
 import requests
 import asyncio
 
-THIS_VERSION = "v8.39.2"
+THIS_VERSION = "v8.39.3"
 
 from download import predbat_update_move, predbat_update_download, check_install, resolve_predbat_repository, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/tests/test_car_charging_smart.py
+++ b/apps/predbat/tests/test_car_charging_smart.py
@@ -49,6 +49,64 @@ def run_car_charging_smart_test(test_name, my_predbat, battery_size=10.0, limit=
     return failed
 
 
+def run_car_charging_slot_integer_test(test_name, my_predbat, battery_size, soc, limit, rate, loss=1.0, smart=True, plan_time="07:00:00"):
+    """
+    Verify that plan_car_charging always produces slots with integer start/end values.
+
+    Regression test for issue #3911: when length-clamping was triggered (kwh_add > kwh_left),
+    round(x, 0) returned a Python float, causing slot['end'] to be a float (e.g. 1570.0).
+    This would later crash range(start, float_end, step) in yesterday_reconstruct_car_slots.
+    """
+    failed = False
+    print("**** Running Test: {} ****".format(test_name))
+
+    # Save state that will be modified
+    saved_battery_size = my_predbat.car_charging_battery_size
+    saved_limit = my_predbat.car_charging_limit
+    saved_soc = my_predbat.car_charging_soc
+    saved_soc_next = my_predbat.car_charging_soc_next
+    saved_rate = my_predbat.car_charging_rate
+    saved_loss = my_predbat.car_charging_loss
+    saved_max_price = my_predbat.car_charging_plan_max_price
+    saved_smart = my_predbat.car_charging_plan_smart
+    saved_plan_time = my_predbat.car_charging_plan_time
+    saved_num_cars = my_predbat.num_cars
+
+    my_predbat.car_charging_battery_size = [battery_size]
+    my_predbat.car_charging_limit = [limit]
+    my_predbat.car_charging_soc = [soc]
+    my_predbat.car_charging_soc_next = [None]
+    my_predbat.car_charging_rate = [rate]
+    my_predbat.car_charging_loss = loss
+    my_predbat.car_charging_plan_max_price = [99]
+    my_predbat.car_charging_plan_smart = [smart]
+    my_predbat.car_charging_plan_time = [plan_time]
+    my_predbat.num_cars = 1
+
+    slots = my_predbat.plan_car_charging(0, my_predbat.low_rates)
+    for slot in slots:
+        if not isinstance(slot["start"], int):
+            print("ERROR: slot start is not int: {} (type {})".format(slot["start"], type(slot["start"])))
+            failed = True
+        if not isinstance(slot["end"], int):
+            print("ERROR: slot end is not int: {} (type {})".format(slot["end"], type(slot["end"])))
+            failed = True
+
+    # Restore state
+    my_predbat.car_charging_battery_size = saved_battery_size
+    my_predbat.car_charging_limit = saved_limit
+    my_predbat.car_charging_soc = saved_soc
+    my_predbat.car_charging_soc_next = saved_soc_next
+    my_predbat.car_charging_rate = saved_rate
+    my_predbat.car_charging_loss = saved_loss
+    my_predbat.car_charging_plan_max_price = saved_max_price
+    my_predbat.car_charging_plan_smart = saved_smart
+    my_predbat.car_charging_plan_time = saved_plan_time
+    my_predbat.num_cars = saved_num_cars
+
+    return failed
+
+
 def run_car_charging_smart_tests(my_predbat):
     """
     Test car charging smart
@@ -70,5 +128,12 @@ def run_car_charging_smart_tests(my_predbat):
     failed |= run_car_charging_smart_test("smart6", my_predbat, battery_size=100.0, limit=100.0, soc=0, rate=1.0, loss=1, max_price=99, smart=True, expect_cost=14 * 15, expect_kwh=14, plan_time="02:00:00")
     failed |= run_car_charging_smart_test("smart7", my_predbat, battery_size=100.0, limit=100.0, soc=0, rate=1.0, loss=1, max_price=10, smart=True, expect_cost=7 * 10, expect_kwh=7, plan_time="02:00:00")
     failed |= run_car_charging_smart_test("smart8", my_predbat, battery_size=100.0, limit=100.0, soc=0, rate=1.0, loss=1, max_price=10, smart=False, expect_cost=7 * 10, expect_kwh=7, plan_time="02:00:00")
+
+    # Regression test for issue #3911: fractional battery size triggers length-clamping
+    # which used round(x, 0) (returns float in Python 3) causing float slot ends
+    # that crash range() in yesterday_reconstruct_car_slots.
+    failed |= run_car_charging_slot_integer_test("smart_int1_issue3911", my_predbat, battery_size=11.9, soc=9.9, limit=11.9, rate=7.4, loss=1.0, plan_time="07:00:00")
+    failed |= run_car_charging_slot_integer_test("smart_int2_issue3911", my_predbat, battery_size=11.9, soc=0.0, limit=11.9, rate=7.4, loss=1.0, plan_time="07:00:00")
+    failed |= run_car_charging_slot_integer_test("smart_int3_issue3911", my_predbat, battery_size=77.0, soc=74.3, limit=77.0, rate=11.0, loss=0.9, plan_time="07:00:00")
 
     return failed


### PR DESCRIPTION
## Problem

Fixes #3911 — crash introduced in v8.39.2: `TypeError: 'float' object cannot be interpreted as an integer` in `yesterday_reconstruct_car_slots`.

## Root Cause

In `plan.py`, both `plan_car_charging` and `plan_iboost_smart` contain a length-clamping block that fires when the battery is nearly full and the charging window supplies more energy than needed:

```python
percent = kwh_left / kwh_add
length = min(round(((length * percent) / 5) + 0.5, 0) * 5, end - start)
end = start + length
```

`round(x, 0)` in Python 3 returns a **float** (e.g. `4.0`, not `4`), so `length` and therefore `end = start + length` become floats (e.g. `1570.0`). These float values are stored in the slot dict and later passed to `range(start, end, PREDICT_STEP)` in `yesterday_reconstruct_car_slots`, which raises `TypeError` because `range` requires integers.

Users with fractional `car_charging_battery_size` (e.g. `11.9`) or iBoost `iboost_max_energy` values are most likely to hit the clamping path and trigger this crash.

## Fix

Wrap the `min(...)` result with `int()` at both sites:

```python
length = int(min(round(((length * percent) / 5) + 0.5, 0) * 5, end - start))
```

This is a minimal, targeted change — only the two clamping expressions are touched.

## Tests

Added `run_car_charging_slot_integer_test` to `test_car_charging_smart.py`. Three new test cases (`smart_int1/2/3_issue3911`) confirm that:
- `battery_size=11.9, soc=9.9` (exact reporter config) — slot `end` is `int`
- `battery_size=11.9, soc=0.0` — all slots have `int` ends
- `battery_size=77.0, soc=74.3, loss=0.9` — different battery/loss combination

All existing tests continue to pass (`./run_all --quick`).