### PR TITLE
Octopus saving sessions: auto-join toggle and Axle conflict avoidance (#4120)

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -706,6 +706,12 @@ CONFIG_ITEMS = [
         "default": True,
     },
     {
+        "name": "octopus_saving_auto_join",
+        "friendly_name": "Octopus Saving Session Auto Join",
+        "type": "switch",
+        "default": True,
+    },
+    {
         "name": "octopus_intelligent_ignore_unplugged",
         "friendly_name": "Ignore Intelligent slots when car is unplugged",
         "type": "switch",

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -950,9 +950,10 @@ class Fetch:
             # Basic rates defined by user over time
             self.rate_export = self.basic_rates(self.get_arg("rates_export", [], indirect=False), "rates_export")
 
-        # Fetch octopus saving sessions and free sessions
-        self.octopus_free_slots, self.octopus_saving_slots = self.fetch_octopus_sessions()
+        # Fetch Axle sessions first so Octopus auto-join can skip saving sessions that overlap an Axle VPP session
         self.axle_sessions = fetch_axle_sessions(self)
+        # Fetch octopus saving sessions and free sessions
+        self.octopus_free_slots, self.octopus_saving_slots = self.fetch_octopus_sessions(self.axle_sessions)
 
         # Standing charge
         self.metric_standing_charge = self.get_arg("metric_standing_charge", 0.0) * 100.0

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2748,8 +2748,9 @@ class Octopus:
 
             if available_events and not self.get_arg("octopus_saving_auto_join", True):
                 self.log("Octopus: Saving session auto-join is disabled, not joining available events")
+                # Clear the 2h throttle so re-enabling auto-join can take effect immediately
+                self.octopus_last_joined_try = None
                 available_events = []
-
             if available_events:
                 # Only try to join every 2 hours to avoid spamming if it fails
                 if not self.octopus_last_joined_try or (self.now_utc - self.octopus_last_joined_try).total_seconds() > 2 * 60 * 60:

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2652,10 +2652,36 @@ class Octopus:
 
         return rate_data
 
-    def fetch_octopus_sessions(self):
+    def _saving_event_conflicts_axle(self, start_time, end_time, axle_sessions):
+        """
+        Return True if the saving session [start_time, end_time) overlaps any Axle VPP session
+        """
+        if not axle_sessions or start_time is None or end_time is None:
+            return False
+        for axle_session in axle_sessions:
+            axle_start = axle_session.get("start_time")
+            axle_end = axle_session.get("end_time")
+            if not axle_start or not axle_end:
+                continue
+            try:
+                axle_start = str2time(axle_start)
+                axle_end = str2time(axle_end)
+            except (ValueError, TypeError):
+                continue
+            # Standard half-open interval overlap test
+            if start_time < axle_end and axle_start < end_time:
+                return True
+        return False
+
+    def fetch_octopus_sessions(self, axle_sessions=None):
         """
         Fetch the Octopus saving/free sessions
+
+        Available saving session events that overlap an Axle VPP session are not auto-joined,
+        so Predbat does not commit to two conflicting events for the same period.
         """
+        if axle_sessions is None:
+            axle_sessions = []
 
         # Octopus free session
         octopus_free_slots = []
@@ -2720,6 +2746,10 @@ class Octopus:
 
                 available_events = self.get_state_wrapper(entity_id=entity_id, attribute="available_events")
 
+            if available_events and not self.get_arg("octopus_saving_auto_join", True):
+                self.log("Octopus: Saving session auto-join is disabled, not joining available events")
+                available_events = []
+
             if available_events:
                 # Only try to join every 2 hours to avoid spamming if it fails
                 if not self.octopus_last_joined_try or (self.now_utc - self.octopus_last_joined_try).total_seconds() > 2 * 60 * 60:
@@ -2734,6 +2764,10 @@ class Octopus:
                             saving_rate = octopoints_kwh / octopoints_per_penny  # Octopoints per pence
                         else:
                             saving_rate = saving_rate  # Use default if not specified
+                        # Do not auto-join a saving session that overlaps an Axle VPP session - we cannot honour both for the same period
+                        if self._saving_event_conflicts_axle(start_time, end_time, axle_sessions):
+                            self.log("Octopus: Skipping saving event code {} {}-{} - conflicts with an Axle VPP session".format(code, start_time.strftime("%a %d/%m %H:%M"), end_time.strftime("%H:%M")))
+                            continue
                         if code:  # Join the new Octopus saving event and send an alert
                             self.log("Octopus: Joining Octopus saving event code {} {}-{} at rate {} p/kWh".format(code, start_time.strftime("%a %d/%m %H:%M"), end_time.strftime("%H:%M"), saving_rate))
                             entity_id_join = self.get_arg("octopus_saving_session_join", indirect=False)

--- a/apps/predbat/tests/test_saving_session.py
+++ b/apps/predbat/tests/test_saving_session.py
@@ -366,6 +366,232 @@ friendly_name: Octoplus Saving Session Events
     return failed
 
 
+def test_saving_session_axle_conflict(my_predbat):
+    """
+    Test that an available Octopus saving session is not auto-joined when it overlaps an Axle VPP session
+    Covers GitHub issue #4120
+    """
+    print("Test saving session Axle conflict avoidance (issue #4120)")
+    ha = my_predbat.ha_interface
+    failed = False
+    date_today = datetime.now().strftime("%Y-%m-%d")
+    tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)
+    tz_offset = f"{tz_offset:02d}"
+
+    session_binary = f"""
+state: off
+current_joined_event_start: null
+current_joined_event_end: null
+current_joined_event_duration_in_minutes: null
+next_joined_event_start: null
+next_joined_event_end: null
+next_joined_event_duration_in_minutes: null
+icon: mdi:leaf
+friendly_name: Octoplus Saving Session
+"""
+
+    # A single available saving session 18:30-19:30
+    session_sensor = f"""
+state: '2025-01-23T12:10:11.108+{tz_offset}:00'
+event_types: octopus_energy_all_octoplus_saving_sessions
+event_type: octopus_energy_all_octoplus_saving_sessions
+account_id: A-4DD6C5EE
+available_events:
+    - id: 9999
+      start: '{date_today}T18:30:00+{tz_offset}:00'
+      end: '{date_today}T19:30:00+{tz_offset}:00'
+      duration_in_minutes: 60
+      rewarded_octopoints: null
+      octopoints_per_kwh: 500
+      code: TEST123
+joined_events: []
+friendly_name: Octoplus Saving Session Events
+"""
+
+    def setup_items():
+        ha.dummy_items.clear()
+        ha.dummy_items["binary_sensor.octopus_energy_test_octoplus_saving_sessions"] = yaml.safe_load(session_binary)
+        ha.dummy_items["event.octopus_energy_test_octoplus_saving_session_event"] = yaml.safe_load(session_sensor)
+        ha.dummy_items["sensor.octopus_free_session"] = {}
+        my_predbat.args["octopus_saving_session"] = "event.octopus_energy_test_octoplus_saving_session_event"
+        my_predbat.args["octopus_free_session"] = "sensor.octopus_free_session"
+        if "octopus_free_url" in my_predbat.args:
+            del my_predbat.args["octopus_free_url"]
+        my_predbat.args["octopus_saving_session_octopoints_per_penny"] = 10
+        # Reset throttle so a join is attempted
+        my_predbat.octopus_last_joined_try = None
+
+    # Test 1: Overlapping Axle session (Axle 19:00-20:00 overlaps saving 18:30-19:30) -> no join
+    print("  Test 1: Overlapping Axle session blocks the join")
+    setup_items()
+    axle_overlap = [
+        {
+            "start_time": f"{date_today}T19:00:00+{tz_offset}:00",
+            "end_time": f"{date_today}T20:00:00+{tz_offset}:00",
+            "import_export": "export",
+            "pence_per_kwh": 50,
+        }
+    ]
+    ha.service_store_enable = True
+    ha.service_store = []
+    my_predbat.fetch_octopus_sessions(axle_overlap)
+    service_result = ha.get_service_store()
+    ha.service_store_enable = False
+
+    join_calls = [svc for svc in service_result if "join" in svc[0]]
+    if join_calls:
+        print(f"ERROR: Expected no join when overlapping an Axle session, got {join_calls}")
+        failed = True
+    else:
+        print("  PASS: Join skipped when saving session overlaps an Axle session")
+
+    # Test 2: Non-overlapping Axle session (Axle 12:00-13:00) -> join proceeds
+    print("  Test 2: Non-overlapping Axle session allows the join")
+    setup_items()
+    axle_clear = [
+        {
+            "start_time": f"{date_today}T12:00:00+{tz_offset}:00",
+            "end_time": f"{date_today}T13:00:00+{tz_offset}:00",
+            "import_export": "export",
+            "pence_per_kwh": 50,
+        }
+    ]
+    ha.service_store_enable = True
+    ha.service_store = []
+    my_predbat.fetch_octopus_sessions(axle_clear)
+    service_result = ha.get_service_store()
+    ha.service_store_enable = False
+
+    join_calls = [svc for svc in service_result if "join" in svc[0]]
+    if len(join_calls) != 1:
+        print(f"ERROR: Expected 1 join when Axle session does not overlap, got {len(join_calls)}: {service_result}")
+        failed = True
+    else:
+        print("  PASS: Join proceeds when no Axle session overlaps")
+
+    # Test 3: No Axle sessions at all -> join proceeds (backwards compatible default)
+    print("  Test 3: No Axle sessions allows the join")
+    setup_items()
+    ha.service_store_enable = True
+    ha.service_store = []
+    my_predbat.fetch_octopus_sessions()
+    service_result = ha.get_service_store()
+    ha.service_store_enable = False
+
+    join_calls = [svc for svc in service_result if "join" in svc[0]]
+    if len(join_calls) != 1:
+        print(f"ERROR: Expected 1 join when no Axle sessions provided, got {len(join_calls)}: {service_result}")
+        failed = True
+    else:
+        print("  PASS: Join proceeds when no Axle sessions are provided")
+
+    if not failed:
+        print("PASS: All Axle conflict avoidance tests passed")
+
+    # Restore default throttle state so we do not leak it to other tests
+    my_predbat.octopus_last_joined_try = None
+
+    return failed
+
+
+def test_saving_session_auto_join_toggle(my_predbat):
+    """
+    Test that the octopus_saving_auto_join switch controls whether available saving sessions are auto-joined
+    Covers GitHub issue #4120
+    """
+    print("Test saving session auto-join toggle (issue #4120)")
+    ha = my_predbat.ha_interface
+    failed = False
+    date_today = datetime.now().strftime("%Y-%m-%d")
+    tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)
+    tz_offset = f"{tz_offset:02d}"
+
+    session_binary = f"""
+state: off
+current_joined_event_start: null
+current_joined_event_end: null
+current_joined_event_duration_in_minutes: null
+next_joined_event_start: null
+next_joined_event_end: null
+next_joined_event_duration_in_minutes: null
+icon: mdi:leaf
+friendly_name: Octoplus Saving Session
+"""
+
+    session_sensor = f"""
+state: '2025-01-23T12:10:11.108+{tz_offset}:00'
+event_types: octopus_energy_all_octoplus_saving_sessions
+event_type: octopus_energy_all_octoplus_saving_sessions
+account_id: A-4DD6C5EE
+available_events:
+    - id: 9999
+      start: '{date_today}T18:30:00+{tz_offset}:00'
+      end: '{date_today}T19:30:00+{tz_offset}:00'
+      duration_in_minutes: 60
+      rewarded_octopoints: null
+      octopoints_per_kwh: 500
+      code: TEST123
+joined_events: []
+friendly_name: Octoplus Saving Session Events
+"""
+
+    def setup_items():
+        ha.dummy_items.clear()
+        ha.dummy_items["binary_sensor.octopus_energy_test_octoplus_saving_sessions"] = yaml.safe_load(session_binary)
+        ha.dummy_items["event.octopus_energy_test_octoplus_saving_session_event"] = yaml.safe_load(session_sensor)
+        ha.dummy_items["sensor.octopus_free_session"] = {}
+        my_predbat.args["octopus_saving_session"] = "event.octopus_energy_test_octoplus_saving_session_event"
+        my_predbat.args["octopus_free_session"] = "sensor.octopus_free_session"
+        if "octopus_free_url" in my_predbat.args:
+            del my_predbat.args["octopus_free_url"]
+        my_predbat.args["octopus_saving_session_octopoints_per_penny"] = 10
+        # Reset throttle so a join is attempted
+        my_predbat.octopus_last_joined_try = None
+
+    # Test 1: auto-join disabled -> no join
+    print("  Test 1: octopus_saving_auto_join=False blocks the join")
+    setup_items()
+    my_predbat.expose_config("octopus_saving_auto_join", False, quiet=True)
+    ha.service_store_enable = True
+    ha.service_store = []
+    my_predbat.fetch_octopus_sessions()
+    service_result = ha.get_service_store()
+    ha.service_store_enable = False
+
+    join_calls = [svc for svc in service_result if "join" in svc[0]]
+    if join_calls:
+        print(f"ERROR: Expected no join when auto-join disabled, got {join_calls}")
+        failed = True
+    else:
+        print("  PASS: Join skipped when octopus_saving_auto_join is False")
+
+    # Test 2: auto-join enabled -> join proceeds
+    print("  Test 2: octopus_saving_auto_join=True allows the join")
+    setup_items()
+    my_predbat.expose_config("octopus_saving_auto_join", True, quiet=True)
+    ha.service_store_enable = True
+    ha.service_store = []
+    my_predbat.fetch_octopus_sessions()
+    service_result = ha.get_service_store()
+    ha.service_store_enable = False
+
+    join_calls = [svc for svc in service_result if "join" in svc[0]]
+    if len(join_calls) != 1:
+        print(f"ERROR: Expected 1 join when auto-join enabled, got {len(join_calls)}: {service_result}")
+        failed = True
+    else:
+        print("  PASS: Join proceeds when octopus_saving_auto_join is True")
+
+    if not failed:
+        print("PASS: All auto-join toggle tests passed")
+
+    # Restore default state so we do not leak it to other tests
+    my_predbat.expose_config("octopus_saving_auto_join", True, quiet=True)
+    my_predbat.octopus_last_joined_try = None
+
+    return failed
+
+
 def test_saving_session_default_rate(my_predbat):
     """
     Test that saving sessions with no octopoints_per_kwh use the default rate

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -45,7 +45,7 @@ from tests.test_alert_feed import test_alert_feed
 from tests.test_solax import run_solax_tests
 from tests.test_sigenergy import run_sigenergy_tests
 from tests.test_single_debug import run_single_debug
-from tests.test_saving_session import test_saving_session, test_saving_session_null_octopoints, test_saving_session_notify_config, test_saving_session_default_rate
+from tests.test_saving_session import test_saving_session, test_saving_session_null_octopoints, test_saving_session_notify_config, test_saving_session_default_rate, test_saving_session_axle_conflict, test_saving_session_auto_join_toggle
 from tests.test_secrets import run_secrets_tests
 from tests.test_ge_cloud import test_ge_cloud
 from tests.test_compare import test_compare
@@ -259,6 +259,8 @@ def main():
         ("saving_session_null", test_saving_session_null_octopoints, "Saving session null octopoints test (issue #3079)", False),
         ("saving_session_notify", test_saving_session_notify_config, "Saving session notification config tests", False),
         ("saving_session_default_rate", test_saving_session_default_rate, "Saving session default rate injection test", False),
+        ("saving_session_axle_conflict", test_saving_session_axle_conflict, "Saving session Axle conflict avoidance test (issue #4120)", False),
+        ("saving_session_auto_join_toggle", test_saving_session_auto_join_toggle, "Saving session auto-join toggle test (issue #4120)", False),
         ("alert_feed", test_alert_feed, "Alert feed tests", False),
         ("fox_api", run_fox_api_tests, "Fox API tests", False),
         ("solcast", run_solcast_tests, "Solcast API tests", False),

--- a/docs/energy-rates.md
+++ b/docs/energy-rates.md
@@ -156,6 +156,12 @@ Like the electricity rates, this is set in the `apps.yaml` template to a regular
 
 When a saving session is available it will be automatically joined by Predbat and should then appear as a joined session within the next 30 minutes.
 
+Auto-joining is controlled by the **switch.predbat_octopus_saving_auto_join** switch (On by default). Turn it Off if you want to decide which saving sessions to join yourself
+(for example through the Octopus app). When auto-join is Off, Predbat still plans your battery activity for any sessions you have already joined - it just will not join
+available sessions on your behalf.
+
+If an available saving session overlaps an Axle VPP session (any overlap in time), Predbat will **not** auto-join the saving session, as the two events cannot both be honoured for the same period. The Axle session takes priority.
+
 In the Predbat plan, for joined saving sessions the energy rates for import and export will be overridden by adding the assumed saving rate to your normal rate.
 The assumed rate will be taken from the Octopus Energy integration and converted into pence
 using the **octopus_saving_session_octopoints_per_penny** configuration item in `apps.yaml` (default is 8).


### PR DESCRIPTION
## Summary

Addresses [#4120](https://github.com/springfall2008/batpred/issues/4120) — a user who had opted out of Octopus saving sessions was auto-joined back in, and the joined session conflicted with an Axle VPP event.

Previously Predbat auto-joined **every** available Octopus saving session unconditionally. The only opt-out was to remove the `octopus_saving_session` entry from `apps.yaml` entirely — which also throws away battery planning for sessions you *do* want to join.

This PR adds two complementary controls:

1. **`switch.predbat_octopus_saving_auto_join`** (On by default) — gate auto-join. When Off, Predbat no longer joins available sessions on your behalf, but still plans battery activity for sessions you've already joined.
2. **Axle conflict avoidance** — when auto-join is On, Predbat skips any available saving session that overlaps (any time overlap) an Axle VPP session, so it never commits to two conflicting events for the same period. The Axle session takes priority.

## Changes

- `config.py` — new `octopus_saving_auto_join` switch config item (default `True`).
- `fetch.py` — fetch Axle sessions before Octopus sessions and pass the list into `fetch_octopus_sessions()` (safe reorder; Axle fetch has no dependency on the Octopus fetch).
- `octopus.py` — gate the auto-join loop on the new switch; add `_saving_event_conflicts_axle()` half-open interval overlap test and skip conflicting events before joining (without stamping the 2h throttle, so a later cycle can still join if the Axle event disappears).
- `tests/test_saving_session.py` — new `test_saving_session_axle_conflict` and `test_saving_session_auto_join_toggle`, registered in `unit_test.py`.
- `docs/energy-rates.md` — document the new switch and the Axle-priority behaviour.

## Testing

- `./run_all -k saving_session` — all saving session tests pass (including the two new ones).
- `./run_all -k octopus_` and `-k axle` — pass.
- `./run_pre_commit` — ruff, black, cspell, markdownlint, and the quick test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)