### PR TITLE
fix(octopus): 2-minute dispatch refresh and replan only on genuine slot changes

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -460,6 +460,7 @@ twinx
 tzfile
 tzpath
 unconfigured
+unparseable
 unsmoothed
 unstaged
 urlsafe

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1083,7 +1083,10 @@ class Fetch:
             self.load_inday_adjustment = 1.0
 
         force_replan = False
-        if str(prev_octopus_slots) != str(self.octopus_slots):
+        # Compare on the change-detection signature, not the raw slots, so the per-cycle re-clocking
+        # of an in-progress dispatch (start advanced to now, energy scaled to remaining time) does not
+        # force a replan every cycle while a slot is active - only genuine slot changes do
+        if self.octopus_slots_signature(prev_octopus_slots) != self.octopus_slots_signature(self.octopus_slots):
             self.log("Octopus slots changed from {} to {}".format(prev_octopus_slots, self.octopus_slots))
             force_replan = True
         if str(prev_octopus_saving_slots) != str(self.octopus_saving_slots):

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -365,6 +365,7 @@ class OctopusAPI(ComponentBase):
         self.intelligent_devices = {}
         self.tariff_fetched_at = None
         self.device_fetched_at = None
+        self.sensor_updated_at = None
         self.automatic = automatic
         self.commands = []
         self.mpan = None
@@ -429,10 +430,6 @@ class OctopusAPI(ComponentBase):
             await self.load_octopus_cache()
             self.log("OctopusAPI: Started")
 
-        # Update time every minute
-        now = datetime.now()
-        count_minutes = now.minute + now.hour * 60
-
         # Process any queued commands
         refresh = False
         if not first and (await self.process_commands(self.account_id)):
@@ -446,7 +443,7 @@ class OctopusAPI(ComponentBase):
 
         tariff_due = self._data_age_minutes(self.tariff_fetched_at) >= 30
         device_due = refresh or self._data_age_minutes(self.device_fetched_at) >= 10
-        sensor_due = first or refresh or (count_minutes % 2) == 0
+        sensor_due = first or refresh or self._data_age_minutes(self.sensor_updated_at) >= 2
 
         if tariff_due:
             # 30-minute API refresh for account and tariff discovery
@@ -458,8 +455,7 @@ class OctopusAPI(ComponentBase):
             await self.async_find_tariffs()
 
         if device_due:
-            # 10-minute API refresh for intelligent device and saving sessions
-            await self.async_update_intelligent_devices(self.account_id)
+            # 10-minute API refresh for saving sessions
             self.saving_sessions = await self.async_get_flexibility_events(self.account_id)
             self.get_saving_session_data()
             self.device_fetched_at = datetime.now()
@@ -469,7 +465,11 @@ class OctopusAPI(ComponentBase):
             await self.fetch_tariffs(self.tariffs)
 
         if sensor_due:
-            # 2-minute update for intelligent device sensor
+            # 2-minute refresh of intelligent dispatches and the dispatch sensor so new slots are
+            # picked up quickly. Stamp before fetching so the fetch/publish duration can't slip
+            # the cadence past the next run
+            self.sensor_updated_at = datetime.now()
+            await self.async_update_intelligent_devices(self.account_id)
             await self.async_intelligent_update_sensor(self.account_id)
 
         if tariff_due or device_due:
@@ -2241,6 +2241,40 @@ class Octopus:
             octopus_slots.append(slot)
             self.log("Octopus: Car is charging now - added new IO slot {}".format(slot))
         return octopus_slots
+
+    def octopus_slots_signature(self, octopus_slots):
+        """
+        Build a single change-detection signature value for the intelligent dispatch slots.
+
+        Returns an opaque tuple intended only to be compared for equality against another signature -
+        callers should not index into it. Per-car grouping is preserved inside so a slot moving
+        between cars still registers as a change.
+
+        An in-progress dispatch has its start advanced to now and its charge_in_kwh scaled to the
+        remaining time on every component refresh (see async_get_intelligent_devices). Comparing the
+        raw slots would therefore report a change on every cycle throughout an active charging window
+        and force a needless replan each time. For a currently active slot the signature keeps only
+        the stable fields (window end, source, location); genuine changes - new/removed slots, a
+        moved window end, a revised future slot, a future slot becoming active - still alter it.
+        """
+        signature = []
+        for car_slots in octopus_slots:
+            car_signature = []
+            for slot in car_slots:
+                start = slot.get("start")
+                end = slot.get("end")
+                source = slot.get("source")
+                location = slot.get("location")
+                start_dt = str2time(start) if start else None
+                end_dt = str2time(end) if end else None
+                in_progress = start_dt is not None and end_dt is not None and start_dt <= self.now_utc < end_dt
+                if in_progress:
+                    # start / charge_in_kwh drift as time elapses - exclude them so only genuine changes count
+                    car_signature.append(("active", end, source, location))
+                else:
+                    car_signature.append((start, end, slot.get("charge_in_kwh", slot.get("kwh")), source, location))
+            signature.append(tuple(car_signature))
+        return tuple(signature)
 
     def load_free_slot(self, octopus_free_slots, export=False, rate_replicate=None):
         """

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2248,7 +2248,10 @@ class Octopus:
 
         Returns an opaque tuple intended only to be compared for equality against another signature -
         callers should not index into it. Per-car grouping is preserved inside so a slot moving
-        between cars still registers as a change.
+        between cars still registers as a change. Timestamps are normalised to the parsed instant so
+        equivalent values in different formats (+0000 vs +00:00 vs Z) do not register as a change;
+        an unparseable value falls back to its raw string (and never raises) so a genuine change is
+        still detected without breaking the update cycle.
 
         An in-progress dispatch has its start advanced to now and its charge_in_kwh scaled to the
         remaining time on every component refresh (see async_get_intelligent_devices). Comparing the
@@ -2265,16 +2268,28 @@ class Octopus:
                 end = slot.get("end")
                 source = slot.get("source")
                 location = slot.get("location")
-                start_dt = str2time(start) if start else None
-                end_dt = str2time(end) if end else None
+                start_dt = self._parse_slot_time(start)
+                end_dt = self._parse_slot_time(end)
+                # Normalise to the parsed instant where possible, else keep the raw string
+                start_key = start_dt if start_dt is not None else start
+                end_key = end_dt if end_dt is not None else end
                 in_progress = start_dt is not None and end_dt is not None and start_dt <= self.now_utc < end_dt
                 if in_progress:
                     # start / charge_in_kwh drift as time elapses - exclude them so only genuine changes count
-                    car_signature.append(("active", end, source, location))
+                    car_signature.append(("active", end_key, source, location))
                 else:
-                    car_signature.append((start, end, slot.get("charge_in_kwh", slot.get("kwh")), source, location))
+                    car_signature.append((start_key, end_key, slot.get("charge_in_kwh", slot.get("kwh")), source, location))
             signature.append(tuple(car_signature))
         return tuple(signature)
+
+    def _parse_slot_time(self, value):
+        """Parse a slot timestamp string into a datetime, returning None if empty or unparseable."""
+        if not value:
+            return None
+        try:
+            return str2time(value)
+        except (ValueError, TypeError):
+            return None
 
     def load_free_slot(self, octopus_free_slots, export=False, rate_replicate=None):
         """

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.45.1"
+THIS_VERSION = "v8.45.2"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/tests/test_kraken.py
+++ b/apps/predbat/tests/test_kraken.py
@@ -1670,12 +1670,19 @@ def test_merge_completed_dispatches_dedup_and_prune():
 
 def test_fetch_dispatches_populates_device():
     """async_fetch_dispatches fills planned + completed dispatches for each known device."""
+    from datetime import datetime, timezone, timedelta
+
     api = make_kraken_api()
     api.intelligent_devices = {"dev-1": {"device_id": "dev-1", "planned_dispatches": [], "completed_dispatches": []}}
+    # Use dates relative to now so the completed dispatch stays inside the history prune window
+    planned_start = (datetime.now(timezone.utc) + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    planned_end = (datetime.now(timezone.utc) + timedelta(hours=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    completed_start = (datetime.now(timezone.utc) - timedelta(hours=4)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    completed_end = (datetime.now(timezone.utc) - timedelta(hours=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
     api.async_graphql_query = AsyncMock(
         return_value={
-            "flexPlannedDispatches": [{"start": "2026-07-08T02:00:00Z", "end": "2026-07-08T05:00:00Z", "type": "SMART", "energyAddedKwh": 10.0}],
-            "completedDispatches": [{"start": "2026-07-08T00:00:00Z", "end": "2026-07-08T01:00:00Z", "delta": 3.0, "meta": {"source": "SMART", "location": "AT_HOME"}}],
+            "flexPlannedDispatches": [{"start": planned_start, "end": planned_end, "type": "SMART", "energyAddedKwh": 10.0}],
+            "completedDispatches": [{"start": completed_start, "end": completed_end, "delta": 3.0, "meta": {"source": "SMART", "location": "AT_HOME"}}],
         }
     )
     asyncio.run(api.async_fetch_dispatches())

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -1875,11 +1875,11 @@ async def test_octopus_run(my_predbat):
 
     Tests:
     - Test 1: First run with no cache (both fetched_at=None) — all methods called
-    - Test 2: Tariff stale (35 min), device fresh (5 min) — only tariff refreshed
+    - Test 2: Tariff stale (35 min), device fresh, sensor fresh — only tariff refreshed
     - Test 3: Device stale (15 min), tariff fresh (5 min) — only device refreshed
-    - Test 4: Both fresh (1 min) at 2-minute sensor mark — only sensor, no cache save
-    - Test 5: Commands processed forces device refresh even when recently fetched
-    - Test 6: Fast restart (first=True) with fresh timestamps — only sensor, no heavy fetches
+    - Test 4: Both fresh (1 min), sensor due — dispatch fetch and sensor update, no cache save
+    - Test 5: Commands processed forces device and dispatch refresh even when recently fetched
+    - Test 6: Fast restart (first=True) with fresh timestamps — dispatches and sensor refreshed, no heavy fetches
     - Test 7: Automatic config on first run
     """
     print("\n**** Running Octopus run method tests ****")
@@ -1925,11 +1925,12 @@ async def test_octopus_run(my_predbat):
     else:
         print("PASS: First run calls all expected methods")
 
-    # Test 2: Tariff stale (35 min old), device fresh (5 min old) — only tariff block runs
-    print("\n*** Test 2: Tariff stale, device fresh — only tariff refreshed ***")
+    # Test 2: Tariff stale (35 min old), device and sensor fresh — only tariff block runs
+    print("\n*** Test 2: Tariff stale, device and sensor fresh — only tariff refreshed ***")
     api2 = _mock_run_api(my_predbat, key="test-api-key-2", account_id="test-account-2")
     api2.tariff_fetched_at = datetime(2025, 1, 1, 9, 55, 0)  # 35 min before mock now
     api2.device_fetched_at = datetime(2025, 1, 1, 10, 25, 0)  # 5 min before mock now
+    api2.sensor_updated_at = datetime(2025, 1, 1, 10, 29, 0)  # 1 min before mock now
 
     with patch("octopus.datetime") as mock_datetime:
         mock_datetime.now.return_value = datetime(2025, 1, 1, 10, 30, 0)
@@ -1945,19 +1946,23 @@ async def test_octopus_run(my_predbat):
         print(f"ERROR: Expected async_find_tariffs called (tariff stale), got {api2.async_find_tariffs.call_count}")
         failed = True
     elif api2.async_update_intelligent_devices.call_count != 0:
-        print(f"ERROR: Expected async_update_intelligent_devices NOT called (device fresh), got {api2.async_update_intelligent_devices.call_count}")
+        print(f"ERROR: Expected async_update_intelligent_devices NOT called (sensor fresh), got {api2.async_update_intelligent_devices.call_count}")
+        failed = True
+    elif api2.async_intelligent_update_sensor.call_count != 0:
+        print(f"ERROR: Expected async_intelligent_update_sensor NOT called (sensor fresh), got {api2.async_intelligent_update_sensor.call_count}")
         failed = True
     elif api2.save_octopus_cache.call_count != 1:
         print(f"ERROR: Expected save_octopus_cache called (tariff_due=True), got {api2.save_octopus_cache.call_count}")
         failed = True
     else:
-        print("PASS: Tariff stale, device fresh — only tariff refreshed")
+        print("PASS: Tariff stale, device and sensor fresh — only tariff refreshed")
 
-    # Test 3: Device stale (15 min old), tariff fresh (5 min old) — only device block runs
-    print("\n*** Test 3: Device stale, tariff fresh — only device refreshed ***")
+    # Test 3: Device stale (15 min old), tariff and sensor fresh — only saving sessions refreshed
+    print("\n*** Test 3: Device stale, tariff and sensor fresh — only saving sessions refreshed ***")
     api3 = _mock_run_api(my_predbat, key="test-api-key-3", account_id="test-account-3")
     api3.tariff_fetched_at = datetime(2025, 1, 1, 10, 5, 0)  # 5 min before mock now
     api3.device_fetched_at = datetime(2025, 1, 1, 9, 55, 0)  # 15 min before mock now
+    api3.sensor_updated_at = datetime(2025, 1, 1, 10, 9, 0)  # 1 min before mock now
     api3.tariffs = {}
 
     with patch("octopus.datetime") as mock_datetime:
@@ -1967,8 +1972,8 @@ async def test_octopus_run(my_predbat):
     if api3.async_get_account.call_count != 0:
         print(f"ERROR: Expected async_get_account NOT called (tariff fresh), got {api3.async_get_account.call_count}")
         failed = True
-    elif api3.async_update_intelligent_devices.call_count != 1:
-        print(f"ERROR: Expected async_update_intelligent_devices called (device stale), got {api3.async_update_intelligent_devices.call_count}")
+    elif api3.async_update_intelligent_devices.call_count != 0:
+        print(f"ERROR: Expected async_update_intelligent_devices NOT called (dispatches follow the sensor cadence), got {api3.async_update_intelligent_devices.call_count}")
         failed = True
     elif api3.fetch_tariffs.call_count != 1:
         print(f"ERROR: Expected fetch_tariffs called (device stale), got {api3.fetch_tariffs.call_count}")
@@ -1983,23 +1988,24 @@ async def test_octopus_run(my_predbat):
         print(f"ERROR: Expected save_octopus_cache called (device_due=True), got {api3.save_octopus_cache.call_count}")
         failed = True
     else:
-        print("PASS: Device stale, tariff fresh — only device refreshed")
+        print("PASS: Device stale, tariff and sensor fresh — only saving sessions refreshed")
 
-    # Test 4: Both fresh (1 min) at 2-minute sensor mark — only sensor fires, no cache save
-    print("\n*** Test 4: Both fresh — only sensor update, no cache save ***")
+    # Test 4: Both fresh (1 min), sensor due — dispatch fetch and sensor fire, no cache save
+    print("\n*** Test 4: Both fresh, sensor due — dispatch fetch and sensor update, no cache save ***")
     api4 = _mock_run_api(my_predbat, key="test-api-key-4", account_id="test-account-4")
     api4.tariff_fetched_at = datetime(2025, 1, 1, 10, 1, 0)  # 1 min before mock now
     api4.device_fetched_at = datetime(2025, 1, 1, 10, 1, 0)  # 1 min before mock now
+    api4.sensor_updated_at = datetime(2025, 1, 1, 10, 0, 0)  # 2 min before mock now
 
     with patch("octopus.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime(2025, 1, 1, 10, 2, 0)  # 10:02 — even minute
+        mock_datetime.now.return_value = datetime(2025, 1, 1, 10, 2, 0)
         result = await api4.run(seconds=0, first=False)
 
     if api4.async_get_account.call_count != 0:
         print(f"ERROR: Expected async_get_account NOT called (tariff fresh), got {api4.async_get_account.call_count}")
         failed = True
-    elif api4.async_update_intelligent_devices.call_count != 0:
-        print(f"ERROR: Expected async_update_intelligent_devices NOT called (device fresh), got {api4.async_update_intelligent_devices.call_count}")
+    elif api4.async_update_intelligent_devices.call_count != 1:
+        print(f"ERROR: Expected async_update_intelligent_devices called at 2-min mark, got {api4.async_update_intelligent_devices.call_count}")
         failed = True
     elif api4.async_intelligent_update_sensor.call_count != 1:
         print(f"ERROR: Expected async_intelligent_update_sensor called at 2-min mark, got {api4.async_intelligent_update_sensor.call_count}")
@@ -2008,7 +2014,7 @@ async def test_octopus_run(my_predbat):
         print(f"ERROR: Expected save_octopus_cache NOT called (no data refreshed), got {api4.save_octopus_cache.call_count}")
         failed = True
     else:
-        print("PASS: Both fresh — only sensor update, no cache save")
+        print("PASS: Both fresh, sensor due — dispatch fetch and sensor update, no cache save")
 
     # Test 5: Commands processed forces device refresh even when recently fetched
     print("\n*** Test 5: Processing commands triggers device refresh regardless of age ***")
@@ -2016,10 +2022,11 @@ async def test_octopus_run(my_predbat):
     api5.process_commands = AsyncMock(return_value=True)
     api5.tariff_fetched_at = datetime(2025, 1, 1, 10, 4, 0)  # 1 min before mock now
     api5.device_fetched_at = datetime(2025, 1, 1, 10, 4, 0)  # 1 min before mock now (fresh)
+    api5.sensor_updated_at = datetime(2025, 1, 1, 10, 4, 0)  # 1 min before mock now (fresh)
     api5.tariffs = {}
 
     with patch("octopus.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime(2025, 1, 1, 10, 5, 0)  # odd minute — sensor not due
+        mock_datetime.now.return_value = datetime(2025, 1, 1, 10, 5, 0)
         result = await api5.run(seconds=0, first=False)
 
     if api5.async_get_account.call_count != 0:
@@ -2037,9 +2044,10 @@ async def test_octopus_run(my_predbat):
     else:
         print("PASS: Processing commands triggers refresh of intelligent device data")
 
-    # Test 6: Fast restart (first=True) with fresh timestamps — API calls skipped but
-    # async_find_tariffs and fetch_tariffs run to rebuild state from cached data
-    print("\n*** Test 6: Fast restart with fresh cache — tariff structure and rates rebuilt, API calls skipped ***")
+    # Test 6: Fast restart (first=True) with fresh timestamps — heavy account/saving-session fetches
+    # skipped but dispatches and sensor refresh, and async_find_tariffs and fetch_tariffs run to
+    # rebuild state from cached data
+    print("\n*** Test 6: Fast restart with fresh cache — tariffs rebuilt, dispatches refreshed, heavy fetches skipped ***")
     api6 = _mock_run_api(my_predbat, key="test-api-key-6", account_id="test-account-6")
     api6.tariff_fetched_at = datetime(2025, 1, 1, 10, 10, 0)  # 5 min before mock now
     api6.device_fetched_at = datetime(2025, 1, 1, 10, 12, 0)  # 3 min before mock now
@@ -2054,8 +2062,8 @@ async def test_octopus_run(my_predbat):
     elif api6.async_find_tariffs.call_count != 1:
         print(f"ERROR: Expected async_find_tariffs called (rebuilds tariff structure from cached account_data), got {api6.async_find_tariffs.call_count}")
         failed = True
-    elif api6.async_update_intelligent_devices.call_count != 0:
-        print(f"ERROR: Expected async_update_intelligent_devices NOT called (device 3 min old < 10), got {api6.async_update_intelligent_devices.call_count}")
+    elif api6.async_update_intelligent_devices.call_count != 1:
+        print(f"ERROR: Expected async_update_intelligent_devices called on first run (dispatches refreshed with the sensor), got {api6.async_update_intelligent_devices.call_count}")
         failed = True
     elif api6.fetch_tariffs.call_count != 1:
         print(f"ERROR: Expected fetch_tariffs called (loads rate data from cache on first run), got {api6.fetch_tariffs.call_count}")
@@ -2067,7 +2075,7 @@ async def test_octopus_run(my_predbat):
         print(f"ERROR: Expected save_octopus_cache NOT called (no API data refreshed), got {api6.save_octopus_cache.call_count}")
         failed = True
     else:
-        print("PASS: Fast restart with fresh cache — tariff structure and rates rebuilt, API calls skipped")
+        print("PASS: Fast restart with fresh cache — tariffs rebuilt, dispatches refreshed, heavy fetches skipped")
 
     # Test 7: Automatic config on first run when automatic=True
     print("\n*** Test 7: Automatic config on first run when automatic=True ***")

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -1876,7 +1876,7 @@ async def test_octopus_run(my_predbat):
     Tests:
     - Test 1: First run with no cache (both fetched_at=None) — all methods called
     - Test 2: Tariff stale (35 min), device fresh, sensor fresh — only tariff refreshed
-    - Test 3: Device stale (15 min), tariff fresh (5 min) — only device refreshed
+    - Test 3: Device stale (15 min), tariff and sensor fresh — only saving sessions refreshed (dispatches follow the sensor cadence)
     - Test 4: Both fresh (1 min), sensor due — dispatch fetch and sensor update, no cache save
     - Test 5: Commands processed forces device and dispatch refresh even when recently fetched
     - Test 6: Fast restart (first=True) with fresh timestamps — dispatches and sensor refreshed, no heavy fetches

--- a/apps/predbat/tests/test_octopus_sensor_due.py
+++ b/apps/predbat/tests/test_octopus_sensor_due.py
@@ -1,0 +1,121 @@
+"""
+Tests for the OctopusAPI intelligent sensor update scheduling (sensor_due)
+
+The intelligent dispatch fetch and sensor are meant to be refreshed every
+2 minutes. The component scheduler (ComponentBase.start) is not
+minute-aligned: it sleeps in 5 second chunks and does not account for the
+time run() itself takes, so run() invocations drift relative to the wall
+clock. A refresh gate keyed off wall-clock even minutes
+(count_minutes % 2 == 0) can therefore land only on odd minutes and starve
+the sensor indefinitely. The gate must instead be based on the age of the
+last sensor update.
+"""
+
+import asyncio
+from datetime import datetime, timedelta
+
+import octopus as octopus_module
+from octopus import OctopusAPI
+
+
+def test_octopus_sensor_due_wrapper(my_predbat):
+    """Wrapper to run the async sensor_due scheduling tests"""
+    return asyncio.run(test_octopus_sensor_due(my_predbat))
+
+
+class FakeDateTime(datetime):
+    """datetime replacement whose now() returns a controllable fixed time"""
+
+    current = None
+
+    @classmethod
+    def now(cls, tz=None):
+        """Return the controlled current time"""
+        return cls.current
+
+
+async def run_at(api, fake_time, seconds):
+    """Run the component loop body once at the given fake wall-clock time"""
+    FakeDateTime.current = fake_time
+    return await api.run(seconds, False)
+
+
+async def test_octopus_sensor_due(my_predbat):
+    """
+    Test the sensor_due scheduling in OctopusAPI.run()
+
+    Tests:
+    - Test 1: Sensor updates must not starve when run() only lands on odd wall-clock minutes
+    - Test 2: Dispatch fetch and sensor update happen on a 2 minute cadence based on the age of the last update
+    """
+    print("**** Running Octopus sensor_due scheduling tests ****")
+    failed = False
+
+    api = OctopusAPI(my_predbat, key="test-key", account_id="test-account", automatic=False)
+
+    # Stub out the dispatch fetch and sensor publish so we only exercise the scheduling logic
+    dispatch_fetches = []
+    sensor_updates = []
+
+    async def fake_update_devices(account_id):
+        """Record a dispatch fetch instead of calling the API"""
+        dispatch_fetches.append(FakeDateTime.current)
+
+    async def fake_update_sensor(account_id):
+        """Record a sensor update instead of publishing entities"""
+        sensor_updates.append(FakeDateTime.current)
+
+    api.async_update_intelligent_devices = fake_update_devices
+    api.async_intelligent_update_sensor = fake_update_sensor
+
+    # Control the wall clock seen by octopus.py
+    saved_datetime = octopus_module.datetime
+    octopus_module.datetime = FakeDateTime
+
+    try:
+        # Test 1: run() landing only on odd minutes must still update the sensor.
+        # Simulates the drifted scheduler (e.g. a slow run() pushing the period to ~120s).
+        print("\n*** Test 1: no starvation when runs land on odd minutes only ***")
+        base = datetime(2024, 6, 15, 0, 1, 0)  # 00:01, an odd minute
+        api.tariff_fetched_at = base
+        api.device_fetched_at = base
+
+        for step in range(3):
+            # Runs at 00:01, 00:03 and 00:05 - all odd minutes
+            await run_at(api, base + timedelta(minutes=2 * step), 60 * (step + 1))
+
+        if not sensor_updates:
+            print("ERROR: Sensor was never updated across 4 minutes of odd-minute runs")
+            failed = True
+        elif not dispatch_fetches:
+            print("ERROR: Intelligent dispatches were never fetched across 4 minutes of odd-minute runs")
+            failed = True
+        else:
+            print("PASS: Sensor updated {} times and dispatches fetched {} times across odd-minute runs".format(len(sensor_updates), len(dispatch_fetches)))
+
+        # Test 2: updates follow a 2 minute cadence from the last update, not minute parity
+        print("\n*** Test 2: 2 minute cadence based on last update age ***")
+        sensor_updates.clear()
+        dispatch_fetches.clear()
+        t0 = datetime(2024, 6, 15, 1, 0, 0)
+        api.tariff_fetched_at = t0
+        api.device_fetched_at = t0
+        api.sensor_updated_at = None
+
+        await run_at(api, t0, 60)  # Never updated - must update now
+        await run_at(api, t0 + timedelta(minutes=1), 120)  # Only 1 minute old - must not update
+        await run_at(api, t0 + timedelta(minutes=2), 180)  # 2 minutes old - must update
+
+        expected = [t0, t0 + timedelta(minutes=2)]
+        if sensor_updates != expected:
+            print("ERROR: Expected sensor updates at {}, got {}".format(expected, sensor_updates))
+            failed = True
+        elif dispatch_fetches != expected:
+            print("ERROR: Expected dispatch fetches at {}, got {}".format(expected, dispatch_fetches))
+            failed = True
+        else:
+            print("PASS: Dispatch fetch and sensor update follow the 2 minute cadence")
+    finally:
+        octopus_module.datetime = saved_datetime
+
+    return failed

--- a/apps/predbat/tests/test_octopus_slots_change.py
+++ b/apps/predbat/tests/test_octopus_slots_change.py
@@ -38,6 +38,8 @@ def test_octopus_slots_change(my_predbat):
     - Test 3: In-progress slot window end changes → different signature
     - Test 4: A future slot's energy changes → different signature
     - Test 5: A slot transitioning from future to active → different signature
+    - Test 6: The same instant in different string formats (+00:00 vs +0000) → same signature
+    - Test 7: Unparseable slot timestamps do not raise and are still comparable
     """
     print("**** Running octopus_slots_signature tests ****")
     failed = False
@@ -93,6 +95,34 @@ def test_octopus_slots_change(my_predbat):
             failed = True
         else:
             print("Test 5 passed - future to active transition forces a replan")
+
+        # Test 6: the same instant expressed with different offset formatting must NOT look changed
+        print("*** Test 6: equivalent timestamps in different formats produce same signature ***")
+        colon_offset = [[_slot("2025-01-15T13:00:00+00:00", "2025-01-15T14:00:00+00:00", 5.0)]]
+        no_colon_offset = [[_slot("2025-01-15T13:00:00+0000", "2025-01-15T14:00:00+0000", 5.0)]]
+        if my_predbat.octopus_slots_signature(colon_offset) != my_predbat.octopus_slots_signature(no_colon_offset):
+            print("ERROR: Equivalent timestamps in different formats reported as changed")
+            failed = True
+        else:
+            print("Test 6 passed - offset formatting does not force a replan")
+
+        # Test 7: unparseable timestamps must not raise, and must still be comparable
+        print("*** Test 7: unparseable timestamps do not raise and remain comparable ***")
+        try:
+            bad = [[_slot("unavailable", "unknown", 5.0)]]
+            bad_same = [[_slot("unavailable", "unknown", 5.0)]]
+            bad_diff = [[_slot("unknown", "unknown", 5.0)]]
+            if my_predbat.octopus_slots_signature(bad) != my_predbat.octopus_slots_signature(bad_same):
+                print("ERROR: Identical unparseable slots reported as changed")
+                failed = True
+            elif my_predbat.octopus_slots_signature(bad) == my_predbat.octopus_slots_signature(bad_diff):
+                print("ERROR: Differing unparseable slots not detected as changed")
+                failed = True
+            else:
+                print("Test 7 passed - unparseable timestamps handled without raising")
+        except (ValueError, TypeError) as e:
+            print("ERROR: octopus_slots_signature raised on unparseable timestamp: {}".format(e))
+            failed = True
     finally:
         my_predbat.now_utc = old_now_utc
 

--- a/apps/predbat/tests/test_octopus_slots_change.py
+++ b/apps/predbat/tests/test_octopus_slots_change.py
@@ -1,0 +1,104 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Tests for octopus_slots_signature - the change-detection signature used by
+fetch_sensor_data to decide whether a genuinely new/changed set of Octopus
+intelligent dispatch slots warrants forcing a replan.
+
+An in-progress dispatch has its start advanced to 'now' and its charge_in_kwh
+scaled to the remaining time on every component refresh (octopus.py
+async_get_intelligent_devices). That re-clocking must NOT be treated as a slot
+change, otherwise a replan is forced on every cycle throughout an active
+charging window. Genuine changes (new/removed slots, changed window end,
+energy of a future slot, source/location) must still be detected.
+"""
+
+from datetime import datetime
+
+
+def _slot(start, end, kwh, source="smart-charge", location="AT_HOME"):
+    """Build an octopus dispatch slot dict"""
+    return {"start": start, "end": end, "charge_in_kwh": kwh, "source": source, "location": location}
+
+
+def test_octopus_slots_change(my_predbat):
+    """
+    Test octopus_slots_signature ignores in-progress re-clocking but detects genuine changes.
+
+    Tests:
+    - Test 1: In-progress slot re-clock (start + charge_in_kwh drift) → same signature
+    - Test 2: A new future slot appears → different signature
+    - Test 3: In-progress slot window end changes → different signature
+    - Test 4: A future slot's energy changes → different signature
+    - Test 5: A slot transitioning from future to active → different signature
+    """
+    print("**** Running octopus_slots_signature tests ****")
+    failed = False
+
+    old_now_utc = my_predbat.now_utc
+    my_predbat.now_utc = datetime.strptime("2025-01-15T10:00:00+00:00", "%Y-%m-%dT%H:%M:%S%z")
+
+    try:
+        # Test 1: in-progress slot re-clocked (start advanced, energy scaled down) - NOT a real change
+        print("*** Test 1: in-progress re-clock produces same signature ***")
+        prev = [[_slot("2025-01-15T09:57:30+00:00", "2025-01-15T11:00:00+00:00", 7.2)]]
+        curr = [[_slot("2025-01-15T09:59:40+00:00", "2025-01-15T11:00:00+00:00", 6.9)]]
+        if my_predbat.octopus_slots_signature(prev) != my_predbat.octopus_slots_signature(curr):
+            print("ERROR: Re-clocked in-progress slot reported as changed")
+            failed = True
+        else:
+            print("Test 1 passed - re-clocking does not force a replan")
+
+        # Test 2: a genuinely new future slot appears - IS a real change
+        print("*** Test 2: new future slot produces different signature ***")
+        curr_new = [[_slot("2025-01-15T09:59:40+00:00", "2025-01-15T11:00:00+00:00", 6.9), _slot("2025-01-15T13:00:00+00:00", "2025-01-15T14:00:00+00:00", 5.0)]]
+        if my_predbat.octopus_slots_signature(prev) == my_predbat.octopus_slots_signature(curr_new):
+            print("ERROR: New future slot not detected as a change")
+            failed = True
+        else:
+            print("Test 2 passed - new slot forces a replan")
+
+        # Test 3: the in-progress slot's window end changes (Octopus extended it) - IS a real change
+        print("*** Test 3: in-progress slot end change produces different signature ***")
+        curr_end = [[_slot("2025-01-15T09:59:40+00:00", "2025-01-15T11:30:00+00:00", 6.9)]]
+        if my_predbat.octopus_slots_signature(prev) == my_predbat.octopus_slots_signature(curr_end):
+            print("ERROR: In-progress slot end change not detected")
+            failed = True
+        else:
+            print("Test 3 passed - end change forces a replan")
+
+        # Test 4: a future slot's energy is revised - IS a real change
+        print("*** Test 4: future slot energy change produces different signature ***")
+        base_future = [[_slot("2025-01-15T13:00:00+00:00", "2025-01-15T14:00:00+00:00", 5.0)]]
+        changed_future = [[_slot("2025-01-15T13:00:00+00:00", "2025-01-15T14:00:00+00:00", 6.0)]]
+        if my_predbat.octopus_slots_signature(base_future) == my_predbat.octopus_slots_signature(changed_future):
+            print("ERROR: Future slot energy change not detected")
+            failed = True
+        else:
+            print("Test 4 passed - future slot energy change forces a replan")
+
+        # Test 5: a slot transitioning from future to active - IS a real change (protection must engage)
+        print("*** Test 5: future to active transition produces different signature ***")
+        future = [[_slot("2025-01-15T10:30:00+00:00", "2025-01-15T11:00:00+00:00", 3.0)]]
+        active = [[_slot("2025-01-15T10:00:00+00:00", "2025-01-15T11:00:00+00:00", 3.0)]]
+        if my_predbat.octopus_slots_signature(future) == my_predbat.octopus_slots_signature(active):
+            print("ERROR: Future to active transition not detected")
+            failed = True
+        else:
+            print("Test 5 passed - future to active transition forces a replan")
+    finally:
+        my_predbat.now_utc = old_now_utc
+
+    if not failed:
+        print("**** All octopus_slots_signature tests PASSED ****")
+    else:
+        print("**** Some octopus_slots_signature tests FAILED ****")
+
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -97,12 +97,14 @@ from tests.test_octopus_rate_limit import test_octopus_rate_limit_wrapper
 from tests.test_octopus_logging import test_octopus_logging_wrapper
 from tests.test_octopus_fetch_previous_dispatch import test_octopus_fetch_previous_dispatch_wrapper
 from tests.test_octopus_intelligent_devices import test_octopus_intelligent_devices_wrapper
+from tests.test_octopus_sensor_due import test_octopus_sensor_due_wrapper
 from tests.test_octopus_day_night_rates import test_octopus_day_night_rates_wrapper
 from tests.test_fetch_octopus_rates import test_fetch_octopus_rates
 from tests.test_fetch_tariffs import test_fetch_tariffs
 from tests.test_fetch_url_cached import test_fetch_url_cached
 from tests.test_load_free_slot import test_load_free_slot
 from tests.test_add_now_to_octopus_slot import test_add_now_to_octopus_slot
+from tests.test_octopus_slots_change import test_octopus_slots_change
 from tests.test_dynamic_load import test_dynamic_load_car_slot_cancellation
 from tests.test_fox_api import run_fox_api_tests
 from tests.test_enphase_api import run_enphase_api_tests
@@ -242,6 +244,7 @@ def main():
         ("octopus_logging", test_octopus_logging_wrapper, "Octopus GraphQL logging redaction tests", False),
         ("octopus_fetch_previous_dispatch", test_octopus_fetch_previous_dispatch_wrapper, "Octopus fetch previous dispatch tests", False),
         ("octopus_intelligent_devices", test_octopus_intelligent_devices_wrapper, "Octopus intelligent devices tests (flexPlannedDispatches, energyAddedKwh)", False),
+        ("octopus_sensor_due", test_octopus_sensor_due_wrapper, "Octopus intelligent sensor 2-minute update scheduling tests", False),
         ("octopus_day_night_rates", test_octopus_day_night_rates_wrapper, "Octopus day/night rate window selection tests (IOG TOU, GO, Economy 7)", False),
         ("download_octopus_rates", test_octopus_download_rates_wrapper, "Test download octopus rates", False),
         ("fetch_octopus_rates", test_fetch_octopus_rates, "Fetch Octopus rates tests", False),
@@ -250,6 +253,7 @@ def main():
         ("fetch_config_options", test_fetch_config_options, "Fetch config options tests", False),
         ("load_free_slot", test_load_free_slot, "Load free slot tests", False),
         ("add_now_to_octopus_slot", test_add_now_to_octopus_slot, "Add now to Octopus slot tests", False),
+        ("octopus_slots_change", test_octopus_slots_change, "Octopus slots change-detection signature tests (in-progress re-clock vs genuine change)", False),
         ("plugin_startup", test_plugin_startup_order, "Plugin startup order tests", False),
         ("active_flag", test_active_flag, "Active flag cleared on exception tests", False),
         ("component_health_status", test_component_health_status, "Component errors fail the recorded run status tests", False),


### PR DESCRIPTION
## Summary

Two related fixes to how Octopus Intelligent dispatch slots reach Predbat's battery-protection path, plus an incidental test fix.

### 1. Intelligent dispatch sensor could starve; slots now refresh every 2 minutes

The `sensor_due` gate in `OctopusAPI.run()` fired on wall-clock minute parity (`count_minutes % 2 == 0`). The component scheduler isn't minute-aligned — it sleeps in 5-second chunks and doesn't account for the time `run()` itself takes — so invocations drift relative to the wall clock. When a run lands only on odd minutes (or a slow run pushes the period past 2 minutes), the parity check never matches and the dispatch sensor **starves indefinitely**.

Fixed by keying the 2-minute cadence off the age of the last update (`self.sensor_updated_at`), matching the existing `tariff_due`/`device_due` gates. The intelligent **dispatch fetch** (`async_update_intelligent_devices`) is also moved onto this 2-minute cadence (it previously sat on the 10-minute `device_due` block), so a new Octopus slot reaches Predbat in ~2 min instead of ~10. The fetch returns immediately for non-IOG tariffs, so there's no extra API load for those users. Saving-session refresh stays on the 10-minute block.

### 2. Force-replan now triggers only on genuine slot changes

An in-progress dispatch has its `start` advanced to *now* and its `charge_in_kwh` scaled to the remaining time on **every** refresh (`async_get_intelligent_devices`, per issue #4114). With the faster 2-minute refresh, the raw-slot comparison in `fetch_sensor_data` would then force a full replan on **every cycle** for the entire duration of an active charging window.

Added `octopus_slots_signature()` — an opaque comparison token that, for a currently-active slot, keeps only the stable fields (window `end`, `source`, `location`) and drops the re-clocked `start`/`charge_in_kwh`. Genuine changes still alter it: new/removed slots, a moved window end, a revised future slot, and a future→active transition (so the battery-hold path still engages on time).

### 3. Incidental: test date-rot

`test_kraken.py::test_fetch_dispatches_populates_device` hard-coded `2026-07-08` dispatch dates that now fall outside the 5-day completed-dispatch prune window and failed on a clean tree. Switched to dates relative to now.

## Testing

- New `octopus_sensor_due` suite: reproduces the odd-minute starvation (fails before the fix) and asserts the 2-minute dispatch-fetch + sensor cadence.
- New `octopus_slots_change` suite: 5 cases covering re-clock (no replan) vs new slot / moved end / revised future slot / future→active (replan).
- Updated `octopus_misc` run-scheduling tests for the new cadence.
- Full quick suite passes; all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)