### PR TITLE
fix(solis): don't force TOU bit on CID 636 when no V2 slot is active

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -658,6 +658,7 @@ class SolisAPI(ComponentBase, OAuthMixin):
                 max_discharge_current_amps = float(self.cached_values.get(inverter_sn, {}).get(SOLIS_CID_BATTERY_MAX_DISCHARGE_CURRENT, 60.0))
                 charge_current = max_charge_current_amps
                 discharge_current = max_discharge_current_amps
+                slot1_active = False  # Whether slot 1 has any charge/discharge window configured
 
                 # There appears to be charge current limit on the slots which confused as slot 1 has a higher limit than the others,
                 # but the value isn't accepted, find the lowest slot limit
@@ -677,6 +678,7 @@ class SolisAPI(ComponentBase, OAuthMixin):
                     if slot == 1:
                         # Predbat only uses slot 1, so it can indicate current here.
                         charge_current = slot_data.get("charge_current", charge_current)
+                        slot1_active = bool(slot_data.get("charge_enable", 0)) or bool(slot_data.get("discharge_enable", 0))
                         discharge_current = slot_data.get("discharge_current", discharge_current)
 
                     # When a slot is disabled, zero out its times so the inverter shows a clean 00:00-00:00
@@ -797,12 +799,23 @@ class SolisAPI(ComponentBase, OAuthMixin):
                                 success &= result
 
                 # Decide if Solar charges the batter or exports
+                # The inverter only retains the TOU bit on CID 636 when a charge/discharge window is
+                # actually configured on slot 1, so gate the mode choice the same way the V1 branch does
+                # (see the in_charge_slot/in_discharge_slot handling below) to avoid a permanent verify-fail loop.
                 if charge_current == 0:
-                    self.log(f"Solis API: Charge current is 0A for {inverter_sn}, setting storage mode to 'Feed-in priority'")
-                    await self.set_storage_mode_if_needed(inverter_sn, "Feed-in priority")
+                    if slot1_active:
+                        self.log(f"Solis API: Charge current is 0A for {inverter_sn}, setting storage mode to 'Feed-in priority'")
+                        await self.set_storage_mode_if_needed(inverter_sn, "Feed-in priority")
+                    else:
+                        self.log(f"Solis API: Charge current is 0A and no active slot for {inverter_sn}, setting storage mode to 'Feed-in priority - No Timed Charge/Discharge'")
+                        await self.set_storage_mode_if_needed(inverter_sn, "Feed-in priority - No Timed Charge/Discharge")
                 else:
-                    self.log(f"Solis API: Charge current is {charge_current}A for {inverter_sn}, setting storage mode to 'Self-Use'")
-                    await self.set_storage_mode_if_needed(inverter_sn, "Self-Use")
+                    if slot1_active:
+                        self.log(f"Solis API: Charge current is {charge_current}A for {inverter_sn}, setting storage mode to 'Self-Use'")
+                        await self.set_storage_mode_if_needed(inverter_sn, "Self-Use")
+                    else:
+                        self.log(f"Solis API: Charge current is {charge_current}A and no active slot for {inverter_sn}, setting storage mode to 'Self-Use - No Timed Charge/Discharge'")
+                        await self.set_storage_mode_if_needed(inverter_sn, "Self-Use - No Timed Charge/Discharge")
 
                 return success
             else:

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -969,6 +969,7 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_write_time_windows_v1_mode())
         failed |= asyncio.run(test_write_time_windows_v2_no_changes())
         failed |= asyncio.run(test_write_time_windows_v2_stale_slot_clearing())
+        failed |= asyncio.run(test_write_time_windows_v2_no_active_slot())
         failed |= asyncio.run(test_write_time_windows_zero_charge_current())
         failed |= asyncio.run(test_write_time_windows_v1_slot_detection())
         failed |= asyncio.run(test_write_time_windows_v1_discharge_slot_detection())
@@ -1905,6 +1906,53 @@ async def test_write_time_windows_v2_stale_slot_clearing():
     assert slot2_time_idx < first_slot1_active, "Slot 2 time clear must precede slot 1 active write"
 
     print("PASSED: V2 mode two-pass clears stale disabled slots before writing active slot")
+    return False
+
+
+async def test_write_time_windows_v2_no_active_slot():
+    """Test write_time_windows_if_changed in V2 mode when slot 1 has no charge or discharge window.
+
+    Regression test: when neither charge nor discharge is enabled for slot 1, the inverter has no
+    time-of-use schedule configured and will not retain the TOU bit (SOLIS_BIT_TOU_MODE) on CID 636 -
+    it always reads back with that bit cleared. Predbat must mirror the V1 branch's behaviour and
+    request the '... - No Timed Charge/Discharge' mode variant in this case, otherwise every cycle
+    writes a value the inverter immediately rejects, producing a permanent verify-failure loop.
+    """
+    print("\n=== Test: write_time_windows_if_changed V2 mode no active slot ===")
+
+    api = MockSolisAPI()
+    api._test_v2_mode = True  # Enable V2 mode
+    api._mock_storage_mode = True  # Mock storage mode tracking
+    inverter_sn = "TEST123"
+    api.inverter_sn = [inverter_sn]
+
+    # Slot 1 has neither charge nor discharge enabled - no TOU schedule configured at all
+    api.charge_discharge_time_windows[inverter_sn] = {
+        1: {
+            "charge_enable": 0,
+            "charge_start_time": "00:00",
+            "charge_end_time": "00:00",
+            "charge_soc": 100,
+            "charge_current": 50,
+            "discharge_enable": 0,
+            "discharge_start_time": "00:00",
+            "discharge_end_time": "00:00",
+            "discharge_soc": 10,
+            "discharge_current": 30,
+        }
+    }
+
+    api.cached_values[inverter_sn] = {}
+
+    result = await api.write_time_windows_if_changed(inverter_sn)
+    assert result == True, "write_time_windows_if_changed should return True"
+
+    # Storage mode must use the 'No Timed Charge/Discharge' variant since no slot is active
+    storage_mode_calls = api.set_storage_mode_calls
+    assert len(storage_mode_calls) == 1, f"Expected 1 storage mode call, got {len(storage_mode_calls)}"
+    assert storage_mode_calls[0]["mode"] == "Self-Use - No Timed Charge/Discharge", f"Storage mode should be 'Self-Use - No Timed Charge/Discharge' when no slot is active, got '{storage_mode_calls[0]['mode']}'"
+
+    print("PASSED: V2 mode uses 'No Timed Charge/Discharge' variant when no slot is active")
     return False
 
 


### PR DESCRIPTION
## Summary
- On V2-mode Solis inverters (per-slot CIDs), `write_time_windows_if_changed` always forced the storage-mode TOU bit (bit 1 of CID 636) on when choosing Self-Use/Feed-in-priority, regardless of whether slot 1 actually has a charge or discharge window configured.
- The physical inverter only retains that bit when a schedule is actually active, and silently clears it on read-back otherwise — this produced a permanent write/verify-fail loop (`Failed to verify CID 636 storage mode ..., wrote 35 but read back 33`) every cycle once both charge and discharge were disabled for slot 1.
- The V1 branch already has the correct behaviour (`in_charge_slot or in_discharge_slot` gating, falling back to the `"... - No Timed Charge/Discharge"` mode variant). This mirrors that same gating into the V2 branch, based on whether slot 1 has any enabled window.
- Cross-checked storage-mode bit numbering, CID 636, and the V2 per-slot CIDs against the independent [mkuthan/solis-cloud-control](https://github.com/mkuthan/solis-cloud-control) integration — identical mapping. That project also deliberately withholds manual TOU-bit control specifically for TOU-V2 inverters, corroborating that this bit shouldn't be forced by client code on V2.

## Test plan
- [x] Added `test_write_time_windows_v2_no_active_slot` regression test (confirmed it fails against the old code, passes after the fix)
- [x] `./run_all --test solis` — full Solis suite passes
- [x] `pre-commit run` (ruff, black, cspell) passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)