### PR TITLE
Fix web UI showing raw 'p' unit instead of configured currency (#4071)

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.41.0"
+THIS_VERSION = "v8.41.1"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -155,5 +155,70 @@ def run_web_functions_tests(my_predbat):
 
     my_predbat.dashboard_index = original_dashboard_index
 
+    # -------------------------------------------------------------------------
+    # Currency unit display in the web config pages (issue #4071)
+    # The web UI must show the user's configured currency symbol, not the raw "p".
+    failed += run_currency_unit_tests(my_predbat, web)
+
     print("**** Web functions tests completed ****")
+    return failed
+
+
+def run_currency_unit_tests(my_predbat, web):
+    """Verify config item units are converted to the user's currency symbols in the web UI."""
+    failed = 0
+    print("Test: web config pages convert currency units (issue #4071)")
+
+    original_symbols = my_predbat.currency_symbols
+    original_num_cars = my_predbat.num_cars
+
+    try:
+        my_predbat.currency_symbols = ["€", "c"]
+        my_predbat.num_cars = 1
+
+        # convert_currency_unit helper
+        if my_predbat.convert_currency_unit("p") != "c":
+            print(f"  ERROR: 'p' should convert to 'c', got: {my_predbat.convert_currency_unit('p')}")
+            failed += 1
+        if my_predbat.convert_currency_unit("p/kWh") != "c/kWh":
+            print(f"  ERROR: 'p/kWh' should convert to 'c/kWh', got: {my_predbat.convert_currency_unit('p/kWh')}")
+            failed += 1
+        if my_predbat.convert_currency_unit("£") != "€":
+            print(f"  ERROR: '£' should convert to '€', got: {my_predbat.convert_currency_unit('£')}")
+            failed += 1
+        if my_predbat.convert_currency_unit("kWh") != "kWh":
+            print(f"  ERROR: 'kWh' should be unchanged, got: {my_predbat.convert_currency_unit('kWh')}")
+            failed += 1
+        if my_predbat.convert_currency_unit("") != "":
+            print(f"  ERROR: empty unit should stay empty, got: {my_predbat.convert_currency_unit('')}")
+            failed += 1
+
+        # Enable and locate the car charging max price config item
+        entity = None
+        for item in my_predbat.CONFIG_ITEMS:
+            if item.get("name") == "car_charging_plan_max_price":
+                item["value"] = 14
+                entity = item.get("entity")
+                break
+
+        if entity is None:
+            print("  ERROR: car_charging_plan_max_price config item not found")
+            return failed + 1
+
+        # html_config_item_text (shown on the /entity page) must use the converted unit
+        item_html = web.html_config_item_text(entity)
+        if item_html is None:
+            print("  ERROR: html_config_item_text returned None for car_charging_plan_max_price")
+            failed += 1
+        else:
+            if "14 c" not in item_html:
+                print(f"  ERROR: expected '14 c' in config item HTML, got: {item_html}")
+                failed += 1
+            if "14 p" in item_html:
+                print(f"  ERROR: unexpected raw 'p' unit in config item HTML: {item_html}")
+                failed += 1
+    finally:
+        my_predbat.currency_symbols = original_symbols
+        my_predbat.num_cars = original_num_cars
+
     return failed

--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -195,8 +195,12 @@ def run_currency_unit_tests(my_predbat, web):
 
         # Enable and locate the car charging max price config item
         entity = None
+        original_item_value = None
+        original_item_ref = None
         for item in my_predbat.CONFIG_ITEMS:
             if item.get("name") == "car_charging_plan_max_price":
+                original_item_ref = item
+                original_item_value = item.get("value", None)
                 item["value"] = 14
                 entity = item.get("entity")
                 break
@@ -218,6 +222,8 @@ def run_currency_unit_tests(my_predbat, web):
                 print(f"  ERROR: unexpected raw 'p' unit in config item HTML: {item_html}")
                 failed += 1
     finally:
+        if original_item_ref is not None:
+            original_item_ref["value"] = original_item_value
         my_predbat.currency_symbols = original_symbols
         my_predbat.num_cars = original_num_cars
 

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -453,6 +453,17 @@ class UserInterface:
             return value, default
         return None, default
 
+    def convert_currency_unit(self, unit):
+        """
+        Convert a config item unit string (using the default £/p symbols) into the
+        user's configured currency symbols so displayed units match the rates.
+        """
+        if not unit:
+            return unit
+        unit = unit.replace("£", self.currency_symbols[0])
+        unit = unit.replace("p", self.currency_symbols[1])
+        return unit
+
     async def async_expose_config(self, name, value, quiet=True, event=False, force=False, in_progress=False):
         return await self.run_in_executor(self.expose_config, name, value, quiet, event, force, in_progress)
 
@@ -482,9 +493,7 @@ class UserInterface:
                     if item["type"] == "input_number":
                         """INPUT_NUMBER"""
                         icon = item.get("icon", "mdi:numeric")
-                        unit = item["unit"]
-                        unit = unit.replace("£", self.currency_symbols[0])
-                        unit = unit.replace("p", self.currency_symbols[1])
+                        unit = self.convert_currency_unit(item["unit"])
                         self.set_state_wrapper(
                             entity_id=entity,
                             state=value,

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -460,8 +460,9 @@ class UserInterface:
         """
         if not unit:
             return unit
-        unit = unit.replace("£", self.currency_symbols[0])
-        unit = unit.replace("p", self.currency_symbols[1])
+        major = self.currency_symbols[0] if self.currency_symbols and len(self.currency_symbols) > 0 else "£"
+        minor = self.currency_symbols[1] if self.currency_symbols and len(self.currency_symbols) > 1 else "p"
+        unit = unit.replace("£", "%%CURR_MAJOR%%").replace("p", minor).replace("%%CURR_MAJOR%%", major)
         return unit
 
     async def async_expose_config(self, name, value, quiet=True, event=False, force=False, in_progress=False):

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -762,7 +762,7 @@ class WebInterface(ComponentBase):
                 if self.base.user_config_item_enabled(item):
                     entity_id = item.get("entity", "")
                     entity_friendly_name = item.get("friendly_name", "")
-                    unit = item.get("unit", "")
+                    unit = self.base.convert_currency_unit(item.get("unit", ""))
                     if unit:
                         entity_friendly_name = f"{entity_friendly_name} ({unit})"
                     if entity_id:
@@ -3583,7 +3583,7 @@ chart.render();
                 itemtype = item.get("type", "")
                 default = item.get("default", "")
                 icon = self.icon2html(item.get("icon", ""))
-                unit = item.get("unit", "")
+                unit = self.base.convert_currency_unit(item.get("unit", ""))
                 text += "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td>".format(icon, friendly, entity, itemtype)
                 if value == default:
                     text += '<td class="cfg_default">{} {}</td><td>{} {}</td>\n'.format(value, unit, default, unit)
@@ -3634,7 +3634,7 @@ chart.render();
                 itemtype = item.get("type", "")
                 default = item.get("default", "")
                 useid = entity.replace(".", "__")
-                unit = item.get("unit", "")
+                unit = self.base.convert_currency_unit(item.get("unit", ""))
                 icon = self.icon2html(item.get("icon", ""))
 
                 if itemtype in ["input_number", "number"] and item.get("step", 1) == 1:


### PR DESCRIPTION
Fixes #4071

## Problem

The *Car Charging Plan max price* field (and other price config items) displayed its unit as `p` in the **Predbat web UI** even when `currency_symbols` was configured to something else (e.g. `['€', 'c']`).

The Home Assistant entity itself was already converted correctly via `expose_config` (it shows `c` in HA). The bug was that the web UI config pages (`/config` and `/entity`) read the *raw* config item `unit` (`"p"`) without applying the `currency_symbols` conversion.

## Fix

- Factored the existing `£`→symbol / `p`→symbol conversion into a shared `convert_currency_unit()` helper on `UserInterface`.
- Reused it in `expose_config` (replacing the duplicated inline logic).
- Applied it at the three `web.py` config display sites: the entity-list builder, `html_config_item_text` (`/entity` page), and `html_config` (`/config` page).
- Added unit tests in `test_web_functions.py` covering the helper (`p`→`c`, `p/kWh`→`c/kWh`, `£`→`€`, unchanged/empty units) and asserting the rendered config item HTML shows `14 c` rather than `14 p`.

## Note on the reporter's "can't enter 0,14"

That part of the report is a misunderstanding rather than a bug: the field has always been in the *minor* unit (pence/cents) with step 1 — `0.14 €` is entered as `14`, the same way `10p` is entered as `10`. Only the displayed label was wrong; the stored/used value was already in cents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)