### PR TITLE
fix(config): clamp input_number config items to their declared min/max

### DIFF
--- a/apps/predbat/tests/test_component_health_status.py
+++ b/apps/predbat/tests/test_component_health_status.py
@@ -41,6 +41,7 @@ def test_component_health_status(my_predbat):
     failed = 0
 
     recorded_statuses = []
+    original_record_status = my_predbat.record_status
     my_predbat.record_status = lambda message, debug="", had_errors=False, notify=False, extra="": recorded_statuses.append((message, had_errors))
 
     # --- All components healthy: final status should be the plan's own success status ---
@@ -106,5 +107,6 @@ def test_component_health_status(my_predbat):
 
     my_predbat.had_errors = False
     my_predbat.components = None
+    my_predbat.record_status = original_record_status
 
     return failed

--- a/apps/predbat/tests/test_component_health_status.py
+++ b/apps/predbat/tests/test_component_health_status.py
@@ -44,69 +44,70 @@ def test_component_health_status(my_predbat):
     original_record_status = my_predbat.record_status
     my_predbat.record_status = lambda message, debug="", had_errors=False, notify=False, extra="": recorded_statuses.append((message, had_errors))
 
-    # --- All components healthy: final status should be the plan's own success status ---
-    my_predbat.had_errors = False
-    my_predbat.components = FakeComponents({"octopus": True, "gecloud": True})
-    recorded_statuses.clear()
-    my_predbat.record_final_run_status("Idle", "")
+    try:
+        # --- All components healthy: final status should be the plan's own success status ---
+        my_predbat.had_errors = False
+        my_predbat.components = FakeComponents({"octopus": True, "gecloud": True})
+        recorded_statuses.clear()
+        my_predbat.record_final_run_status("Idle", "")
 
-    if len(recorded_statuses) != 1 or recorded_statuses[0] != ("Idle", False):
-        print("ERROR: Expected a single success status record, got {}".format(recorded_statuses))
-        failed = 1
-    else:
-        print("OK: All components healthy -> success status recorded")
-
-    # --- Octopus component in error (active but not alive): run must be recorded as an error ---
-    my_predbat.had_errors = False
-    my_predbat.components = FakeComponents({"octopus": False, "gecloud": True})
-    recorded_statuses.clear()
-    my_predbat.record_final_run_status("Idle", "")
-
-    if len(recorded_statuses) != 1:
-        print("ERROR: Expected a single status record for a failed component, got {}".format(recorded_statuses))
-        failed = 1
-    else:
-        message, had_errors = recorded_statuses[0]
-        if not had_errors:
-            print("ERROR: Component error did not mark the run as an error")
-            failed = 1
-        elif "Octopus Energy Direct" not in message:
-            print("ERROR: Failed component name not present in recorded status message: {}".format(message))
+        if len(recorded_statuses) != 1 or recorded_statuses[0] != ("Idle", False):
+            print("ERROR: Expected a single success status record, got {}".format(recorded_statuses))
             failed = 1
         else:
-            print("OK: Component error correctly recorded as an error, naming the component")
+            print("OK: All components healthy -> success status recorded")
 
-    # --- Multiple components in error: all should be listed ---
-    my_predbat.had_errors = False
-    my_predbat.components = FakeComponents({"octopus": False, "gecloud": False})
-    recorded_statuses.clear()
-    my_predbat.record_final_run_status("Idle", "")
+        # --- Octopus component in error (active but not alive): run must be recorded as an error ---
+        my_predbat.had_errors = False
+        my_predbat.components = FakeComponents({"octopus": False, "gecloud": True})
+        recorded_statuses.clear()
+        my_predbat.record_final_run_status("Idle", "")
 
-    if len(recorded_statuses) != 1:
-        print("ERROR: Expected a single status record for multiple failed components, got {}".format(recorded_statuses))
-        failed = 1
-    else:
-        message, had_errors = recorded_statuses[0]
-        if not had_errors or "Octopus Energy Direct" not in message or "GivEnergy Cloud" not in message:
-            print("ERROR: Not all failed components listed in status message: {}".format(message))
+        if len(recorded_statuses) != 1:
+            print("ERROR: Expected a single status record for a failed component, got {}".format(recorded_statuses))
             failed = 1
         else:
-            print("OK: All failed components listed in the recorded error status")
+            message, had_errors = recorded_statuses[0]
+            if not had_errors:
+                print("ERROR: Component error did not mark the run as an error")
+                failed = 1
+            elif "Octopus Energy Direct" not in message:
+                print("ERROR: Failed component name not present in recorded status message: {}".format(message))
+                failed = 1
+            else:
+                print("OK: Component error correctly recorded as an error, naming the component")
 
-    # --- Pre-existing error takes precedence, and is not overwritten by the component check ---
-    my_predbat.had_errors = True
-    my_predbat.components = FakeComponents({"octopus": False})
-    recorded_statuses.clear()
-    my_predbat.record_final_run_status("Idle", "")
+        # --- Multiple components in error: all should be listed ---
+        my_predbat.had_errors = False
+        my_predbat.components = FakeComponents({"octopus": False, "gecloud": False})
+        recorded_statuses.clear()
+        my_predbat.record_final_run_status("Idle", "")
 
-    if recorded_statuses:
-        print("ERROR: record_status should not be called again when had_errors was already set: {}".format(recorded_statuses))
-        failed = 1
-    else:
-        print("OK: Pre-existing error state left untouched by the component health check")
+        if len(recorded_statuses) != 1:
+            print("ERROR: Expected a single status record for multiple failed components, got {}".format(recorded_statuses))
+            failed = 1
+        else:
+            message, had_errors = recorded_statuses[0]
+            if not had_errors or "Octopus Energy Direct" not in message or "GivEnergy Cloud" not in message:
+                print("ERROR: Not all failed components listed in status message: {}".format(message))
+                failed = 1
+            else:
+                print("OK: All failed components listed in the recorded error status")
 
-    my_predbat.had_errors = False
-    my_predbat.components = None
-    my_predbat.record_status = original_record_status
+        # --- Pre-existing error takes precedence, and is not overwritten by the component check ---
+        my_predbat.had_errors = True
+        my_predbat.components = FakeComponents({"octopus": False})
+        recorded_statuses.clear()
+        my_predbat.record_final_run_status("Idle", "")
+
+        if recorded_statuses:
+            print("ERROR: record_status should not be called again when had_errors was already set: {}".format(recorded_statuses))
+            failed = 1
+        else:
+            print("OK: Pre-existing error state left untouched by the component health check")
+    finally:
+        my_predbat.had_errors = False
+        my_predbat.components = None
+        my_predbat.record_status = original_record_status
 
     return failed

--- a/apps/predbat/tests/test_integer_config.py
+++ b/apps/predbat/tests/test_integer_config.py
@@ -286,3 +286,43 @@ def test_config_item_range_clamp(my_predbat):
 
     print("✓ Test passed: config item range clamp works correctly")
     return False
+
+
+def test_config_item_step_min_max_types_consistent(my_predbat):
+    """
+    Schema self-check: for any input_number CONFIG_ITEM with an integer-valued step, min/max
+    must also be integer-valued (e.g. 250 or 250.0 - the numeric type doesn't matter, just that
+    there's no fractional part). A float step is compatible with any min/max, integer or not, so
+    only the integer-step direction is checked.
+
+    This exists because load_user_config's integer-preservation logic only makes sense for a
+    schema declared this way in the first place - a mismatch here (integer step, fractional
+    min/max) would mean the "preserve as int" intent and the declared range disagree with each
+    other, and it's cheap to catch that at test time rather than only in generated values.
+    """
+    print("**** test_config_item_step_min_max_types_consistent ****")
+
+    def is_integer_valued(value):
+        return isinstance(value, int) or (isinstance(value, float) and value == int(value))
+
+    mismatches = []
+    for item in my_predbat.CONFIG_ITEMS:
+        if item.get("type") != "input_number":
+            continue
+
+        step = item.get("step", 1)
+        if not is_integer_valued(step):
+            # A float step (e.g. 0.01, 0.25) is compatible with any min/max - nothing to check.
+            continue
+
+        for bound_name in ("min", "max"):
+            bound = item.get(bound_name)
+            if bound is None:
+                continue
+            if not is_integer_valued(bound):
+                mismatches.append("{}: step={} but {}={}".format(item.get("name"), step, bound_name, bound))
+
+    assert not mismatches, "input_number items with an integer step must have integer-valued min/max: {}".format(mismatches)
+
+    print("✓ Test passed: all integer-step input_number items have integer-valued min/max")
+    return False

--- a/apps/predbat/tests/test_integer_config.py
+++ b/apps/predbat/tests/test_integer_config.py
@@ -196,3 +196,63 @@ def test_expose_config_preserves_integer(my_predbat):
 
     print("✓ Test passed: expose_config preserves type correctly")
     return False
+
+
+def test_config_item_range_clamp(my_predbat):
+    """
+    Test that load_user_config clamps input_number config items to their declared min/max
+    (e.g. an out-of-range apps.yaml override), rather than passing the raw value straight
+    through to the optimiser, and flags the clamp via had_errors.
+    """
+    print("**** test_config_item_range_clamp ****")
+
+    original_args = my_predbat.args.copy()
+    original_had_errors = my_predbat.had_errors
+
+    item = None
+    for config_item in my_predbat.CONFIG_ITEMS:
+        if config_item.get("name") == "pv_metric10_weight":
+            item = config_item
+            break
+
+    assert item is not None, "pv_metric10_weight config item not found"
+    assert item.get("min") == 0, f"pv_metric10_weight min should be 0, got {item.get('min')}"
+    assert item.get("max") == 1.0, f"pv_metric10_weight max should be 1.0, got {item.get('max')}"
+
+    # load_user_config() prefers a value already stored on the HA entity over the apps.yaml
+    # default (that's only used on very first load), so simulate a stale/raw out-of-range
+    # value already sitting in HA state - exactly how this reaches Predbat in practice (an
+    # apps.yaml override gets pushed straight to the entity with no min/max enforcement) -
+    # then confirm a subsequent config refresh catches and clamps it.
+
+    # Test 1: a stored value above the declared max should clamp to the max and flag an error
+    my_predbat.expose_config("pv_metric10_weight", 30, force_ha=True)
+    my_predbat.had_errors = False
+    my_predbat.load_user_config()
+    assert item["value"] == 1.0, f"Expected clamp to max 1.0, got {item['value']}"
+    assert my_predbat.had_errors is True, "Out-of-range config value should flag had_errors"
+    print("✓ Above-max value (30) clamped to max (1.0) and flagged")
+
+    # Test 2: a stored value below the declared min should clamp to the min and flag an error
+    my_predbat.expose_config("pv_metric10_weight", -5, force_ha=True)
+    my_predbat.had_errors = False
+    my_predbat.load_user_config()
+    assert item["value"] == 0, f"Expected clamp to min 0, got {item['value']}"
+    assert my_predbat.had_errors is True, "Out-of-range config value should flag had_errors"
+    print("✓ Below-min value (-5) clamped to min (0) and flagged")
+
+    # Test 3: an in-range value should pass through unmodified and not flag an error
+    my_predbat.expose_config("pv_metric10_weight", 0.3, force_ha=True)
+    my_predbat.had_errors = False
+    my_predbat.load_user_config()
+    assert item["value"] == 0.3, f"Expected in-range value to pass through as 0.3, got {item['value']}"
+    assert my_predbat.had_errors is False, "In-range config value should not flag had_errors"
+    print("✓ In-range value (0.3) passes through unclamped")
+
+    # Restore original state
+    my_predbat.args = original_args
+    my_predbat.had_errors = original_had_errors
+    my_predbat.expose_config("pv_metric10_weight", item.get("default"), force_ha=True)
+
+    print("✓ Test passed: config item range clamp works correctly")
+    return False

--- a/apps/predbat/tests/test_integer_config.py
+++ b/apps/predbat/tests/test_integer_config.py
@@ -249,6 +249,36 @@ def test_config_item_range_clamp(my_predbat):
     assert my_predbat.had_errors is False, "In-range config value should not flag had_errors"
     print("✓ In-range value (0.3) passes through unclamped")
 
+    # Test 4: an integer-step item with a float-typed max (metric_min_improvement_plan: step=1,
+    # max=250.0) must still come out as an int after clamping, not the raw float max - clamping
+    # runs before the integer-preservation check, so it needs to re-apply after the clamp rather
+    # than just handing back the schema's float boundary value untouched.
+    int_item = None
+    for config_item in my_predbat.CONFIG_ITEMS:
+        if config_item.get("name") == "metric_min_improvement_plan":
+            int_item = config_item
+            break
+
+    assert int_item is not None, "metric_min_improvement_plan config item not found"
+    assert int_item.get("step") == 1, f"metric_min_improvement_plan step should be 1, got {int_item.get('step')}"
+    assert int_item.get("max") == 250.0, f"metric_min_improvement_plan max should be 250.0, got {int_item.get('max')}"
+    assert int_item.get("enable") == "expert_mode", "metric_min_improvement_plan is expected to require expert_mode"
+
+    # This item is gated on expert_mode - enable it so load_user_config doesn't just null the value out
+    original_expert_mode = my_predbat.config_index["expert_mode"].get("value")
+    my_predbat.expose_config("expert_mode", True, force_ha=True)
+
+    my_predbat.expose_config("metric_min_improvement_plan", 300, force_ha=True)
+    my_predbat.had_errors = False
+    my_predbat.load_user_config()
+    assert int_item["value"] == 250, f"Expected clamp to max 250, got {int_item['value']}"
+    assert isinstance(int_item["value"], int), f"Clamped value for an integer-step item should stay an int, got {type(int_item['value'])}"
+    assert my_predbat.had_errors is True, "Out-of-range config value should flag had_errors"
+    print("✓ Above-max value (300) on an integer-step item clamps to an int (250), not a float")
+
+    my_predbat.expose_config("metric_min_improvement_plan", int_item.get("default"), force_ha=True)
+    my_predbat.expose_config("expert_mode", original_expert_mode, force_ha=True)
+
     # Restore original state
     my_predbat.args = original_args
     my_predbat.had_errors = original_had_errors

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -114,7 +114,7 @@ from tests.test_rate_add_io_slots import run_rate_add_io_slots_tests
 from tests.test_battery_curve_keys import run_battery_curve_keys_tests
 from tests.test_balance_inverters import run_balance_inverters_tests
 from tests.test_octopus_download_rates import test_octopus_download_rates_wrapper
-from tests.test_integer_config import test_integer_config_entities, test_expose_config_preserves_integer
+from tests.test_integer_config import test_integer_config_entities, test_expose_config_preserves_integer, test_config_item_range_clamp
 from tests.test_validate_config import test_validate_config
 from tests.test_plan_json_rate_adjust import run_test_plan_json_rate_adjust
 from tests.test_rate_replicate_missing_slots import test_rate_replicate
@@ -303,6 +303,7 @@ def main():
         ("integer_config", test_integer_config_entities, "Integer config entities tests", False),
         ("validate_config", test_validate_config, "APPS_SCHEMA validator tests (string types, sensor boolean states)", False),
         ("expose_config_integer", test_expose_config_preserves_integer, "Expose config preserves integer tests", False),
+        ("config_item_range_clamp", test_config_item_range_clamp, "Config item min/max range clamp tests", False),
         ("plan_json_rate_adjust", run_test_plan_json_rate_adjust, "Plan JSON rate adjust type field tests", False),
         # Download tests
         ("download", test_download, "Predbat download/update comprehensive tests (GitHub API, SHA1, install check, file ops)", False),

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -114,7 +114,7 @@ from tests.test_rate_add_io_slots import run_rate_add_io_slots_tests
 from tests.test_battery_curve_keys import run_battery_curve_keys_tests
 from tests.test_balance_inverters import run_balance_inverters_tests
 from tests.test_octopus_download_rates import test_octopus_download_rates_wrapper
-from tests.test_integer_config import test_integer_config_entities, test_expose_config_preserves_integer, test_config_item_range_clamp
+from tests.test_integer_config import test_integer_config_entities, test_expose_config_preserves_integer, test_config_item_range_clamp, test_config_item_step_min_max_types_consistent
 from tests.test_validate_config import test_validate_config
 from tests.test_plan_json_rate_adjust import run_test_plan_json_rate_adjust
 from tests.test_rate_replicate_missing_slots import test_rate_replicate
@@ -304,6 +304,7 @@ def main():
         ("validate_config", test_validate_config, "APPS_SCHEMA validator tests (string types, sensor boolean states)", False),
         ("expose_config_integer", test_expose_config_preserves_integer, "Expose config preserves integer tests", False),
         ("config_item_range_clamp", test_config_item_range_clamp, "Config item min/max range clamp tests", False),
+        ("config_item_step_min_max_types", test_config_item_step_min_max_types_consistent, "Config item step/min/max type consistency tests", False),
         ("plan_json_rate_adjust", run_test_plan_json_rate_adjust, "Plan JSON rate adjust type field tests", False),
         # Download tests
         ("download", test_download, "Predbat download/update comprehensive tests (GitHub API, SHA1, install check, file ops)", False),

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -991,12 +991,6 @@ class UserInterface:
                 try:
                     # Convert to float first
                     ha_value = float(ha_value)
-                    # For entities with integer step, convert to int to preserve integer format
-                    step = item.get("step", 1)
-                    if isinstance(step, int) or (isinstance(step, float) and step == int(step)):
-                        # Step is an integer (e.g., 1, 2, etc.), so keep value as integer if it has no decimal part
-                        if ha_value == int(ha_value):
-                            ha_value = int(ha_value)
 
                     # Clamp to the declared min/max. This is reachable from an apps.yaml override,
                     # which bypasses the HA input_number entity's own min/max enforcement entirely -
@@ -1007,10 +1001,20 @@ class UserInterface:
                     item_max = item.get("max", None)
                     if item_min is not None and ha_value < item_min:
                         self.record_status("Warn: Config item {} value {} is below the minimum {} - clamping to {}".format(name, ha_value, item_min, item_min), had_errors=True)
-                        ha_value = item_min
+                        ha_value = float(item_min)
                     elif item_max is not None and ha_value > item_max:
                         self.record_status("Warn: Config item {} value {} is above the maximum {} - clamping to {}".format(name, ha_value, item_max, item_max), had_errors=True)
-                        ha_value = item_max
+                        ha_value = float(item_max)
+
+                    # For entities with integer step, convert to int to preserve integer format.
+                    # Done after clamping since min/max can themselves be declared as floats (e.g.
+                    # metric_min_improvement_plan has step=1 but max=250.0) - clamping alone would
+                    # otherwise silently hand back a float and defeat this normalisation.
+                    step = item.get("step", 1)
+                    if isinstance(step, int) or (isinstance(step, float) and step == int(step)):
+                        # Step is an integer (e.g., 1, 2, etc.), so keep value as integer if it has no decimal part
+                        if ha_value == int(ha_value):
+                            ha_value = int(ha_value)
                 except (ValueError, TypeError):
                     ha_value = None
 

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -997,6 +997,20 @@ class UserInterface:
                         # Step is an integer (e.g., 1, 2, etc.), so keep value as integer if it has no decimal part
                         if ha_value == int(ha_value):
                             ha_value = int(ha_value)
+
+                    # Clamp to the declared min/max. This is reachable from an apps.yaml override,
+                    # which bypasses the HA input_number entity's own min/max enforcement entirely -
+                    # an out-of-range value here can otherwise silently distort the optimiser (e.g.
+                    # pv_metric10_weight is documented/limited to 0.0-1.0 but a raw apps.yaml value
+                    # of, say, 30 passes straight through unclamped).
+                    item_min = item.get("min", None)
+                    item_max = item.get("max", None)
+                    if item_min is not None and ha_value < item_min:
+                        self.record_status("Warn: Config item {} value {} is below the minimum {} - clamping to {}".format(name, ha_value, item_min, item_min), had_errors=True)
+                        ha_value = item_min
+                    elif item_max is not None and ha_value > item_max:
+                        self.record_status("Warn: Config item {} value {} is above the maximum {} - clamping to {}".format(name, ha_value, item_max, item_max), had_errors=True)
+                        ha_value = item_max
                 except (ValueError, TypeError):
                     ha_value = None
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -189,11 +189,11 @@ See also [PV configuration options in apps.yaml](apps-yaml.md#solcast-solar-fore
 **input_number.predbat_pv_scaling** is a percentage scaling factor applied to PV data, decrease this if you want to be more pessimistic on PV production vs Solcast.<BR>
 Use 1.0 to accurately apply the Solcast forecast generation data. A value of 0.9, for instance, would reduce 10% from the Solcast generation forecast.
 
-**input_number.predbat_pv_metric10_weight** is the percentage weighting given to the Solcast 10% PV scenario in calculating solar generation.
+**input_number.predbat_pv_metric10_weight** is a weighting, expressed as a fraction between 0.0 and 1.0 (not a whole-number percentage), given to the Solcast 10% PV scenario in calculating solar generation.
 Use 0.0 to disable using the PV 10% in Predbat's forecast of solar generation.
 A value of 0.1 assumes that 1 in every 10 times we will get the Solcast 10% scenario, and 9 in every 10 times we will get the 'median' Solcast forecast.<BR>
 Predbat estimates solar generation for each half-hour slot to be a pv_metric10_weight weighting of the Solcast 10% PV forecast to the Solcast Median forecast.<BR>
-A value of 0.15 (the default) is recommended.
+A value of 0.15 (the default) is recommended. Do not enter a value above 1.0 (e.g. 30 for "30%") - Predbat will clamp it back into range and log a warning, but the resulting plan is likely to look very wrong in the meantime.
 
 **switch.predbat_metric_pv_calibration_enable** When turned On (the default), Predbat will use your historical solar generation data to calibrate your PV production estimates on a slot duration (default 30 minute) basis.<BR>
 This can be useful to adjust for your systems real performance.<BR>


### PR DESCRIPTION
## Summary

While investigating issue #4231 ("plan not economic, charging at higher rates than necessary"), root-caused it to `pv_metric10_weight` being set to `30` in the reporter's `apps.yaml` - the config item is documented and range-limited (`0.0`-`1.0`, default `0.15`) as the weighting given to the pessimistic PV10 forecast in `compute_metric()`, but an `apps.yaml` override bypasses the HA `input_number` entity's own min/max enforcement entirely, so the raw value passes straight through unvalidated.

At `weight=30`, the PV10 risk-hedging term in `compute_metric()` (`plan.py`) dominates the optimiser's objective by 30x whenever the pessimistic scenario looks even slightly worse than the mid-forecast one, driving the search to charge to ~100% in nearly every window "just in case" - rational under that (garbage) input, but producing a plan that costs roughly double doing nothing on real-world/mid-scenario cost. Forcing the weight back to the documented default and re-running the search produces a plan that legitimately beats doing nothing, confirming the optimiser's search itself has no bug here - this was pure garbage-in/garbage-out from an unvalidated config value.

Likely contributing cause: `docs/customisation.md` calls `pv_metric10_weight` a "**percentage** weighting" while giving `0.0`-`1.0` fractional worked examples in the same paragraph - a plausible source for a user reading "percentage" and typing `30` meaning "30%".

## Changes

- `apps/predbat/userinterface.py`: `load_user_config()` - the single generic funnel every `input_number` `CONFIG_ITEMS` value passes through (apps.yaml default, restored JSON config, or live HA entity state) - now clamps the value to its declared `min`/`max` and surfaces it via `record_status(..., had_errors=True)`, the same status-sensor mechanism already used for bad float/int config values, so an out-of-range value shows up as a visible error on the Predbat status sensor/dashboard rather than only in a log line.
- `docs/customisation.md`: corrected the `pv_metric10_weight` description to state it's a `0.0`-`1.0` fraction, not a percentage, and added a note that out-of-range values get clamped with a warning.
- `apps/predbat/tests/test_integer_config.py`: new `test_config_item_range_clamp` covering above-max, below-min, and in-range cases.
- `apps/predbat/tests/test_component_health_status.py`: fixed a pre-existing test-isolation bug found while adding the above test - this file permanently monkey-patched `my_predbat.record_status` onto the shared test fixture without restoring it, which silently broke `record_status`'s real behaviour for any test running afterwards in the same suite process.

## Test plan

- [x] `./run_all --test config_item_range_clamp` - new test passes in isolation
- [x] `./run_all --test component_health_status --test config_item_range_clamp` - passes in the order that previously exposed the isolation bug
- [x] `./run_all --quick` - full quick suite passes (589 tests, 0 failures)
- [x] `./run_pre_commit` - clean (ruff, black, cspell, markdownlint)

🤖 Investigated and implemented with Claude Code, disclosed per repo convention.