### PR TITLE
Fix: Tesla access token field size

### DIFF
--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -2588,27 +2588,27 @@ Now create an automation to populate the access token:
       target:
         entity_id: input_text.tesla_access_token_part1
       data:
-        value: "{{ token_response.stdout[0:220] }}"
+        value: "{{ token_response.stdout[0:250] }}"
     - action: input_text.set_value
       target:
         entity_id: input_text.tesla_access_token_part2
       data:
-        value: "{{ token_response.stdout[220:440] }}"
+        value: "{{ token_response.stdout[250:500] }}"
     - action: input_text.set_value
       target:
         entity_id: input_text.tesla_access_token_part3
       data:
-        value: "{{ token_response.stdout[440:660] }}"
+        value: "{{ token_response.stdout[500:750] }}"
     - action: input_text.set_value
       target:
         entity_id: input_text.tesla_access_token_part4
       data:
-        value: "{{ token_response.stdout[660:880] }}"
+        value: "{{ token_response.stdout[750:1000] }}"
     - action: input_text.set_value
       target:
         entity_id: input_text.tesla_access_token_part5
       data:
-        value: "{{ token_response.stdout[880:] }}"
+        value: "{{ token_response.stdout[1000:] }}"
   mode: single
   ```
 


### PR DESCRIPTION
As per @dexterstu in #3965 the Tesla access token's configured size may be too small - likely a copy/paste error.

This increases the maximum token size to 1250. Right now the entire method of storing the access token is a bit of a legacy as it could be replaced by a simple shell command on each use:

```yaml
shell_command:
  get_tesla_fleet_token: >-
    jq -r '.data.entries[] | select(.domain == "tesla_fleet") | .data.token.access_token' /config/.storage/core.config_entries
```

However, that would require changing several automations and a bit more testing. It would also break non-Tesla Fleet setups. One for a future PR.