### PR TITLE
feat(sigenergy): publish onboard_status sensor

### DIFF
--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -282,6 +282,7 @@ class SigenergyAPI(ComponentBase):
         self.system_status = {}   # systemId → latest systemStatus dict
         self.daily_summary = {}   # systemId → latest summary dict
         self.current_mode = {}    # systemId → energyStorageOperationMode int
+        self.onboard_status = {}  # systemId → onboarding status string (published for the SaaS UI)
 
         # Control state keyed by systemId
         self.controls = {}        # systemId → {charge: {…}, export: {…}, reserve: …}
@@ -824,13 +825,24 @@ class SigenergyAPI(ComponentBase):
                     code = item_codes[0]
 
         if code == SIGENERGY_CODE_SYSTEM_PENDING_REVIEW:
+            for sid in system_ids:
+                self.onboard_status[str(sid)] = "pending_approval"
             self.log("Warn: SigenergyAPI: Onboard for {} pending user approval in the Sigenergy app — approve to enable controls".format(system_ids))
             return None
         if code in (SIGENERGY_CODE_IN_OTHER_VPP, SIGENERGY_CODE_IN_OTHER_VPP_EVERGEN):
+            for sid in system_ids:
+                self.onboard_status[str(sid)] = "in_other_vpp"
             self.log("Warn: SigenergyAPI: Onboard failed — system {} is registered to another VPP (code={})".format(system_ids, code))
             return False
         if code == SIGENERGY_CODE_SOFTWARE_NO_VPP:
+            for sid in system_ids:
+                self.onboard_status[str(sid)] = "firmware_no_vpp"
             self.log("Warn: SigenergyAPI: Onboard failed — system {} firmware does not support VPP (code=1105)".format(system_ids))
+            return False
+        if code in (SIGENERGY_CODE_NO_PERMISSION_STATION, SIGENERGY_CODE_STATION_NOT_PERMITTED):
+            for sid in system_ids:
+                self.onboard_status[str(sid)] = "no_permission"
+            self.log("Warn: SigenergyAPI: Onboard failed — no permission for system {} (code={})".format(system_ids, code))
             return False
         if result is None:
             self.log("Warn: SigenergyAPI: Onboard request failed for systems {} (code={})".format(system_ids, code))
@@ -2089,6 +2101,7 @@ class SigenergyAPI(ComponentBase):
             # For each expected system ID not yet visible, attempt onboarding
             missing_ids = self.system_id_filter - set(self.systems.keys()) if self.system_id_filter else set()
             for sid in missing_ids:
+                self.onboard_status.setdefault(str(sid), "not_onboarded")
                 slug = self._system_slug(sid)
                 is_offboard_at_start = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default="off") == "on"
                 if is_offboard_at_start:
@@ -2136,6 +2149,29 @@ class SigenergyAPI(ComponentBase):
                 slug = self._system_slug(sid)
                 is_offboard = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default="off") == "on"
                 await self._manage_vpp_registration(sid, is_readonly_vpp, is_offboard)
+                # Derive the user-facing onboarding status for the visible system.
+                if is_offboard:
+                    self.onboard_status[str(sid)] = "offboarded"
+                elif self.current_mode.get(sid) == SIGENERGY_MODE_VPP:
+                    self.onboard_status[str(sid)] = "active"
+                else:
+                    self.onboard_status[str(sid)] = "pending_approval"
+
+        # Publish onboarding status for the SaaS UI. Iterates the expected system IDs
+        # (not just visible ones) so a system still pending approval still gets a sensor.
+        if first or seconds % SIGENERGY_POLL_INTERVAL == 0:
+            for sid in (self.system_id_filter or set(self.systems.keys())):
+                slug = self._system_slug(sid)
+                self.dashboard_item(
+                    "sensor.{}_sigenergy_{}_onboard_status".format(self.prefix, slug),
+                    state=self.onboard_status.get(str(sid), "not_onboarded"),
+                    attributes={
+                        "friendly_name": "Sigenergy {} Onboarding Status".format(sid),
+                        "system_id": sid,
+                        "in_vpp": self.current_mode.get(sid) == SIGENERGY_MODE_VPP,
+                    },
+                    app="sigenergy",
+                )
 
         # Fetch controls from HA on first run only
         if first:

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -837,7 +837,7 @@ class SigenergyAPI(ComponentBase):
         if code == SIGENERGY_CODE_SOFTWARE_NO_VPP:
             for sid in system_ids:
                 self.onboard_status[str(sid)] = "firmware_no_vpp"
-            self.log("Warn: SigenergyAPI: Onboard failed — system {} firmware does not support VPP (code=1105)".format(system_ids))
+            self.log("Warn: SigenergyAPI: Onboard failed — system {} firmware does not support VPP (code={})".format(system_ids, code))
             return False
         if code in (SIGENERGY_CODE_NO_PERMISSION_STATION, SIGENERGY_CODE_STATION_NOT_PERMITTED):
             for sid in system_ids:
@@ -2070,6 +2070,26 @@ class SigenergyAPI(ComponentBase):
 
         return in_vpp
 
+    def _publish_onboard_status(self):
+        """Publish onboarding-status sensors for all expected system IDs.
+
+        Iterates system_id_filter (or visible systems as a fallback) so that a
+        system still pending approval gets a sensor state even before it appears
+        in the authorised-system list.
+        """
+        for sid in (self.system_id_filter or set(self.systems.keys())):
+            slug = self._system_slug(sid)
+            self.dashboard_item(
+                "sensor.{}_sigenergy_{}_onboard_status".format(self.prefix, slug),
+                state=self.onboard_status.get(str(sid), "not_onboarded"),
+                attributes={
+                    "friendly_name": "Sigenergy {} Onboarding Status".format(sid),
+                    "system_id": sid,
+                    "in_vpp": self.current_mode.get(sid) == SIGENERGY_MODE_VPP,
+                },
+                app="sigenergy",
+            )
+
     # -----------------------------------------------------------------------
     # Main run loop
     # -----------------------------------------------------------------------
@@ -2110,6 +2130,8 @@ class SigenergyAPI(ComponentBase):
                 self.log("SigenergyAPI: System {} not found in authorised list — attempting onboard".format(sid))
                 result = await self.onboard_systems([sid])
                 if result is not True:
+                    # Publish status before exiting — run() won't reach the normal publish block.
+                    self._publish_onboard_status()
                     return False
                 await self.fetch_system_list()
 
@@ -2157,21 +2179,9 @@ class SigenergyAPI(ComponentBase):
                 else:
                     self.onboard_status[str(sid)] = "pending_approval"
 
-        # Publish onboarding status for the SaaS UI. Iterates the expected system IDs
-        # (not just visible ones) so a system still pending approval still gets a sensor.
+        # Publish onboarding status for the SaaS UI.
         if first or seconds % SIGENERGY_POLL_INTERVAL == 0:
-            for sid in (self.system_id_filter or set(self.systems.keys())):
-                slug = self._system_slug(sid)
-                self.dashboard_item(
-                    "sensor.{}_sigenergy_{}_onboard_status".format(self.prefix, slug),
-                    state=self.onboard_status.get(str(sid), "not_onboarded"),
-                    attributes={
-                        "friendly_name": "Sigenergy {} Onboarding Status".format(sid),
-                        "system_id": sid,
-                        "in_vpp": self.current_mode.get(sid) == SIGENERGY_MODE_VPP,
-                    },
-                    app="sigenergy",
-                )
+            self._publish_onboard_status()
 
         # Fetch controls from HA on first run only
         if first:

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -1670,7 +1670,7 @@ def test_sigenergy_onboard_status(my_predbat):
     # Pending approval (1116) → pending_approval, returns None
     api._request = AsyncMock(return_value=None)
     api._last_api_code = SIGENERGY_CODE_SYSTEM_PENDING_REVIEW
-    result = asyncio.run(api.onboard_systems(["sys-1"]))
+    result = run_async(api.onboard_systems(["sys-1"]))
     assert result is None, "pending review returns None"
     assert api.onboard_status["sys-1"] == "pending_approval", "pending_approval status set"
 
@@ -1678,9 +1678,126 @@ def test_sigenergy_onboard_status(my_predbat):
     api2 = MockSigenergyAPI()
     api2._request = AsyncMock(return_value=None)
     api2._last_api_code = SIGENERGY_CODE_IN_OTHER_VPP
-    result2 = asyncio.run(api2.onboard_systems("sys-2"))
+    result2 = run_async(api2.onboard_systems("sys-2"))
     assert result2 is False, "in-other-vpp returns False"
     assert api2.onboard_status["sys-2"] == "in_other_vpp", "in_other_vpp status set"
+
+    return failed
+
+
+def test_sigenergy_publish_onboard_status_sensors(my_predbat):
+    """_publish_onboard_status publishes the correct sensor state for each status value."""
+    failed = False
+
+    # active — system in VPP mode
+    api = MockSigenergyAPI()
+    api.system_id_filter = {"SIG001"}
+    api.onboard_status = {"SIG001": "active"}
+    api.current_mode = {"SIG001": SIGENERGY_MODE_VPP}
+    api._publish_onboard_status()
+    key = "sensor.predbat_sigenergy_sig001_onboard_status"
+    assert api.dashboard_items[key]["state"] == "active", "active state published"
+    assert api.dashboard_items[key]["attributes"]["in_vpp"] is True, "in_vpp True for VPP mode"
+    assert api.dashboard_items[key]["attributes"]["system_id"] == "SIG001", "system_id in attributes"
+
+    # offboarded — system present but toggled off
+    api2 = MockSigenergyAPI()
+    api2.system_id_filter = {"SIG002"}
+    api2.onboard_status = {"SIG002": "offboarded"}
+    api2.current_mode = {"SIG002": SIGENERGY_MODE_MSC}
+    api2._publish_onboard_status()
+    key2 = "sensor.predbat_sigenergy_sig002_onboard_status"
+    assert api2.dashboard_items[key2]["state"] == "offboarded", "offboarded state published"
+    assert api2.dashboard_items[key2]["attributes"]["in_vpp"] is False, "in_vpp False for MSC mode"
+
+    # pending_approval — visible system not yet in VPP
+    api3 = MockSigenergyAPI()
+    api3.system_id_filter = {"SIG003"}
+    api3.onboard_status = {"SIG003": "pending_approval"}
+    api3.current_mode = {}
+    api3._publish_onboard_status()
+    key3 = "sensor.predbat_sigenergy_sig003_onboard_status"
+    assert api3.dashboard_items[key3]["state"] == "pending_approval", "pending_approval state published"
+
+    # not_onboarded — system in filter but onboard_status not yet set
+    api4 = MockSigenergyAPI()
+    api4.system_id_filter = {"SIG004"}
+    api4.onboard_status = {}
+    api4.current_mode = {}
+    api4._publish_onboard_status()
+    key4 = "sensor.predbat_sigenergy_sig004_onboard_status"
+    assert api4.dashboard_items[key4]["state"] == "not_onboarded", "missing status defaults to not_onboarded"
+
+    return failed
+
+
+def test_sigenergy_run_derives_onboard_status(my_predbat):
+    """run() correctly derives and publishes onboard_status for visible systems on each poll cycle."""
+    failed = False
+    sid = "SIG001"
+
+    def _make_api(mode, offboard_on=False):
+        api = MockSigenergyAPI()
+        api.systems = {sid: {"deviceList": []}}
+        api.current_mode = {sid: mode}
+        api.system_id_filter = {sid}
+        # Fake a running MQTT task so run() does not try to start one
+        task = MagicMock()
+        task.done = MagicMock(return_value=False)
+        api._mqtt_task = task
+        if offboard_on:
+            slug = api._system_slug(sid)
+            api.dashboard_items["switch.predbat_sigenergy_{}_offboard".format(slug)] = {"state": "on"}
+        # Stub async helpers called by run()
+        api._manage_vpp_registration = AsyncMock(return_value=True)
+        api.fetch_inverter_realtime = AsyncMock(return_value=True)
+        api.fetch_daily_summary = AsyncMock()
+        api.publish_system_entities = AsyncMock()
+        api.apply_controls = AsyncMock()
+        return api
+
+    # System in VPP mode → active
+    api_active = _make_api(SIGENERGY_MODE_VPP)
+    ok = run_async(api_active.run(seconds=300, first=False))
+    assert ok is True, "run() returns True on success"
+    assert api_active.onboard_status[sid] == "active", "active derived from VPP mode"
+    sensor_key = "sensor.predbat_sigenergy_sig001_onboard_status"
+    assert api_active.dashboard_items[sensor_key]["state"] == "active", "active sensor published"
+    assert api_active.dashboard_items[sensor_key]["attributes"]["in_vpp"] is True
+
+    # System in MSC mode, not offboarded → pending_approval
+    api_pending = _make_api(SIGENERGY_MODE_MSC)
+    run_async(api_pending.run(seconds=300, first=False))
+    assert api_pending.onboard_status[sid] == "pending_approval", "pending_approval derived from MSC mode"
+    assert api_pending.dashboard_items[sensor_key]["state"] == "pending_approval"
+
+    # Offboard toggle on → offboarded regardless of mode
+    api_offboard = _make_api(SIGENERGY_MODE_VPP, offboard_on=True)
+    run_async(api_offboard.run(seconds=300, first=False))
+    assert api_offboard.onboard_status[sid] == "offboarded", "offboarded when toggle is on"
+    assert api_offboard.dashboard_items[sensor_key]["state"] == "offboarded"
+
+    return failed
+
+
+def test_sigenergy_run_pending_publishes_before_early_exit(my_predbat):
+    """When onboard_systems returns None (pending approval), sensor is published before run() returns False."""
+    failed = False
+    sid = "SIG001"
+
+    api = MockSigenergyAPI()
+    api.system_id_filter = {sid}
+    api.get_access_token = AsyncMock(return_value="tok")
+    api.fetch_system_list = AsyncMock()  # leaves self.systems empty (system not yet visible)
+    api.onboard_systems = AsyncMock(return_value=None)
+
+    result = run_async(api.run(seconds=0, first=True))
+
+    assert result is False, "run() returns False when onboarding is pending"
+    sensor_key = "sensor.predbat_sigenergy_sig001_onboard_status"
+    assert sensor_key in api.dashboard_items, "sensor published before early return"
+    # Status was set to not_onboarded by the setdefault call in run() before onboard_systems
+    assert api.dashboard_items[sensor_key]["state"] in ("not_onboarded", "pending_approval"), "sensor has a known status value"
 
     return failed
 
@@ -1741,6 +1858,9 @@ def run_sigenergy_tests(my_predbat):
         ("offboard_toggle_in_vpp", test_sigenergy_offboard_toggle_in_vpp),
         ("offboard_toggle_not_in_vpp", test_sigenergy_offboard_toggle_not_in_vpp),
         ("offboard_toggle_switch_event", test_sigenergy_offboard_toggle_switch_event),
+        ("publish_onboard_status_sensors", test_sigenergy_publish_onboard_status_sensors),
+        ("run_derives_onboard_status", test_sigenergy_run_derives_onboard_status),
+        ("run_pending_publishes_before_early_exit", test_sigenergy_run_pending_publishes_before_early_exit),
     ]
 
     for name, fn in tests:

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -1661,6 +1661,30 @@ def test_sigenergy_offboard_toggle_switch_event(my_predbat):
 # ---------------------------------------------------------------------------
 
 
+def test_sigenergy_onboard_status(my_predbat):
+    """onboard_systems records the user-facing onboarding status per result code."""
+    failed = False
+    api = MockSigenergyAPI()
+    assert api.onboard_status == {}, "onboard_status starts empty"
+
+    # Pending approval (1116) → pending_approval, returns None
+    api._request = AsyncMock(return_value=None)
+    api._last_api_code = SIGENERGY_CODE_SYSTEM_PENDING_REVIEW
+    result = asyncio.run(api.onboard_systems(["sys-1"]))
+    assert result is None, "pending review returns None"
+    assert api.onboard_status["sys-1"] == "pending_approval", "pending_approval status set"
+
+    # Registered to another VPP (1103) → in_other_vpp, returns False
+    api2 = MockSigenergyAPI()
+    api2._request = AsyncMock(return_value=None)
+    api2._last_api_code = SIGENERGY_CODE_IN_OTHER_VPP
+    result2 = asyncio.run(api2.onboard_systems("sys-2"))
+    assert result2 is False, "in-other-vpp returns False"
+    assert api2.onboard_status["sys-2"] == "in_other_vpp", "in_other_vpp status set"
+
+    return failed
+
+
 def run_sigenergy_tests(my_predbat):
     """Run all Sigenergy API unit tests.
 
@@ -1671,6 +1695,7 @@ def run_sigenergy_tests(my_predbat):
     tests = [
         ("helper_functions", test_sigenergy_helper_functions),
         ("initialize", test_sigenergy_initialize),
+        ("onboard_status", test_sigenergy_onboard_status),
         ("system_slug", test_sigenergy_system_slug),
         ("battery_capacity", test_sigenergy_battery_capacity),
         ("publish_system_entities", test_sigenergy_publish_system_entities),


### PR DESCRIPTION
Publishes a per-system `sensor.<prefix>_sigenergy_<slug>_onboard_status` so a managing UI can show a live VPP-onboarding/approval stepper.

### Changes
- `onboard_systems` records `pending_approval` / `in_other_vpp` / `firmware_no_vpp` / `no_permission` from the API result codes.
- `run()` derives `active` / `offboarded` / `pending_approval` for visible systems and defaults not-yet-visible expected systems to `not_onboarded`.
- Publishes the sensor for every expected `system_id` (so a pending system still gets a sensor).
- Test: status transitions for the pending-review and in-other-VPP codes.

Read-only addition; no change to existing SigEnergy control behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)