### PR TITLE
Lattice 3/3: Fox/Solax/Solis producers (read-only)

### DIFF
--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -1618,6 +1618,14 @@ class FoxAPI(ComponentBase, OAuthMixin):
 
                 self.dashboard_item(entity_id, state=state, attributes=attributes, app="fox")
 
+    def lattice_fragment(self):
+        """Read-only Lattice fragment: FoxESS cloud devices (topology + sensor inventory)."""
+        from lattice import device_fragment
+
+        serials = [d.get("deviceSN") for d in (getattr(self, "device_list", None) or []) if isinstance(d, dict) and d.get("deviceSN")]
+        devices = [{"serial": str(s), "device_type": "fox", "sensors": [{"capability": "soc", "unit": "%"}, {"capability": "battery_power", "unit": "W"}]} for s in serials]
+        return device_fragment(devices, provider="fox-cloud", name="FoxESS Cloud", transport="https", preference=1, locality="cloud")
+
     async def write_setting_from_event(self, entity_id, value, is_number=False):
         """
         Handle write events

--- a/apps/predbat/solax.py
+++ b/apps/predbat/solax.py
@@ -453,6 +453,13 @@ class SolaxAPI(ComponentBase):
         if "_battery_schedule_" in entity_id:
             await self.write_battery_schedule_event(entity_id, service)
 
+    def lattice_fragment(self):
+        """Read-only Lattice fragment: Solax cloud plants (topology + sensor inventory)."""
+        from lattice import device_fragment
+
+        devices = [{"serial": str(p), "device_type": "solax", "sensors": [{"capability": "soc", "unit": "%"}]} for p in getattr(self, "plant_list", []) or []]
+        return device_fragment(devices, provider="solax-cloud", name="Solax Cloud", transport="https", preference=1, locality="cloud")
+
     async def write_battery_schedule_event(self, entity_id, value):
         """
         Write a battery schedule based on an event

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -578,6 +578,13 @@ class SolisAPI(ComponentBase):
         self.log("Solis API: Decoded time windows v2 for {}: {}".format(inverter_sn, result))  # Debug log
         return result
 
+    def lattice_fragment(self):
+        """Read-only Lattice fragment: Solis cloud inverters (topology + sensor inventory)."""
+        from lattice import device_fragment
+
+        devices = [{"serial": str(s), "device_type": "solis", "sensors": [{"capability": "soc", "unit": "%"}, {"capability": "battery_power", "unit": "W"}]} for s in getattr(self, "inverter_sn", []) or []]
+        return device_fragment(devices, provider="solis-cloud", name="Solis Cloud", transport="https", preference=1, locality="cloud")
+
     async def reset_charge_windows_if_needed(self, inverter_sn):
         """
         Predbat only uses 1 slot so disable the others to avoid conflicts.


### PR DESCRIPTION
**PR 3/3** of the read-only Lattice device-map train. Stacked on #4082.

Read-only fragments (device identity + sensor inventory) for the remaining cloud brands. No control.

**Commits:** Fox (real `deviceSN` identity), Solax (plants), Solis (inverters) — each a cloud-path producer with a soc/power sensor inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)