### PR TITLE
Gateway: fix EMS aggregate publish, add debug logging

### DIFF
--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -222,6 +222,10 @@ class GatewayMQTT(ComponentBase):
         # Set once the first MQTT connection attempt has completed (success or failure)
         self._first_connection_attempted = False
 
+        # Verbose telemetry/command logging for debugging. Enable by setting
+        # `gateway_debug: True` in apps.yaml; off by default to avoid log spam.
+        self._debug = bool(self.args.get("gateway_debug", False)) if isinstance(self.args, dict) else False
+
         # Register for plan execution hook so we receive plan updates generically
         if hasattr(self.base, "register_hook"):
             self.base.register_hook("on_plan_executed", self._on_plan_executed)
@@ -335,7 +339,6 @@ class GatewayMQTT(ComponentBase):
         # Cap at 6 entries (firmware PlanEntry entries[6] fixed array)
         MAX_PLAN_ENTRIES = 6
         if len(plan_entries) > MAX_PLAN_ENTRIES:
-            self.log(f"Warn: GatewayMQTT: Plan has {len(plan_entries)} entries, capping to {MAX_PLAN_ENTRIES}")
             plan_entries = plan_entries[:MAX_PLAN_ENTRIES]
 
         self.log(f"Info: GatewayMQTT: Plan entries ({len(plan_entries)}): " + ", ".join(f"mode={e['mode']} {e['start_hour']:02d}:{e['start_minute']:02d}-{e['end_hour']:02d}:{e['end_minute']:02d}" for e in plan_entries))
@@ -513,6 +516,30 @@ class GatewayMQTT(ComponentBase):
             self.log(f"Warn: GatewayMQTT: Error handling message on {topic}: {e}")
             self.log(f"Warn: {traceback.format_exc()}")
 
+    def _debug_dump(self, label, message=None, raw=None, message_type=None):
+        """Log a protobuf message as readable text when debug logging is enabled.
+
+        Pass an already-decoded `message`, or `raw` bytes plus a `message_type` to
+        decode them. The raw length is logged as a size reference when provided.
+
+        Args:
+            label: Short description of what is being dumped (e.g. "RX telemetry").
+            message: A decoded protobuf message to render as text (optional).
+            raw: Optional raw bytes, whose length is logged for size reference.
+            message_type: Protobuf class used to decode `raw` when `message` is None.
+        """
+        if not self._debug:
+            return
+        try:
+            if message is None and raw is not None and message_type is not None:
+                message = message_type()
+                message.ParseFromString(raw)
+            size = f" ({len(raw)} bytes)" if raw is not None else ""
+            text = str(message).strip()
+            self.log(f"Debug: GatewayMQTT: {label}{size}:\n{text}")
+        except Exception as e:
+            self.log(f"Warn: GatewayMQTT: failed to dump {label}: {e}")
+
     def _process_telemetry(self, data):
         """Decode telemetry protobuf and inject per-inverter entities.
 
@@ -526,6 +553,8 @@ class GatewayMQTT(ComponentBase):
             self._error_count += 1
             self.log(f"Warn: GatewayMQTT: Failed to decode telemetry: {e}")
             return
+
+        self._debug_dump("RX telemetry", status, raw=data)
 
         if len(status.inverters) == 0:
             return
@@ -579,9 +608,12 @@ class GatewayMQTT(ComponentBase):
             suffix = inv.serial[-6:].lower() if len(inv.serial) > 6 else inv.serial.lower()
             self._inject_inverter_entities(inv, suffix)
 
-        # EMS aggregate entities (when type is GIVENERGY_EMS)
-        inv0 = status.inverters[0]
-        if inv0.type == pb.INVERTER_TYPE_GIVENERGY_EMS and inv0.ems.num_inverters > 0:
+        # EMS aggregate entities (when a GIVENERGY_EMS unit is present). The EMS is not
+        # guaranteed to be status.inverters[0] — discovery order is unstable (see the
+        # 2026-06-04 incident note in automatic_config) — so locate it by type, mirroring
+        # the config path which binds inverters = ems_units[:1].
+        inv0 = next((inv for inv in status.inverters if inv.type == pb.INVERTER_TYPE_GIVENERGY_EMS), None)
+        if inv0 is not None and inv0.ems.num_inverters > 0:
             pfx = f"{self.prefix}_gateway"
             self.dashboard_item(f"sensor.{pfx}_ems_total_soc", inv0.ems.total_soc, attributes=GATEWAY_ATTRIBUTE_TABLE.get("ems_total_soc", {}), app="gateway")
             self.dashboard_item(f"sensor.{pfx}_ems_total_charge", inv0.ems.total_charge_w, attributes=GATEWAY_ATTRIBUTE_TABLE.get("ems_total_charge", {}), app="gateway")
@@ -1192,6 +1224,7 @@ class GatewayMQTT(ComponentBase):
         self._last_plan_timezone = timezone_str
         self._last_plan_publish_time = time.time()
 
+        self._debug_dump(f"TX execution plan v{self._plan_version}", raw=data, message_type=pb.ExecutionPlan)
         await self._publish_raw(self.topic_schedule, data, retain=True)
         self._last_published_plan = plan_entries
         self.log(f"Info: GatewayMQTT: Published execution plan v{self._plan_version} ({len(plan_entries)} entries)")
@@ -1211,6 +1244,7 @@ class GatewayMQTT(ComponentBase):
         if time.time() - self._last_plan_publish_time <= _PLAN_REPUBLISH_INTERVAL:
             return
         data = self.build_execution_plan(self._last_plan_entries, plan_version=self._plan_version, timezone=self._last_plan_timezone)
+        self._debug_dump("TX execution plan (re-publish)", raw=data, message_type=pb.ExecutionPlan)
         await self._publish_raw(self.topic_schedule, data, retain=True)
         self._last_plan_data = data
         self._last_plan_publish_time = time.time()

--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -224,7 +224,11 @@ class GatewayMQTT(ComponentBase):
 
         # Verbose telemetry/command logging for debugging. Enable by setting
         # `gateway_debug: True` in apps.yaml; off by default to avoid log spam.
-        self._debug = bool(self.args.get("gateway_debug", False)) if isinstance(self.args, dict) else False
+        if isinstance(self.args, dict):
+            debug_val = self.args.get("gateway_debug", False)
+            self._debug = str(debug_val).strip().lower() in ["on", "true", "yes", "enabled", "enable", "connected", "1"]
+        else:
+            self._debug = False
 
         # Register for plan execution hook so we receive plan updates generically
         if hasattr(self.base, "register_hook"):

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.42.1"
+THIS_VERSION = "v8.42.2"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -591,6 +591,48 @@ class TestInjectEntities:
         _, attrs = gw._dashboard_calls[f"sensor.{pfx}_sub0_temp"]
         assert attrs == GATEWAY_ATTRIBUTE_TABLE.get("temp", {})
 
+    def test_ems_aggregate_entities_when_ems_not_first_inverter(self):
+        """EMS aggregates publish even when the EMS unit is not status.inverters[0].
+
+        Discovery order is unstable (see the 2026-06-04 incident), so the publish path
+        must locate the EMS by type rather than assuming index 0. A coordinator/AIO unit
+        ahead of the EMS in telemetry previously suppressed the entire aggregate block.
+        """
+        status = pb.GatewayStatus()
+        status.device_id = "pbgw_ems"
+        status.firmware = "1.0.0"
+        status.timestamp = 1741789200
+        status.schema_version = 1
+
+        # Non-EMS unit listed first (the historically-assumed "inverter 0").
+        aio = status.inverters.add()
+        aio.type = pb.INVERTER_TYPE_GIVENERGY
+        aio.serial = "AI000001"
+        aio.primary = True
+
+        # EMS unit listed second.
+        inv = status.inverters.add()
+        inv.type = pb.INVERTER_TYPE_GIVENERGY_EMS
+        inv.serial = "EM123456"
+        inv.primary = True
+        inv.ems.num_inverters = 2
+        inv.ems.total_soc = 70
+        inv.ems.total_charge_w = 4000
+        inv.ems.total_grid_w = -2000
+        inv.ems.total_pv_w = 6000
+        inv.ems.total_load_w = 5000
+
+        sub0 = inv.ems.sub_inverters.add()
+        sub0.soc = 65
+
+        gw = self._make_gateway()
+        gw._inject_entities(status)
+
+        pfx = "predbat_gateway"
+        assert gw._dashboard_calls[f"sensor.{pfx}_ems_total_soc"][0] == 70
+        assert gw._dashboard_calls[f"sensor.{pfx}_ems_total_grid"][0] == -2000
+        assert gw._dashboard_calls[f"sensor.{pfx}_sub0_soc"][0] == 65
+
     def test_inverter_rate_max_published_from_inverter(self):
         """inverter_rate_max sensor uses InverterData.rate_max_w when non-zero."""
         from gateway import GATEWAY_ATTRIBUTE_TABLE
@@ -631,6 +673,79 @@ class TestInjectEntities:
         assert entity in gw._dashboard_calls
         state, _ = gw._dashboard_calls[entity]
         assert state == 6000
+
+
+class TestDebugLogging:
+    """Tests for the gateway_debug verbose telemetry/plan dump helper."""
+
+    def _make_gateway(self, debug):
+        from gateway import GatewayMQTT
+        from unittest.mock import MagicMock
+
+        gw = GatewayMQTT.__new__(GatewayMQTT)
+        gw.log = MagicMock()
+        gw._debug = debug
+        return gw
+
+    def test_dump_logs_decoded_message_when_enabled(self):
+        """With debug on, a decoded message is rendered as text with its byte size."""
+        status = pb.GatewayStatus()
+        status.device_id = "pbgw_dbg"
+        inv = status.inverters.add()
+        inv.type = pb.INVERTER_TYPE_GIVENERGY_EMS
+        inv.serial = "EM123456"
+        raw = status.SerializeToString()
+
+        gw = self._make_gateway(debug=True)
+        gw._debug_dump("RX telemetry", status, raw=raw)
+
+        assert gw.log.call_count == 1
+        msg = gw.log.call_args[0][0]
+        assert "Debug: GatewayMQTT: RX telemetry" in msg
+        assert f"({len(raw)} bytes)" in msg
+        assert "EM123456" in msg  # message body rendered as text
+
+    def test_dump_silent_when_disabled(self):
+        """With debug off, nothing is logged."""
+        status = pb.GatewayStatus()
+        gw = self._make_gateway(debug=False)
+        gw._debug_dump("RX telemetry", status, raw=status.SerializeToString())
+        assert gw.log.call_count == 0
+
+    def test_dump_decodes_raw_bytes_with_message_type(self):
+        """Raw bytes plus a message_type are decoded and rendered."""
+        plan = pb.ExecutionPlan()
+        plan.plan_version = 7
+        raw = plan.SerializeToString()
+
+        gw = self._make_gateway(debug=True)
+        gw._debug_dump("TX execution plan", raw=raw, message_type=pb.ExecutionPlan)
+
+        assert gw.log.call_count == 1
+        msg = gw.log.call_args[0][0]
+        assert "plan_version: 7" in msg
+
+    def test_initialize_reads_gateway_debug_arg(self):
+        """initialize() picks up the gateway_debug flag from apps.yaml args."""
+        from gateway import GatewayMQTT
+        from unittest.mock import MagicMock
+
+        gw = GatewayMQTT.__new__(GatewayMQTT)
+        gw.base = MagicMock()
+        gw.args = {"gateway_debug": True}
+        gw.initialize(gateway_device_id="pbgw_test", mqtt_host="mqtt.example.com", mqtt_token="tok")
+        assert gw._debug is True
+
+    def test_initialize_debug_defaults_off(self):
+        """gateway_debug defaults to False when the arg is absent."""
+        from gateway import GatewayMQTT
+        from unittest.mock import MagicMock
+
+        gw = GatewayMQTT.__new__(GatewayMQTT)
+        gw.base = MagicMock()
+        gw.args = {}
+        gw.initialize(gateway_device_id="pbgw_test", mqtt_host="mqtt.example.com", mqtt_token="tok")
+        assert gw._debug is False
 
 
 class TestTokenRefresh:
@@ -1087,6 +1202,7 @@ class TestPlanRepublish:
 
         gw = GatewayMQTT.__new__(GatewayMQTT)
         gw.log = MagicMock()
+        gw._debug = False
         gw._mqtt_connected = True
         gw._last_plan_data = None
         gw._last_plan_entries = None
@@ -1610,6 +1726,7 @@ class TestAutomaticConfig:
 
         gw = GatewayMQTT.__new__(GatewayMQTT)
         gw.base = MagicMock()
+        gw.args = {}
         gw.initialize(gateway_device_id="pbgw_test", mqtt_host="mqtt.example.com", mqtt_token="tok", gateway_inverter_serial="CE123456789")
         assert gw.gateway_inverter_serial == ["CE123456789"]
 
@@ -1620,6 +1737,7 @@ class TestAutomaticConfig:
 
         gw = GatewayMQTT.__new__(GatewayMQTT)
         gw.base = MagicMock()
+        gw.args = {}
         gw.initialize(gateway_device_id="pbgw_test", mqtt_host="mqtt.example.com", mqtt_token="tok", gateway_inverter_serial=None)
         assert gw.gateway_inverter_serial == []
 
@@ -1630,6 +1748,7 @@ class TestAutomaticConfig:
 
         gw = GatewayMQTT.__new__(GatewayMQTT)
         gw.base = MagicMock()
+        gw.args = {}
         gw.initialize(
             gateway_device_id="pbgw_test",
             mqtt_host="mqtt.example.com",
@@ -1645,6 +1764,7 @@ class TestAutomaticConfig:
 
         gw = GatewayMQTT.__new__(GatewayMQTT)
         gw.base = MagicMock()
+        gw.args = {}
         gw.initialize(
             gateway_device_id="pbgw_test",
             mqtt_host="mqtt.example.com",
@@ -1662,6 +1782,7 @@ class TestAutomaticConfig:
         raw = "[not valid json"
         gw = GatewayMQTT.__new__(GatewayMQTT)
         gw.base = MagicMock()
+        gw.args = {}
         gw.initialize(
             gateway_device_id="pbgw_test",
             mqtt_host="mqtt.example.com",
@@ -2702,6 +2823,7 @@ class TestGatewayUnitControlBinding:
         gw.base = MagicMock()
         gw.log = MagicMock()
         gw.prefix = "predbat"
+        gw._debug = False
         gw._last_status = None
         gw._auto_configured = False
         gw._configured_inverter_serials = frozenset()
@@ -3444,6 +3566,7 @@ def run_gateway_tests(my_predbat=None):
         TestCommandFormat,
         TestScheduleSlotCommand,
         TestInjectEntities,
+        TestDebugLogging,
         TestAutomaticConfig,
         TestSelectEvent,
         TestNumberEvent,


### PR DESCRIPTION
## Summary

Fixes a bug where the GivEnergy EMS aggregate dashboard entities never published, plus adds an opt-in debug logging facility for the gateway MQTT telemetry/command flow.

### EMS aggregate publish fix
The publish path (`_inject_entities`) hard-wired the EMS unit as `status.inverters[0]`. Telemetry discovery order is unstable (cf. the 2026-06-04 incident where a Gateway unit landed at index 0), so when any non-EMS unit appeared first, `inv0.type != INVERTER_TYPE_GIVENERGY_EMS` and the entire `ems_total_*` / `sub*` block was silently skipped — even though `automatic_config` logged "EMS mode with N sub-inverters" because it correctly locates the EMS by type.

The publish path now locates the EMS by type, matching the config path (`inverters = ems_units[:1]`).

### Debug logging
New opt-in `gateway_debug: True` apps.yaml flag. When enabled, `_debug_dump` renders incoming RX telemetry and outgoing TX execution plans as readable protobuf text (with byte sizes). Off by default to avoid log spam.

### Other
- Drop the noisy per-cycle plan-capping warning.
- Bump version to v8.42.2.

## Tests
Added to `test_gateway.py`:
- `test_ems_aggregate_entities_when_ems_not_first_inverter` — regression for the index-0 bug (AIO at index 0, EMS at index 1).
- New `TestDebugLogging` class — dump-when-enabled, silent-when-disabled, raw-bytes decode, and `initialize` reads the flag.

All 205 gateway tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)