### PR TITLE
Fix TypeError in dp1/dp2/dp3/dp4 when value is None

### DIFF
--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -851,6 +851,8 @@ def dp1(value):
     """
     Round to 1 decimal place
     """
+    if value is None:
+        return None
     return round(value, 1)
 
 
@@ -858,6 +860,8 @@ def dp2(value):
     """
     Round to 2 decimal places
     """
+    if value is None:
+        return None
     return round(value, 2)
 
 
@@ -865,6 +869,8 @@ def dp3(value):
     """
     Round to 3 decimal places
     """
+    if value is None:
+        return None
     return round(value, 3)
 
 
@@ -872,6 +878,8 @@ def dp4(value):
     """
     Round to 4 decimal places
     """
+    if value is None:
+        return None
     return round(value, 4)
 
 


### PR DESCRIPTION
The `dp1`/`dp2`/`dp3`/`dp4` rounding helpers in `utils.py` crash with `TypeError` when passed `None` (e.g. an inverter entity not yet initialised). Add an early `None` guard to each.

```python
def dp1(value):
    if value is None:
        return None
    return round(value, 1)
```

Same pattern for `dp2`, `dp3`, `dp4`. 1 file changed, 8 lines inserted.