### PR TITLE
Improve battery degradation estimation

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -774,10 +774,20 @@ class Inverter:
             self.log("Find battery size has {} days of data, max days {}".format(dp0(min_len / 60 / 24.0), self.base.max_days_previous))
 
             estimate_battery_sizes = []
+            rejected_battery_sizes = {}
 
             # Find continuous charging periods and calculate battery size from energy/SoC relationship
             # Data is indexed backwards: minute 0 = now, minute N = N minutes ago
-            max_power_threshold = 50
+            max_charge_power_w = max(self.battery_rate_max_charge * MINUTE_WATT, 0)
+            max_power_threshold = max(250, max_charge_power_w * 0.2)
+            loss_factor = self.base.battery_loss * self.base.inverter_loss
+            capacity_reference = nominal_capacity if nominal_capacity and nominal_capacity > 0 else self.soc_max
+            plausible_min = capacity_reference * 0.65 if capacity_reference and capacity_reference > 0 else 0
+            plausible_max = capacity_reference * 1.20 if capacity_reference and capacity_reference > 0 else 0
+            min_power_added_kwh = max(0.5, min(1.0, capacity_reference * 0.04)) if capacity_reference and capacity_reference > 0 else 0.5
+
+            def reject_battery_sample(reason):
+                rejected_battery_sizes[reason] = rejected_battery_sizes.get(reason, 0) + 1
 
             # Scan backwards through time to find charging periods
             in_charge = False
@@ -870,32 +880,102 @@ class Inverter:
                             )
                         )
 
-                        if percent_change > 5:  # Need at least 5% change for a meaningful estimate
-                            # Calculate energy added during this period (using clipped range)
-                            power_added = 0.0
-                            sample_count = 0
-                            for power_minute in range(clipped_start_minute, clipped_end_minute - 1, -1):
-                                minute_power = -battery_power.get(power_minute, 0)
-                                power_added += minute_power / 60.0  # W to Wh
-                                sample_count += 1
+                        if percent_change < 10:
+                            reject_battery_sample("soc_change_too_small")
+                            continue
 
-                            self.log("  Power added over {} samples is {}kWh".format(sample_count, dp1(power_added / 1000)))
+                        if percent_change > 80:
+                            reject_battery_sample("soc_change_too_large")
+                            continue
 
-                            if power_added > 0:
-                                estimated_battery_size = (power_added / percent_change) * 100.0 / 1000.0  # Convert Wh to kWh
-                                estimated_battery_size = dp2(estimated_battery_size)
-                                estimate_battery_sizes.append(estimated_battery_size)
+                        # Need enough real charge data to avoid SoC telemetry jumps being mistaken for capacity.
+                        if clipped_start_minute - clipped_end_minute < 20:
+                            reject_battery_sample("charge_period_too_short")
+                            continue
+
+                        if percent_change >= clipped_start_minute - clipped_end_minute:
+                            reject_battery_sample("soc_jump_too_fast")
+                            continue
+
+                        # Calculate energy added during this period (using clipped range)
+                        power_added = 0.0
+                        sample_count = 0
+                        for power_minute in range(clipped_start_minute, clipped_end_minute - 1, -1):
+                            minute_power = -battery_power.get(power_minute, 0)
+                            power_added += minute_power / 60.0  # W to Wh
+                            sample_count += 1
+
+                        power_added_kwh = power_added / 1000.0
+                        self.log("  Power added over {} samples is {}kWh".format(sample_count, dp1(power_added_kwh)))
+
+                        if power_added_kwh < min_power_added_kwh:
+                            reject_battery_sample("energy_too_small")
+                            continue
+
+                        estimated_battery_size = (power_added / percent_change) * 100.0 / 1000.0  # Convert Wh to kWh
+                        adjusted_battery_size = estimated_battery_size * loss_factor
+
+                        if plausible_min and adjusted_battery_size < plausible_min:
+                            reject_battery_sample("capacity_too_low")
+                            continue
+
+                        if plausible_max and adjusted_battery_size > plausible_max:
+                            reject_battery_sample("capacity_too_high")
+                            continue
+
+                        estimate_battery_sizes.append(
+                            {
+                                "size": estimated_battery_size,
+                                "adjusted_size": adjusted_battery_size,
+                                "soc_change": percent_change,
+                                "sample_count": sample_count,
+                                "power_added_kwh": power_added_kwh,
+                            }
+                        )
+
+                        self.log(
+                            "  Battery size sample accepted raw {}kWh adjusted {}kWh from {}% SoC over {} minutes".format(
+                                dp2(estimated_battery_size),
+                                dp2(adjusted_battery_size),
+                                percent_change,
+                                sample_count,
+                            )
+                        )
 
             # Average the estimated battery sizes
             if len(estimate_battery_sizes) > 0:
-                average_battery_size = sum(estimate_battery_sizes) / len(estimate_battery_sizes)
-                average_battery_size = dp2(average_battery_size)
-                # Add in charging loss factor, assume the inverter loss is not counted in the charge rate sensor (as it's AC side)
-                average_battery_size *= self.base.battery_loss * self.base.inverter_loss
-                self.log("Estimated battery size is {}kWh from {} samples (assumed charging loss factor {})".format(dp2(average_battery_size), len(estimate_battery_sizes), dp1(self.base.battery_loss * self.base.inverter_loss)))
+                strong_battery_sizes = [
+                    sample
+                    for sample in estimate_battery_sizes
+                    if sample["soc_change"] >= 20 and sample["sample_count"] >= 60 and sample["power_added_kwh"] >= max(min_power_added_kwh * 4, 4.0)
+                ]
+                selected_battery_sizes = strong_battery_sizes if len(strong_battery_sizes) >= 3 else estimate_battery_sizes
+                selected_values = sorted([sample["adjusted_size"] for sample in selected_battery_sizes])
+
+                if len(selected_values) >= 5:
+                    trim_count = max(1, int(len(selected_values) * 0.1))
+                    trimmed_values = selected_values[trim_count:-trim_count]
+                elif len(selected_values) >= 3:
+                    trimmed_values = selected_values[1:-1]
+                else:
+                    trimmed_values = selected_values
+
+                average_battery_size = dp2(sum(trimmed_values) / len(trimmed_values))
+                median_battery_size = selected_values[len(selected_values) // 2] if len(selected_values) % 2 else (selected_values[len(selected_values) // 2 - 1] + selected_values[len(selected_values) // 2]) / 2
+                self.log(
+                    "Estimated battery size is {}kWh from {} selected samples, {} accepted samples, {} rejected samples, median {}kWh (assumed charging loss factor {}, rejects {})".format(
+                        dp2(average_battery_size),
+                        len(selected_battery_sizes),
+                        len(estimate_battery_sizes),
+                        sum(rejected_battery_sizes.values()),
+                        dp2(median_battery_size),
+                        dp1(loss_factor),
+                        rejected_battery_sizes,
+                    )
+                )
                 return average_battery_size
             else:
-                self.log("Warn: Unable to find any suitable charge periods to estimate battery size")
+                self.log("Warn: Unable to find any suitable charge periods to estimate battery size, rejected samples {}".format(rejected_battery_sizes))
                 return None
         else:
             self.log("Warn: Unable to estimate battery size from soc_percent and battery_power data")

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -780,11 +780,13 @@ class Inverter:
             # Data is indexed backwards: minute 0 = now, minute N = N minutes ago
             max_charge_power_w = max(self.battery_rate_max_charge * MINUTE_WATT, 0)
             max_power_threshold = max(250, max_charge_power_w * 0.2)
-            loss_factor = self.base.battery_loss * self.base.inverter_loss
-            capacity_reference = nominal_capacity if nominal_capacity and nominal_capacity > 0 else self.soc_max
-            plausible_min = capacity_reference * 0.65 if capacity_reference and capacity_reference > 0 else 0
-            plausible_max = capacity_reference * 1.20 if capacity_reference and capacity_reference > 0 else 0
-            min_power_added_kwh = max(0.5, min(1.0, capacity_reference * 0.04)) if capacity_reference and capacity_reference > 0 else 0.5
+loss_factor = self.base.battery_loss * self.base.inverter_loss
+size_hint = self.soc_max if self.soc_max and self.soc_max > 0 else 0
+capacity_reference = nominal_capacity if nominal_capacity and nominal_capacity > 0 else 0
+plausible_min = capacity_reference * 0.65 if capacity_reference else 0
+plausible_max = capacity_reference * 1.20 if capacity_reference else 0
+reference_for_energy = capacity_reference or size_hint
+min_power_added_kwh = max(0.5, min(1.0, reference_for_energy * 0.04)) if reference_for_energy else 0.5
 
             def reject_battery_sample(reason):
                 rejected_battery_sizes[reason] = rejected_battery_sizes.get(reason, 0) + 1

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -944,11 +944,7 @@ class Inverter:
 
             # Average the estimated battery sizes
             if len(estimate_battery_sizes) > 0:
-                strong_battery_sizes = [
-                    sample
-                    for sample in estimate_battery_sizes
-                    if sample["soc_change"] >= 20 and sample["sample_count"] >= 60 and sample["power_added_kwh"] >= max(min_power_added_kwh * 4, 4.0)
-                ]
+                strong_battery_sizes = [sample for sample in estimate_battery_sizes if sample["soc_change"] >= 20 and sample["sample_count"] >= 60 and sample["power_added_kwh"] >= max(min_power_added_kwh * 4, 4.0)]
                 selected_battery_sizes = strong_battery_sizes if len(strong_battery_sizes) >= 3 else estimate_battery_sizes
                 selected_values = sorted([sample["adjusted_size"] for sample in selected_battery_sizes])
 

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -780,13 +780,13 @@ class Inverter:
             # Data is indexed backwards: minute 0 = now, minute N = N minutes ago
             max_charge_power_w = max(self.battery_rate_max_charge * MINUTE_WATT, 0)
             max_power_threshold = max(250, max_charge_power_w * 0.2)
-loss_factor = self.base.battery_loss * self.base.inverter_loss
-size_hint = self.soc_max if self.soc_max and self.soc_max > 0 else 0
-capacity_reference = nominal_capacity if nominal_capacity and nominal_capacity > 0 else 0
-plausible_min = capacity_reference * 0.65 if capacity_reference else 0
-plausible_max = capacity_reference * 1.20 if capacity_reference else 0
-reference_for_energy = capacity_reference or size_hint
-min_power_added_kwh = max(0.5, min(1.0, reference_for_energy * 0.04)) if reference_for_energy else 0.5
+            loss_factor = self.base.battery_loss * self.base.inverter_loss
+            size_hint = self.soc_max if self.soc_max and self.soc_max > 0 else 0
+            capacity_reference = nominal_capacity if nominal_capacity and nominal_capacity > 0 else 0
+            plausible_min = capacity_reference * 0.65 if capacity_reference else 0
+            plausible_max = capacity_reference * 1.20 if capacity_reference else 0
+            reference_for_energy = capacity_reference or size_hint
+            min_power_added_kwh = max(0.5, min(1.0, reference_for_energy * 0.04)) if reference_for_energy else 0.5
 
             def reject_battery_sample(reason):
                 rejected_battery_sizes[reason] = rejected_battery_sizes.get(reason, 0) + 1

--- a/apps/predbat/tests/test_find_battery_size.py
+++ b/apps/predbat/tests/test_find_battery_size.py
@@ -149,6 +149,48 @@ def create_test_history_data_soc_kw(my_predbat, num_days=2, battery_size_kwh=10.
     my_predbat.ha_interface.get_history = mock_get_history
 
 
+def create_test_history_data_with_soc_glitches(my_predbat, battery_size_kwh=10.0):
+    """
+    Create one real charge period plus short SoC jumps that should be rejected.
+    """
+    ha = my_predbat.ha_interface
+    base_time = my_predbat.midnight_utc - timedelta(hours=8)
+
+    history_dict = {"sensor.soc_percent": [], "sensor.battery_power": []}
+    ha.dummy_items["sensor.soc_percent"] = 70
+    ha.dummy_items["sensor.battery_power"] = 0
+
+    charge_power_w = 2500
+    current_soc = 20.0
+    glitch_soc = {300: 30.0, 301: 50.0, 302: 70.0, 303: 80.0, 360: 25.0, 361: 60.0, 362: 85.0}
+
+    for minutes in range(0, 8 * 60):
+        timestamp = base_time + timedelta(minutes=minutes)
+        timestamp_str = timestamp.strftime("%Y-%m-%dT%H:%M:%S%z")
+
+        if 60 <= minutes < 180:
+            battery_power = -charge_power_w
+            energy_added_wh = charge_power_w / 60.0
+            current_soc = min(100.0, current_soc + (energy_added_wh / (battery_size_kwh * 1000.0)) * 100.0)
+            soc = current_soc
+        elif minutes in glitch_soc:
+            battery_power = -charge_power_w
+            soc = glitch_soc[minutes]
+        else:
+            battery_power = 0
+            soc = current_soc
+
+        history_dict["sensor.soc_percent"].append({"state": str(round(soc)), "last_updated": timestamp_str, "attributes": {"unit_of_measurement": "%"}})
+        history_dict["sensor.battery_power"].append({"state": round(battery_power, 1), "last_updated": timestamp_str, "attributes": {"unit_of_measurement": "W"}})
+
+    def mock_get_history(entity_id, now=None, days=30):
+        if entity_id in history_dict:
+            return [history_dict[entity_id]]
+        return None
+
+    my_predbat.ha_interface.get_history = mock_get_history
+
+
 def remove_test_history_data(my_predbat):
     def mock_get_history(entity_id, now=None, days=30):
         return None
@@ -411,6 +453,49 @@ def test_find_battery_size_different_size(my_predbat):
         else:
             print("ERROR: No battery size estimate returned")
             failed = True
+    except Exception as e:
+        print("ERROR: find_battery_size raised exception: {}".format(e))
+        import traceback
+
+        traceback.print_exc()
+        failed = True
+
+    return failed
+
+
+def test_find_battery_size_rejects_soc_glitches(my_predbat):
+    """
+    Test that short, physically impossible SoC jumps do not drag down the capacity estimate.
+    """
+    print("*** Running test: find_battery_size_rejects_soc_glitches ***")
+    failed = False
+
+    expected_battery_size = 10.0
+    inv = Inverter(my_predbat, 0)
+    inv.battery_rate_max_charge = 2600 / 60000
+    inv.battery_rate_max_discharge = 2600 / 60000
+    inv.soc_max = expected_battery_size
+    inv.nominal_capacity = expected_battery_size
+    inv.battery_scaling = 1.0
+
+    setup_predbat(my_predbat)
+    create_test_history_data_with_soc_glitches(my_predbat, battery_size_kwh=expected_battery_size)
+
+    try:
+        estimated_size = inv.find_battery_size(expected_battery_size)
+        if estimated_size is None:
+            print("ERROR: No battery size estimate returned")
+            failed = True
+        else:
+            print("Estimated battery size with SoC glitches: {} kWh (expected: {} kWh)".format(estimated_size, expected_battery_size))
+            tolerance = 0.15
+            lower_bound = expected_battery_size * (1 - tolerance)
+            upper_bound = expected_battery_size * (1 + tolerance)
+            if not (lower_bound <= estimated_size <= upper_bound):
+                print("ERROR: Estimated battery size {} kWh is outside acceptable range [{}, {}] kWh".format(estimated_size, lower_bound, upper_bound))
+                failed = True
+            else:
+                print("SUCCESS: SoC glitches were rejected from the estimate")
     except Exception as e:
         print("ERROR: find_battery_size raised exception: {}".format(e))
         import traceback
@@ -1306,6 +1391,10 @@ def run_find_battery_size_tests(my_predbat):
         return failed
 
     failed |= test_find_battery_size_different_size(my_predbat)
+    if failed:
+        return failed
+
+    failed |= test_find_battery_size_rejects_soc_glitches(my_predbat)
     if failed:
         return failed
 


### PR DESCRIPTION
Previously, the battery degradation estimator was too trusting of noisy SoC history. It accepted charge samples with very small SoC changes, very short charge periods, and obvious SoC telemetry jumps, then averaged everything together. In one example this made Predbat estimate around 15% battery degradation, even though the battery had not degraded that much.

That bad capacity estimate then fed into planning: Predbat believed the battery was smaller than it really was, so charge targets and overnight plans could be wrong, for example planning to charge to a high SoC but only reaching a much lower actual SoC because the model’s assumed capacity was distorted.

This change tightens the estimator so it now:

- Uses a more realistic charging power threshold instead of treating tiny power movement as a charge session.
- Rejects samples with too little SoC movement, too little energy, very short duration, or physically implausible SoC jumps.
- Applies plausible capacity bounds when nominal capacity is known.
- Prefers stronger, longer charge sessions for the final estimate when enough good samples exist.
- Uses a trimmed average to reduce outlier influence.
- Logs accepted, selected, and rejected sample counts with reject reasons.
- Adds a regression test covering short SoC jump glitches so they cannot drag the capacity estimate down again.

With the new filtering, the same kind of data produces a much more plausible capacity estimate instead of the inflated degradation figure, which should lead to more reliable charge planning.