### PR TITLE
feat(storage+octopus): fetch_cached helper + migrate Octopus onto the storage component

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -9,8 +9,8 @@
 
 Provides both REST and GraphQL API access to Octopus Energy for fetching
 tariff rates, intelligent dispatch schedules, saving sessions, and account
-data. Implements file-based caching with stale-while-revalidate strategy
-for multi-pod deployments.
+data. Delegates caching to the StorageComponent with stale-while-revalidate
+semantics for multi-pod deployments.
 """
 
 import asyncio
@@ -22,9 +22,9 @@ from const import TIME_FORMAT, TIME_FORMAT_OCTOPUS
 from utils import str2time, minutes_to_time, dp1, dp2, dp4, minute_data
 from component_base import ComponentBase
 import aiohttp
+import hashlib
 import json
 import os
-import json
 import pytz
 
 user_agent_value = "predbat-octopus-energy"
@@ -358,7 +358,6 @@ class OctopusAPI(ComponentBase):
         self.graphql_token = None
         self.graphql_expiration = None
         self.account_data = {}
-        self.url_cache = {}
         self.tariffs = {}
         self.saving_sessions = {}
         self.saving_sessions_to_join = []
@@ -513,7 +512,6 @@ class OctopusAPI(ComponentBase):
         Returns datetime object if successful, None otherwise.
         """
         import base64
-        import json
 
         if not token:
             return None
@@ -545,9 +543,6 @@ class OctopusAPI(ComponentBase):
             self.graphql_token = data.get("kraken_token")
 
         self.tariffs = {}
-        self.url_cache = {}
-        if self.tariffs is None:
-            self.tariffs = {}
         if self.account_data is None:
             self.account_data = {}
         if self.saving_sessions is None:
@@ -1316,8 +1311,6 @@ class OctopusAPI(ComponentBase):
         behaviour is unchanged. If json_only=True, the raw JSON dict is returned without
         results unwrapping or pagination.
         """
-        import hashlib
-
         url_hash = hashlib.sha256(url.encode()).hexdigest()[:16]
         storage = self._get_storage()
 
@@ -1328,7 +1321,8 @@ class OctopusAPI(ComponentBase):
             return data
 
         async def _download():
-            return await self.async_download_octopus_url(url, json_only=json_only)
+            result = await self.async_download_octopus_url(url, json_only=json_only)
+            return result if result else None
 
         data = await storage.fetch_cached("octopus", url_hash, _download, fresh_minutes=30, stale_minutes=35, format="yaml")
         if not data:

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -1306,10 +1306,12 @@ class OctopusAPI(ComponentBase):
         """
         Fetch a URL from the shared cache or reload it via the storage component.
 
-        Uses storage.fetch_cached (stale-while-revalidate) so that in multi-instance
-        deployments only one instance refreshes while others serve stale. Single-instance
-        behaviour is unchanged. If json_only=True, the raw JSON dict is returned without
-        results unwrapping or pagination.
+        Uses storage.fetch_cached (stale-while-revalidate). With the default
+        single-instance StorageBase the refresh lock is a no-op; a StorageBase
+        subclass that implements a real distributed lock (e.g. a multi-instance
+        backend) ensures only one instance refreshes while others serve stale.
+        If json_only=True, the raw JSON dict is returned without results
+        unwrapping or pagination.
         """
         url_hash = hashlib.sha256(url.encode()).hexdigest()[:16]
         storage = self._get_storage()
@@ -1318,7 +1320,7 @@ class OctopusAPI(ComponentBase):
             data = await self.async_download_octopus_url(url, json_only=json_only)
             if not data:
                 self.log("Warn: Unable to download Octopus data from URL {}".format(url))
-            return data
+            return data or None
 
         async def _download():
             result = await self.async_download_octopus_url(url, json_only=json_only)

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -24,7 +24,6 @@ from component_base import ComponentBase
 import aiohttp
 import json
 import os
-import yaml
 import json
 import pytz
 
@@ -373,22 +372,22 @@ class OctopusAPI(ComponentBase):
         self.requests_total = 0
         self.failures_total = 0
 
-        # Shared cache directories for tariffs and URLs (shared across all users)
-        self.cache_path = self.config_root + "/octopus"
-        self.shared_cache_path = self.config_root + "/octopus/shared"
-        self.urls_cache_path = self.shared_cache_path + "/urls"
-
-        for path in [self.cache_path, self.shared_cache_path, self.urls_cache_path]:
-            if not os.path.exists(path):
-                os.makedirs(path, exist_ok=True)
-
-        # User-specific cache file (account_data, intelligent_device, saving_sessions only)
-        self.user_cache_file = self.cache_path + "/octopus_user_{}.yaml".format(self.account_id)
+        # Storage override (tests set this to inject a StorageComponent); when None the
+        # storage component is resolved lazily via the orchestrator in _get_storage().
+        self._storage_override = None
 
         # In-memory cache for product info (keyed by product_code) to avoid repeated API calls
         self._product_info_cache = {}
 
-        self.log("OctopusAPI: Initialised with account ID {}, cache {}, shared {}".format(self.account_id, self.user_cache_file, self.shared_cache_path))
+        self.log("OctopusAPI: Initialised with account ID {}".format(self.account_id))
+
+    def _get_storage(self):
+        """Return the storage component, preferring an explicitly-set one (tests), else resolving via the orchestrator."""
+        existing = getattr(self, "_storage_override", None)
+        if existing is not None:
+            return existing
+        components = getattr(self.base, "components", None)
+        return components.get_component("storage") if components else None
 
     async def select_event(self, entity_id, value):
         suffix = self.get_entity_suffix(entity_id)
@@ -508,38 +507,6 @@ class OctopusAPI(ComponentBase):
         key = f"{product_code}_{tariff_code}".replace("/", "_").replace("\\", "_")
         return key
 
-    def load_url_from_cache(self, url):
-        """
-        Load cached HTTP response for a URL
-        Returns: cached data or None
-        """
-        import hashlib
-
-        url_hash = hashlib.sha256(url.encode()).hexdigest()[:16]
-        cache_file = f"{self.urls_cache_path}/{url_hash}.yaml"
-        if os.path.exists(cache_file):
-            try:
-                with open(cache_file, "r") as f:
-                    return yaml.safe_load(f)
-            except Exception as e:
-                self.log(f"Warn: OctopusAPI: Failed to load URL cache {url_hash}: {e}")
-        return None
-
-    def save_url_to_cache(self, url, data):
-        """
-        Save HTTP response to cache for a URL
-        No locking needed - each URL is in a separate file
-        """
-        import hashlib
-
-        url_hash = hashlib.sha256(url.encode()).hexdigest()[:16]
-        cache_file = f"{self.urls_cache_path}/{url_hash}.yaml"
-        try:
-            with open(cache_file, "w") as f:
-                yaml.dump(data, f)
-        except Exception as e:
-            self.log(f"Warn: OctopusAPI: Failed to save URL cache {url_hash}: {e}")
-
     def decode_kraken_token_expiry(self, token):
         """
         Extract expiration timestamp from Kraken JWT token without verification.
@@ -568,31 +535,16 @@ class OctopusAPI(ComponentBase):
             return None
 
     async def load_octopus_cache(self):
-        """
-        Load the octopus cache
-        User-specific data from user file, tariffs/URLs from shared individual files
-        """
-        # Load user-specific data
-        data = {}
-        if os.path.exists(self.user_cache_file):
-            try:
-                with open(self.user_cache_file, "r") as f:
-                    data = yaml.safe_load(f)
-            except Exception as e:
-                self.log("Warn: OctopusAPI: Failed to load cache from {} - {}".format(self.user_cache_file, e))
+        """Load the octopus user cache via the storage component, normalising missing fields."""
+        storage = self._get_storage()
+        data = await storage.load("octopus_user", "account") if storage else None
+        if data:
+            self.account_data = data.get("account_data", {})
+            self.saving_sessions = data.get("saving_sessions", {})
+            self.intelligent_devices = data.get("intelligent_devices", {})
+            self.graphql_token = data.get("kraken_token")
 
-            if data:
-                self.account_data = data.get("account_data", {})
-                self.saving_sessions = data.get("saving_sessions", {})
-                self.intelligent_devices = data.get("intelligent_devices", {})
-                self.graphql_token = data.get("kraken_token")
-
-        # Load tariffs from individual shared cache files
-        # Tariffs will be loaded on-demand when needed via load_tariff_from_cache()
         self.tariffs = {}
-
-        # Load URL cache from individual shared files
-        # URL cache will be checked on-demand via load_url_from_cache()
         self.url_cache = {}
         if self.tariffs is None:
             self.tariffs = {}
@@ -604,21 +556,16 @@ class OctopusAPI(ComponentBase):
             self.intelligent_devices = {}
 
     async def save_octopus_cache(self):
-        """
-        Save the octopus cache
-        User-specific data to user file, tariffs/URLs to individual shared files
-        """
-        # Save user-specific data only
-        octopus_cache = {}
-        octopus_cache["account_data"] = self.account_data
-        octopus_cache["saving_sessions"] = self.saving_sessions
-        octopus_cache["intelligent_devices"] = self.intelligent_devices
-        octopus_cache["kraken_token"] = self.graphql_token
-        with open(self.user_cache_file, "w") as f:
-            yaml.dump(octopus_cache, f)
-
-        # URL cache entries are saved on-demand via save_url_to_cache()
-        # These allow the re-loading of tariffs so we don't need to save them directly
+        """Save the octopus user cache (account data, tokens, sessions, devices) via the storage component."""
+        octopus_cache = {
+            "account_data": self.account_data,
+            "saving_sessions": self.saving_sessions,
+            "intelligent_devices": self.intelligent_devices,
+            "kraken_token": self.graphql_token,
+        }
+        storage = self._get_storage()
+        if storage:
+            await storage.save("octopus_user", "account", octopus_cache, format="yaml", expiry=None)
 
     def get_tariff(self, tariff_type):
         if tariff_type in self.tariffs:
@@ -1360,92 +1307,38 @@ class OctopusAPI(ComponentBase):
 
         return mdata
 
-    async def clean_url_cache(self):
-        """
-        Clean the URL cache - now uses individual files in shared cache
-        """
-        now = datetime.now()
-
-        # Clean old cache files from shared URLs directory
-        if os.path.exists(self.urls_cache_path):
-            for filename in os.listdir(self.urls_cache_path):
-                filepath = os.path.join(self.urls_cache_path, filename)
-                if filename.endswith(".yaml"):
-                    try:
-                        with open(filepath, "r") as f:
-                            cache_entry = yaml.safe_load(f)
-                        if cache_entry and "stamp" in cache_entry:
-                            stamp = cache_entry["stamp"]
-                            age = now - stamp
-                            if age.total_seconds() > (24 * 60 * 60):
-                                os.remove(filepath)
-                                self.log(f"OctopusAPI: Cleaned old URL cache file: {filename}")
-                    except Exception as e:
-                        self.log(f"Warn: OctopusAPI: Failed to clean cache file {filename}: {e}")
-
     async def fetch_url_cached(self, url, json_only=False):
         """
-        Fetch a URL from the cache or reload it
-        Uses individual file per URL in shared cache directory
-        Implements stale-while-revalidate to prevent thundering herd
-        If json_only=True, the raw JSON dict is returned without results unwrapping or pagination.
+        Fetch a URL from the shared cache or reload it via the storage component.
+
+        Uses storage.fetch_cached (stale-while-revalidate) so that in multi-instance
+        deployments only one instance refreshes while others serve stale. Single-instance
+        behaviour is unchanged. If json_only=True, the raw JSON dict is returned without
+        results unwrapping or pagination.
         """
         import hashlib
 
         url_hash = hashlib.sha256(url.encode()).hexdigest()[:16]
+        storage = self._get_storage()
 
-        # Check shared file cache first
-        cached_data = self.load_url_from_cache(url)
-        if cached_data and "stamp" in cached_data and "data" in cached_data:
-            stamp = cached_data["stamp"]
-            age = datetime.now() - stamp
-
-            # Fresh cache (< 30 minutes) - return immediately
-            if age.total_seconds() < (30 * 60):
-                return cached_data["data"]
-
-            # Stale cache (30-35 minutes) - serve stale while ONE pod refreshes
-            if age.total_seconds() < (35 * 60):
-                lock_file = f"{self.urls_cache_path}/{url_hash}.lock"
-                try:
-                    # Try to acquire lock atomically (non-blocking)
-                    # cspell:ignore CREAT WRONLY
-                    fd = os.open(lock_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-                    try:
-                        # We got the lock! Refresh in background
-                        data = await self.async_download_octopus_url(url, json_only=json_only)
-                        if data:
-                            cache_entry = {"stamp": datetime.now(), "data": data}
-                            self.save_url_to_cache(url, cache_entry)
-                            self.log(f"OctopusAPI: Refreshed stale cache for {url_hash}")
-                    finally:
-                        os.close(fd)
-                        os.remove(lock_file)
-                except FileExistsError:
-                    # Another pod is refreshing, serve stale data
-                    self.log(f"OctopusAPI: Serving stale cache due to file access lock {url_hash}")
-                    pass
-
-                # Serve stale data (either we just refreshed, or another pod is refreshing)
-                return cached_data["data"]
-
-        # Cache completely missing or too stale (>35 min) - must fetch
-        data = await self.async_download_octopus_url(url, json_only=json_only)
-        if data:
-            # Save to shared file cache
-            cache_entry = {"stamp": datetime.now(), "data": data}
-            self.save_url_to_cache(url, cache_entry)
+        if not storage:
+            data = await self.async_download_octopus_url(url, json_only=json_only)
+            if not data:
+                self.log("Warn: Unable to download Octopus data from URL {}".format(url))
             return data
-        else:
+
+        async def _download():
+            return await self.async_download_octopus_url(url, json_only=json_only)
+
+        data = await storage.fetch_cached("octopus", url_hash, _download, fresh_minutes=30, stale_minutes=35, format="yaml")
+        if not data:
             self.log("Warn: Unable to download Octopus data from URL {}".format(url))
-            return None
+        return data
 
     async def fetch_tariffs(self, tariffs):
         """
         Fetch the tariff data
         """
-        await self.clean_url_cache()
-
         for tariff in sorted(tariffs, key=lambda t: 0 if t == "import" else 1):
             product_code = tariffs[tariff]["productCode"]
             tariff_code = tariffs[tariff]["tariffCode"]

--- a/apps/predbat/storage.py
+++ b/apps/predbat/storage.py
@@ -112,6 +112,64 @@ class StorageBase(ABC):
         """Delete all expired cached files."""
         pass
 
+    async def _acquire_refresh_lock(self, module, filename):
+        """Try to acquire a refresh lock for a key. Default: always succeeds (no coordination).
+
+        Args:
+            module: The calling module name
+            filename: Logical filename identifier
+
+        Returns:
+            True if the caller should perform the refresh.
+        """
+        return True
+
+    async def _release_refresh_lock(self, module, filename):
+        """Release a refresh lock. Default: no-op.
+
+        Args:
+            module: The calling module name
+            filename: Logical filename identifier
+        """
+        return None
+
+    async def fetch_cached(self, module, filename, fetch_fn, fresh_minutes=30, stale_minutes=35, format="yaml"):
+        """Return cached data if fresh; serve stale while one caller refreshes; else fetch and store.
+
+        Args:
+            module: The calling module name
+            filename: Logical filename identifier
+            fetch_fn: Zero-arg coroutine function that fetches fresh data
+            fresh_minutes: Below this age the cached value is returned without refresh
+            stale_minutes: Between fresh_minutes and this, serve stale while one caller refreshes
+            format: One of 'yaml', 'json', or 'text'
+
+        Returns:
+            Cached or freshly fetched data, or None if nothing could be obtained
+        """
+        age_minutes = await self.age(module, filename)
+
+        if age_minutes is not None and age_minutes < fresh_minutes:
+            return await self.load(module, filename)
+
+        if age_minutes is not None and age_minutes < stale_minutes:
+            cached = await self.load(module, filename)
+            if await self._acquire_refresh_lock(module, filename):
+                try:
+                    data = await fetch_fn()
+                    if data is not None:
+                        await self.save(module, filename, data, format=format)
+                        return data
+                finally:
+                    await self._release_refresh_lock(module, filename)
+            return cached
+
+        data = await fetch_fn()
+        if data is not None:
+            await self.save(module, filename, data, format=format)
+            return data
+        return await self.load(module, filename)
+
 
 class StorageLocalFiles(StorageBase):
     """Local filesystem storage backend.
@@ -393,6 +451,22 @@ class StorageComponent(ComponentBase):
             Age in minutes as a float, or None if the entry does not exist
         """
         return await self.backend.age(module, filename)
+
+    async def fetch_cached(self, module, filename, fetch_fn, fresh_minutes=30, stale_minutes=35, format="yaml"):
+        """Fetch-or-cache via the storage backend's stale-while-revalidate helper.
+
+        Args:
+            module: The calling module name
+            filename: Logical filename identifier
+            fetch_fn: Zero-arg coroutine function that fetches fresh data
+            fresh_minutes: Below this age the cached value is returned without refresh
+            stale_minutes: Between fresh_minutes and this, serve stale while one caller refreshes
+            format: One of 'yaml', 'json', or 'text'
+
+        Returns:
+            Cached or freshly fetched data
+        """
+        return await self.backend.fetch_cached(module, filename, fetch_fn, fresh_minutes=fresh_minutes, stale_minutes=stale_minutes, format=format)
 
     async def run(self, seconds, first):
         """Run the storage component, cleaning up expired files every hour.

--- a/apps/predbat/storage.py
+++ b/apps/predbat/storage.py
@@ -150,8 +150,11 @@ class StorageBase(ABC):
         age_minutes = await self.age(module, filename)
 
         if age_minutes is not None and age_minutes < fresh_minutes:
-            return await self.load(module, filename)
-
+            cached = await self.load(module, filename)
+            if cached is not None:
+                return cached
+            # Entry exists but is expired/unreadable; treat as a miss and re-fetch.
+            age_minutes = None
         if age_minutes is not None and age_minutes < stale_minutes:
             cached = await self.load(module, filename)
             if await self._acquire_refresh_lock(module, filename):

--- a/apps/predbat/storage.py
+++ b/apps/predbat/storage.py
@@ -160,11 +160,19 @@ class StorageBase(ABC):
                     if data is not None:
                         await self.save(module, filename, data, format=format)
                         return data
+                except Exception as e:  # pylint: disable=broad-except
+                    if hasattr(self, "log") and callable(getattr(self, "log")):
+                        self.log("Storage: Warn: refresh failed for {}/{}, serving cached: {}".format(module, filename, e))
                 finally:
                     await self._release_refresh_lock(module, filename)
             return cached
 
-        data = await fetch_fn()
+        try:
+            data = await fetch_fn()
+        except Exception as e:  # pylint: disable=broad-except
+            if hasattr(self, "log") and callable(getattr(self, "log")):
+                self.log("Storage: Warn: fetch failed for {}/{}: {}".format(module, filename, e))
+            data = None
         if data is not None:
             await self.save(module, filename, data, format=format)
             return data
@@ -464,7 +472,7 @@ class StorageComponent(ComponentBase):
             format: One of 'yaml', 'json', or 'text'
 
         Returns:
-            Cached or freshly fetched data
+            Cached or freshly fetched data, or None if nothing could be obtained
         """
         return await self.backend.fetch_cached(module, filename, fetch_fn, fresh_minutes=fresh_minutes, stale_minutes=stale_minutes, format=format)
 

--- a/apps/predbat/tests/test_fetch_url_cached.py
+++ b/apps/predbat/tests/test_fetch_url_cached.py
@@ -74,6 +74,9 @@ async def test_fetch_url_cached_async(my_predbat):
             return mock_rate_data_agile
         elif "INVALID" in url:
             return None
+        elif "empty-error" in url:
+            # Mirrors async_download_octopus_url's real error return ({} on HTTP/parse errors)
+            return {}
         else:
             # Return generic data for other URLs
             return [{"value_inc_vat": 10.0, "valid_from": "2025-01-01T00:00:00Z", "valid_to": "2025-01-01T00:30:00Z"}]
@@ -171,6 +174,22 @@ async def test_fetch_url_cached_async(my_predbat):
             failed = True
         else:
             print("Successfully handled invalid URL")
+
+        # Test 5: Download returns {} (the real error return) — must NOT be cached
+        print("*** Test 5: Empty error response is not cached")
+        empty_url = "https://api.octopus.energy/v1/products/empty-error/electricity-tariffs/empty-error/standard-unit-rates/"
+        empty_hash = hashlib.sha256(empty_url.encode()).hexdigest()[:16]
+
+        data5 = await api.fetch_url_cached(empty_url)
+        cached5 = await storage.load("octopus", empty_hash)
+        if data5:
+            print("ERROR Test 5: Expected falsy result for empty error response, got {}".format(data5))
+            failed = True
+        elif cached5 is not None:
+            print("ERROR Test 5: Empty error response should not be cached, found {}".format(cached5))
+            failed = True
+        else:
+            print("Empty error response not cached")
 
     finally:
         # Clean up temporary directory

--- a/apps/predbat/tests/test_fetch_url_cached.py
+++ b/apps/predbat/tests/test_fetch_url_cached.py
@@ -9,11 +9,12 @@
 # pylint: disable=attribute-defined-outside-init
 
 import asyncio
-from datetime import datetime, timedelta
+import hashlib
 import os
 import tempfile
 import shutil
 from octopus import OctopusAPI
+from storage import StorageComponent, StorageLocalFiles
 
 
 def test_fetch_url_cached(my_predbat):
@@ -23,18 +24,24 @@ def test_fetch_url_cached(my_predbat):
     return asyncio.run(test_fetch_url_cached_async(my_predbat))
 
 
+def _attach_storage(api, temp_dir):
+    """Attach a real StorageComponent backed by a temp directory to the api instance."""
+    storage = StorageComponent(api.base)
+    storage.backend = StorageLocalFiles(temp_dir, api.base.log)
+    api._storage_override = storage
+    return storage
+
+
 async def test_fetch_url_cached_async(my_predbat):
     """
-    Test the fetch_url_cached function with stale-while-revalidate caching
+    Test the fetch_url_cached function with storage-component-backed caching.
 
-    Tests various scenarios:
-    - Fresh cache (< 30 minutes)
-    - Stale cache (30-35 minutes) with stale-while-revalidate
-    - Too stale cache (> 35 minutes)
-    - Missing cache
-    - Multiple URLs
-    - Cache file structure and hash-based filenames
-    - clean_url_cache removes old entries (> 24 hours)
+    Tests:
+    - Missing/first call fetches data and returns it
+    - Fresh hit: a second call within the fresh window does not re-download
+    - Multiple distinct URLs cache independently
+    - Invalid URL (download returns None) is handled gracefully
+    - Data persists in the attached storage component
     """
     print("**** Running fetch_url_cached tests ****")
     failed = False
@@ -55,9 +62,12 @@ async def test_fetch_url_cached_async(my_predbat):
         {"value_inc_vat": 11.9, "valid_from": "2025-01-01T01:00:00Z", "valid_to": "2025-01-01T01:30:00Z"},
     ]
 
-    # Mock function to replace async_download_octopus_url
+    # Mock function to replace async_download_octopus_url, with a call counter
+    download_calls = {"count": 0}
+
     async def mock_download(url, **kwargs):
         """Mock download function that returns test data based on URL"""
+        download_calls["count"] += 1
         if "VAR-22-11-01" in url:
             return mock_rate_data_var
         elif "AGILE-FLEX-22-11-25" in url:
@@ -69,12 +79,11 @@ async def test_fetch_url_cached_async(my_predbat):
             return [{"value_inc_vat": 10.0, "valid_from": "2025-01-01T00:00:00Z", "valid_to": "2025-01-01T00:30:00Z"}]
 
     try:
-        # Create OctopusAPI instance with temporary cache directory
+        # Create OctopusAPI instance with a real storage component backed by a temp dir
         api = OctopusAPI(my_predbat, key="test_key", account_id="test_account", automatic=False)
-        api.urls_cache_path = temp_dir
+        storage = _attach_storage(api, temp_dir)
 
         # Replace async_download_octopus_url with mock
-        original_download = api.async_download_octopus_url
         api.async_download_octopus_url = mock_download
 
         # Test URL for VAR-22-11-01 tariff (electricity rates)
@@ -90,26 +99,25 @@ async def test_fetch_url_cached_async(my_predbat):
         elif not isinstance(data1, list):
             print("ERROR Test 1: Expected list, got {}".format(type(data1)))
             failed = True
-        elif len(data1) == 0:
-            print("ERROR Test 1: Expected non-empty data")
-            failed = True
         elif len(data1) != 3:
             print("ERROR Test 1: Expected 3 rate points, got {}".format(len(data1)))
             failed = True
-        else:
-            print("Successfully fetched {} rate points".format(len(data1)))
-
-        # Verify cache file was created
-        import hashlib
-
-        url_hash = hashlib.sha256(test_url.encode()).hexdigest()[:16]
-        cache_file = os.path.join(temp_dir, f"{url_hash}.yaml")
-
-        if not os.path.exists(cache_file):
-            print("ERROR Test 1: Cache file not created at {}".format(cache_file))
+        elif download_calls["count"] != 1:
+            print("ERROR Test 1: Expected exactly 1 download, got {}".format(download_calls["count"]))
             failed = True
+        else:
+            print("Successfully fetched {} rate points (1 download)".format(len(data1)))
 
-        # Test 2: Fetch same URL again (should return cached data without download)
+        # Test 1b: Data persisted in the attached storage component
+        url_hash = hashlib.sha256(test_url.encode()).hexdigest()[:16]
+        stored = await storage.load("octopus", url_hash)
+        if stored != data1:
+            print("ERROR Test 1b: Stored data does not match fetched data")
+            failed = True
+        else:
+            print("Stored data round-tripped via storage component")
+
+        # Test 2: Fetch same URL again within the fresh window (no re-download)
         print("*** Test 2: Fetch from fresh cache (< 30 min)")
         data2 = await api.fetch_url_cached(test_url)
 
@@ -119,180 +127,52 @@ async def test_fetch_url_cached_async(my_predbat):
         elif data1 != data2:
             print("ERROR Test 2: Cached data differs from original")
             failed = True
-        else:
-            print("Successfully retrieved {} rate points from cache".format(len(data2)))
-
-        # Test 3: Test stale cache (30-35 minutes old)
-        print("*** Test 3: Simulate stale cache (30-35 min)")
-        # Manually modify cache timestamp to be 32 minutes old
-        cached_data = api.load_url_from_cache(test_url)
-        if cached_data:
-            old_stamp = datetime.now() - timedelta(minutes=32)
-            cached_data["stamp"] = old_stamp
-            api.save_url_to_cache(test_url, cached_data)
-
-            # Fetch should return stale data immediately
-            data3 = await api.fetch_url_cached(test_url)
-
-            if not data3:
-                print("ERROR Test 3: Failed to fetch stale data")
-                failed = True
-            elif len(data3) == 0:
-                print("ERROR Test 3: Stale data is empty")
-                failed = True
-            else:
-                print("Successfully retrieved stale data with {} rate points".format(len(data3)))
-
-        # Test 4: Test too stale cache (> 35 minutes old)
-        print("*** Test 4: Simulate too stale cache (> 35 min)")
-        # Manually modify cache timestamp to be 40 minutes old
-        cached_data = api.load_url_from_cache(test_url)
-        if cached_data:
-            old_stamp = datetime.now() - timedelta(minutes=40)
-            cached_data["stamp"] = old_stamp
-            api.save_url_to_cache(test_url, cached_data)
-
-            # Fetch should download fresh data
-            data4 = await api.fetch_url_cached(test_url)
-
-            if not data4:
-                print("ERROR Test 4: Failed to fetch fresh data after stale cache")
-                failed = True
-            else:
-                print("Successfully refreshed data with {} rate points".format(len(data4)))
-
-                # Verify cache was updated with fresh timestamp
-                updated_cache = api.load_url_from_cache(test_url)
-                if updated_cache:
-                    age = datetime.now() - updated_cache["stamp"]
-                    if age.seconds > 10:
-                        print("ERROR Test 4: Cache timestamp not updated (age: {} seconds)".format(age.seconds))
-                        failed = True
-
-        # Test 5: Multiple different URLs
-        print("*** Test 5: Multiple URLs with different caches")
-        url2 = "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-A/standard-unit-rates/"
-
-        data5 = await api.fetch_url_cached(url2)
-
-        if not data5:
-            print("ERROR Test 5: Failed to fetch second URL")
+        elif download_calls["count"] != 1:
+            print("ERROR Test 2: Fresh hit should not re-download, download count is {}".format(download_calls["count"]))
             failed = True
         else:
-            print("Successfully fetched {} rate points from second URL".format(len(data5)))
+            print("Successfully retrieved {} rate points from cache (no re-download)".format(len(data2)))
 
-            # Verify both caches exist
-            url2_hash = hashlib.sha256(url2.encode()).hexdigest()[:16]
-            cache_file2 = os.path.join(temp_dir, f"{url2_hash}.yaml")
+        # Test 3: Multiple different URLs cache independently
+        print("*** Test 3: Multiple URLs with different caches")
+        url2 = "https://api.octopus.energy/v1/products/AGILE-FLEX-22-11-25/electricity-tariffs/E-1R-AGILE-FLEX-22-11-25-A/standard-unit-rates/"
 
-            if not os.path.exists(cache_file):
-                print("ERROR Test 5: First cache file disappeared")
+        data3 = await api.fetch_url_cached(url2)
+
+        if not data3:
+            print("ERROR Test 3: Failed to fetch second URL")
+            failed = True
+        elif data3 == data1:
+            print("ERROR Test 3: Second URL returned the first URL's data")
+            failed = True
+        elif download_calls["count"] != 2:
+            print("ERROR Test 3: Expected 2 downloads after second distinct URL, got {}".format(download_calls["count"]))
+            failed = True
+        else:
+            # First URL still served from cache (no further download)
+            data1_again = await api.fetch_url_cached(test_url)
+            if data1_again != data1:
+                print("ERROR Test 3: First URL cache corrupted after caching second URL")
                 failed = True
-            if not os.path.exists(cache_file2):
-                print("ERROR Test 5: Second cache file not created")
+            elif download_calls["count"] != 2:
+                print("ERROR Test 3: First URL re-downloaded after second URL cached")
                 failed = True
+            else:
+                print("Two URLs cached independently")
 
-        # Test 6: Invalid URL (should handle gracefully)
-        print("*** Test 6: Invalid URL")
+        # Test 4: Invalid URL (download returns None) handled gracefully
+        print("*** Test 4: Invalid URL")
         invalid_url = "https://api.octopus.energy/v1/products/INVALID/electricity-tariffs/INVALID/standard-unit-rates/"
 
-        data6 = await api.fetch_url_cached(invalid_url)
+        data4 = await api.fetch_url_cached(invalid_url)
 
-        if data6 is not None:
-            print("ERROR Test 6: Expected None for invalid URL, got {}".format(type(data6)))
+        if data4:
+            print("ERROR Test 4: Expected falsy result for invalid URL, got {}".format(type(data4)))
             failed = True
         else:
             print("Successfully handled invalid URL")
 
-        # Test 7: Verify cache data structure
-        print("*** Test 7: Verify cache data structure")
-        cached = api.load_url_from_cache(test_url)
-
-        if not cached:
-            print("ERROR Test 7: Failed to load cache")
-            failed = True
-        elif "stamp" not in cached:
-            print("ERROR Test 7: Cache missing 'stamp' field")
-            failed = True
-        elif "data" not in cached:
-            print("ERROR Test 7: Cache missing 'data' field")
-            failed = True
-        elif not isinstance(cached["stamp"], datetime):
-            print("ERROR Test 7: Stamp should be datetime, got {}".format(type(cached["stamp"])))
-            failed = True
-        elif not isinstance(cached["data"], list):
-            print("ERROR Test 7: Data should be list, got {}".format(type(cached["data"])))
-            failed = True
-        else:
-            print("Cache structure validated")
-
-        # Test 8: Verify hash-based filenames
-        print("*** Test 8: Verify hash-based filenames")
-        files = os.listdir(temp_dir)
-        yaml_files = [f for f in files if f.endswith(".yaml")]
-
-        if len(yaml_files) < 2:
-            print("ERROR Test 8: Expected at least 2 cache files, found {}".format(len(yaml_files)))
-            failed = True
-        else:
-            print("Found {} cache files with hash-based names".format(len(yaml_files)))
-
-            # Verify filename format (16-char hash + .yaml)
-            for filename in yaml_files:
-                if len(filename) != 21:  # 16 chars + '.yaml' (5 chars)
-                    print("ERROR Test 8: Invalid filename length: {}".format(filename))
-                    failed = True
-
-        # Test 9: Test clean_url_cache removes old entries
-        print("*** Test 9: Test clean_url_cache removes old entries")
-
-        # Create some test URLs with different ages
-        old_url = "https://api.octopus.energy/v1/products/OLD-TARIFF/electricity-tariffs/E-1R-OLD-TARIFF-A/standard-unit-rates/"
-        recent_url = "https://api.octopus.energy/v1/products/RECENT-TARIFF/electricity-tariffs/E-1R-RECENT-TARIFF-A/standard-unit-rates/"
-
-        # Save old cache entry (25 hours old - should be cleaned)
-        old_data = {"stamp": datetime.now() - timedelta(hours=25), "data": [{"value_inc_vat": 99.9, "valid_from": "2025-01-01T00:00:00Z"}]}
-        api.save_url_to_cache(old_url, old_data)
-
-        # Save recent cache entry (2 hours old - should be kept)
-        recent_data = {"stamp": datetime.now() - timedelta(hours=2), "data": [{"value_inc_vat": 88.8, "valid_from": "2025-01-01T00:00:00Z"}]}
-        api.save_url_to_cache(recent_url, recent_data)
-
-        # Count files before cleaning
-        files_before = [f for f in os.listdir(temp_dir) if f.endswith(".yaml")]
-        cache_count_before = len(files_before)
-
-        # Run clean_url_cache
-        await api.clean_url_cache()
-
-        # Count files after cleaning
-        files_after = [f for f in os.listdir(temp_dir) if f.endswith(".yaml")]
-        cache_count_after = len(files_after)
-
-        # Verify old cache was removed
-        old_cache = api.load_url_from_cache(old_url)
-        recent_cache = api.load_url_from_cache(recent_url)
-
-        if old_cache is not None:
-            print("ERROR Test 9: Old cache (25 hours) should have been cleaned but still exists")
-            failed = True
-
-        if recent_cache is None:
-            print("ERROR Test 9: Recent cache (2 hours) should have been kept but was cleaned")
-            failed = True
-
-        if cache_count_after >= cache_count_before:
-            print("ERROR Test 9: Expected fewer cache files after cleaning, before: {}, after: {}".format(cache_count_before, cache_count_after))
-            failed = True
-        else:
-            cleaned_count = cache_count_before - cache_count_after
-            print("Successfully cleaned {} old cache file(s), {} files remaining".format(cleaned_count, cache_count_after))
-
     finally:
-        # Restore original function
-        if "api" in locals() and "original_download" in locals():
-            api.async_download_octopus_url = original_download
-
         # Clean up temporary directory
         if os.path.exists(temp_dir):
             shutil.rmtree(temp_dir)

--- a/apps/predbat/tests/test_octopus_cache.py
+++ b/apps/predbat/tests/test_octopus_cache.py
@@ -1,81 +1,68 @@
 """
-Tests for Octopus cache save/load functions
+Tests for Octopus cache save/load functions (storage-component backed)
 """
 
 import asyncio
-import os
 import tempfile
 import shutil
 from octopus import OctopusAPI
-import yaml
+from storage import StorageComponent, StorageLocalFiles
 
 
 def test_octopus_cache_wrapper(my_predbat):
     return asyncio.run(test_octopus_cache(my_predbat))
 
 
+def _attach_storage(api, temp_dir):
+    """Attach a real StorageComponent backed by a temp directory to the api instance."""
+    storage = StorageComponent(api.base)
+    storage.backend = StorageLocalFiles(temp_dir, api.base.log)
+    api._storage_override = storage
+    return storage
+
+
 async def test_octopus_cache(my_predbat):
     """
-    Test save_octopus_cache and load_octopus_cache functions.
+    Test save_octopus_cache and load_octopus_cache functions via the storage component.
 
     Tests:
-    - Test 1: Save and load user cache data (account_data, saving_sessions, intelligent_device, kraken_token)
-    - Test 2: Load from non-existent cache file (should initialize empty)
-    - Test 3: Save and load tariff data to shared cache
-    - Test 4: Handle corrupted cache file gracefully
-    - Test 5: Verify None values are handled correctly
-    - Test 6: Test get_tariff_cache_key sanitization
-    - Test 7: Save multiple tariffs and verify separation
-    - Test 8: Verify fetch_tariffs loads from cache when data not present
+    - Test 1: Save and load user cache data (account_data, saving_sessions, intelligent_devices, kraken_token)
+    - Test 2: Load with no prior save initialises empty (no crash)
+    - Test 3: None values are normalised to empty dicts on load
+    - Test 4: get_tariff_cache_key sanitisation (pure string logic)
     """
     print("**** Running Octopus cache save/load tests ****")
     failed = False
 
-    # Create a temporary directory for cache testing
+    # Create a temporary directory for cache testing (shared backend across instances)
     test_cache_dir = tempfile.mkdtemp(prefix="predbat_test_cache_")
 
     try:
-        # Test 1: Save and load user cache data
+        # Test 1: Save and load user cache data round-trips via storage
         print("\n*** Test 1: Save and load user cache data ***")
         api = OctopusAPI(my_predbat, key="test-key", account_id="test-account", automatic=False)
+        _attach_storage(api, test_cache_dir)
 
-        # Override cache paths to use temp directory
-        api.cache_path = test_cache_dir
-        api.shared_cache_path = test_cache_dir + "/shared"
-        api.tariffs_cache_path = api.shared_cache_path + "/tariffs"
-        api.urls_cache_path = api.shared_cache_path + "/urls"
-        api.user_cache_file = api.cache_path + "/octopus_user_test-account.yaml"
-
-        # Create directories
-        for path in [api.cache_path, api.shared_cache_path, api.tariffs_cache_path, api.urls_cache_path]:
-            os.makedirs(path, exist_ok=True)
-
-        # Set up test data
         api.account_data = {"account": {"number": "A-12345678", "electricityAgreements": [{"meterPoint": {"mpan": "1234567890123"}}]}}
         api.saving_sessions = {"events": [{"id": "event1", "startAt": "2024-06-15T18:00:00+00:00"}], "account": {"hasJoinedCampaign": True}}
         api.intelligent_devices = {"device123": {"planned_dispatches": [{"start": "2024-06-15T23:00:00+00:00", "end": "2024-06-16T05:00:00+00:00"}]}}
         api.graphql_token = "test-token-12345"
         api.tariffs = {}
 
-        # Save the cache
         await api.save_octopus_cache()
 
-        # Verify file was created
-        if not os.path.exists(api.user_cache_file):
-            print("ERROR: Cache file was not created: {}".format(api.user_cache_file))
+        # Verify the user cache round-trips via the storage component
+        stored = await api._get_storage().load("octopus_user", "account")
+        if not stored:
+            print("ERROR: User cache was not stored")
             failed = True
         else:
-            # Create new API instance and load the cache
+            # Create new API instance sharing the same storage backend and load
             api2 = OctopusAPI(my_predbat, key="test-key", account_id="test-account", automatic=False)
-            api2.cache_path = test_cache_dir
-            api2.shared_cache_path = test_cache_dir + "/shared"
-            api2.tariffs_cache_path = api2.shared_cache_path + "/tariffs"
-            api2.urls_cache_path = api2.shared_cache_path + "/urls"
-            api2.user_cache_file = api.user_cache_file
+            _attach_storage(api2, test_cache_dir)
 
             await api2.load_octopus_cache()
 
-            # Verify loaded data matches
             if api2.account_data != api.account_data:
                 print("ERROR: account_data mismatch. Expected: {}, Got: {}".format(api.account_data, api2.account_data))
                 failed = True
@@ -91,165 +78,78 @@ async def test_octopus_cache(my_predbat):
             else:
                 print("PASS: User cache data saved and loaded correctly")
 
-        # Test 2: Load from non-existent cache file
-        print("\n*** Test 2: Load from non-existent cache file ***")
-        api3 = OctopusAPI(my_predbat, key="test-key", account_id="nonexistent", automatic=False)
-        api3.cache_path = test_cache_dir
-        api3.shared_cache_path = test_cache_dir + "/shared"
-        api3.tariffs_cache_path = api3.shared_cache_path + "/tariffs"
-        api3.urls_cache_path = api3.shared_cache_path + "/urls"
-        api3.user_cache_file = api3.cache_path + "/octopus_user_nonexistent.yaml"
+        # Test 2: Load with no prior save initialises empty (no crash)
+        print("\n*** Test 2: Load with no prior save initialises empty ***")
+        empty_cache_dir = tempfile.mkdtemp(prefix="predbat_test_cache_empty_")
+        try:
+            api3 = OctopusAPI(my_predbat, key="test-key", account_id="nonexistent", automatic=False)
+            _attach_storage(api3, empty_cache_dir)
 
-        await api3.load_octopus_cache()
+            await api3.load_octopus_cache()
 
-        if api3.account_data != {}:
-            print("ERROR: Expected empty account_data, got: {}".format(api3.account_data))
+            if api3.account_data != {}:
+                print("ERROR: Expected empty account_data, got: {}".format(api3.account_data))
+                failed = True
+            elif api3.saving_sessions != {}:
+                print("ERROR: Expected empty saving_sessions, got: {}".format(api3.saving_sessions))
+                failed = True
+            elif api3.intelligent_devices != {}:
+                print("ERROR: Expected empty intelligent_devices, got: {}".format(api3.intelligent_devices))
+                failed = True
+            elif api3.tariffs != {}:
+                print("ERROR: Expected empty tariffs, got: {}".format(api3.tariffs))
+                failed = True
+            else:
+                print("PASS: Missing cache initialised to empty dicts")
+        finally:
+            shutil.rmtree(empty_cache_dir, ignore_errors=True)
+
+        # Test 3: None values are normalised to empty dicts on load
+        print("\n*** Test 3: Verify None values are handled correctly ***")
+        none_cache_dir = tempfile.mkdtemp(prefix="predbat_test_cache_none_")
+        try:
+            api6 = OctopusAPI(my_predbat, key="test-key", account_id="test-none", automatic=False)
+            _attach_storage(api6, none_cache_dir)
+
+            api6.account_data = None
+            api6.saving_sessions = None
+            api6.intelligent_devices = None
+            api6.graphql_token = None
+            api6.tariffs = {}
+
+            await api6.save_octopus_cache()
+
+            api7 = OctopusAPI(my_predbat, key="test-key", account_id="test-none", automatic=False)
+            _attach_storage(api7, none_cache_dir)
+
+            await api7.load_octopus_cache()
+
+            if api7.account_data != {}:
+                print("ERROR: Expected empty dict for None account_data, got: {}".format(api7.account_data))
+                failed = True
+            elif api7.saving_sessions != {}:
+                print("ERROR: Expected empty dict for None saving_sessions, got: {}".format(api7.saving_sessions))
+                failed = True
+            elif api7.intelligent_devices != {}:
+                print("ERROR: Expected empty dict for None intelligent_devices, got: {}".format(api7.intelligent_devices))
+                failed = True
+            else:
+                print("PASS: None values handled correctly")
+        finally:
+            shutil.rmtree(none_cache_dir, ignore_errors=True)
+
+        # Test 4: get_tariff_cache_key sanitisation (pure string logic)
+        print("\n*** Test 4: get_tariff_cache_key sanitisation ***")
+        api8 = OctopusAPI(my_predbat, key="test-key", account_id="test-key-san", automatic=False)
+        key = api8.get_tariff_cache_key({"productCode": "AGILE/22", "tariffCode": "E-1R\\AGILE-22-A"})
+        if "/" in key or "\\" in key:
+            print("ERROR: get_tariff_cache_key did not sanitise path separators: {}".format(key))
             failed = True
-        elif api3.saving_sessions != {}:
-            print("ERROR: Expected empty saving_sessions, got: {}".format(api3.saving_sessions))
-            failed = True
-        elif api3.intelligent_devices != {}:
-            print("ERROR: Expected empty intelligent_devices, got: {}".format(api3.intelligent_devices))
-            failed = True
-        elif api3.tariffs != {}:
-            print("ERROR: Expected empty tariffs, got: {}".format(api3.tariffs))
-            failed = True
-        else:
-            print("PASS: Non-existent cache initialized to empty dicts")
-
-        # Test 3: Save and load tariff data to shared cache
-        print("\n*** Test 3: Save and load tariff data to shared cache ***")
-        api4 = OctopusAPI(my_predbat, key="test-key", account_id="test-tariffs", automatic=False)
-        api4.cache_path = test_cache_dir
-        api4.shared_cache_path = test_cache_dir + "/shared"
-        api4.urls_cache_path = api4.shared_cache_path + "/urls"
-        api4.user_cache_file = api4.cache_path + "/octopus_user_test-tariffs.yaml"
-
-        # Set up tariff data
-        api4.account_data = {}
-        api4.saving_sessions = {}
-        api4.intelligent_devices = {}
-        api4.graphql_token = None
-        api4.tariffs = {"import": {"tariffCode": "E-1R-AGILE-24-01-01-A", "productCode": "AGILE-24-01-01", "deviceID": "device-import", "data": [{"value_inc_vat": 25.0}], "standing": [{"value_inc_vat": 0.5}]}}
-
-        await api4.save_octopus_cache()
-        # Check user cache data
-        user_cache_file = api4.user_cache_file
-        if not os.path.exists(user_cache_file):
-            print("ERROR: User cache file not created: {}".format(user_cache_file))
-            failed = True
-        else:
-            with open(user_cache_file, "r") as f:
-                loaded_cache = yaml.safe_load(f)
-                if not loaded_cache:
-                    print("ERROR: User cache file is empty")
-                    failed = True
-
-        # Test 4: Handle corrupted cache file gracefully
-        print("\n*** Test 4: Handle corrupted cache file gracefully ***")
-        api5 = OctopusAPI(my_predbat, key="test-key", account_id="corrupted", automatic=False)
-        api5.cache_path = test_cache_dir
-        api5.shared_cache_path = test_cache_dir + "/shared"
-        api5.urls_cache_path = api5.shared_cache_path + "/urls"
-        api5.user_cache_file = api5.cache_path + "/octopus_user_corrupted.yaml"
-        api5.account_data = {"some": "data"}
-
-        # Create a corrupted cache file
-        with open(api5.user_cache_file, "w") as f:
-            f.write("this is not valid yaml: {[{]}")
-
-        await api5.load_octopus_cache()
-
-        # Should initialize to empty dicts without crashing
-        if api5.account_data != {"some": "data"}:
-            print("ERROR: Expected old account_data after corrupted load, got: {}".format(api5.account_data))
+        elif key != "AGILE_22_E-1R_AGILE-22-A":
+            print("ERROR: Unexpected sanitised key: {}".format(key))
             failed = True
         else:
-            print("PASS: Corrupted cache handled gracefully")
-
-        # Test 5: Verify None values are handled correctly
-        print("\n*** Test 5: Verify None values are handled correctly ***")
-        api6 = OctopusAPI(my_predbat, key="test-key", account_id="test-none", automatic=False)
-        api6.cache_path = test_cache_dir
-        api6.shared_cache_path = test_cache_dir + "/shared"
-        api6.urls_cache_path = api6.shared_cache_path + "/urls"
-        api6.user_cache_file = api6.cache_path + "/octopus_user_test-none.yaml"
-
-        # Create directories
-        for path in [api6.cache_path, api6.shared_cache_path, api6.urls_cache_path]:
-            os.makedirs(path, exist_ok=True)
-
-        # Set data to None
-        api6.account_data = None
-        api6.saving_sessions = None
-        api6.intelligent_devices = None
-        api6.graphql_token = None
-        api6.tariffs = {}
-
-        await api6.save_octopus_cache()
-
-        # Load and verify None values are converted to empty dicts
-        api7 = OctopusAPI(my_predbat, key="test-key", account_id="test-none", automatic=False)
-        api7.cache_path = test_cache_dir
-        api7.shared_cache_path = test_cache_dir + "/shared"
-        api7.urls_cache_path = api7.shared_cache_path + "/urls"
-        api7.user_cache_file = api6.user_cache_file
-
-        await api7.load_octopus_cache()
-
-        if api7.account_data != {}:
-            print("ERROR: Expected empty dict for None account_data, got: {}".format(api7.account_data))
-            failed = True
-        elif api7.saving_sessions != {}:
-            print("ERROR: Expected empty dict for None saving_sessions, got: {}".format(api7.saving_sessions))
-            failed = True
-        elif api7.intelligent_devices != {}:
-            print("ERROR: Expected empty dict for None intelligent_devices, got: {}".format(api7.intelligent_devices))
-            failed = True
-        else:
-            print("PASS: None values handled correctly")
-
-        # Test 6: Save multiple tariffs and verify separation
-        print("\n*** Test 6: Save User data and check it ***")
-        api9 = OctopusAPI(my_predbat, key="test-key", account_id="test-multi", automatic=False)
-        api9.cache_path = test_cache_dir
-        api9.shared_cache_path = test_cache_dir + "/shared"
-        api9.urls_cache_path = api9.shared_cache_path + "/urls"
-        api9.user_cache_file = api9.cache_path + "/octopus_user_test-multi.yaml"
-
-        # Create directories
-        for path in [api9.cache_path, api9.shared_cache_path, api9.urls_cache_path]:
-            os.makedirs(path, exist_ok=True)
-
-        api9.account_data = {"account": {"number": "A-87654321"}}
-        api9.saving_sessions = {"events": []}
-        api9.intelligent_devices = {"device-multi": {}}
-        api9.graphql_token = None
-        api9.tariffs = {
-            "import": {"productCode": "AGILE-24-01-01", "tariffCode": "E-1R-AGILE-24-01-01-A", "data": [{"value_inc_vat": 25.0}]},
-            "export": {"productCode": "OUTGOING-24-01-01", "tariffCode": "E-1R-OUTGOING-24-01-01-A", "data": [{"value_inc_vat": 5.0}]},
-            "gas": {"productCode": "VAR-24-01-01", "tariffCode": "G-1R-VAR-24-01-01-A", "data": [{"value_inc_vat": 10.0}]},
-        }
-
-        await api9.save_octopus_cache()
-
-        # Check user cache file
-        user_cache_file = api9.user_cache_file
-        if not os.path.exists(user_cache_file):
-            print("ERROR: User cache file not created: {}".format(user_cache_file))
-            failed = True
-        else:
-            with open(user_cache_file, "r") as f:
-                loaded_cache = yaml.safe_load(f)
-                if "account_data" not in loaded_cache or loaded_cache["account_data"] != api9.account_data:
-                    print("ERROR: account_data missing or incorrect in user cache")
-                    failed = True
-                if "saving_sessions" not in loaded_cache or loaded_cache["saving_sessions"] != api9.saving_sessions:
-                    print("ERROR: saving_sessions missing or incorrect in user cache")
-                    failed = True
-                if "intelligent_devices" not in loaded_cache or loaded_cache["intelligent_devices"] != api9.intelligent_devices:
-                    print("ERROR: intelligent_devices missing or incorrect in user cache")
-                    failed = True
+            print("PASS: get_tariff_cache_key sanitised correctly")
 
     finally:
         # Clean up temp directory

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -630,7 +630,6 @@ async def test_octopus_fetch_tariffs(my_predbat):
     - Test 3: Fetch tariffs for gas
     - Test 4: Fetch multiple tariffs (import + export)
     - Test 5: Verify dashboard_item called with correct entity names
-    - Test 6: Verify clean_url_cache called
     """
     print("\n**** Running Octopus fetch_tariffs tests ****")
     failed = False
@@ -658,18 +657,10 @@ async def test_octopus_fetch_tariffs(my_predbat):
             return mock_rates_data
 
     api.fetch_url_cached = mock_fetch_url
-    api.clean_url_cache = AsyncMock()
     api.dashboard_item = MagicMock()
 
     # Call fetch_tariffs
     await api.fetch_tariffs(tariffs_input)
-
-    # Verify clean_url_cache was called
-    if api.clean_url_cache.call_count != 1:
-        print(f"ERROR: Expected clean_url_cache to be called once, got {api.clean_url_cache.call_count} calls")
-        failed = True
-    else:
-        print("PASS: clean_url_cache called")
 
     # Verify tariff data was stored
     if "data" not in tariffs_input["import"]:
@@ -716,7 +707,6 @@ async def test_octopus_fetch_tariffs(my_predbat):
             return mock_export_rates
 
     api2.fetch_url_cached = mock_fetch_url2
-    api2.clean_url_cache = AsyncMock()
     api2.dashboard_item = MagicMock()
 
     await api2.fetch_tariffs(tariffs_input2)
@@ -752,7 +742,6 @@ async def test_octopus_fetch_tariffs(my_predbat):
             return mock_gas_rates
 
     api3.fetch_url_cached = mock_fetch_url3
-    api3.clean_url_cache = AsyncMock()
     api3.dashboard_item = MagicMock()
 
     await api3.fetch_tariffs(tariffs_input3)
@@ -783,7 +772,6 @@ async def test_octopus_fetch_tariffs(my_predbat):
         return [{"valid_from": "2025-01-01T00:00:00Z", "valid_to": "2025-01-01T00:30:00Z", "value_inc_vat": 15.0}]
 
     api4.fetch_url_cached = mock_fetch_url4
-    api4.clean_url_cache = AsyncMock()
     api4.dashboard_item = MagicMock()
 
     await api4.fetch_tariffs(tariffs_input4)
@@ -814,7 +802,6 @@ async def test_octopus_fetch_tariffs(my_predbat):
         return [{"valid_from": "2025-01-01T00:00:00Z", "valid_to": "2025-01-01T00:30:00Z", "value_inc_vat": 20.0}]
 
     api5.fetch_url_cached = mock_fetch_url5
-    api5.clean_url_cache = AsyncMock()
     dashboard_calls = []
 
     def capture_dashboard_item(entity_id, state, attributes=None, app=None):
@@ -909,7 +896,6 @@ async def test_octopus_fetch_tariffs(my_predbat):
         return []  # should not be called for rate data in this path
 
     api7.fetch_url_cached = mock_fetch_url7
-    api7.clean_url_cache = AsyncMock()
     api7.dashboard_item = MagicMock()
     api7.async_get_day_night_rates = AsyncMock(return_value=mock_day_night_result)
 

--- a/apps/predbat/tests/test_storage.py
+++ b/apps/predbat/tests/test_storage.py
@@ -140,6 +140,28 @@ def test_storage(my_predbat=None):
 
         assert run_async(storage.fetch_cached("fc3", "missing", _fetch_none, format="json")) is None
 
+        # fetch_cached: stale window + fetch_fn returns None → serve cached stale value
+        run_async(storage.save("fc4", "k", {"w": 0}, format="json"))
+
+        async def _fetch_none_stale():
+            return None
+
+        out = run_async(storage.fetch_cached("fc4", "k", _fetch_none_stale, fresh_minutes=0, stale_minutes=999999, format="json"))
+        assert out == {"w": 0}, "stale path with None fetch should return cached stale: {}".format(out)
+
+        # fetch_cached: stale window + fetch_fn RAISES → serve cached stale value, do not propagate
+        run_async(storage.save("fc5", "k", {"w": 7}, format="json"))
+
+        async def _fetch_raise():
+            raise RuntimeError("boom")
+
+        out = run_async(storage.fetch_cached("fc5", "k", _fetch_raise, fresh_minutes=0, stale_minutes=999999, format="json"))
+        assert out == {"w": 7}, "stale path with raising fetch should return cached stale: {}".format(out)
+
+        # fetch_cached: hard miss + fetch_fn RAISES → return None, do not propagate
+        out = run_async(storage.fetch_cached("fc6", "missing", _fetch_raise, fresh_minutes=30, stale_minutes=35, format="json"))
+        assert out is None, "hard miss with raising fetch should return None: {}".format(out)
+
         print("All storage tests passed!")
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/apps/predbat/tests/test_storage.py
+++ b/apps/predbat/tests/test_storage.py
@@ -122,6 +122,24 @@ def test_storage(my_predbat=None):
         assert second == {"v": 1}, "fresh hit should return cached value: {}".format(second)
         assert calls["n"] == 1, "fetch_fn must not be called on a fresh hit"
 
+        # fetch_cached: with fresh_minutes=0 every existing entry is "stale" → refresh path runs once
+        calls2 = {"n": 0}
+
+        async def _fetch2():
+            calls2["n"] += 1
+            return {"w": calls2["n"]}
+
+        run_async(storage.save("fc2", "k", {"w": 0}, format="json"))
+        out = run_async(storage.fetch_cached("fc2", "k", _fetch2, fresh_minutes=0, stale_minutes=999999, format="json"))
+        assert out == {"w": 1}, "stale path should refresh and return fresh data: {}".format(out)
+        assert calls2["n"] == 1, "stale path should call fetch_fn once"
+
+        # fetch_cached: fetch_fn returning None on a hard miss → returns None, no crash
+        async def _fetch_none():
+            return None
+
+        assert run_async(storage.fetch_cached("fc3", "missing", _fetch_none, format="json")) is None
+
         print("All storage tests passed!")
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/apps/predbat/tests/test_storage.py
+++ b/apps/predbat/tests/test_storage.py
@@ -106,6 +106,22 @@ def test_storage(my_predbat=None):
         # 12. age() returns None for a missing file
         assert run_async(storage.age("mod", "nonexistent_age")) is None, "age() should return None for missing file"
 
+        # fetch_cached: miss → calls fetch_fn once, stores, returns
+        calls = {"n": 0}
+
+        async def _fetch():
+            calls["n"] += 1
+            return {"v": calls["n"]}
+
+        first = run_async(storage.fetch_cached("fc", "k", _fetch, fresh_minutes=30, stale_minutes=35, format="json"))
+        assert first == {"v": 1}, "fetch_cached miss should fetch: {}".format(first)
+        assert calls["n"] == 1, "fetch_fn should be called exactly once on miss"
+
+        # fetch_cached: fresh hit → does NOT call fetch_fn again
+        second = run_async(storage.fetch_cached("fc", "k", _fetch, fresh_minutes=30, stale_minutes=35, format="json"))
+        assert second == {"v": 1}, "fresh hit should return cached value: {}".format(second)
+        assert calls["n"] == 1, "fetch_fn must not be called on a fresh hit"
+
         print("All storage tests passed!")
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Adds a `fetch_cached` stale-while-revalidate helper to the storage component and migrates the Octopus integration off its bespoke file cache onto `self.storage` — bringing Octopus in line with `solcast.py`, `gecloud.py`, and `futurerate.py`, which already use the storage component.

## Motivation

`octopus.py` was the last component still doing its own `open()`/YAML caching (URL cache + per-user cache) with a bespoke file-lock stale-while-revalidate loop. Routing it through `StorageComponent` means there's a single, testable cache path across all components, and the cache backend can be swapped (e.g. for a shared/distributed backend) without touching component logic.

## What changed

**`storage.py` — new `fetch_cached` helper (single-instance-clean):**
- `StorageBase.fetch_cached(module, filename, fetch_fn, fresh_minutes=30, stale_minutes=35, format="yaml")` — fresh hit returns cache without calling `fetch_fn`; stale window serves cached while one caller refreshes; hard miss fetches and stores. A refresh that returns `None` or raises degrades gracefully to the cached/`None` value (never propagates).
- `_acquire_refresh_lock` / `_release_refresh_lock` hooks default to **no-ops** (a single instance never contends). A subclass can override them to add real coordination; the OSS base stays single-instance with no notion of instances or distributed locks.
- `StorageComponent.fetch_cached` delegates to the backend.

**`octopus.py` — migrate onto `self.storage`:**
- URL/tariff responses (public, no secrets) cache under module `"octopus"`; account data, Kraken token, saving sessions and intelligent devices cache under module `"octopus_user"`.
- `fetch_url_cached` now uses `storage.fetch_cached`; its `_download` wrapper normalises the `{}` error return of `async_download_octopus_url` to `None` so error responses are never cached.
- Removed the bespoke `load_url_from_cache` / `save_url_to_cache` / `clean_url_cache`, the file-lock loop, the cache-directory plumbing, and a duplicate import.
- Falls back to a direct download (single-instance behaviour unchanged) when no storage component is present.

## Behaviour

Single-instance behaviour is unchanged: same 30-minute fresh window / 30–35-minute stale window, same user-cache fields preserved across restart. Self-hosted users see no functional difference.

## Tests

- `test_storage.py`: `fetch_cached` miss, fresh hit, stale-refresh (success / returns-None / raises), hard-miss-raises.
- `test_fetch_url_cached.py`: rewritten for storage-backed behaviour — first-fetch, fresh-hit-no-redownload, independent multi-URL caching, invalid-URL handling, and an empty-`{}`-error-not-cached regression test.
- `test_octopus_cache.py`: user-cache save/load round-trip via storage, missing-init-empty, None normalisation, key sanitisation.
- `test_octopus_misc.py`: updated for the removed `clean_url_cache`.

All targeted tests and `run_all --quick` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
