### PR TITLE
fix(solis): use OAuth2 gateway route namespace for reads and control

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -22,8 +22,10 @@ from oauth_mixin import OAuthMixin
 
 # API Endpoints
 SOLIS_BASE_URL = "https://www.soliscloud.com:13333"
-# OAuth 2.0 host (Bearer auth). Used when auth_method == "oauth"; reads/control use the
-# same cid/value payloads as the HMAC path, just at this host (design #366, approach 1).
+# OAuth 2.0 host (Bearer auth). Used when auth_method == "oauth". Reads/control use the same
+# cid/value payload shapes as the HMAC path, but NOT the same routes — this host serves a
+# different namespace, so paths are translated via SOLIS_OAUTH_ENDPOINTS below. (Design #366
+# approach 1 assumed path parity here; that was verified false against the live gateway.)
 SOLIS_OAUTH_BASE_URL = "https://api-oauth2.soliscloud.com"
 SOLIS_READ_ENDPOINT = "/v2/api/atRead"
 SOLIS_READ_BATCH_ENDPOINT = "/v2/api/atReadBatch"

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -31,6 +31,18 @@ SOLIS_CONTROL_ENDPOINT = "/v2/api/control"
 SOLIS_INVERTER_LIST_ENDPOINT = "/v1/api/inverterList"
 SOLIS_INVERTER_DETAIL_ENDPOINT = "/v1/api/inverterDetail"
 
+# The OAuth2 gateway serves a different route namespace to the HMAC host: discovery sits under
+# /api/access_data/, register reads and control under /api/control_device/. Verified against the
+# live gateway 2026-07-21. The HMAC paths return an XML <ForbiddenException> on the OAuth host,
+# which _execute_request mistook for an expired token, refreshing and retrying until it gave up.
+SOLIS_OAUTH_ENDPOINTS = {
+    SOLIS_READ_ENDPOINT: "/api/control_device/atRead",
+    SOLIS_READ_BATCH_ENDPOINT: "/api/control_device/atReadBatch",
+    SOLIS_CONTROL_ENDPOINT: "/api/control_device/control",
+    SOLIS_INVERTER_LIST_ENDPOINT: "/api/access_data/inverterList",
+    SOLIS_INVERTER_DETAIL_ENDPOINT: "/api/access_data/inverterDetail",
+}
+
 # Retry configuration
 SOLIS_MAX_RETRY_TIME = 30  # seconds
 SOLIS_INITIAL_RETRY_DELAY = 1  # seconds
@@ -373,6 +385,10 @@ class SolisAPI(ComponentBase, OAuthMixin):
 
     async def _execute_request(self, endpoint, payload):
         """Execute HTTP POST request to Solis API"""
+        # OAuth reads/control live in a different route namespace (see SOLIS_OAUTH_ENDPOINTS).
+        # Translate before building the URL; in api-key mode the paths are used unchanged.
+        if self.auth_method == "oauth":
+            endpoint = SOLIS_OAUTH_ENDPOINTS.get(endpoint, endpoint)
         url = f"{self.base_url}{endpoint}"
         # OAuth: proactively refresh the token before the call (no-op for api-key mode).
         # If the token can't be obtained (refresh failed / needs reauth), fail fast — the

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -18,6 +18,7 @@ from solis import SOLIS_CID_STORAGE_MODE, SOLIS_BIT_GRID_CHARGING, SOLIS_BIT_TOU
 from solis import SOLIS_CID_ALLOW_EXPORT, SOLIS_ALLOW_EXPORT_ON, SOLIS_ALLOW_EXPORT_OFF, SOLIS_CID_BATTERY_RESERVE_SOC
 from solis import SOLIS_CID_BATTERY_MAX_CHARGE_CURRENT
 from solis import SOLIS_CID_POWER_LIMIT, SOLIS_BIT_BACKUP_MODE
+from solis import SOLIS_READ_ENDPOINT, SOLIS_READ_BATCH_ENDPOINT, SOLIS_CONTROL_ENDPOINT, SOLIS_INVERTER_LIST_ENDPOINT, SOLIS_INVERTER_DETAIL_ENDPOINT
 from solis import get_solis_mode_enum, compute_solis_mode_value
 from solis import ENUM_OTHER, ENUM_SELF_USE, ENUM_SELF_USE_NO_GRID_CHARGING, ENUM_FEED_IN_PRIORITY, ENUM_FEED_IN_PRIORITY_NO_GRID_CHARGING
 from solis import SOLIS_BIT_SELF_USE, SOLIS_BIT_FEED_IN_PRIORITY, SOLIS_BIT_GRID_CHARGING, SOLIS_BIT_OFF_GRID
@@ -884,6 +885,63 @@ async def test_oauth_execute_request_refreshes_before_call():
     return failed
 
 
+async def _always_valid_token():
+    """Pretend the OAuth token is already valid so no refresh is attempted."""
+    return True
+
+
+async def test_oauth_endpoint_namespace_translation():
+    """OAuth mode must post to the gateway's /api/access_data|control_device routes.
+
+    Regression test for FD#1538: the HMAC host's paths are not served on
+    api-oauth2.soliscloud.com (they return an XML <ForbiddenException>), so an
+    OAuth-only instance never discovered its inverter and published no entities.
+    """
+    failed = False
+
+    expected = {
+        SOLIS_READ_ENDPOINT: "/api/control_device/atRead",
+        SOLIS_READ_BATCH_ENDPOINT: "/api/control_device/atReadBatch",
+        SOLIS_CONTROL_ENDPOINT: "/api/control_device/control",
+        SOLIS_INVERTER_LIST_ENDPOINT: "/api/access_data/inverterList",
+        SOLIS_INVERTER_DETAIL_ENDPOINT: "/api/access_data/inverterDetail",
+    }
+
+    for hmac_path, oauth_path in expected.items():
+        api = MockSolisAPI()
+        api.auth_method = "oauth"
+        api.access_token = "tok"
+        api.base_url = "https://solis.test"
+        api.check_and_refresh_oauth_token = _always_valid_token
+        api.session = _RecordingSession(_FakeResponse(status=200, payload={"code": "0", "data": {}}))
+
+        await api._execute_request(hmac_path, {})
+
+        got = api.session.post_calls[0]["url"]
+        if got != "https://solis.test" + oauth_path:
+            print("ERROR: OAuth {} should post to {}, got {}".format(hmac_path, oauth_path, got))
+            failed = True
+
+    # api-key mode must keep the HMAC paths untouched.
+    api = MockSolisAPI()
+    api.auth_method = "api_key"
+    api.api_key = "key"
+    api.api_secret = "secret"
+    api.base_url = "https://solis.hmac"
+    api.session = _RecordingSession(_FakeResponse(status=200, payload={"code": "0", "data": {}}))
+
+    await api._execute_request(SOLIS_INVERTER_LIST_ENDPOINT, {})
+
+    got = api.session.post_calls[0]["url"]
+    if got != "https://solis.hmac" + SOLIS_INVERTER_LIST_ENDPOINT:
+        print("ERROR: api-key mode must not translate endpoints, got {}".format(got))
+        failed = True
+
+    if not failed:
+        print("PASSED: OAuth endpoint namespace translation (api-key paths unchanged)")
+    return failed
+
+
 async def test_oauth_execute_request_aborts_when_token_missing():
     """In OAuth mode, _execute_request must fail fast (no HTTP) when no access_token is available,
     even if check_and_refresh_oauth_token() reports success (e.g. refresh skipped — missing env)."""
@@ -958,6 +1016,7 @@ def run_solis_tests(my_predbat):
         failed |= test_solis_activated_with_api_key()
         failed |= test_solis_activated_with_oauth_token()
         failed |= asyncio.run(test_oauth_execute_request_refreshes_before_call())
+        failed |= asyncio.run(test_oauth_endpoint_namespace_translation())
         failed |= asyncio.run(test_oauth_execute_request_aborts_when_token_missing())
         failed |= asyncio.run(test_with_retry_aborts_on_oauth_failed())
         failed |= asyncio.run(test_read_cid())


### PR DESCRIPTION
## Problem

A SolisCloud instance authenticating via **OAuth** (rather than API key + secret) can never discover its inverter. Every request fails and the user sees:

```
Error: Exception raised
Error: No entity IDs provided for pv_today
Error: You have not set load_today or load_forecast in apps.yaml
Error: Inverter 0 unable to read charge window time as neither REST,
       charge_start_time or charge_start_hour are set
```

The cause is that `SolisAPI` switches the **host** to `api-oauth2.soliscloud.com` in OAuth mode but keeps the HMAC host's **paths**. The OAuth2 gateway does not serve those routes — it rejects them at the gateway, before the request reaches the Solis application:

```
<ForbiddenException><error>access_denied</error>
  <error_description>Access is denied</error_description></ForbiddenException>
```

Note that is **XML**, whereas Solis's application API always returns the JSON envelope `{success, code, msg, data}` — so this is a routing failure, not a credential or permission problem.

It is then compounded by `_execute_request` treating `401/403` in OAuth mode as an expired token: each failure triggers `handle_oauth_401()`, so the driver burns a full retry window of successful-but-pointless token refreshes before giving up.

## Verified against the live gateway

| Purpose | HMAC host `www.soliscloud.com:13333` | OAuth2 gateway |
|---|---|---|
| inverterList | `/v1/api/inverterList` | `/api/access_data/inverterList` |
| inverterDetail | `/v1/api/inverterDetail` | `/api/access_data/inverterDetail` |
| atRead | `/v2/api/atRead` | `/api/control_device/atRead` |
| atReadBatch | `/v2/api/atReadBatch` | `/api/control_device/atReadBatch` |
| control | `/v2/api/control` | `/api/control_device/control` |

```
/v1/api/inverterList          -> 403 (XML ForbiddenException)
/api/access_data/inverterList -> 200 {"success":true,"code":"0", ...}
/api/control_device/atRead    -> 200, returns live register values
```

Discovery and register reads sit in **different** namespaces, which is easy to miss. Also worth noting: `/api/access_data/stationList` is a 404 (it is `userStationList`), and a Bearer token against the HMAC host returns `403 "Date can not be empty"` because that host demands HMAC signing.

The control path matches the one already documented for OAuth, which supports the mapping being correct rather than coincidental.

## Change

Map the paths at the single choke point in `_execute_request`, so all five call sites are covered without touching them. API-key mode is entirely unaffected — the lookup only runs when `auth_method == "oauth"`.

## Testing

- New `test_oauth_endpoint_namespace_translation` asserts every OAuth path translation, and that api-key mode still posts the HMAC paths unchanged
- Full Solis suite passes (`./run_all --test solis`)
- Verified in production on a real OAuth-only Solis instance: inverter discovered, `poll_success True`, live SoC/PV/grid/load values publishing