### PR TITLE
EnphaseCloud: activate CFG/DTG/RBD modes after schedule write to fix stuck pending schedules

### DIFF
--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -751,6 +751,21 @@ class EnphaseAPI(ComponentBase):
                 await self.get_schedules(site_id)
         return result is not None
 
+    async def _set_charge_from_grid(self, site_id, **extra_body):
+        """PUT batterySettings chargeFromGrid:True and cache the result on success.
+
+        Accepts optional extra body keys (e.g. acceptedItcDisclaimer). Returns True if
+        the API call succeeded, False otherwise.
+        """
+        params = {"source": "enho"}
+        if self.user_id:
+            params["userId"] = self.user_id
+        body = {"chargeFromGrid": True, **extra_body}
+        result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body)
+        if result is not None:
+            self.battery_settings.setdefault(site_id, {})["chargeFromGrid"] = True
+        return result is not None
+
     async def _activate_cfg_mode(self, site_id):
         """Activate charge-from-grid mode after writing the CFG schedule.
 
@@ -759,21 +774,40 @@ class EnphaseAPI(ComponentBase):
         is required to transition it to "active" so the Enphase gateway
         picks it up and starts charging.
         """
+        now_iso = datetime.now(timezone.utc).isoformat()
+        await self._set_charge_from_grid(site_id, acceptedItcDisclaimer=now_iso)
+
+    async def _activate_dtg_mode(self, site_id):
+        """Activate discharge-to-grid mode after writing the DTG schedule.
+
+        The DTG schedule write puts the schedule into "pending" status;
+        a subsequent batterySettings PUT with dtgControl.enabled is
+        required to transition it to "active" so the Enphase gateway
+        picks it up.
+        """
         params = {"source": "enho"}
         if self.user_id:
             params["userId"] = self.user_id
-        now_iso = datetime.now().isoformat()
-        await self.request_json(
-            "PUT",
-            f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}",
-            family="battery_config",
-            params=params,
-            json_body={
-                "chargeFromGrid": True,
-                "acceptedItcDisclaimer": now_iso,
-            },
-        )
-        self.battery_settings.setdefault(site_id, {})["chargeFromGrid"] = True
+        body = {"dtgControl": {"enabled": True}}
+        result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body)
+        if result is not None:
+            self.battery_settings.setdefault(site_id, {}).setdefault("dtgControl", {})["enabled"] = True
+
+    async def _activate_rbd_mode(self, site_id):
+        """Activate restrict-battery-discharge mode after writing the RBD schedule.
+
+        The RBD schedule write puts the schedule into "pending" status;
+        a subsequent batterySettings PUT with rbdControl.enabled is
+        required to transition it to "active" so the Enphase gateway
+        picks it up.
+        """
+        params = {"source": "enho"}
+        if self.user_id:
+            params["userId"] = self.user_id
+        body = {"rbdControl": {"enabled": True}}
+        result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body)
+        if result is not None:
+            self.battery_settings.setdefault(site_id, {}).setdefault("rbdControl", {})["enabled"] = True
 
     async def _ensure_charge_from_grid(self, site_id):
         """Enable the charge-from-grid setting, accepting the one-time ITC disclaimer first."""
@@ -781,8 +815,7 @@ class EnphaseAPI(ComponentBase):
             return
         self.log(f"Enphase: Enabling charge-from-grid on site {site_id}")
         await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/batterySettings/acceptDisclaimer/{site_id}", family="battery_config", json_body={"disclaimer-type": "itc"})
-        await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", json_body={"chargeFromGrid": True})
-        self.battery_settings.setdefault(site_id, {})["chargeFromGrid"] = True
+        await self._set_charge_from_grid(site_id)
 
     async def set_reserve(self, site_id, reserve):
         """Write the battery backup reserve (batteryBackupPercentage) via a profile PUT.
@@ -869,10 +902,16 @@ class EnphaseAPI(ComponentBase):
         dtg_limit = max(export_soc, int(local.get("reserve", 0)))
 
         # Forced export to a target (DTG). A configured inverter always supports DTG.
-        wrote |= await self._write_schedule(site_id, SCHEDULE_EXPORT, export_start, export_end, dtg_limit, real_export)
+        wrote_dtg = await self._write_schedule(site_id, SCHEDULE_EXPORT, export_start, export_end, dtg_limit, real_export)
+        if wrote_dtg and real_export:
+            await self._activate_dtg_mode(site_id)
+        wrote |= wrote_dtg
 
         # Freeze export = restrict battery discharge (RBD) over the export window
-        wrote |= await self._write_schedule(site_id, SCHEDULE_FREEZE, export_start, export_end, None, freeze_export)
+        wrote_rbd = await self._write_schedule(site_id, SCHEDULE_FREEZE, export_start, export_end, None, freeze_export)
+        if wrote_rbd and freeze_export:
+            await self._activate_rbd_mode(site_id)
+        wrote |= wrote_rbd
         return wrote
 
     async def get_battery_status(self, site_id):

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -858,6 +858,9 @@ class EnphaseAPI(ComponentBase):
         result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body)
         if result is not None:
             self.battery_settings.setdefault(site_id, {}).setdefault("rbdControl", {})["enabled"] = True
+            entry = self.schedules.get(site_id, {}).get(family.lower())
+            if isinstance(entry, dict):
+                entry.pop("status", None)
         else:
             self.log(f"Warn: Enphase: RBD activation failed for site {site_id}")
             self._invalidate_cached_schedule(site_id, family)

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -766,7 +766,19 @@ class EnphaseAPI(ComponentBase):
             self.battery_settings.setdefault(site_id, {})["chargeFromGrid"] = True
         return result is not None
 
-    async def _activate_cfg_mode(self, site_id):
+    def _invalidate_cached_schedule(self, site_id, family):
+        """Clear the cached cloud schedule so the next apply detects a diff and retries.
+
+        Removes startTime from the cached entry (but keeps the id) so that
+        schedules_equal returns False and _write_schedule will PUT the update
+        again (instead of creating a duplicate schedule).
+        """
+        family_key = family.lower()
+        entry = self.schedules.get(site_id, {}).get(family_key)
+        if isinstance(entry, dict):
+            entry.pop("startTime", None)
+
+    async def _activate_cfg_mode(self, site_id, family=SCHEDULE_CHARGE):
         """Activate charge-from-grid mode after writing the CFG schedule.
 
         The CFG schedule write puts the schedule into "pending" status;
@@ -774,21 +786,28 @@ class EnphaseAPI(ComponentBase):
         is required to transition it to "active" so the Enphase gateway
         picks it up and starts charging.
 
+        On failure, clears the cached schedule startTime so the next
+        apply re-detects a diff and retries write + activation.
+
         Returns True if the activation call succeeded.
         """
         now_iso = datetime.now(timezone.utc).isoformat()
         ok = await self._set_charge_from_grid(site_id, acceptedItcDisclaimer=now_iso)
         if not ok:
             self.log(f"Warn: Enphase: CFG activation failed for site {site_id}")
+            self._invalidate_cached_schedule(site_id, family)
         return ok
 
-    async def _activate_dtg_mode(self, site_id):
+    async def _activate_dtg_mode(self, site_id, family=SCHEDULE_EXPORT):
         """Activate discharge-to-grid mode after writing the DTG schedule.
 
         The DTG schedule write puts the schedule into "pending" status;
         a subsequent batterySettings PUT with dtgControl.enabled is
         required to transition it to "active" so the Enphase gateway
         picks it up.
+
+        On failure, clears the cached schedule startTime so the next
+        apply re-detects a diff and retries write + activation.
 
         Returns True if the activation call succeeded.
         """
@@ -801,15 +820,19 @@ class EnphaseAPI(ComponentBase):
             self.battery_settings.setdefault(site_id, {}).setdefault("dtgControl", {})["enabled"] = True
         else:
             self.log(f"Warn: Enphase: DTG activation failed for site {site_id}")
+            self._invalidate_cached_schedule(site_id, family)
         return result is not None
 
-    async def _activate_rbd_mode(self, site_id):
+    async def _activate_rbd_mode(self, site_id, family=SCHEDULE_FREEZE):
         """Activate restrict-battery-discharge mode after writing the RBD schedule.
 
         The RBD schedule write puts the schedule into "pending" status;
         a subsequent batterySettings PUT with rbdControl.enabled is
         required to transition it to "active" so the Enphase gateway
         picks it up.
+
+        On failure, clears the cached schedule startTime so the next
+        apply re-detects a diff and retries write + activation.
 
         Returns True if the activation call succeeded.
         """
@@ -822,6 +845,7 @@ class EnphaseAPI(ComponentBase):
             self.battery_settings.setdefault(site_id, {}).setdefault("rbdControl", {})["enabled"] = True
         else:
             self.log(f"Warn: Enphase: RBD activation failed for site {site_id}")
+            self._invalidate_cached_schedule(site_id, family)
         return result is not None
 
     async def _ensure_charge_from_grid(self, site_id):

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -751,6 +751,30 @@ class EnphaseAPI(ComponentBase):
                 await self.get_schedules(site_id)
         return result is not None
 
+    async def _activate_cfg_mode(self, site_id):
+        """Activate charge-from-grid mode after writing the CFG schedule.
+
+        The CFG schedule write puts the schedule into "pending" status;
+        a subsequent batterySettings PUT with acceptedItcDisclaimer
+        is required to transition it to "active" so the Enphase gateway
+        picks it up and starts charging.
+        """
+        params = {"source": "enho"}
+        if self.user_id:
+            params["userId"] = self.user_id
+        now_iso = datetime.now().isoformat()
+        await self.request_json(
+            "PUT",
+            f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}",
+            family="battery_config",
+            params=params,
+            json_body={
+                "chargeFromGrid": True,
+                "acceptedItcDisclaimer": now_iso,
+            },
+        )
+        self.battery_settings.setdefault(site_id, {})["chargeFromGrid"] = True
+
     async def _ensure_charge_from_grid(self, site_id):
         """Enable the charge-from-grid setting, accepting the one-time ITC disclaimer first."""
         if self.battery_settings.get(site_id, {}).get("chargeFromGrid"):
@@ -822,7 +846,10 @@ class EnphaseAPI(ComponentBase):
         charge = local.get("charge", {})
         if charge.get("enable"):
             await self._ensure_charge_from_grid(site_id)
-        wrote |= await self._write_schedule(site_id, SCHEDULE_CHARGE, charge.get("start_time", "00:00:00"), charge.get("end_time", "00:00:00"), charge.get("soc", 100), charge.get("enable", False))
+        wrote_cfg = await self._write_schedule(site_id, SCHEDULE_CHARGE, charge.get("start_time", "00:00:00"), charge.get("end_time", "00:00:00"), charge.get("soc", 100), charge.get("enable", False))
+        if wrote_cfg and charge.get("enable"):
+            await self._activate_cfg_mode(site_id)
+        wrote |= wrote_cfg
 
         # Export window. Predbat encodes the mode in the export/discharge target SOC:
         #   < 99  -> real forced export to that floor (DTG)

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -769,14 +769,15 @@ class EnphaseAPI(ComponentBase):
     def _invalidate_cached_schedule(self, site_id, family):
         """Clear the cached cloud schedule so the next apply detects a diff and retries.
 
-        Removes startTime from the cached entry (but keeps the id) so that
-        schedules_equal returns False and _write_schedule will PUT the update
-        again (instead of creating a duplicate schedule).
+        Sets startTime to an empty string (rather than removing the key) so that
+        schedules_equal always returns False regardless of the desired enabled state.
+        Removing the key would cause schedules_equal to return ``not enabled``, which
+        incorrectly no-ops a disable request after an activation failure.
         """
         family_key = family.lower()
         entry = self.schedules.get(site_id, {}).get(family_key)
         if isinstance(entry, dict):
-            entry.pop("startTime", None)
+            entry["startTime"] = ""
 
     async def _activate_cfg_mode(self, site_id, family=SCHEDULE_CHARGE):
         """Activate charge-from-grid mode after writing the CFG schedule.

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -751,6 +751,12 @@ class EnphaseAPI(ComponentBase):
                 await self.get_schedules(site_id)
         return result is not None
 
+    def _is_schedule_pending(self, site_id, family):
+        """Return True when the cached cloud schedule exists but is stuck in pending status."""
+        family_key = family.lower()
+        entry = self.schedules.get(site_id, {}).get(family_key, {})
+        return isinstance(entry, dict) and entry.get("status", "").lower() == "pending"
+
     async def _set_charge_from_grid(self, site_id, params=None, **extra_body):
         """PUT batterySettings chargeFromGrid:True and cache the result on success.
 
@@ -924,8 +930,13 @@ class EnphaseAPI(ComponentBase):
         if charge.get("enable"):
             await self._ensure_charge_from_grid(site_id)
         wrote_cfg = await self._write_schedule(site_id, SCHEDULE_CHARGE, charge.get("start_time", "00:00:00"), charge.get("end_time", "00:00:00"), charge.get("soc", 100), charge.get("enable", False))
-        if wrote_cfg and charge.get("enable"):
-            await self._activate_cfg_mode(site_id)
+        if charge.get("enable"):
+            if wrote_cfg:
+                await self._activate_cfg_mode(site_id)
+            elif self._is_schedule_pending(site_id, SCHEDULE_CHARGE):
+                # Schedule matches but is stuck pending — activate without rewriting
+                self.log(f"Enphase: CFG schedule for site {site_id} is pending; activating without rewrite")
+                await self._activate_cfg_mode(site_id)
         wrote |= wrote_cfg
 
         # Export window. Predbat encodes the mode in the export/discharge target SOC:
@@ -947,14 +958,22 @@ class EnphaseAPI(ComponentBase):
 
         # Forced export to a target (DTG). A configured inverter always supports DTG.
         wrote_dtg = await self._write_schedule(site_id, SCHEDULE_EXPORT, export_start, export_end, dtg_limit, real_export)
-        if wrote_dtg and real_export:
-            await self._activate_dtg_mode(site_id)
+        if real_export:
+            if wrote_dtg:
+                await self._activate_dtg_mode(site_id)
+            elif self._is_schedule_pending(site_id, SCHEDULE_EXPORT):
+                self.log(f"Enphase: DTG schedule for site {site_id} is pending; activating without rewrite")
+                await self._activate_dtg_mode(site_id)
         wrote |= wrote_dtg
 
         # Freeze export = restrict battery discharge (RBD) over the export window
         wrote_rbd = await self._write_schedule(site_id, SCHEDULE_FREEZE, export_start, export_end, None, freeze_export)
-        if wrote_rbd and freeze_export:
-            await self._activate_rbd_mode(site_id)
+        if freeze_export:
+            if wrote_rbd:
+                await self._activate_rbd_mode(site_id)
+            elif self._is_schedule_pending(site_id, SCHEDULE_FREEZE):
+                self.log(f"Enphase: RBD schedule for site {site_id} is pending; activating without rewrite")
+                await self._activate_rbd_mode(site_id)
         wrote |= wrote_rbd
         return wrote
 

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -751,16 +751,15 @@ class EnphaseAPI(ComponentBase):
                 await self.get_schedules(site_id)
         return result is not None
 
-    async def _set_charge_from_grid(self, site_id, **extra_body):
+    async def _set_charge_from_grid(self, site_id, params=None, **extra_body):
         """PUT batterySettings chargeFromGrid:True and cache the result on success.
 
-        Accepts optional extra body keys (e.g. acceptedItcDisclaimer). Returns True if
-        the API call succeeded, False otherwise.
+        Accepts optional extra body keys (e.g. acceptedItcDisclaimer) and optional
+        query params (e.g. source/userId for activation). chargeFromGrid is always
+        forced to True regardless of extra_body. Returns True if the API call succeeded.
         """
-        params = {"source": "enho"}
-        if self.user_id:
-            params["userId"] = self.user_id
-        body = {"chargeFromGrid": True, **extra_body}
+        body = dict(extra_body)
+        body["chargeFromGrid"] = True
         result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body)
         if result is not None:
             self.battery_settings.setdefault(site_id, {})["chargeFromGrid"] = True
@@ -770,9 +769,11 @@ class EnphaseAPI(ComponentBase):
         """Clear the cached cloud schedule so the next apply detects a diff and retries.
 
         Sets startTime to an empty string (rather than removing the key) so that
-        schedules_equal always returns False regardless of the desired enabled state.
-        Removing the key would cause schedules_equal to return ``not enabled``, which
-        incorrectly no-ops a disable request after an activation failure.
+        schedules_equal returns ``not enabled`` (False when enabled=True), causing
+        _write_schedule to re-issue the update on the next apply. Removing the key
+        would also return ``not enabled``, which incorrectly no-ops a disable
+        request after an activation failure (False for enabled=False means True —
+        equal, so no write is issued).
         """
         family_key = family.lower()
         entry = self.schedules.get(site_id, {}).get(family_key)
@@ -793,7 +794,10 @@ class EnphaseAPI(ComponentBase):
         Returns True if the activation call succeeded.
         """
         now_iso = datetime.now(timezone.utc).isoformat()
-        ok = await self._set_charge_from_grid(site_id, acceptedItcDisclaimer=now_iso)
+        params = {"source": "enho"}
+        if self.user_id:
+            params["userId"] = self.user_id
+        ok = await self._set_charge_from_grid(site_id, params=params, acceptedItcDisclaimer=now_iso)
         if not ok:
             self.log(f"Warn: Enphase: CFG activation failed for site {site_id}")
             self._invalidate_cached_schedule(site_id, family)

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -804,7 +804,11 @@ class EnphaseAPI(ComponentBase):
         if self.user_id:
             params["userId"] = self.user_id
         ok = await self._set_charge_from_grid(site_id, params=params, acceptedItcDisclaimer=now_iso)
-        if not ok:
+        if ok:
+            entry = self.schedules.get(site_id, {}).get(family.lower())
+            if isinstance(entry, dict):
+                entry.pop("status", None)
+        else:
             self.log(f"Warn: Enphase: CFG activation failed for site {site_id}")
             self._invalidate_cached_schedule(site_id, family)
         return ok

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -773,9 +773,14 @@ class EnphaseAPI(ComponentBase):
         a subsequent batterySettings PUT with acceptedItcDisclaimer
         is required to transition it to "active" so the Enphase gateway
         picks it up and starts charging.
+
+        Returns True if the activation call succeeded.
         """
         now_iso = datetime.now(timezone.utc).isoformat()
-        await self._set_charge_from_grid(site_id, acceptedItcDisclaimer=now_iso)
+        ok = await self._set_charge_from_grid(site_id, acceptedItcDisclaimer=now_iso)
+        if not ok:
+            self.log(f"Warn: Enphase: CFG activation failed for site {site_id}")
+        return ok
 
     async def _activate_dtg_mode(self, site_id):
         """Activate discharge-to-grid mode after writing the DTG schedule.
@@ -784,6 +789,8 @@ class EnphaseAPI(ComponentBase):
         a subsequent batterySettings PUT with dtgControl.enabled is
         required to transition it to "active" so the Enphase gateway
         picks it up.
+
+        Returns True if the activation call succeeded.
         """
         params = {"source": "enho"}
         if self.user_id:
@@ -792,6 +799,9 @@ class EnphaseAPI(ComponentBase):
         result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body)
         if result is not None:
             self.battery_settings.setdefault(site_id, {}).setdefault("dtgControl", {})["enabled"] = True
+        else:
+            self.log(f"Warn: Enphase: DTG activation failed for site {site_id}")
+        return result is not None
 
     async def _activate_rbd_mode(self, site_id):
         """Activate restrict-battery-discharge mode after writing the RBD schedule.
@@ -800,6 +810,8 @@ class EnphaseAPI(ComponentBase):
         a subsequent batterySettings PUT with rbdControl.enabled is
         required to transition it to "active" so the Enphase gateway
         picks it up.
+
+        Returns True if the activation call succeeded.
         """
         params = {"source": "enho"}
         if self.user_id:
@@ -808,6 +820,9 @@ class EnphaseAPI(ComponentBase):
         result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body)
         if result is not None:
             self.battery_settings.setdefault(site_id, {}).setdefault("rbdControl", {})["enabled"] = True
+        else:
+            self.log(f"Warn: Enphase: RBD activation failed for site {site_id}")
+        return result is not None
 
     async def _ensure_charge_from_grid(self, site_id):
         """Enable the charge-from-grid setting, accepting the one-time ITC disclaimer first."""

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -1150,6 +1150,89 @@ def test_apply_no_change_no_write():
     assert writes == []
 
 
+def test_activate_cfg_mode():
+    """_activate_cfg_mode PUTs batterySettings with acceptedItcDisclaimer to transition CFG from pending to active."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.battery_settings.clear()
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    run_async(api._activate_cfg_mode("12345"))
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
+    assert len(puts) == 1
+    body = puts[0]["json"]
+    assert body["chargeFromGrid"] is True
+    assert "acceptedItcDisclaimer" in body
+    # Timestamp must be a current ISO-8601 string (e.g. "2026-07-14T20:25:00")
+    from datetime import datetime as dt
+
+    parsed = dt.fromisoformat(body["acceptedItcDisclaimer"])
+    assert parsed.year >= 2025  # not a stale date
+    # Cached battery settings updated optimistically on success
+    assert api.battery_settings["12345"]["chargeFromGrid"] is True
+
+
+def test_apply_activates_cfg_after_write():
+    """apply_battery_schedule activates CFG mode after a schedule write when charge is enabled."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    api.schedules["12345"] = {"cfg": {"supported": True}, "dtg": {"supported": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": False, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}}
+    # _ensure_charge_from_grid paths
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/12345", 200, {})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    # _write_schedule (POST) path
+    api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    run_async(api.apply_battery_schedule("12345"))
+    # CFG schedule was created (POST to schedules)
+    posts = [r for r in api.request_log if r["method"] == "POST" and r["path"].endswith("/schedules")]
+    assert len(posts) == 1
+    # Activation was called: PUT batterySettings/12345 with acceptedItcDisclaimer
+    # The base _ensure_charge_from_grid also PUTs to this path once, so expect 2 PUTs total
+    # (one from activation, one from _ensure_charge_from_grid).
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
+    # At least one PUT has acceptedItcDisclaimer (the activation call)
+    activation_puts = [p for p in puts if p.get("json", {}).get("acceptedItcDisclaimer")]
+    assert len(activation_puts) == 1
+    assert activation_puts[0]["json"]["chargeFromGrid"] is True
+
+
+def test_apply_no_activate_cfg_when_charge_disabled():
+    """_activate_cfg_mode is NOT called when the charge window is disabled."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    api.schedules["12345"] = {"cfg": {"supported": True}, "dtg": {"supported": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 100, "enable": False}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}}
+    # Only the CFG write (no cloud cfg exists, so it will POST to schedules).
+    # charge is disabled, so no activation call.
+    api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    run_async(api.apply_battery_schedule("12345"))
+    # No PUTs to batterySettings (no _ensure_charge_from_grid, no _activate_cfg_mode)
+    puts = [r for r in api.request_log if r["method"] == "PUT" and "batterySettings" in r["path"]]
+    assert puts == []
+
+
+def test_apply_no_activate_cfg_when_unchanged():
+    """_activate_cfg_mode is NOT called when the CFG schedule already matches (no-op write)."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    # Cloud CFG already matches the local desired state
+    api.schedules["12345"] = {"cfg": {"supported": True, "id": "u1", "startTime": "02:00", "endTime": "05:00", "limit": 90, "enabled": True}, "dtg": {"supported": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}}
+    run_async(api.apply_battery_schedule("12345"))
+    # No writes at all (schedules_match -> False, _ensure_charge_from_grid already done)
+    writes = [r for r in api.request_log if r["method"] in ("POST", "PUT")]
+    assert writes == []
+
+
 def run_enphase_api_tests(my_predbat):
     """Run all Enphase API tests, returning 0 on success."""
     test_initialize_defaults()
@@ -1211,5 +1294,9 @@ def run_enphase_api_tests(my_predbat):
     test_apply_caches_write_no_rewrite()
     test_set_reserve_caches_written_value()
     test_apply_no_change_no_write()
+    test_activate_cfg_mode()
+    test_apply_activates_cfg_after_write()
+    test_apply_no_activate_cfg_when_charge_disabled()
+    test_apply_no_activate_cfg_when_unchanged()
     print("**** Enphase API tests passed ****")
     return 0

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -1409,7 +1409,7 @@ def test_activate_cfg_mode_invalidates_cache_on_failure():
     assert ok is False
     # Cached startTime must be cleared so schedules_equal detects a diff next time
     cached = api.schedules["12345"]["cfg"]
-    assert "startTime" not in cached
+    assert cached["startTime"] == ""
     assert "id" in cached  # id preserved for PUT update
 
 
@@ -1423,7 +1423,7 @@ def test_activate_dtg_mode_invalidates_cache_on_failure():
     ok = run_async(api._activate_dtg_mode("12345"))
     assert ok is False
     cached = api.schedules["12345"]["dtg"]
-    assert "startTime" not in cached
+    assert cached["startTime"] == ""
     assert "id" in cached
 
 
@@ -1437,7 +1437,7 @@ def test_activate_rbd_mode_invalidates_cache_on_failure():
     ok = run_async(api._activate_rbd_mode("12345"))
     assert ok is False
     cached = api.schedules["12345"]["rbd"]
-    assert "startTime" not in cached
+    assert cached["startTime"] == ""
     assert "id" in cached
 
 

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -1441,6 +1441,26 @@ def test_activate_rbd_mode_invalidates_cache_on_failure():
     assert "id" in cached
 
 
+def test_apply_activates_pending_schedule_without_rewrite():
+    """When a schedule matches but status is pending, activation is called without re-writing."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    # Cloud CFG already matches desired state BUT status is pending
+    api.schedules["12345"] = {"cfg": {"supported": True, "id": "u1", "startTime": "02:00", "endTime": "05:00", "limit": 90, "enabled": True, "status": "pending"}, "dtg": {"supported": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}}
+    # Activation PUT succeeds
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    run_async(api.apply_battery_schedule("12345"))
+    # No schedule write (schedules equal) but activation was called
+    writes = [r for r in api.request_log if r["method"] in ("POST", "PUT") and "schedules" in r["path"]]
+    assert writes == []
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
+    assert len(puts) == 1  # activation PUT, not the _ensure_charge_from_grid one
+
+
 def run_enphase_api_tests(my_predbat):
     """Run all Enphase API tests, returning 0 on success."""
     test_initialize_defaults()
@@ -1516,5 +1536,6 @@ def run_enphase_api_tests(my_predbat):
     test_activate_cfg_mode_invalidates_cache_on_failure()
     test_activate_dtg_mode_invalidates_cache_on_failure()
     test_activate_rbd_mode_invalidates_cache_on_failure()
+    test_apply_activates_pending_schedule_without_rewrite()
     print("**** Enphase API tests passed ****")
     return 0

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -1162,11 +1162,12 @@ def test_activate_cfg_mode():
     body = puts[0]["json"]
     assert body["chargeFromGrid"] is True
     assert "acceptedItcDisclaimer" in body
-    # Timestamp must be a current ISO-8601 string (e.g. "2026-07-14T20:25:00")
-    from datetime import datetime as dt
+    # Timestamp must be a recent UTC ISO-8601 string (e.g. "2026-07-14T20:25:00+00:00")
+    from datetime import datetime as dt, timezone as tz
 
     parsed = dt.fromisoformat(body["acceptedItcDisclaimer"])
-    assert parsed.year >= 2025  # not a stale date
+    age = (dt.now(tz.utc) - parsed).total_seconds()
+    assert 0 <= age <= 60, f"acceptedItcDisclaimer age {age}s outside [0, 60] — stale timestamp"
     # Cached battery settings updated optimistically on success
     assert api.battery_settings["12345"]["chargeFromGrid"] is True
 
@@ -1229,6 +1230,158 @@ def test_apply_no_activate_cfg_when_unchanged():
     api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}}
     run_async(api.apply_battery_schedule("12345"))
     # No writes at all (schedules_match -> False, _ensure_charge_from_grid already done)
+    writes = [r for r in api.request_log if r["method"] in ("POST", "PUT")]
+    assert writes == []
+
+
+def test_activate_dtg_mode():
+    """_activate_dtg_mode PUTs batterySettings with dtgControl.enabled to transition DTG from pending to active."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.battery_settings.clear()
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    run_async(api._activate_dtg_mode("12345"))
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
+    assert len(puts) == 1
+    body = puts[0]["json"]
+    assert body == {"dtgControl": {"enabled": True}}
+    # Cached battery settings updated on success
+    assert api.battery_settings["12345"]["dtgControl"]["enabled"] is True
+
+
+def test_activate_rbd_mode():
+    """_activate_rbd_mode PUTs batterySettings with rbdControl.enabled to transition RBD from pending to active."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.battery_settings.clear()
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    run_async(api._activate_rbd_mode("12345"))
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
+    assert len(puts) == 1
+    body = puts[0]["json"]
+    assert body == {"rbdControl": {"enabled": True}}
+    assert api.battery_settings["12345"]["rbdControl"]["enabled"] is True
+
+
+def test_apply_activates_dtg_after_write():
+    """apply_battery_schedule activates DTG mode after a schedule write when real export is enabled."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    api.schedules["12345"] = {"cfg": {"supported": True}, "dtg": {"supported": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {
+        "reserve": 20,
+        "charge": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 100, "enable": False},
+        "export": {"start_time": "16:00:00", "end_time": "19:00:00", "soc": 60, "enable": True},
+    }
+    api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    run_async(api.apply_battery_schedule("12345"))
+    # DTG schedule was created (POST to schedules with scheduleType DTG)
+    posts = [r for r in api.request_log if r["method"] == "POST" and r["path"].endswith("/schedules")]
+    assert len(posts) == 1
+    assert posts[0]["json"]["scheduleType"] == "DTG"
+    # Activation PUT with dtgControl.enabled
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
+    activation = [p for p in puts if p.get("json", {}).get("dtgControl", {}).get("enabled") is True]
+    assert len(activation) == 1
+
+
+def test_apply_activates_rbd_after_write():
+    """apply_battery_schedule activates RBD mode after a schedule write when freeze export is enabled."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    api.schedules["12345"] = {"cfg": {"supported": True}, "dtg": {"supported": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {
+        "reserve": 20,
+        "charge": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 100, "enable": False},
+        "export": {"start_time": "22:00:00", "end_time": "23:00:00", "soc": 99, "enable": True},
+    }
+    api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    run_async(api.apply_battery_schedule("12345"))
+    # RBD schedule was created (POST to schedules with scheduleType RBD)
+    posts = [r for r in api.request_log if r["method"] == "POST" and r["path"].endswith("/schedules")]
+    assert len(posts) == 1
+    assert posts[0]["json"]["scheduleType"] == "RBD"
+    # Activation PUT with rbdControl.enabled
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
+    activation = [p for p in puts if p.get("json", {}).get("rbdControl", {}).get("enabled") is True]
+    assert len(activation) == 1
+
+
+def test_apply_no_activate_dtg_when_export_disabled():
+    """_activate_dtg_mode is NOT called when export is disabled (no real or freeze export)."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    api.schedules["12345"] = {"cfg": {"supported": True}, "dtg": {"supported": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {
+        "reserve": 20,
+        "charge": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 100, "enable": False},
+        "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False},
+    }
+    # No schedule write (no cloud DTG, export disabled → enabled=False, _write_schedule returns False)
+    # No HTTP needed — nothing is written.
+    api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    run_async(api.apply_battery_schedule("12345"))
+    # No PUTs to batterySettings (no activation for DTG or RBD)
+    puts = [r for r in api.request_log if r["method"] == "PUT" and "batterySettings" in r["path"]]
+    assert puts == []
+
+
+def test_apply_no_activate_dtg_when_freeze_not_real_export():
+    """_activate_dtg_mode is NOT called for freeze export (soc == 99 triggers RBD, not DTG)."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    api.schedules["12345"] = {"cfg": {"supported": True}, "dtg": {"supported": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {
+        "reserve": 20,
+        "charge": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 100, "enable": False},
+        "export": {"start_time": "22:00:00", "end_time": "23:00:00", "soc": 99, "enable": True},
+    }
+    # DTG is not written (real_export=False when soc==99), but RBD is.
+    api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    run_async(api.apply_battery_schedule("12345"))
+    # RBD schedule was created
+    posts = [r for r in api.request_log if r["method"] == "POST" and r["path"].endswith("/schedules")]
+    assert len(posts) == 1
+    assert posts[0]["json"]["scheduleType"] == "RBD"
+    # Activation PUTs: only rbdControl, no dtgControl
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
+    dtg_activation = [p for p in puts if p.get("json", {}).get("dtgControl")]
+    rbd_activation = [p for p in puts if p.get("json", {}).get("rbdControl", {}).get("enabled") is True]
+    assert dtg_activation == []
+    assert len(rbd_activation) == 1
+
+
+def test_apply_no_activate_dtg_when_unchanged():
+    """_activate_dtg_mode is NOT called when the DTG schedule already matches (no-op write)."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    # Cloud DTG already matches local desired state
+    api.schedules["12345"] = {"cfg": {"supported": True}, "dtg": {"supported": True, "id": "d1", "startTime": "16:00", "endTime": "19:00", "limit": 60, "enabled": True}, "rbd": {"supported": True}}
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 20}
+    api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
+    api.local_schedule["12345"] = {
+        "reserve": 20,
+        "charge": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 100, "enable": False},
+        "export": {"start_time": "16:00:00", "end_time": "19:00:00", "soc": 60, "enable": True},
+    }
+    run_async(api.apply_battery_schedule("12345"))
+    # No writes at all (all schedules match cloud state, no reserve change)
     writes = [r for r in api.request_log if r["method"] in ("POST", "PUT")]
     assert writes == []
 
@@ -1298,5 +1451,12 @@ def run_enphase_api_tests(my_predbat):
     test_apply_activates_cfg_after_write()
     test_apply_no_activate_cfg_when_charge_disabled()
     test_apply_no_activate_cfg_when_unchanged()
+    test_activate_dtg_mode()
+    test_activate_rbd_mode()
+    test_apply_activates_dtg_after_write()
+    test_apply_activates_rbd_after_write()
+    test_apply_no_activate_dtg_when_export_disabled()
+    test_apply_no_activate_dtg_when_freeze_not_real_export()
+    test_apply_no_activate_dtg_when_unchanged()
     print("**** Enphase API tests passed ****")
     return 0

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -1171,7 +1171,7 @@ def test_activate_cfg_mode():
 
     parsed = dt.fromisoformat(body["acceptedItcDisclaimer"])
     age = (dt.now(tz.utc) - parsed).total_seconds()
-    assert 0 <= age <= 60, f"acceptedItcDisclaimer age {age}s outside [0, 60] — stale timestamp"
+    assert -5 <= age <= 60, f"acceptedItcDisclaimer age {age}s outside [-5, 60] — stale or future timestamp"
     # Cached battery settings updated optimistically on success
     assert api.battery_settings["12345"]["chargeFromGrid"] is True
 

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -1229,7 +1229,7 @@ def test_apply_no_activate_cfg_when_unchanged():
     api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
     api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}}
     run_async(api.apply_battery_schedule("12345"))
-    # No writes at all (schedules_match -> False, _ensure_charge_from_grid already done)
+    # No writes at all (schedules_match -> True, _ensure_charge_from_grid already done)
     writes = [r for r in api.request_log if r["method"] in ("POST", "PUT")]
     assert writes == []
 

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -86,7 +86,7 @@ class MockEnphaseAPI(EnphaseAPI):
     async def request_raw(self, method, url, headers=None, data=None, json_body=None, params=None):
         """Return canned responses instead of performing HTTP."""
         path = url.split("enphaseenergy.com", 1)[-1].split("?")[0]
-        self.request_log.append({"method": method, "path": path, "json": json_body, "data": data})
+        self.request_log.append({"method": method, "path": path, "json": json_body, "data": data, "params": params})
         response = self.http_responses.get(path, {"status": 404, "json_data": None, "text_data": "not found"})
         return response["status"], response["json_data"], response.get("text_data") or "", {}
 
@@ -1162,6 +1162,8 @@ def test_activate_cfg_mode():
     body = puts[0]["json"]
     assert body["chargeFromGrid"] is True
     assert "acceptedItcDisclaimer" in body
+    # Verify required query params are sent
+    assert puts[0].get("params") == {"source": "enho", "userId": "9999"}
     # Timestamp must be a recent UTC ISO-8601 string (e.g. "2026-07-14T20:25:00+00:00")
     from datetime import datetime as dt, timezone as tz
 
@@ -1198,6 +1200,7 @@ def test_apply_activates_cfg_after_write():
     activation_puts = [p for p in puts if p.get("json", {}).get("acceptedItcDisclaimer")]
     assert len(activation_puts) == 1
     assert activation_puts[0]["json"]["chargeFromGrid"] is True
+    assert activation_puts[0].get("params") == {"source": "enho", "userId": "9999"}
 
 
 def test_apply_no_activate_cfg_when_charge_disabled():
@@ -1245,6 +1248,8 @@ def test_activate_dtg_mode():
     assert len(puts) == 1
     body = puts[0]["json"]
     assert body == {"dtgControl": {"enabled": True}}
+    # Verify required query params are sent
+    assert puts[0].get("params") == {"source": "enho", "userId": "9999"}
     # Cached battery settings updated on success
     assert api.battery_settings["12345"]["dtgControl"]["enabled"] is True
 
@@ -1260,6 +1265,8 @@ def test_activate_rbd_mode():
     assert len(puts) == 1
     body = puts[0]["json"]
     assert body == {"rbdControl": {"enabled": True}}
+    # Verify required query params are sent
+    assert puts[0].get("params") == {"source": "enho", "userId": "9999"}
     assert api.battery_settings["12345"]["rbdControl"]["enabled"] is True
 
 
@@ -1287,6 +1294,7 @@ def test_apply_activates_dtg_after_write():
     puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
     activation = [p for p in puts if p.get("json", {}).get("dtgControl", {}).get("enabled") is True]
     assert len(activation) == 1
+    assert activation[0].get("params") == {"source": "enho", "userId": "9999"}
 
 
 def test_apply_activates_rbd_after_write():
@@ -1313,6 +1321,7 @@ def test_apply_activates_rbd_after_write():
     puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"] == "/service/batteryConfig/api/v1/batterySettings/12345"]
     activation = [p for p in puts if p.get("json", {}).get("rbdControl", {}).get("enabled") is True]
     assert len(activation) == 1
+    assert activation[0].get("params") == {"source": "enho", "userId": "9999"}
 
 
 def test_apply_no_activate_dtg_when_export_disabled():

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -1096,6 +1096,7 @@ def test_apply_updates_existing_by_id():
     api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
     api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}, "freeze": {"enable": False}}
     api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules/u1", 200, {})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})  # activation PUT
     api.set_http_response(
         "/service/batteryConfig/api/v1/battery/sites/12345/schedules",
         200,
@@ -1120,6 +1121,7 @@ def test_apply_caches_write_no_rewrite():
     api.battery_settings["12345"] = {"chargeFromGrid": True, "veryLowSocMin": 5}
     api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}}
     api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules/u1", 200, {})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})  # activation PUT
     run_async(api.apply_battery_schedule("12345"))
     run_async(api.apply_battery_schedule("12345"))  # second apply, unchanged desired state
     puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"].endswith("/schedules/u1")]
@@ -1395,6 +1397,50 @@ def test_apply_no_activate_dtg_when_unchanged():
     assert writes == []
 
 
+def test_activate_cfg_mode_invalidates_cache_on_failure():
+    """Cache is cleared on CFG activation failure so next apply retries write+activation."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.battery_settings.clear()
+    api.schedules["12345"] = {"cfg": {"supported": True, "id": "u1", "startTime": "02:00", "endTime": "05:00", "limit": 90, "enabled": True}}
+    # Set up a 404 response — activation will fail
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 404, {})
+    ok = run_async(api._activate_cfg_mode("12345"))
+    assert ok is False
+    # Cached startTime must be cleared so schedules_equal detects a diff next time
+    cached = api.schedules["12345"]["cfg"]
+    assert "startTime" not in cached
+    assert "id" in cached  # id preserved for PUT update
+
+
+def test_activate_dtg_mode_invalidates_cache_on_failure():
+    """Cache is cleared on DTG activation failure so next apply retries write+activation."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.battery_settings.clear()
+    api.schedules["12345"] = {"dtg": {"supported": True, "id": "d1", "startTime": "16:00", "endTime": "19:00", "limit": 60, "enabled": True}}
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 404, {})
+    ok = run_async(api._activate_dtg_mode("12345"))
+    assert ok is False
+    cached = api.schedules["12345"]["dtg"]
+    assert "startTime" not in cached
+    assert "id" in cached
+
+
+def test_activate_rbd_mode_invalidates_cache_on_failure():
+    """Cache is cleared on RBD activation failure so next apply retries write+activation."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.battery_settings.clear()
+    api.schedules["12345"] = {"rbd": {"supported": True, "id": "r1", "startTime": "22:00", "endTime": "23:00", "limit": 99, "enabled": True}}
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 404, {})
+    ok = run_async(api._activate_rbd_mode("12345"))
+    assert ok is False
+    cached = api.schedules["12345"]["rbd"]
+    assert "startTime" not in cached
+    assert "id" in cached
+
+
 def run_enphase_api_tests(my_predbat):
     """Run all Enphase API tests, returning 0 on success."""
     test_initialize_defaults()
@@ -1467,5 +1513,8 @@ def run_enphase_api_tests(my_predbat):
     test_apply_no_activate_dtg_when_export_disabled()
     test_apply_no_activate_dtg_when_freeze_not_real_export()
     test_apply_no_activate_dtg_when_unchanged()
+    test_activate_cfg_mode_invalidates_cache_on_failure()
+    test_activate_dtg_mode_invalidates_cache_on_failure()
+    test_activate_rbd_mode_invalidates_cache_on_failure()
     print("**** Enphase API tests passed ****")
     return 0


### PR DESCRIPTION
Enphase Cloud writes schedules correctly (HTTP 200, correct times and limits), but schedules remain in "pending" status indefinitely because the Enphase Cloud API requires a follow-up activation call to commit each schedule type to the gateway:

- **CFG** (charge-from-grid): `PUT /batterySettings/{id}` with `acceptedItcDisclaimer`
- **DTG** (discharge-to-grid): `PUT /batterySettings/{id}` with `dtgControl.enabled`
- **RBD** (restrict-battery-discharge): `PUT /batterySettings/{id}` with `rbdControl.enabled`

Without these activation calls, schedules are queued but never committed. The PR adds `_activate_cfg_mode`, `_activate_dtg_mode`, and `_activate_rbd_mode`, called after each successful schedule write when the corresponding mode is enabled.

Each activation method logs on failure and invalidates the cached schedule entry so the next apply cycle re-detects the diff and retries write + activation (avoiding stuck-pending schedules from transient API failures).

Fixes springfall2008/batpred#4252.