### PR TITLE
GE REST: Enable charge target register (reg 20) when setting charge target SOC

### DIFF
--- a/apps/predbat/config/apps.yaml
+++ b/apps/predbat/config/apps.yaml
@@ -143,6 +143,9 @@ pred_bat:
   charge_limit:
     - number.givtcp_{geserial}_target_soc
     - number.givtcp2_{geserial2}_target_soc
+  charge_limit_enable:
+    - switch.givtcp_{geserial}_enable_charge_target
+    - switch.givtcp2_{geserial2}_enable_charge_target
   scheduled_charge_enable:
     - switch.givtcp_{geserial}_enable_charge_schedule
     - switch.givtcp2_{geserial2}_enable_charge_schedule

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1895,14 +1895,16 @@ class Inverter:
             self.base.log("Inverter {} Current charge limit is {}% and new target is {}%".format(self.id, current_soc, soc))
             self.current_charge_limit = soc
             if self.rest_data:
+                # Enable charge target, without it the inverter ignores the target SOC.
+                # rest_enableChargeTarget no-ops if already enabled.
+                self.rest_enableChargeTarget(True)
                 self.rest_setChargeTarget(soc)
             else:
                 self.write_and_poll_value("charge_limit", self.base.get_arg("charge_limit", indirect=False, index=self.id, required_unit="%"), soc)
-
-            charge_limit_enable_entity_id = self.base.get_arg("charge_limit_enable", indirect=False, index=self.id)
-            if charge_limit_enable_entity_id:
-                # If we have a separate enable for the charge limit then make sure it's enabled when we set the charge limit
-                self.write_and_poll_switch("charge_limit_enable", charge_limit_enable_entity_id, True)
+                charge_limit_enable_entity_id = self.base.get_arg("charge_limit_enable", indirect=False, index=self.id)
+                if charge_limit_enable_entity_id:
+                    # If we have a separate enable for the charge limit then make sure it's enabled when we set the charge limit
+                    self.write_and_poll_switch("charge_limit_enable", charge_limit_enable_entity_id, True)
 
             # For inverters that need a button press to apply changes (e.g., Fox), press the button now
             if self.inv_time_button_press:
@@ -3101,6 +3103,37 @@ class Inverter:
             return r.json()
         else:
             return None
+
+    def rest_enableChargeTarget(self, enable):
+        """
+        Enable or disable the charge target SOC limit register via REST.
+        Without this being enabled, CHARGE_TARGET_SOC (reg 116) is ignored by the inverter.
+        No-ops if the register already matches the requested state.
+        """
+        current = self.rest_data["Control"].get("Enable_Charge_Target", "disable")
+        if isinstance(current, str):
+            current = current.lower() in ["enable", "on", "true"]
+        if current == enable:
+            return True
+
+        url = self.rest_api + "/enableChargeTarget"
+        data = {"state": "enable" if enable else "disable"}
+
+        for retry in range(INVERTER_MAX_RETRY_REST):
+            r = self.rest_postCommand(url, json=data)
+            self.rest_data = self.rest_runAll(self.rest_data)
+            new_value = self.rest_data["Control"].get("Enable_Charge_Target", "disable")
+            if isinstance(new_value, str):
+                new_value = new_value.lower() in ["enable", "on", "true"]
+            if new_value == enable:
+                self.count_register_writes += 1
+                self.base.log("Set inverter {} charge target enable {} via REST successful on retry {}".format(self.id, enable, retry))
+                return True
+            self.sleep(2)
+
+        self.base.log("Warn: Set inverter {} charge target enable {} via REST failed".format(self.id, enable))
+        self.base.record_status("Warn: Inverter {} REST failed to enableChargeTarget".format(self.id), had_errors=True)
+        return False
 
     def rest_setChargeTarget(self, target):
         """

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.42.4"
+THIS_VERSION = "v8.42.5"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -628,11 +628,16 @@ def test_adjust_battery_target(test_name, ha, inv, dummy_rest, prev_soc, soc, is
     inv.rest_data["Control"]["Target_SOC"] = prev_soc
     dummy_rest.rest_data = copy.deepcopy(inv.rest_data)
     dummy_rest.rest_data["Control"]["Target_SOC"] = expect_soc
+    # enableChargeTarget always enables (True), so set Enable_Charge_Target to "enable" so it passes on first try
+    dummy_rest.rest_data["Control"]["Enable_Charge_Target"] = "enable"
 
     inv.adjust_battery_target(soc, isCharging=isCharging, isExporting=isExporting)
     rest_command = dummy_rest.get_commands()
     if expect_soc != prev_soc:
-        expect_data = [["dummy/setChargeTarget", {"chargeToPercent": expect_soc}]]
+        expect_data = [
+            ["dummy/enableChargeTarget", {"state": "enable"}],
+            ["dummy/setChargeTarget", {"chargeToPercent": expect_soc}],
+        ]
     else:
         expect_data = []
     if json.dumps(expect_data) != json.dumps(rest_command):
@@ -674,7 +679,48 @@ def test_adjust_battery_target_charge_limit_enable(test_name, my_predbat, ha, in
     return failed
 
 
+def test_rest_enable_charge_target(test_name, ha, inv, dummy_rest, enable, expect_commands, queued_rest_states=None, initial_state=None):
+    """
+    Test rest_enableChargeTarget: verifies the correct REST command is issued and the retry logic works.
+
+    initial_state: the Enable_Charge_Target value already in inv.rest_data before the call.
+                   Defaults to the opposite of enable so the guard fires.
+    queued_rest_states: list of Enable_Charge_Target values to return on successive runAll calls.
+    When None, the dummy_rest.rest_data is pre-set to the expected state so it passes on the first try.
+    """
+    failed = False
+    print("Test: {}".format(test_name))
+
+    inv.rest_api = "dummy"
+    inv.rest_data = {}
+    inv.rest_data["Control"] = {}
+    # Start with the opposite state by default so the guard always fires
+    if initial_state is None:
+        initial_state = "disable" if enable else "enable"
+    inv.rest_data["Control"]["Enable_Charge_Target"] = initial_state
+
+    if queued_rest_states is not None:
+        for state in queued_rest_states:
+            data = {"Control": {"Enable_Charge_Target": state}}
+            dummy_rest.queue_rest_data(data)
+    else:
+        dummy_rest.rest_data = {"Control": {"Enable_Charge_Target": "enable" if enable else "disable"}}
+
+    inv.rest_enableChargeTarget(enable)
+
+    rest_commands = dummy_rest.get_commands()
+    if json.dumps(expect_commands) != json.dumps(rest_commands):
+        print("ERROR: {}: rest commands should be {} got {}".format(test_name, expect_commands, rest_commands))
+        failed = True
+
+    dummy_rest.clear_queue()
+    return failed
+
+
 def test_inverter_self_test(test_name, my_predbat):
+    """
+    Test the inverter self test function.
+    """
     failed = 0
 
     print("**** Running Test: {} ****".format(test_name))
@@ -710,8 +756,11 @@ def test_inverter_self_test(test_name, my_predbat):
     repeats = INVERTER_MAX_RETRY_REST  # configurable number of repeats
     expected = []
 
-    # Define the command patterns
+    # Define the command patterns (each repeated INVERTER_MAX_RETRY_REST times due to the retry loop).
+    # Enable_Charge_Target is not set in the mock rest_data so enableChargeTarget exhausts all retries,
+    # same as setChargeTarget exhausts retries because Target_SOC stays at 99.
     commands = [
+        ["dummy/enableChargeTarget", {"state": "enable"}],
         ["dummy/setChargeTarget", {"chargeToPercent": 100}],
         ["dummy/setChargeRate", {"chargeRate": 215}],
         ["dummy/setChargeRate", {"chargeRate": 0}],
@@ -2117,6 +2166,50 @@ def run_inverter_tests(my_predbat_dummy):
     failed |= test_adjust_battery_target("adjust_target100", ha, inv, dummy_rest, 99, 100, True, False, 100, has_inv_time_button_press=True, expect_button_press=True)
     failed |= test_adjust_battery_target("adjust_target100r", ha, inv, dummy_rest, 100, 100, True, False, 100, has_inv_time_button_press=True, expect_button_press=False)  # No change, no button press
     failed |= test_adjust_battery_target("adjust_target0x", ha, inv, dummy_rest, 50, 0, False, True, 50, has_inv_time_button_press=False, expect_button_press=False)  # No button press feature
+    if failed:
+        return failed
+
+    # Test rest_enableChargeTarget directly: enable=True passes first try
+    failed |= test_rest_enable_charge_target(
+        "rest_enable_charge_target_enable",
+        ha,
+        inv,
+        dummy_rest,
+        enable=True,
+        expect_commands=[["dummy/enableChargeTarget", {"state": "enable"}]],
+    )
+    # enable=False passes first try (default Enable_Charge_Target is "disable")
+    failed |= test_rest_enable_charge_target(
+        "rest_enable_charge_target_disable",
+        ha,
+        inv,
+        dummy_rest,
+        enable=False,
+        expect_commands=[["dummy/enableChargeTarget", {"state": "disable"}]],
+    )
+    # Retry logic: first response is wrong, second is correct — expect 2 commands
+    failed |= test_rest_enable_charge_target(
+        "rest_enable_charge_target_retry",
+        ha,
+        inv,
+        dummy_rest,
+        enable=True,
+        expect_commands=[
+            ["dummy/enableChargeTarget", {"state": "enable"}],
+            ["dummy/enableChargeTarget", {"state": "enable"}],
+        ],
+        queued_rest_states=["disable", "enable"],
+    )
+    # Guard no-op: already in the target state, no command sent
+    failed |= test_rest_enable_charge_target(
+        "rest_enable_charge_target_noop",
+        ha,
+        inv,
+        dummy_rest,
+        enable=True,
+        expect_commands=[],
+        initial_state="enable",
+    )
     if failed:
         return failed
 

--- a/templates/givenergy_givtcp.yaml
+++ b/templates/givenergy_givtcp.yaml
@@ -141,6 +141,9 @@ pred_bat:
   charge_limit:
     - number.givtcp_{geserial}_target_soc
   #  - number.givtcp2_{geserial2}_target_soc
+  charge_limit_enable:
+    - switch.givtcp_{geserial}_enable_charge_target
+  #  - switch.givtcp2_{geserial2}_enable_charge_target
   scheduled_charge_enable:
     - switch.givtcp_{geserial}_enable_charge_schedule
   #  - switch.givtcp2_{geserial2}_enable_charge_schedule


### PR DESCRIPTION
## Summary

Fixes #4139 — Hold Charge not holding on GE AIO inverters.

- GivTCP's `/setChargeTarget` REST endpoint only writes `CHARGE_TARGET_SOC` (reg 116) via `set_charge_target_only()`, but never writes `ENABLE_CHARGE_TARGET` (reg 20). GivTCP's default for reg 20 is `disable`, so the inverter ignores the SOC limit entirely and charges to 100%.
- Added `rest_enableChargeTarget()` with the same retry/read-back verification pattern as `rest_enableChargeSchedule`. It no-ops if reg 20 is already in the desired state.
- Called from `adjust_battery_target()` before `rest_setChargeTarget()` in the REST branch. The non-REST branch uses the existing `charge_limit_enable` entity mechanism.
- Added `charge_limit_enable: switch.givtcp_{geserial}_enable_charge_target` to both `templates/givenergy_givtcp.yaml` and `apps/predbat/config/apps.yaml` so users on the non-REST HA entity path get the same fix.

## Test plan

- [ ] New `test_rest_enable_charge_target_*` tests in `tests/test_inverter.py` cover: enable success, disable success, retry logic, and no-op guard
- [ ] `test_adjust_battery_target` REST mode updated to assert `enableChargeTarget` is sent before `setChargeTarget`
- [ ] `test_inverter_self_test` updated to include `enableChargeTarget` in expected command sequence
- [ ] All inverter tests pass: `./run_all --test inverter`
- [ ] On a live AIO: set a charge window with target < 100% and confirm battery stops charging at the target SOC rather than continuing to 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)