### PR TITLE
fix(car-charging): hold battery discharge during car charging regardless of car_energy_reported_load (#4246)

### DIFF
--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -432,9 +432,11 @@ class Execute:
 
                 status_freeze_export = " [Freeze exporting]"
 
-            # Car charging from battery disable?
+            # Car charging from battery disable? Applies regardless of car_energy_reported_load - that
+            # switch only controls CT-clamp load-history/export accounting, not whether the battery is
+            # physically able to serve the car (it shares the same busbar either way).
             carHolding = False
-            if self.set_charge_window and not self.car_charging_from_battery and self.car_energy_reported_load:
+            if self.set_charge_window and not self.car_charging_from_battery:
                 for car_n in range(self.num_cars):
                     if self.car_charging_slots[car_n]:
                         window = self.car_charging_slots[car_n][0]

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -433,8 +433,8 @@ class Execute:
                 status_freeze_export = " [Freeze exporting]"
 
             # Car charging from battery disable? Applies regardless of car_energy_reported_load - that
-            # switch only controls CT-clamp load-history/export accounting, not whether the battery is
-            # physically able to serve the car (it shares the same busbar either way).
+            # switch only controls whether EV energy is included in the CT-clamp house-load model, not
+            # whether we enforce the discharge hold.
             carHolding = False
             if self.set_charge_window and not self.car_charging_from_battery:
                 for car_n in range(self.num_cars):

--- a/apps/predbat/prediction.py
+++ b/apps/predbat/prediction.py
@@ -720,7 +720,7 @@ class Prediction:
                             car_load_energy_bypass += car_load_scale / self.car_charging_loss
 
                         # Model not allowing the car to charge from the battery - applies regardless of
-                        # car_energy_reported_load, as the battery shares the same busbar either way
+                        # car_energy_reported_load, which only controls CT-clamp house-load inclusion
                         if (car_load_scale > 0) and (not self.car_charging_from_battery) and set_charge_window:
                             discharge_rate_now = battery_rate_min  # 0
 

--- a/apps/predbat/prediction.py
+++ b/apps/predbat/prediction.py
@@ -716,11 +716,13 @@ class Prediction:
                             # Only add load if the car is reporting it as load, otherwise its outside the CT Clamp
                             car_amount_premium += car_load_scale / self.car_charging_loss
                             load_yesterday += car_amount_premium
-                            # Model not allowing the car to charge from the battery
-                            if (car_load_scale > 0) and (not self.car_charging_from_battery) and set_charge_window:
-                                discharge_rate_now = battery_rate_min  # 0
                         else:
                             car_load_energy_bypass += car_load_scale / self.car_charging_loss
+
+                        # Model not allowing the car to charge from the battery - applies regardless of
+                        # car_energy_reported_load, as the battery shares the same busbar either way
+                        if (car_load_scale > 0) and (not self.car_charging_from_battery) and set_charge_window:
+                            discharge_rate_now = battery_rate_min  # 0
 
             # Iboost
             iboost_rate_okay = True

--- a/apps/predbat/prediction_kernel.cpp
+++ b/apps/predbat/prediction_kernel.cpp
@@ -503,12 +503,14 @@ int32_t pk_run(int64_t handle, const PkScenario *s, PkResult *out)
                         // Note: mirrors the Python engine exactly - the cumulative premium amount is added per car
                         car_amount_premium += car_load_scale / c->car_charging_loss;
                         load_yesterday += car_amount_premium;
-                        // Model not allowing the car to charge from the battery
-                        if ((car_load_scale > 0) && (!c->car_charging_from_battery) && c->set_charge_window) {
-                            discharge_rate_now = battery_rate_min; // 0
-                        }
                     } else {
                         car_load_energy_bypass += car_load_scale / c->car_charging_loss;
+                    }
+
+                    // Model not allowing the car to charge from the battery - applies regardless of
+                    // car_energy_reported_load, as the battery shares the same busbar either way
+                    if ((car_load_scale > 0) && (!c->car_charging_from_battery) && c->set_charge_window) {
+                        discharge_rate_now = battery_rate_min; // 0
                     }
                 }
             }

--- a/apps/predbat/prediction_kernel.cpp
+++ b/apps/predbat/prediction_kernel.cpp
@@ -508,7 +508,7 @@ int32_t pk_run(int64_t handle, const PkScenario *s, PkResult *out)
                     }
 
                     // Model not allowing the car to charge from the battery - applies regardless of
-                    // car_energy_reported_load, as the battery shares the same busbar either way
+                    // car_energy_reported_load, which only controls CT-clamp house-load inclusion
                     if ((car_load_scale > 0) && (!c->car_charging_from_battery) && c->set_charge_window) {
                         discharge_rate_now = battery_rate_min; // 0
                     }

--- a/apps/predbat/tests/test_execute.py
+++ b/apps/predbat/tests/test_execute.py
@@ -2170,6 +2170,25 @@ def run_execute_tests(my_predbat):
     if failed:
         return failed
 
+    # Battery and car share a busbar upstream of the CT clamp (car_energy_reported_load=False is a
+    # monitoring blind spot, not electrical isolation), so discharge must still be held here exactly
+    # as it is for the reported_load=True case above (no_discharge_car_demand1) - see issue #4246.
+    failed |= run_execute_test(
+        my_predbat,
+        "no_discharge_car_demand1c_shared_busbar",
+        set_charge_window=True,
+        set_export_window=True,
+        soc_kw=100,
+        assert_status="Hold for car",
+        assert_pause_discharge=True,
+        car_slot=charge_window_best_slot,
+        assert_immediate_soc_target=100,
+        car_charging_from_battery=False,
+        car_energy_reported_load=False,
+    )
+    if failed:
+        return failed
+
     failed |= run_execute_test(
         my_predbat,
         "no_discharge_car_demand2",

--- a/apps/predbat/tests/test_execute.py
+++ b/apps/predbat/tests/test_execute.py
@@ -2154,28 +2154,11 @@ def run_execute_tests(my_predbat):
     if failed:
         return failed
 
+    # Discharge-hold applies regardless of car_energy_reported_load - that switch only controls
+    # CT-clamp load-history/export accounting, not whether the battery can physically serve the car.
     failed |= run_execute_test(
         my_predbat,
         "no_discharge_car_demand1b",
-        set_charge_window=True,
-        set_export_window=True,
-        soc_kw=100,
-        assert_status="Demand",
-        assert_pause_discharge=False,
-        car_slot=charge_window_best_slot,
-        assert_immediate_soc_target=100,
-        car_charging_from_battery=False,
-        car_energy_reported_load=False,
-    )
-    if failed:
-        return failed
-
-    # Battery and car share a busbar upstream of the CT clamp (car_energy_reported_load=False is a
-    # monitoring blind spot, not electrical isolation), so discharge must still be held here exactly
-    # as it is for the reported_load=True case above (no_discharge_car_demand1) - see issue #4246.
-    failed |= run_execute_test(
-        my_predbat,
-        "no_discharge_car_demand1c_shared_busbar",
         set_charge_window=True,
         set_export_window=True,
         soc_kw=100,

--- a/apps/predbat/tests/test_execute.py
+++ b/apps/predbat/tests/test_execute.py
@@ -2154,8 +2154,8 @@ def run_execute_tests(my_predbat):
     if failed:
         return failed
 
-    # Discharge-hold applies regardless of car_energy_reported_load - that switch only controls
-    # CT-clamp load-history/export accounting, not whether the battery can physically serve the car.
+    # Discharge-hold applies regardless of car_energy_reported_load; that switch controls whether EV
+    # energy is included in the CT-clamp house-load model, not whether we enforce the discharge hold.
     failed |= run_execute_test(
         my_predbat,
         "no_discharge_car_demand1b",


### PR DESCRIPTION
> 🤖 Drafted with Claude Code assistance.

Fixes #4246. Contains two commits: a regression test that reproduces the bug against `main`, followed by a fix.

## The fix

Removes the `and self.car_energy_reported_load` condition from the discharge-hold gate in `execute.py` and `prediction.py` (with the matching change mirrored in `prediction_kernel.cpp` to keep C++/Python parity), so `car_charging_from_battery = Off` always holds discharge during car-charging windows, regardless of CT-clamp visibility.

This is **"option 1"** from the fix options discussed in #4246 - the simplest of a few possible approaches, chosen because:
- `car_energy_reported_load` only ever gated CT-clamp *load-history/export-accounting* logic elsewhere in the codebase (confirmed by auditing every remaining use) - conditioning the *discharge-hold* decision on it as well looks like a category error rather than intentional design, since that switch says nothing about whether the battery can physically reach the car.
- Charging and discharge-holding are controlled by independent code paths (`adjust_charge_window`/charge-rate vs. `adjust_pause_mode`/discharge-rate), so this doesn't risk interfering with a legitimate "charge now, rate is cheap" decision - verified both by code inspection and the included regression test.

It is **not** the only way to close this gap - #4246 also discusses:
- **Option 2**: an opt-in switch, defaulting Off, for shared-busbar topologies specifically - preserves current behaviour for any (largely theoretical) genuinely-isolated-circuit population, at the cost of more config surface.
- **Option 3**: a proper cost comparison (round-trip battery cost vs. import rate) instead of an unconditional hold - the more "correct" long-term answer, but meaningfully larger in scope (also touches the compiled kernel's cost model, not just this one gate) and out of scope for this PR.

Went with option 1 here as the smallest, most surgical change that fixes the reported behaviour; happy to rework this PR toward option 2 or 3 instead if a maintainer prefers a different tradeoff.

## Verification

- New/updated regression test (`no_discharge_car_demand1b` in `test_execute.py`) passes against the fix, fails against `main`.
- Full local suite (`unit_test.py`, no `--quick`) passes, including `kernel_parity` and `model_kernel` (C++/Python engines stay in sync).
- `run_pre_commit` passes cleanly (ruff, black, cspell, etc.).
