### PR TITLE
Extend dynamic load high-load baseline into next slot on sustained spikes

### DIFF
--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -131,7 +131,8 @@ class Plan:
             minutes_now = self.minutes_now
             minutes_end_slot = int((self.minutes_now + self.plan_interval_minutes) / self.plan_interval_minutes) * self.plan_interval_minutes
             # When dynamic load is enabled we try can do two things
-            # 1. Increase the load prediction in the current self.plan_interval_minutes minute period to match the actual load (if the load is higher than expected)
+            # 1. Increase the load prediction in the current self.plan_interval_minutes minute period to match the actual load (if the load is higher than expected),
+            #    extending into the following period too once the load has been high for two consecutive checks in a row (mirrors the low-load debounce below)
             # 2. If the load is low and car charging is predicted then cancel off future car slots
             # Note never do this just after midnight due to the load sensor reset
             if self.load_last_status == "low" and self.minutes_now > 5:
@@ -146,7 +147,12 @@ class Plan:
 
             if self.load_last_status == "high":
                 have_printed = False
-                for minute_absolute in range(minutes_now, minutes_end_slot, PREDICT_STEP):
+                minutes_end_baseline = minutes_end_slot
+                if prev_last_load_status == "high":
+                    # Load has been high for two consecutive checks, so also predict it will continue
+                    # into the following slot to keep the plan up to date across the slot boundary
+                    minutes_end_baseline = minutes_end_slot + self.plan_interval_minutes
+                for minute_absolute in range(minutes_now, minutes_end_baseline, PREDICT_STEP):
                     if not self.car_energy_reported_load:
                         # If car energy is not reported as load then we should not attempt to adjust the load prediction based on car load.
                         car_load = 0

--- a/apps/predbat/tests/test_dynamic_load.py
+++ b/apps/predbat/tests/test_dynamic_load.py
@@ -7,6 +7,7 @@
 # pylint: disable=consider-using-f-string
 # pylint: disable=line-too-long
 # pylint: disable=attribute-defined-outside-init
+from const import PREDICT_STEP
 from tests.test_infra import reset_inverter
 
 
@@ -166,5 +167,110 @@ def test_dynamic_load_car_slot_cancellation(my_predbat):
         print("*** Dynamic load car slot cancellation test PASSED")
     else:
         print("*** Dynamic load car slot cancellation test FAILED")
+
+    return failed
+
+
+def test_dynamic_load_high_load_baseline(my_predbat):
+    """
+    Test the dynamic_load high-load branch which raises the near-term load forecast
+    (dynamic_load_baseline) to match an observed load spike, e.g. a car charging
+    outside any known/planned (including Octopus dispatch) slot.
+    """
+    print("*** Running test: Dynamic load high load baseline")
+    failed = False
+
+    reset_inverter(my_predbat)
+    my_predbat.num_cars = 1
+    my_predbat.minutes_now = 12 * 60  # 12:00 PM, on a plan_interval_minutes boundary
+    my_predbat.battery_rate_max_discharge = 5.0 / 60.0  # 5kW converted to kW per minute
+    my_predbat.car_charging_threshold = 3.0
+    my_predbat.metric_dynamic_load_adjust = True
+    my_predbat.load_last_status = "baseline"
+    my_predbat.load_last_car_slot = False
+    my_predbat.load_last_period = 6.0  # 6kW - above the 5kW battery threshold, so "high"
+
+    minutes_end_slot = my_predbat.minutes_now + my_predbat.plan_interval_minutes
+    interval_minutes = list(range(my_predbat.minutes_now, minutes_end_slot, PREDICT_STEP))
+    expected_value = my_predbat.load_last_period / 60 * PREDICT_STEP  # 0.5kWh per 5-minute step
+
+    # Test 1: Car charging outside all known/Octopus slots - Predbat can't attribute the spike
+    # to a recognised car window, so the whole load should be folded into the near-term baseline.
+    print("Test 1: High load, car charging outside all known/Octopus slots")
+    my_predbat.car_charging_slots = [[], [], [], []]
+    my_predbat.car_energy_reported_load = True
+
+    my_predbat.dynamic_load()
+
+    if set(my_predbat.dynamic_load_baseline.keys()) != set(interval_minutes):
+        print(f"ERROR: Expected baseline keys {interval_minutes}, got {sorted(my_predbat.dynamic_load_baseline.keys())}")
+        failed = True
+    for minute_absolute in interval_minutes:
+        value = my_predbat.dynamic_load_baseline.get(minute_absolute)
+        if value is None or abs(value - expected_value) > 0.001:
+            print(f"ERROR: Expected baseline at {minute_absolute} to be {expected_value}, got {value}")
+            failed = True
+
+    # Test 2: Car recognised in a slot that fully covers the current interval and the load sensor
+    # is known to include car energy - the car's own consumption absorbs the spike so no baseline
+    # floor is needed.
+    print("Test 2: High load, car recognised in a fully-covering slot")
+    my_predbat.load_last_status = "baseline"
+    my_predbat.car_charging_slots[0] = [{"start": my_predbat.minutes_now, "end": minutes_end_slot, "kwh": 3.0}]
+    my_predbat.car_energy_reported_load = True
+
+    my_predbat.dynamic_load()
+
+    if my_predbat.dynamic_load_baseline:
+        print(f"ERROR: Expected no baseline entries when the car slot fully covers the load spike, got {my_predbat.dynamic_load_baseline}")
+        failed = True
+
+    # Test 3: Same recognised car slot, but car_energy_reported_load is off (the default) -
+    # Predbat has no way to know the load sensor includes the car's energy, so it must fall back
+    # to folding in the whole spike, same as when the car is outside any slot.
+    print("Test 3: High load, car recognised in slot but car_energy_reported_load is off")
+    my_predbat.load_last_status = "baseline"
+    my_predbat.car_energy_reported_load = False
+
+    my_predbat.dynamic_load()
+
+    if set(my_predbat.dynamic_load_baseline.keys()) != set(interval_minutes):
+        print(f"ERROR: Expected baseline keys {interval_minutes} when car_energy_reported_load is off, got {sorted(my_predbat.dynamic_load_baseline.keys())}")
+        failed = True
+    for minute_absolute in interval_minutes:
+        value = my_predbat.dynamic_load_baseline.get(minute_absolute)
+        if value is None or abs(value - expected_value) > 0.001:
+            print(f"ERROR: Expected baseline at {minute_absolute} to be {expected_value} when car_energy_reported_load is off, got {value}")
+            failed = True
+
+    # Test 4: Sustained high load over two consecutive checks in a row extends the baseline into
+    # the following slot too, so the plan doesn't lag a whole cycle behind at the slot boundary.
+    print("Test 4: High load sustained over two consecutive checks extends into the next slot")
+    my_predbat.car_charging_slots = [[], [], [], []]
+    my_predbat.car_energy_reported_load = True
+    my_predbat.load_last_status = "baseline"  # First check - establishes the initial "high" reading
+
+    my_predbat.dynamic_load()
+
+    if set(my_predbat.dynamic_load_baseline.keys()) != set(interval_minutes):
+        print(f"ERROR: First high reading should only cover the current slot, expected {interval_minutes}, got {sorted(my_predbat.dynamic_load_baseline.keys())}")
+        failed = True
+
+    my_predbat.dynamic_load()  # Second consecutive high check - should now extend into the next slot
+
+    extended_interval_minutes = list(range(my_predbat.minutes_now, minutes_end_slot + my_predbat.plan_interval_minutes, PREDICT_STEP))
+    if set(my_predbat.dynamic_load_baseline.keys()) != set(extended_interval_minutes):
+        print(f"ERROR: Expected baseline keys {extended_interval_minutes} after two consecutive high checks, got {sorted(my_predbat.dynamic_load_baseline.keys())}")
+        failed = True
+    for minute_absolute in extended_interval_minutes:
+        value = my_predbat.dynamic_load_baseline.get(minute_absolute)
+        if value is None or abs(value - expected_value) > 0.001:
+            print(f"ERROR: Expected baseline at {minute_absolute} to be {expected_value} after two consecutive high checks, got {value}")
+            failed = True
+
+    if not failed:
+        print("*** Dynamic load high load baseline test PASSED")
+    else:
+        print("*** Dynamic load high load baseline test FAILED")
 
     return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -105,7 +105,7 @@ from tests.test_fetch_url_cached import test_fetch_url_cached
 from tests.test_load_free_slot import test_load_free_slot
 from tests.test_add_now_to_octopus_slot import test_add_now_to_octopus_slot
 from tests.test_octopus_slots_change import test_octopus_slots_change
-from tests.test_dynamic_load import test_dynamic_load_car_slot_cancellation
+from tests.test_dynamic_load import test_dynamic_load_car_slot_cancellation, test_dynamic_load_high_load_baseline
 from tests.test_fox_api import run_fox_api_tests
 from tests.test_enphase_api import run_enphase_api_tests
 from tests.test_solcast import run_solcast_tests
@@ -258,6 +258,7 @@ def main():
         ("active_flag", test_active_flag, "Active flag cleared on exception tests", False),
         ("component_health_status", test_component_health_status, "Component errors fail the recorded run status tests", False),
         ("dynamic_load_car", test_dynamic_load_car_slot_cancellation, "Dynamic load car slot cancellation tests", False),
+        ("dynamic_load_high", test_dynamic_load_high_load_baseline, "Dynamic load high-load baseline tests", False),
         ("units", run_test_units, "Unit tests", False),
         ("manual_api", run_test_manual_api, "Manual API tests", False),
         ("manual_soc", run_test_manual_soc, "Manual SOC target tests", False),

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -145,7 +145,7 @@ This setting will not impact the real calculated costs and is only used for plan
 
 **switch.predbat_metric_dynamic_load_adjust** (default False) is a toggle that when enabled allows Predbat to take into account your energy consumption within the last 5 minutes.
 If the load is above what your battery can deliver the plan is updated to predict this load will continue during the current slot, thus preventing forced export in the plan.
-If the load remains high for two consecutive checks in a row this prediction is extended into the following slot too, so the plan stays up to date across the slot boundary.
+If the load remains high for two checks in a row, this prediction is extended into the following slot too, so the plan stays up to date across the slot boundary.
 If car charging is planned but the load indicates that the car is not charging then Predbat will assume the car will no longer charge during this slot thus allowing the plan to include potential export.
 
 **input_number.predbat_battery_rate_max_scaling** is a percentage factor to adjust your maximum charge rate from that reported by the inverter.

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -145,6 +145,7 @@ This setting will not impact the real calculated costs and is only used for plan
 
 **switch.predbat_metric_dynamic_load_adjust** (default False) is a toggle that when enabled allows Predbat to take into account your energy consumption within the last 5 minutes.
 If the load is above what your battery can deliver the plan is updated to predict this load will continue during the current slot, thus preventing forced export in the plan.
+If the load remains high for two consecutive checks in a row this prediction is extended into the following slot too, so the plan stays up to date across the slot boundary.
 If car charging is planned but the load indicates that the car is not charging then Predbat will assume the car will no longer charge during this slot thus allowing the plan to include potential export.
 
 **input_number.predbat_battery_rate_max_scaling** is a percentage factor to adjust your maximum charge rate from that reported by the inverter.


### PR DESCRIPTION
## Summary
- `dynamic_load()`'s high-load branch (used by `switch.predbat_metric_dynamic_load_adjust`) only floored the near-term load forecast through the end of the *current* plan interval, so an observed spike (e.g. a car charging outside any known/Octopus dispatch slot) was briefly "forgotten" by the plan right at each slot boundary until the next cycle re-evaluated it.
- If load has been `"high"` for two consecutive checks in a row, the floor now also extends into the following slot, mirroring the existing two-reading debounce already used by the low-load car-slot cancellation branch just above it.
- The floor is applied via `max()` against the regular load estimate in `step_data_history()`, so this never double-counts load that was already forecast that high.

## Test plan
- [x] Added `test_dynamic_load_high_load_baseline` (`apps/predbat/tests/test_dynamic_load.py`) covering: car charging outside all known slots, car recognised in a fully-covering slot (with/without `car_energy_reported_load`), and the new two-consecutive-checks extension into the next slot.
- [x] Verified each new assertion actually catches a regression by temporarily reverting the corresponding logic and confirming the test fails, then restoring it.
- [x] `./run_pre_commit` passes (ruff, black, cspell, markdownlint, full quick test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)