### PR TITLE
Sustain in-progress forced export across plan cycles (anti-flapping on flat peaks)

### DIFF
--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -1721,7 +1721,11 @@ class Plan:
                 dwindow = self.export_window[0]
                 if self.minutes_now >= pwindow["start"] and self.minutes_now < pwindow["end"] and ((self.minutes_now >= dwindow["start"] and self.minutes_now < dwindow["end"]) or (dwindow["end"] == pwindow["start"])):
                     metric -= max(0.5, self.metric_min_improvement_export)
-                    keep_export = True
+                    # Only relax the cost gate (further below) for an option that actually covers the current
+                    # minute. The option start is varied during optimisation, so a future-starting option is
+                    # not the in-progress export and must not receive the cost-gate commitment.
+                    if start <= self.minutes_now:
+                        keep_export = True
 
             # Round metric to 4 DP
             metric = dp4(metric)

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -1715,11 +1715,13 @@ class Plan:
                 metric -= 0.001
 
             # Adjust to try to keep existing windows
+            keep_export = False
             if window_n < 2 and this_export_limit < 99.0 and self.export_window and self.isExporting:
                 pwindow = export_window[window_n]
                 dwindow = self.export_window[0]
                 if self.minutes_now >= pwindow["start"] and self.minutes_now < pwindow["end"] and ((self.minutes_now >= dwindow["start"] and self.minutes_now < dwindow["end"]) or (dwindow["end"] == pwindow["start"])):
                     metric -= max(0.5, self.metric_min_improvement_export)
+                    keep_export = True
 
             # Round metric to 4 DP
             metric = dp4(metric)
@@ -1764,6 +1766,14 @@ class Plan:
                 min_improvement_scaled = self.metric_min_improvement_export * rate_scale * len(all_n)
             else:
                 min_improvement_scaled = self.metric_min_improvement_export * window_size * rate_scale / float(self.plan_interval_minutes)
+
+            # When already exporting within this window keep the export going across planning cycles by
+            # relaxing the cost gate (not just the metric above). This only sustains an in-progress forced
+            # export (it never opens a new one) so it cannot reintroduce the metric_keep gaming of issue #2984.
+            # It prevents export oscillation on near-flat multi-slot price peaks where exporting now versus
+            # holding and exporting the adjacent equal-priced slot is otherwise a cost coin-toss each cycle.
+            if keep_export:
+                min_improvement_scaled = min(min_improvement_scaled, -max(0.5, self.metric_min_improvement_export))
 
             # Only select an export if it makes a notable improvement has defined by min_improvement (divided in M windows)
             # Also require cost improvement to prevent exports that only game metric_keep without actual savings (issue #2984)

--- a/apps/predbat/tests/test_export_commitment.py
+++ b/apps/predbat/tests/test_export_commitment.py
@@ -121,6 +121,15 @@ def run_export_commitment_tests(my_predbat):
         print("ERROR: expected export gated out (100%) when the prior export window does not cover now, got {}".format(best_export_outside))
         failed = True
 
+    # Restore the fields mutated above so we do not make later tests in the shared suite order-dependent
+    my_predbat.isExporting = False
+    my_predbat.export_window = []
+    my_predbat.set_export_freeze = True
+    my_predbat.set_export_freeze_only = False
+    my_predbat.set_export_low_power = False
+    my_predbat.metric_min_improvement_export = 0.1
+    my_predbat.metric_min_improvement_export_freeze = 0.1
+
     if failed:
         print("**** Export commitment tests FAILED ****")
     else:

--- a/apps/predbat/tests/test_export_commitment.py
+++ b/apps/predbat/tests/test_export_commitment.py
@@ -129,11 +129,11 @@ def run_export_commitment_tests(my_predbat):
     # Restore the fields mutated above so we do not make later tests in the shared suite order-dependent
     my_predbat.isExporting = False
     my_predbat.export_window = []
-    my_predbat.set_export_freeze = True
-    my_predbat.set_export_freeze_only = False
-    my_predbat.set_export_low_power = False
-    my_predbat.metric_min_improvement_export = 0.1
-    my_predbat.metric_min_improvement_export_freeze = 0.1
+    my_predbat.set_export_freeze = orig_set_export_freeze
+    my_predbat.set_export_freeze_only = orig_set_export_freeze_only
+    my_predbat.set_export_low_power = orig_set_export_low_power
+    my_predbat.metric_min_improvement_export = orig_metric_min_improvement_export
+    my_predbat.metric_min_improvement_export_freeze = orig_metric_min_improvement_export_freeze
 
     if failed:
         print("**** Export commitment tests FAILED ****")

--- a/apps/predbat/tests/test_export_commitment.py
+++ b/apps/predbat/tests/test_export_commitment.py
@@ -82,6 +82,12 @@ def run_export_commitment_tests(my_predbat):
     export_window_best, record_export_windows, end_record = setup_single_export_window(my_predbat)
 
     # Restrict the export options to [100, 0] so the freeze (99) option cannot interfere
+    orig_set_export_freeze = my_predbat.set_export_freeze
+    orig_set_export_freeze_only = my_predbat.set_export_freeze_only
+    orig_set_export_low_power = my_predbat.set_export_low_power
+    orig_metric_min_improvement_export = my_predbat.metric_min_improvement_export
+    orig_metric_min_improvement_export_freeze = my_predbat.metric_min_improvement_export_freeze
+
     my_predbat.set_export_freeze = False
     my_predbat.set_export_freeze_only = False
     my_predbat.set_export_low_power = False
@@ -90,7 +96,6 @@ def run_export_commitment_tests(my_predbat):
     # fresh plan, but is small enough to be overcome by the commitment relaxation.
     my_predbat.metric_min_improvement_export = 100.0
     my_predbat.metric_min_improvement_export_freeze = 0.1
-
     charge_window_best = []
     charge_limit_best = []
     export_limits_best = [100.0]

--- a/apps/predbat/tests/test_export_commitment.py
+++ b/apps/predbat/tests/test_export_commitment.py
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+from tests.test_infra import reset_rates, update_rates_export, reset_inverter
+from prediction import Prediction
+
+
+def setup_single_export_window(my_predbat, rate_import=10.0, rate_export=30.0, battery_size=10.0, battery_soc=10.0, window_minutes=120):
+    """
+    Build a Predbat instance with a single export window covering the current time, a full battery and no load/PV.
+
+    The export rate is set well above the import rate so that exporting is metric-favourable (keeping the battery
+    is worth less than exporting it), isolating the behaviour to the cost gate in optimise_export.
+
+    Returns (export_window_best, record_export_windows, end_record).
+    """
+    my_predbat.load_user_config()
+    my_predbat.fetch_config_options()
+    reset_inverter(my_predbat)
+    my_predbat.pool = None
+
+    my_predbat.forecast_minutes = 24 * 60
+    end_record = my_predbat.forecast_minutes
+    my_predbat.end_record = end_record
+
+    # No load and no solar keeps the simulation deterministic
+    pv_step = {}
+    load_step = {}
+    for minute in range(0, my_predbat.forecast_minutes, 5):
+        pv_step[minute] = 0.0
+        load_step[minute] = 0.0
+    my_predbat.load_minutes_step = load_step
+    my_predbat.load_minutes_step10 = load_step
+    my_predbat.pv_forecast_minute_step = pv_step
+    my_predbat.pv_forecast_minute10_step = pv_step
+    my_predbat.prediction = Prediction(my_predbat, pv_step, pv_step, load_step, load_step)
+
+    my_predbat.calculate_best_charge = True
+    my_predbat.calculate_best_export = True
+    my_predbat.soc_max = battery_size
+    my_predbat.soc_kw = battery_soc
+    my_predbat.inverter_hybrid = False
+    my_predbat.inverter_loss = 1.0
+    my_predbat.battery_loss = 1.0
+    my_predbat.battery_loss_discharge = 1.0
+    my_predbat.best_soc_keep = 0.0
+    my_predbat.best_soc_min = 0.0
+    my_predbat.reserve = 0.0
+    my_predbat.num_inverters = 1
+    my_predbat.metric_battery_cycle = 0.0
+    my_predbat.debug_enable = False
+
+    # A single two hour export window starting at the current time
+    start = my_predbat.minutes_now
+    end = my_predbat.minutes_now + window_minutes
+    export_window_best = [{"start": start, "end": end, "average": rate_export}]
+
+    reset_rates(my_predbat, rate_import, rate_export)
+    update_rates_export(my_predbat, export_window_best)
+
+    record_export_windows = max(my_predbat.max_charge_windows(end_record + my_predbat.minutes_now, export_window_best), 1)
+    return export_window_best, record_export_windows, end_record
+
+
+def run_export_commitment_tests(my_predbat):
+    """
+    Regression tests for the forced export commitment in optimise_export (plan.py).
+
+    When Predbat is already exporting within a window the cost gate is relaxed so the export is sustained
+    across planning cycles. This stops the export "flapping" on near-flat multi-slot price peaks where
+    exporting now versus holding and exporting the adjacent equal-priced slot is a cost coin toss each cycle.
+    """
+    print("**** Running Export commitment tests ****")
+    failed = False
+
+    export_window_best, record_export_windows, end_record = setup_single_export_window(my_predbat)
+
+    # Restrict the export options to [100, 0] so the freeze (99) option cannot interfere
+    my_predbat.set_export_freeze = False
+    my_predbat.set_export_freeze_only = False
+    my_predbat.set_export_low_power = False
+
+    # A deliberately huge min improvement so a genuinely beneficial export is rejected by the cost gate on a
+    # fresh plan, but is small enough to be overcome by the commitment relaxation.
+    my_predbat.metric_min_improvement_export = 100.0
+    my_predbat.metric_min_improvement_export_freeze = 0.1
+
+    charge_window_best = []
+    charge_limit_best = []
+    export_limits_best = [100.0]
+
+    # 1) Fresh plan, not currently exporting -> the export is gated out and the window is held at 100%
+    my_predbat.isExporting = False
+    my_predbat.export_window = []
+    best_export_fresh = my_predbat.optimise_export(0, record_export_windows, charge_limit_best, charge_window_best, export_window_best, export_limits_best, end_record=end_record)[0]
+    if best_export_fresh != 100.0:
+        print("ERROR: expected export gated out (100%) on a fresh plan with huge min_improvement, got {}".format(best_export_fresh))
+        failed = True
+
+    # 2) Same scenario but we are already exporting within this window -> the commitment relaxes the cost gate
+    #    and the in-progress export is retained (limit below 100%)
+    my_predbat.isExporting = True
+    my_predbat.export_window = [{"start": my_predbat.minutes_now, "end": my_predbat.minutes_now + 120, "average": 30.0}]
+    best_export_keep = my_predbat.optimise_export(0, record_export_windows, charge_limit_best, charge_window_best, export_window_best, export_limits_best, end_record=end_record)[0]
+    if best_export_keep >= 100.0:
+        print("ERROR: expected an in-progress export to be retained (<100%) under commitment, got {}".format(best_export_keep))
+        failed = True
+
+    # 3) Guard: the commitment must not fire when the prior export window does not cover the current time, so a
+    #    stale export flag cannot force a fresh export. The window is gated out again.
+    my_predbat.isExporting = True
+    my_predbat.export_window = [{"start": my_predbat.minutes_now - 300, "end": my_predbat.minutes_now - 180, "average": 30.0}]
+    best_export_outside = my_predbat.optimise_export(0, record_export_windows, charge_limit_best, charge_window_best, export_window_best, export_limits_best, end_record=end_record)[0]
+    if best_export_outside != 100.0:
+        print("ERROR: expected export gated out (100%) when the prior export window does not cover now, got {}".format(best_export_outside))
+        failed = True
+
+    if failed:
+        print("**** Export commitment tests FAILED ****")
+    else:
+        print("**** Export commitment tests passed ****")
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -38,6 +38,7 @@ from tests.test_car_charging_smart import run_car_charging_smart_tests
 from tests.test_plugin_startup import test_plugin_startup_order
 from tests.test_active_flag import test_active_flag
 from tests.test_optimise_levels import run_optimise_levels_tests
+from tests.test_export_commitment import run_export_commitment_tests
 from tests.test_energydataservice import run_energydataservice_tests
 from tests.test_iboost import run_iboost_smart_tests
 from tests.test_alert_feed import test_alert_feed
@@ -326,6 +327,7 @@ def main():
         ("compare", test_compare, "Compare tariff engine tests (hardware overrides, bleed isolation)", False),
         ("gateway", run_gateway_tests, "GatewayMQTT component tests (protobuf, plan serialization, commands, telemetry)", False),
         ("optimise_levels", run_optimise_levels_tests, "Optimise levels tests", False),
+        ("export_commitment", run_export_commitment_tests, "Forced-export commitment / anti-flapping tests", False),
         ("load_ml", test_load_ml, "ML Load Forecaster tests (MLP, training, persistence, validation)", True),
         ("optimise_windows", run_optimise_all_windows_tests, "Optimise all windows tests", True),
         ("debug_cases", run_debug_cases, "Debug case file tests", True),


### PR DESCRIPTION
## Problem

On an evening with a high export price that stays nearly flat across several half-hour slots while PV is still producing, forced export does not run continuously through the peak. Predbat re-plans every ~5 minutes and the per-slot forced-export decision oscillates: the battery exports for a few minutes, the slot then flips to "hold", PV charges the battery instead of exporting, then it flips back. Net effect is that energy is shifted out of the most expensive slot into later, cheaper ones.

The offline plan is clean and continuous — the oscillation only shows up across live recomputes.

## Root cause

`optimise_export` already has a hysteresis to keep an existing export window:

```python
if window_n < 2 and this_export_limit < 99.0 and self.export_window and self.isExporting:
    ...
    metric -= max(0.5, self.metric_min_improvement_export)
```

But the binding selection gate is on the raw `cost`, not the metric:

```python
if (metric <= off_metric) and (metric <= best_metric) and ((cost + min_improvement_scaled) <= off_cost):
```

On a near-flat multi-slot peak, exporting the current slot versus holding it and exporting the adjacent equal-priced slot is a cost coin-toss (tipped by the intraday load/PV adjustment each cycle). Because the hysteresis only lowers `metric` and never touches the cost gate, it cannot hold the export and the decision flip-flops between recomputes.

## Fix

When that same hysteresis condition fires (we are already exporting within this window) also relax the cost gate by the commitment amount, so an in-progress forced export is sustained across recomputes:

```python
if keep_export:
    min_improvement_scaled = min(min_improvement_scaled, -max(0.5, self.metric_min_improvement_export))
```

This only sustains an export that is **already running** (`self.isExporting`, `window_n < 2`, current time inside the window). It never opens a new export window, so it cannot reintroduce the `metric_keep` gaming guarded by #2984. The relaxation is bounded (`max(0.5, metric_min_improvement_export)`), so if holding becomes clearly better the export is still released.

## Tests

Adds `apps/predbat/tests/test_export_commitment.py` (registered as `export_commitment`):

- fresh plan, not exporting, large min-improvement → export correctly gated out (100%)
- already exporting within the window → export retained under commitment (<100%)
- stale export flag outside the prior window → no spurious export (guard)

The test fails without the patch (the in-progress export is dropped to 100%) and passes with it. `optimise_levels`, `optimise_windows`, `compute_metric`, `execute` and `model` groups still pass; black / ruff (F401) / interrogate / cspell are clean.


## Live validation

Validated on a real SolarEdge hybrid install across two consecutive evenings with similar near-flat two-hour export peaks — the two peak half-hours within ~2c/kWh of each other, which is the condition that triggers the oscillation (the absolute height is not what drives it):

- **Before (unpatched, ~0.69/0.67 peak):** the storage-mode select flipped mid-peak — `Discharge to Maximize Export` → `Maximize Self Consumption` → `Discharge to Maximize Export` within the first 15 minutes — and during the "hold" the remaining PV charged the battery instead of exporting, shifting energy out of the dearest slot into cheaper later ones.
- **After (this patch, ~0.94/0.96 peak):** a single transition into `Discharge to Maximize Export` at the start of the peak, held continuously for the full two hours, returning to demand only when the price dropped. **Zero mode-flips**; the battery held a steady ~10 kW discharge with no charging dips; SoC fell monotonically (100% → ~23%) with no saw-tooth.

A single evening is not conclusive on its own, but the oscillation condition was present and the before/after contrast on the same install is clear.
