### PR TITLE
fix(kraken): only wire metric_octopus_export when export rates are available

### DIFF
--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -162,6 +162,7 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
         self.export_tariff = None  # Export tariff (discovered dynamically)
         self.wired = False
         self.export_wired = False
+        self.export_rates_available = False  # True once export rates are actually fetched (not just tariff discovered)
         self.requests_total = 0
         self.failures_total = 0
         self.oauth_failed = False
@@ -804,6 +805,7 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
                 export_rates = await self.async_fetch_rates(tariff=self.export_tariff)
                 if export_rates:
                     had_success = True
+                    self.export_rates_available = True
                     self.dashboard_item(
                         self.get_entity_name("sensor", "export_rates"),
                         state=len(export_rates),
@@ -823,8 +825,14 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
             self.set_arg("metric_standing_charge", self.get_entity_name("sensor", "import_standing"))
             self.wired = True
 
-        # Wire export into fetch.py once export tariff is discovered
-        if not self.export_wired and self.export_tariff:
+        # Wire export into fetch.py once export rates are actually available.
+        # An export tariff can be discovered (e.g. EDF SEG tariffs registered on the
+        # meter point) while the standard-unit-rates endpoint returns HTTP 404, so no
+        # rates are ever fetched. Wiring metric_octopus_export to the empty export_rates
+        # sensor would make fetch.py take the octopus-export branch and ignore the user's
+        # manual rates_export fallback, zeroing out all export in the plan. Only wire once
+        # we have real export rate data.
+        if not self.export_wired and self.export_tariff and self.export_rates_available:
             self.set_arg("metric_octopus_export", self.get_entity_name("sensor", "export_rates"))
             self.export_wired = True
 

--- a/apps/predbat/tests/test_kraken.py
+++ b/apps/predbat/tests/test_kraken.py
@@ -398,6 +398,49 @@ def test_run_wires_export_when_discovered():
     api.set_arg.assert_any_call("metric_octopus_export", api.get_entity_name("sensor", "export_rates"))
 
 
+def test_run_does_not_wire_export_when_rates_unavailable():
+    """An export tariff can be discovered while its rate endpoint returns no data.
+
+    Real case: EDF SEG export tariffs (e.g. EDF_EXPORT_SEG_12M) are registered on
+    the meter point so the tariff is discovered, but Kraken's standard-unit-rates
+    endpoint returns HTTP 404, so no export rates are ever fetched. Wiring
+    metric_octopus_export to the (empty) export_rates sensor in that case makes
+    fetch.py take the octopus-export branch and ignore the user's manual
+    rates_export fallback, zeroing out all export in the plan. So when no export
+    rates are available, metric_octopus_export must NOT be wired.
+    """
+    api = make_kraken_api()
+    discovered = {"tariff_code": "E-1R-IMP-01", "product_code": "IMP-01"}
+
+    async def find_tariffs_side_effect():
+        api.current_tariff = discovered
+        api.export_tariff = {"tariff_code": "E-1R-EDF_EXPORT_SEG_12M_HH-B", "product_code": "EDF_EXPORT_SEG_12M"}
+        return discovered
+
+    async def fetch_rates_side_effect(tariff=None):
+        # Export fetch (tariff kwarg set) returns nothing — simulates the SEG 404.
+        if tariff is not None:
+            return []
+        return [{"value_inc_vat": 24.5}]
+
+    api.async_find_tariffs = AsyncMock(side_effect=find_tariffs_side_effect)
+    api.async_fetch_rates = AsyncMock(side_effect=fetch_rates_side_effect)
+    api.async_fetch_standing_charges = AsyncMock(return_value=53.0)
+    api.dashboard_item = MagicMock()
+    api.set_arg = MagicMock()
+    api.update_success_timestamp = MagicMock()
+
+    result = asyncio.run(api.run(0, True))
+
+    assert result is True
+    # Import is still wired normally.
+    api.set_arg.assert_any_call("metric_octopus_import", api.get_entity_name("sensor", "import_rates"))
+    # Export must NOT be wired — no export rates were available.
+    export_calls = [c for c in api.set_arg.call_args_list if c.args and c.args[0] == "metric_octopus_export"]
+    assert export_calls == [], "metric_octopus_export should not be wired when export rates are unavailable, got {}".format(export_calls)
+    assert api.export_wired is False
+
+
 def test_find_active_tariff_prefers_configured_mpan():
     """_find_active_tariff should prefer the configured MPAN."""
     api = make_kraken_api()


### PR DESCRIPTION
Fixes #4157

## Problem

`KrakenAPI.run()` wires `metric_octopus_export` into `fetch.py` whenever an export **tariff is discovered**, regardless of whether any export **rate data** was actually fetched.

An export tariff can be registered on a meter point (so it's discovered) while its rate endpoint returns nothing — e.g. EDF SEG export tariffs (`EDF_EXPORT_SEG_12M`), which return HTTP 404 on `/standard-unit-rates/`. In that case `metric_octopus_export` was pointed at an empty `export_rates` sensor.

`fetch.py` selects the export-rate source by **key presence** (`elif "metric_octopus_export" in self.args:`), so a wired-but-empty `metric_octopus_export` takes precedence over the user's manual `rates_export` fallback. Result: **all export is dropped from the plan** and a manual flat export rate can never take effect.

Production logs from an affected EDF customer:

```
Warn: Kraken: Rates HTTP 404 for .../EDF_EXPORT_SEG_12M/electricity-tariffs/E-1R-EDF_EXPORT_SEG_12M_HH-B/standard-unit-rates/
Warn: ...'metric_octopus_export' element sensor.predbat_kraken_..._export_rates returned value 'None'
Warning: No export rate data provided
```

## Fix

Track whether export rates were actually fetched (`export_rates_available`) and only wire `metric_octopus_export` once real export rate data exists. When no export rates are available, leave it unwired so `fetch.py` falls back to the user's manual `rates_export`.

## Tests

- **New:** `test_run_does_not_wire_export_when_rates_unavailable` — export tariff discovered but rate fetch returns empty (the SEG 404 case); asserts `metric_octopus_export` is **not** wired and import wiring is unaffected. Written test-first; verified it failed on the old code for the right reason, then passes with the fix.
- Existing `test_run_wires_export_when_discovered` (rates present) still passes — wiring still happens when real rates exist.
- Full suite: `apps/predbat/tests/test_kraken.py` 51 passed; `test_kraken_auth_mixin.py` 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
