### PR TITLE
docs: clarify watts-only rule for literal power-limit values

### DIFF
--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -893,6 +893,8 @@ for more accurate predictions.
 
 ## Inverter control configurations
 
+NB: literal numeric values for the power-limit settings below (`inverter_limit`, `pv_ac_limit`, `export_limit`, `inverter_limit_charge`, `inverter_limit_discharge`, `inverter_limit_export`, `inverter_limit_charge_dc`, `battery_rate_max`, `inverter_battery_rate_min`) must always be in **watts** — e.g. `7300` for a 7.3 kW inverter, never `7.3`. Predbat's unit auto-conversion only fires when the value is a sensor reference (it reads `unit_of_measurement` from the HA entity); for literal values there is no entity to read, so the raw number is taken as watts. A literal `inverter_limit: 7.3` will be interpreted as 7.3 W and clamp `battery_draw` to ~0.0006 kWh per 5-min step, producing a plan that looks like Predbat refuses to discharge the battery.
+
 ### **inverter_limit**
 
 One per inverter.
@@ -910,6 +912,12 @@ For an AC Coupled inverter make sure the Hybrid Inverter toggle is off and set t
 Do not add on separate Micro Inverters to the total power.
 
 If you have multiple inverters then set the value of each one in a list format.
+
+Example:
+
+```yaml
+  inverter_limit: 5000   # 5 kW — must be in watts when set as a literal
+```
 
 NB: inverter_limit is ONLY used by Predbat to improve the quality of the plan, any solar clipping is done by the inverter and is not controlled by Predbat.
 

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -2891,6 +2891,7 @@ This is at an early stage of development, see Github discussion [#789](https://g
 - You **must** set [inverter_type in apps.yaml](apps-yaml.md#inverter_type) with a custom name ('MINE' in the example below) - if you do not do this then Predbat will assume you have a GivEnergy inverter
   and will apply inverter limits for that inverter (e.g. max charge/discharge of 2600W)
 - Configure Predbat with the appropriate Home Assistant services to start charges and discharges, etc.
+- If your inverter doesn't expose a sensor for its power limits, set them as **literal watt values** in `apps.yaml` (e.g. `inverter_limit: 5000` not `inverter_limit: 5`). Predbat's unit auto-conversion only fires for sensor references — literal values are taken as watts regardless. See [Inverter control configurations](apps-yaml.md#inverter-control-configurations) for the full list of affected keys.
 
 The following template can be used as a starting point:
 


### PR DESCRIPTION
## Summary

Spawned from [discussion #3979](https://github.com/springfall2008/batpred/discussions/3979) where gcoan asked for a docs note making the literal-vs-entity behaviour explicit. Two surgical edits:

- **`docs/apps-yaml.md`** — NB callout at the top of *Inverter control configurations* naming every key affected by the literal-vs-entity unit rule, plus a concrete YAML example block under `### **inverter_limit**` (for consistency with `### **pv_ac_limit**` which already has one).
- **`docs/inverter-setup.md`** — one bullet added to *I want to add an unsupported inverter to Predbat*, cross-linking to the new callout. Custom-inverter users are the most likely to hit this trap (they hand-write the dict rather than copy a tested template, so don't get a sensor-reference example to follow).

## Why

Without the callout, a user reasoning "I have a 7.3 kW inverter, the docs say 'in watts' so 7.3 is wrong, but I'll use what feels natural" could easily land on `inverter_limit: 7.3` and silently lose discharge planning. The existing docs say `5000` for a 5 kW inverter but don't explain *why* the unit handling is asymmetric between literals and sensor references — so the rule is invisible if you don't already understand the auto-conversion machinery.

The callout names the specific failure mode (`battery_draw` clamp, plan with no discharge) so future searchers hitting the symptom find the docs by Google rather than via a github discussion.

## Out of scope (could be a follow-up if useful)

- Adding a header comment to each vendor template under `templates/*.yaml`. Most use sensor entities for the relevant keys (so auto-conversion works) and commented-out literal examples are already correct; trap doesn't bite copy-pasters in practice. Happy to PR that separately if you'd like coverage there too.

## Test plan

- [ ] Render `docs/apps-yaml.md` and `docs/inverter-setup.md` via mkdocs locally or on the docs site after merge — confirm the new callout + YAML block render cleanly and the cross-link from inverter-setup.md resolves.