### PR TITLE
Fix unnecessary ML retraining on startup by setting `last_train_time`

### DIFF
--- a/apps/predbat/load_ml_component.py
+++ b/apps/predbat/load_ml_component.py
@@ -155,6 +155,11 @@ class LoadMLComponent(ComponentBase):
                     self.model_valid = True
                     self.model_status = "active"
                     self.initial_training_done = True
+                    try:
+                        mtime = os.path.getmtime(self.model_filepath)
+                        self.last_train_time = datetime.fromtimestamp(mtime, timezone.utc)
+                    except Exception as e:
+                        self.log("Warn: ML Component: Failed to get model file time: {}".format(e))
                 else:
                     self.log("ML Component: Loaded model is invalid ({}), will retrain".format(reason))
                     self.model_status = "fallback_" + reason


### PR DESCRIPTION
### Bug
When Predbat starts up and successfully loads the cached ML model (`predbat_ml_model.npz`) from disk, `load_ml_component.py` fails to update its internal `last_train_time` tracker. Because this variable stays `None`, the script incorrectly assumes the model is infinitely old on its next background loop and immediately forces an unnecessary 30-epoch training cycle (causing a 10-15 minute delay before the UI is ready).

### Fix
Added logic to parse the file modification time (`os.path.getmtime`) of the cached model upon a successful load and assign it to `last_train_time`. Predbat will now correctly evaluate the model's true age and instantly skip the training block on startup if the cached model is fresh.
