### PR TITLE
fix(github): don't cache failed GitHub API responses for the full 2-h…

### DIFF
--- a/apps/predbat/github.py
+++ b/apps/predbat/github.py
@@ -68,32 +68,43 @@ class GitHub:
     def download_predbat_releases_url(self, url):
         """
         Download release data from GitHub, but use the cache for 2 hours
+
+        On failure (network error, non-2xx status, or bad JSON) falls back to the last
+        successfully cached data if any, and never caches the failure itself - this way
+        a transient error (e.g. rate limiting) is retried on the next plan cycle rather
+        than getting stuck for the full 2-hour cache window after it's already cleared.
         """
         self._load_github_url_cache_from_storage()
 
         # Check the cache first
         now = datetime.now()
-        if url in self.github_url_cache:
-            entry = self.github_url_cache[url]
-            stamp = entry.get("stamp")
-            pdata = entry.get("data")
+        cached_entry = self.github_url_cache.get(url)
+        if cached_entry:
+            stamp = cached_entry.get("stamp")
+            pdata = cached_entry.get("data")
             if stamp is not None and pdata is not None:
                 age = now - stamp
                 if age.total_seconds() < (120 * 60):
                     self.log("Using cached GitHub data for {} age {} minutes".format(url, dp1(age.total_seconds() / 60)))
                     return pdata
 
+        stale_data = cached_entry.get("data", []) if cached_entry else []
+
         try:
-            r = requests.get(url)
+            r = requests.get(url, timeout=10)
         except Exception:
             self.log("Warn: Unable to load data from GitHub URL: {}".format(url))
-            return []
+            return stale_data
+
+        if not r.ok:
+            self.log("Warn: GitHub returned status {} for {} - will retry next cycle".format(r.status_code, url))
+            return stale_data
 
         try:
             pdata = r.json()
         except requests.exceptions.JSONDecodeError:
             self.log("Warn: Unable to decode data from GitHub URL: {}".format(url))
-            return []
+            return stale_data
 
         # Save to in-memory cache and persist to storage
         self.github_url_cache[url] = {}

--- a/apps/predbat/github.py
+++ b/apps/predbat/github.py
@@ -79,6 +79,9 @@ class GitHub:
         # Check the cache first
         now = datetime.now()
         cached_entry = self.github_url_cache.get(url)
+        if not isinstance(cached_entry, dict):
+            cached_entry = None
+
         if cached_entry:
             stamp = cached_entry.get("stamp")
             pdata = cached_entry.get("data")
@@ -88,8 +91,7 @@ class GitHub:
                     self.log("Using cached GitHub data for {} age {} minutes".format(url, dp1(age.total_seconds() / 60)))
                     return pdata
 
-        stale_data = cached_entry.get("data", []) if cached_entry else []
-
+        stale_data = (cached_entry.get("data") or []) if cached_entry else []
         try:
             r = requests.get(url, timeout=10)
         except Exception:

--- a/apps/predbat/tests/test_github.py
+++ b/apps/predbat/tests/test_github.py
@@ -127,6 +127,38 @@ def test_github(my_predbat):
         print("  FAILED: cache should not be populated after JSON error")
         failed += 1
 
+    print("  Test 4b: non-2xx status (e.g. rate limited) with no prior cache returns [] and does not cache the failure")
+    _setup(my_predbat)
+    mock_resp = MagicMock()
+    mock_resp.ok = False
+    mock_resp.status_code = 403
+    with patch("requests.get", return_value=mock_resp):
+        result = my_predbat.download_predbat_releases_url(test_url)
+    if result != []:
+        print("  FAILED: non-2xx status with no prior cache should return [], got {}".format(result))
+        failed += 1
+    if test_url in my_predbat.github_url_cache:
+        print("  FAILED: cache should not be populated after a non-2xx response")
+        failed += 1
+
+    print("  Test 4c: non-2xx status falls back to stale cached data instead of blanking it out for the full cache window")
+    _setup(my_predbat)
+    stale_stamp2 = datetime.now() - timedelta(hours=3)
+    stale_data2 = [{"tag_name": "v0.9"}]
+    my_predbat.github_url_cache[test_url] = {"stamp": stale_stamp2, "data": stale_data2}
+    mock_resp = MagicMock()
+    mock_resp.ok = False
+    mock_resp.status_code = 403
+    with patch("requests.get", return_value=mock_resp):
+        result = my_predbat.download_predbat_releases_url(test_url)
+    if result != stale_data2:
+        print("  FAILED: non-2xx status should fall back to stale cached data, got {}".format(result))
+        failed += 1
+    # The failed fetch must not overwrite the stamp, so the next cycle retries rather than waiting out the full cache window
+    if my_predbat.github_url_cache.get(test_url, {}).get("stamp") != stale_stamp2:
+        print("  FAILED: a failed fetch should not refresh the cache stamp")
+        failed += 1
+
     print("  Test 5: cache miss fetches from GitHub and stores result")
     _setup(my_predbat)
     fetched_data = [{"tag_name": "v2.0"}]


### PR DESCRIPTION
Symptom: After clearing problems with GitHub api calls for my account, present continues to complain about being unable to download GitHub version information, leading to som confusion as to the continuing problem. download_predbat_releases_url fetches the GitHub version and caches it for a 2 hour window to reduce api calls to a minimum. 
However it never checked the HTTP status before treating the response body as valid data - GitHub's API returns a JSON body even on errors (e.g. rate limiting), so a 403 was parsed fine and cached as if it were real release data for 2 hours. That meant a transient rate limit kept showing "Unable to download Predbat version information" for up to 2 hours after the limit had actually cleared.

Now checks response.ok before parsing/caching, and on any failure (network error, non-2xx, bad JSON) falls back to the last successfully cached data instead of caching the failure - so the next 5-minute plan cycle retries rather than waiting out the full cache window. Also adds a request timeout, since this is an external call with no bound on how long it can hang.