### PR TITLE
fix(gecloud): report API access-denied instead of false inverter clock skew

### DIFF
--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -239,6 +239,8 @@ class GECloudDirect(ComponentBase):
         self.evc_data = {}
         self.evc_sessions = {}
         self.api_fatal = False
+        self.api_auth_failed = False
+        self.auth_denied_reported = False
         self.devices_dict = {}
         self.device_list = []
         self.ems_device = None
@@ -506,6 +508,14 @@ class GECloudDirect(ComponentBase):
                'inverter': {'temperature': 27.2, 'power': 1029, 'output_voltage': 237.8, 'output_frequency': 50.06, 'eps_power': 10}, 'consumption': 878}
 
         """
+
+        if not status and self.api_auth_failed:
+            # No fresh status because the API denied access (e.g. GivEnergy Premium now required).
+            # Mark the time sensor unavailable so downstream skew detection treats it as "no reading"
+            # instead of misreading a frozen timestamp as inverter clock skew.
+            entity_name = f"sensor.{self.prefix}_gecloud_{device}".lower()
+            self.dashboard_item(entity_name + "_time", state="unavailable", attributes=attribute_table.get("time", {}), app="gecloud")
+            return
 
         for key in status:
             entity_name = f"sensor.{self.prefix}_gecloud_{device}"
@@ -1028,13 +1038,33 @@ class GECloudDirect(ComponentBase):
                     self.log("GECloud: No valid settings found in storage cache, will poll")
 
         if first or (seconds % 120 == 0):
+            inverter_auth_denied = False
             for device in self.device_list:
                 self.status[device] = await self.async_get_inverter_status(device, self.status.get(device, {}))
+                # Capture auth state from the core inverter status call (before EVC/other endpoints
+                # below can toggle the shared flag), so the status we surface reflects the inverter
+                # data path that actually drives optimisation.
+                inverter_auth_denied = inverter_auth_denied or self.api_auth_failed
                 await self.publish_status(device, self.status[device])
                 self.meter[device] = await self.async_get_inverter_meter(device, self.meter.get(device, {}))
                 await self.publish_meter(device, self.meter[device])
                 self.info[device] = await self.async_get_device_info(device, self.info.get(device, {}))
                 await self.publish_info(device, self.info[device])
+
+            # Surface a clear, correct status when the GivEnergy cloud API denied access to the core
+            # inverter data, rather than letting stale data be misdiagnosed downstream (e.g. as
+            # inverter clock skew). Scoped to inverter — not EVC — auth failures, and reported only
+            # once per episode (on transition into the denied state) to avoid inflating error_count.
+            if inverter_auth_denied:
+                if not self.auth_denied_reported and getattr(self.base, "record_status", None):
+                    self.base.record_status(
+                        "Warn: GivEnergy cloud API access denied — check your GivEnergy API key. A GivEnergy Premium subscription is now required for API access (since May 2026). PredBat cannot read live inverter data.",
+                        had_errors=True,
+                    )
+                self.auth_denied_reported = True
+            else:
+                self.auth_denied_reported = False
+
             for uuid in self.evc_device_list:
                 self.evc_device[uuid] = await self.async_get_evc_device(uuid, self.evc_device.get(uuid, {}))
                 serial = self.evc_device[uuid].get("serial_number", "unknown")
@@ -1560,6 +1590,7 @@ class GECloudDirect(ComponentBase):
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             self.log(f"GECloud: Warn: Exception during request to {url}: {e}")
             self.failures_total += 1
+            self.api_auth_failed = False
             record_api_call("givenergy", False, "connection_error")
             return None
 
@@ -1568,17 +1599,30 @@ class GECloudDirect(ComponentBase):
             data = data["data"]
         else:
             data = None
+
+        # Only a 401/403 indicates an auth/subscription problem; any other outcome (success, 404/422,
+        # 429, 5xx) clears the flag so a transient failure after an auth failure is not reported as an
+        # ongoing access-denied condition.
+        self.api_auth_failed = status in [401, 403]
+
         if status in [200, 201]:
             if data is None:
                 data = {}
             self.update_success_timestamp()
             record_api_call("givenergy")
             return data
-        elif status in [401, 403, 404, 422]:
-            # Unauthorized
+        elif status in [401, 403]:
+            # Authentication / authorisation failure. As well as an invalid API key this now
+            # covers accounts without an active GivEnergy Premium subscription, which (since
+            # May 2026) is required for cloud API access.
+            self.failures_total += 1
+            self.log("GECloud: Warn: API access denied from {}, response code {} — check your GivEnergy API key; a GivEnergy Premium subscription may now be required for API access".format(endpoint, status))
+            record_api_call("givenergy", False, "auth_error")
+            return {}
+        elif status in [404, 422]:
             self.failures_total += 1
             self.log("GECloud: Warn: Failed to get data from {}, response code {}".format(endpoint, status))
-            record_api_call("givenergy", False, "auth_error")
+            record_api_call("givenergy", False, "client_error")
             return {}
         elif status == 429:
             # Rate limiting so wait up to 30 seconds

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -410,7 +410,12 @@ class Inverter:
         # Track and update battery size (if automatic)
         self.battery_size_tracking()
 
-        # Convert inverter time into timestamp
+        # Convert inverter time into timestamp.
+        # An absent or unavailable reading (e.g. the cloud API denied access because a GivEnergy
+        # Premium subscription is now required) is treated as "no reading" — skew detection is
+        # skipped rather than misreporting it as inverter clock skew or triggering an auto-restart.
+        if isinstance(ivtime, str) and ivtime.strip().lower() in ("", "unavailable", "unknown", "none"):
+            ivtime = None
         if ivtime:
             try:
                 self.inverter_time = datetime.strptime(ivtime, TIME_FORMAT)

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -37,6 +37,8 @@ class MockGECloudDirect(GECloudDirect):
         # Initialise instance variables that GECloudDirect expects
         self.requests_total = 0
         self.failures_total = 0
+        self.api_auth_failed = False
+        self.auth_denied_reported = False
         self.register_list = {}
         self.settings = {}
         self.status = {}
@@ -187,6 +189,12 @@ def test_ge_cloud(my_predbat=None):
     sub_tests = [
         ("api_success", _test_async_get_inverter_data_success, "API call success"),
         ("api_auth_error", _test_async_get_inverter_data_auth_error, "API auth error handling"),
+        ("api_auth_sets_flag", _test_async_get_inverter_data_auth_sets_flag, "API 403 sets api_auth_failed flag"),
+        ("api_success_clears_auth_flag", _test_async_get_inverter_data_success_clears_auth_flag, "API success clears api_auth_failed flag"),
+        ("publish_status_auth_unavailable", _test_publish_status_auth_failure_marks_time_unavailable, "Auth failure marks time sensor unavailable"),
+        ("run_auth_denied_scoped", _test_run_reports_auth_denied_scoped, "Auth-denied status scoped to inverter poll cycle"),
+        ("non_auth_clears_auth_flag", _test_async_get_inverter_data_non_auth_clears_flag, "Non-401/403 response clears api_auth_failed"),
+        ("auth_status_transition_only", _test_run_auth_status_reported_on_transition_only, "Auth-denied status reported once per episode"),
         ("api_rate_limit", _test_async_get_inverter_data_rate_limit, "API rate limit handling"),
         ("api_timeout", _test_async_get_inverter_data_timeout, "API timeout handling"),
         ("api_json_error", _test_async_get_inverter_data_json_error, "API JSON error handling"),
@@ -325,6 +333,247 @@ def _test_async_get_inverter_data_auth_error(my_predbat):
                 if ge_cloud.failures_total != 1:
                     print("ERROR: Expected failures_total=1, got {}".format(ge_cloud.failures_total))
                     return 1
+        return 0
+
+    return run_async(test())
+
+
+def _test_async_get_inverter_data_auth_sets_flag(my_predbat):
+    """Test that a 403 (e.g. GivEnergy Premium / subscription required) sets the api_auth_failed flag"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.api_auth_failed = False
+
+        mock_response = create_aiohttp_mock_response(status=403, json_data={"error": "Forbidden"})
+        mock_session = create_aiohttp_mock_session(mock_response)
+
+        with patch("aiohttp.ClientSession") as mock_session_class:
+            with patch("gecloud.asyncio.sleep", new_callable=AsyncMock):
+                mock_session_class.return_value = mock_session
+
+                result = await ge_cloud.async_get_inverter_data(GE_API_DEVICES)
+
+                if result != {}:
+                    print("ERROR: Expected empty dict for 403, got {}".format(result))
+                    return 1
+                if not ge_cloud.api_auth_failed:
+                    print("ERROR: Expected api_auth_failed=True after 403")
+                    return 1
+        return 0
+
+    return run_async(test())
+
+
+def _test_async_get_inverter_data_success_clears_auth_flag(my_predbat):
+    """Test that a successful call clears a previously-set api_auth_failed flag"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.api_auth_failed = True
+
+        mock_response = create_aiohttp_mock_response(status=200, json_data={"data": {"ok": 1}})
+        mock_session = create_aiohttp_mock_session(mock_response)
+
+        with patch("aiohttp.ClientSession") as mock_session_class:
+            with patch("gecloud.asyncio.sleep", new_callable=AsyncMock):
+                mock_session_class.return_value = mock_session
+
+                await ge_cloud.async_get_inverter_data(GE_API_DEVICES)
+
+                if ge_cloud.api_auth_failed:
+                    print("ERROR: Expected api_auth_failed=False after a successful call")
+                    return 1
+        return 0
+
+    return run_async(test())
+
+
+def _test_publish_status_auth_failure_marks_time_unavailable(my_predbat):
+    """Test that when auth has failed and no fresh status is available, the inverter time
+    sensor is marked unavailable rather than left holding a stale (frozen) timestamp.
+
+    A frozen timestamp drifts against wall-clock and is misdiagnosed downstream as inverter
+    clock skew, triggering false warnings and auto-restart loops.
+    """
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.api_auth_failed = True
+
+        await ge_cloud.publish_status("ABC123", {})
+
+        entity = "sensor.predbat_gecloud_abc123_time"
+        item = ge_cloud.dashboard_items.get(entity, {})
+        if item.get("state") != "unavailable":
+            print("ERROR: Expected {} state 'unavailable', got {}".format(entity, item.get("state")))
+            return 1
+        return 0
+
+    return run_async(test())
+
+
+def _test_run_reports_auth_denied_scoped(my_predbat):
+    """run() must report GivEnergy access-denied only on a poll cycle and only for INVERTER auth
+    failures — not from a stale flag on an in-between 60s tick, and not from an EVC/other-endpoint
+    403 while inverter polling succeeded.
+    """
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.automatic = False
+        ge_cloud.device_list = ["inv001"]
+        ge_cloud.evc_device_list = ["evc-001"]
+        ge_cloud.pending_writes = {"inv001": []}
+
+        status_messages = []
+
+        def capture_status(message, had_errors=False, **kwargs):
+            status_messages.append(message)
+
+        ge_cloud.base.record_status = capture_status
+
+        async def benign(*args, **kwargs):
+            return {}
+
+        async def status_ok(device, previous):
+            ge_cloud.api_auth_failed = False
+            return {"power": 1}
+
+        async def status_auth_fail(device, previous):
+            ge_cloud.api_auth_failed = True
+            return {}
+
+        async def evc_clears_flag(uuid, previous):
+            ge_cloud.api_auth_failed = False
+            return {"serial_number": "evc-serial"}
+
+        async def evc_sets_flag(uuid, previous):
+            ge_cloud.api_auth_failed = True
+            return {"serial_number": "evc-serial"}
+
+        ge_cloud.publish_status = benign
+        ge_cloud.async_get_inverter_meter = benign
+        ge_cloud.publish_meter = benign
+        ge_cloud.async_get_device_info = benign
+        ge_cloud.publish_info = benign
+        ge_cloud.async_get_evc_device_data = benign
+        ge_cloud.async_get_evc_sessions = benign
+        ge_cloud.publish_evc_data = benign
+
+        denied = "access denied"
+
+        # Case 1: inverter status auth-fails on a poll cycle -> report denied, even though the later
+        # EVC call clears the global flag.
+        ge_cloud.async_get_inverter_status = status_auth_fail
+        ge_cloud.async_get_evc_device = evc_clears_flag
+        status_messages.clear()
+        await ge_cloud.run(seconds=120, first=False)
+        if not any(denied in m for m in status_messages):
+            print("ERROR: inverter auth failure on a poll cycle should report access-denied, got {}".format(status_messages))
+            return 1
+
+        # Case 2 (cadence): a stale flag on a non-poll 60s tick must NOT re-report.
+        ge_cloud.api_auth_failed = True
+        status_messages.clear()
+        await ge_cloud.run(seconds=60, first=False)
+        if any(denied in m for m in status_messages):
+            print("ERROR: non-poll 60s tick must not re-report denied from a stale flag, got {}".format(status_messages))
+            return 1
+
+        # Case 3 (scope): inverter ok but an EVC-only 403 must NOT report inverter access-denied.
+        ge_cloud.api_auth_failed = False
+        ge_cloud.async_get_inverter_status = status_ok
+        ge_cloud.async_get_evc_device = evc_sets_flag
+        status_messages.clear()
+        await ge_cloud.run(seconds=120, first=False)
+        if any(denied in m for m in status_messages):
+            print("ERROR: an EVC-only auth failure must not report inverter access-denied, got {}".format(status_messages))
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_async_get_inverter_data_non_auth_clears_flag(my_predbat):
+    """A non-401/403 response (404/429/5xx) must clear a previously-set api_auth_failed flag, so a
+    transient failure after an auth failure is not reported as an ongoing access-denied condition."""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+
+        for status in (404, 429, 500):
+            ge_cloud.api_auth_failed = True
+            mock_response = create_aiohttp_mock_response(status=status, json_data={"error": "x"})
+            mock_session = create_aiohttp_mock_session(mock_response)
+
+            with patch("aiohttp.ClientSession") as mock_session_class:
+                with patch("gecloud.asyncio.sleep", new_callable=AsyncMock):
+                    mock_session_class.return_value = mock_session
+
+                    await ge_cloud.async_get_inverter_data(GE_API_DEVICES)
+
+                    if ge_cloud.api_auth_failed:
+                        print("ERROR: a {} response should clear api_auth_failed (not an auth failure)".format(status))
+                        return 1
+        return 0
+
+    return run_async(test())
+
+
+def _test_run_auth_status_reported_on_transition_only(my_predbat):
+    """A persistent inverter auth failure must report access-denied only once (on transition), not
+    on every poll cycle, to avoid inflating the HA error_count. A new episode after recovery reports
+    again."""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.automatic = False
+        ge_cloud.device_list = ["inv001"]
+        ge_cloud.evc_device_list = []
+        ge_cloud.pending_writes = {"inv001": []}
+
+        status_messages = []
+        ge_cloud.base.record_status = lambda message, had_errors=False, **kwargs: status_messages.append(message)
+
+        async def benign(*args, **kwargs):
+            return {}
+
+        async def status_auth_fail(device, previous):
+            ge_cloud.api_auth_failed = True
+            return {}
+
+        async def status_ok(device, previous):
+            ge_cloud.api_auth_failed = False
+            return {"power": 1}
+
+        ge_cloud.publish_status = benign
+        ge_cloud.async_get_inverter_meter = benign
+        ge_cloud.publish_meter = benign
+        ge_cloud.async_get_device_info = benign
+        ge_cloud.publish_info = benign
+
+        denied = "access denied"
+
+        # Two consecutive denied poll cycles -> reported only once.
+        ge_cloud.async_get_inverter_status = status_auth_fail
+        await ge_cloud.run(seconds=120, first=False)
+        await ge_cloud.run(seconds=240, first=False)
+        count = sum(1 for m in status_messages if denied in m)
+        if count != 1:
+            print("ERROR: a persistent auth denial should report once (transition), got {} reports".format(count))
+            return 1
+
+        # Recover, then deny again -> reported again (new episode).
+        ge_cloud.async_get_inverter_status = status_ok
+        await ge_cloud.run(seconds=360, first=False)
+        ge_cloud.async_get_inverter_status = status_auth_fail
+        status_messages.clear()
+        await ge_cloud.run(seconds=480, first=False)
+        if not any(denied in m for m in status_messages):
+            print("ERROR: a new denial episode after recovery should report again")
+            return 1
         return 0
 
     return run_async(test())

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -12,7 +12,7 @@ import json
 import copy
 import yaml
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from utils import calc_percent_limit
 from tests.test_infra import TestHAInterface
 from predbat import PredBat
@@ -1641,6 +1641,63 @@ def test_rest_battery_capacity_fallback(test_name, my_predbat):
     return failed
 
 
+def test_inverter_time_handling(my_predbat, dummy_items):
+    """Verify inverter clock-skew detection handles a stale/unavailable cloud time source correctly.
+
+    When the cloud time source is unavailable (e.g. GivEnergy API access denied because a
+    GivEnergy Premium subscription is now required), PredBat must treat it as "no reading" and
+    skip skew detection rather than misreporting it as inverter clock skew and triggering an
+    auto-restart loop. A genuinely skewed inverter clock must still be detected.
+    """
+    failed = False
+    print("**** Running Test: inverter_time_handling ****")
+
+    def _no_sleep(self, seconds):
+        """No-op sleep so construction never really blocks, even if an auto-restart path is hit."""
+        return None
+
+    saved_time = dummy_items.get("sensor.inverter_time")
+    saved_sleep = Inverter.sleep
+    Inverter.sleep = _no_sleep
+    try:
+        # Case 1: cloud time source unavailable -> skip skew detection, no auto-restart.
+        dummy_items["sensor.inverter_time"] = "unavailable"
+        my_predbat.ha_interface.dummy_items = dummy_items
+        my_predbat.current_status = ""
+        my_predbat.restart_active = False
+        inv = Inverter(my_predbat, 0)
+        if inv.inverter_time is not None:
+            print("ERROR: unavailable inverter time should resolve to None, got {}".format(inv.inverter_time))
+            failed = True
+        if my_predbat.restart_active:
+            print("ERROR: unavailable inverter time must not trigger an auto-restart")
+            failed = True
+        if "skew" in (my_predbat.current_status or "").lower():
+            print("ERROR: unavailable inverter time must not be reported as clock skew, status={}".format(my_predbat.current_status))
+            failed = True
+
+        # Case 2: a genuinely skewed clock (2 hours ahead) must still be detected.
+        skew_time = (my_predbat.now_utc + timedelta(minutes=120)).strftime("%Y-%m-%dT%H:%M:%S%z")
+        dummy_items["sensor.inverter_time"] = skew_time
+        my_predbat.ha_interface.dummy_items = dummy_items
+        my_predbat.current_status = ""
+        my_predbat.restart_active = True  # suppress real restart side-effects; record_status still fires
+        Inverter(my_predbat, 0)
+        if "skew" not in (my_predbat.current_status or "").lower():
+            print("ERROR: a 2-hour clock skew should still be detected, status={}".format(my_predbat.current_status))
+            failed = True
+    finally:
+        Inverter.sleep = saved_sleep
+        dummy_items["sensor.inverter_time"] = saved_time
+        my_predbat.ha_interface.dummy_items = dummy_items
+        my_predbat.current_status = ""
+        my_predbat.restart_active = False
+
+    if not failed:
+        print("**** Test inverter_time_handling PASSED ****")
+    return failed
+
+
 def run_inverter_tests(my_predbat_dummy):
     """
     Test the inverter functions
@@ -1701,6 +1758,8 @@ def run_inverter_tests(my_predbat_dummy):
     for entity_id in dummy_items.keys():
         arg_name = entity_id.split(".")[1]
         my_predbat.args[arg_name] = entity_id
+
+    failed |= test_inverter_time_handling(my_predbat, dummy_items)
 
     failed |= test_inverter_update(
         "update1",


### PR DESCRIPTION
## Problem

Since GivEnergy moved cloud **API access behind a paid Premium tier (May 2026)**, accounts without an active subscription now get **HTTP 401/403** from the cloud API. PredBat misdiagnoses this as an **"inverter clock skew"** error and enters an **auto-restart loop**, telling users to fix their inverter clock / HA sync / timezone — none of which is the real cause.

### Root cause (traced)

1. `gecloud.py async_get_inverter_data` returned `{}` for a 401/403 — indistinguishable from a successful empty response. So `async_get_inverter_status` kept serving it and `publish_status` no-op'd, leaving the GE cloud time sensor (`sensor.{prefix}_gecloud_{device}_time`) **frozen** at its last value.
2. As wall-clock time advanced, the frozen timestamp drifted past the 30-minute threshold in `Inverter.__init__`, which called `record_status(... "minutes skewed", had_errors=True)` and `auto_restart()` — repeatedly.

## Fix

- **gecloud**: track auth failure (`api_auth_failed`); split `401/403` (auth) from `404/422` (client_error); clear the flag on success.
- **gecloud**: when auth has failed, surface a **correct** status — *"GivEnergy cloud API access denied — a GivEnergy Premium subscription is now required for API access"* — and mark the time sensor `unavailable` instead of leaving it stale.
- **inverter**: treat an `unavailable`/`unknown`/empty time reading as "no reading" → skip skew detection, no auto-restart. A genuine clock skew is still detected.

## Tests (TDD)

New, all passing (full quick suite green; ruff/black/cspell pass):

- `ge_cloud`: `api_auth_sets_flag` (403 sets the flag), `api_success_clears_auth_flag`, `publish_status_auth_unavailable`.
- `inverter`: `inverter_time_handling` — an unavailable inverter time no longer triggers skew or auto-restart, while a real 2-hour skew still is detected.