### PR TITLE
Debug harness: use load_scaling when evaluating the original plan

### DIFF
--- a/apps/predbat/tests/test_single_debug.py
+++ b/apps/predbat/tests/test_single_debug.py
@@ -155,6 +155,10 @@ def run_single_debug(test_name, my_predbat, debug_file, expected_file=None, comp
         return
 
     # Reset load model
+    # Mirror the load model rebuild done by calculate_plan (plan.py) so the original plan metric is
+    # evaluated against the same load data as the re-calculated plan - in particular load_scaling.
+    # Otherwise the two metrics printed by this harness differ by the load scaling and look like a
+    # plan regression when the plans are identical.
     if reset_load_model:
         print("Reset load model")
         my_predbat.load_minutes_step = my_predbat.step_data_history(
@@ -162,11 +166,13 @@ def run_single_debug(test_name, my_predbat, debug_file, expected_file=None, comp
             my_predbat.minutes_now,
             forward=False,
             scale_today=my_predbat.load_inday_adjustment,
-            scale_fixed=1.0 * load_override,
+            scale_fixed=my_predbat.load_scaling * load_override,
             type_load=True,
             load_forecast=my_predbat.load_forecast,
             load_scaling_dynamic=my_predbat.load_scaling_dynamic,
             cloud_factor=my_predbat.metric_load_divergence,
+            load_adjust=my_predbat.manual_load_adjust,
+            load_baseline=my_predbat.dynamic_load_baseline,
         )
         my_predbat.load_minutes_step10 = my_predbat.step_data_history(
             my_predbat.load_minutes,
@@ -178,6 +184,8 @@ def run_single_debug(test_name, my_predbat, debug_file, expected_file=None, comp
             load_forecast=my_predbat.load_forecast,
             load_scaling_dynamic=my_predbat.load_scaling_dynamic,
             cloud_factor=min(my_predbat.metric_load_divergence + 0.5, 1.0) if my_predbat.metric_load_divergence else None,
+            load_adjust=my_predbat.manual_load_adjust,
+            load_baseline=my_predbat.dynamic_load_baseline,
         )
         my_predbat.pv_forecast_minute_step = my_predbat.step_data_history(my_predbat.pv_forecast_minute, my_predbat.minutes_now, forward=True, cloud_factor=my_predbat.metric_cloud_coverage)
         my_predbat.pv_forecast_minute10_step = my_predbat.step_data_history(


### PR DESCRIPTION
## Problem

`unit_test.py --debug <file> --redo` prints two headline metrics: the original plan's (as loaded from the customer dump) and the re-calculated plan's. The original plan was evaluated against a load model built with `scale_fixed=1.0`, but `calculate_plan` immediately rebuilds `load_minutes_step` with the customer's `load_scaling` (plus `load_adjust`/`load_baseline`).

With `load_scaling: 1.05` this made byte-identical plans appear to be a ~15p optimizer regression (orig metric -1146.86 vs final -1131.92), which cost a debugging session chasing a phantom "levels stage won't charge" bug.

## Fix

Mirror `calculate_plan`'s load-model parameters in the harness's `reset_load_model` block so both metrics are computed against the same load data. Verified on the triggering dump: orig and final now both report -1131.9186 for the identical plan.

Only affects manual `--debug --redo` runs; the `debug_cases` regression suite calls `run_single_debug` with `redo=False` and is unaffected (suite passes).

## Testing

- `./run_all --test debug_cases` — PASSED
- `./run_pre_commit` — clean
- Re-ran the triggering customer dump with `--redo`: orig/final metrics now identical for identical plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)