### PR TITLE
Fix: Remove Tesla Wall Connector session energy, incorrect format

### DIFF
--- a/apps/predbat/config/apps.yaml
+++ b/apps/predbat/config/apps.yaml
@@ -298,11 +298,11 @@ pred_bat:
   #ohme_password: !secret ohme_password
   #ohme_automatic_octopus_intelligent: True
 
-  # car_charging_energy defines an incrementing sensor which measures the charge added to your car
+  # car_charging_energy defines a daily incrementing sensor which measures the charge added to your car and resets to zero at midnight
   # is used for car_charging_hold feature to filter out car charging from the previous load data
   # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
-  car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy|sensor.tesla_wall_connector_session_energy)'
+  car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1


### PR DESCRIPTION
Removed Tesla Wall Connector session energy due to incorrect format, needs a Utility Meter helper to reset daily. (My bad!)

I only found out about this after noticing the car charge was logged on the following days, it's mentioned in the docs as a note but not mentioned in the apps.yaml description, I've modified this to hopefully avoid this confusion for others!

If you deem it's not worth keeping the automatic detection for just car_charging_planned, you can just revert my prior commit if it's easier.