### PR TITLE
fix(gecloud): make standalone PV inverters opt-in for pv_today/pv_power

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -2192,6 +2192,7 @@ APPS_SCHEMA = {
     "ge_cloud_load_today_ignore": {"type": "boolean"},
     "ge_cloud_automatic_shared_ct": {"type": "boolean"},
     "ge_cloud_automatic_split_ct": {"type": "boolean"},
+    "ge_cloud_automatic_split_pv": {"type": "boolean"},
     "num_inverters": {"type": "integer", "zero": False},
     "balance_inverters_seconds": {"type": "integer", "zero": True},
     "givtcp_rest": {"type": "string_list", "entries": "num_inverters"},

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -921,8 +921,9 @@ class GECloudDirect(ComponentBase):
         self.set_arg("battery_scaling", [f"sensor.{self.prefix}_gecloud_{device}_battery_dod_soh" for device in batteries])
         self.set_arg("inverter_limit", [f"sensor.{self.prefix}_gecloud_{device}_max_inverter_rate" for device in batteries])
 
-        self.set_arg("pv_today", [f"sensor.{self.prefix}_gecloud_{device}_solar_total" for device in batteries + pvs])
-        self.set_arg("pv_power", [f"sensor.{self.prefix}_gecloud_{device}_solar_power" for device in batteries + pvs])
+        pv_devices = batteries + pvs if self.get_arg("ge_cloud_automatic_split_pv", default=False) else batteries
+        self.set_arg("pv_today", [f"sensor.{self.prefix}_gecloud_{device}_solar_total" for device in pv_devices])
+        self.set_arg("pv_power", [f"sensor.{self.prefix}_gecloud_{device}_solar_power" for device in pv_devices])
 
         if len(batteries):
             self.set_arg("battery_temperature_history", f"sensor.{self.prefix}_gecloud_{batteries[0]}_battery_temperature")

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.46.2"
+THIS_VERSION = "v8.46.3"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -3170,7 +3170,7 @@ def _test_async_automatic_config(my_predbat):
         assert ge.config_args.get("pv_today") == ["sensor.predbat_gecloud_battery001_solar_total", "sensor.predbat_gecloud_pv001_solar_total"], "pv_today should include standalone PV inverters when ge_cloud_automatic_split_pv is set"
         assert ge.config_args.get("pv_power") == ["sensor.predbat_gecloud_battery001_solar_power", "sensor.predbat_gecloud_pv001_solar_power"], "pv_power should include standalone PV inverters when ge_cloud_automatic_split_pv is set"
 
-        # Test 3d: Three-phase alternative names should be auto-selected when default names do not exist
+        # Test 3j: Three-phase alternative names should be auto-selected when default names do not exist
         ge.config_args = {}
         ge.settings = {
             "battery003": {

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -3148,6 +3148,28 @@ def _test_async_automatic_config(my_predbat):
         assert ge.config_args.get("grid_power") == ["sensor.predbat_gecloud_battery001_grid_power", "sensor.predbat_gecloud_battery002_grid_power"], "split CT should win when both overrides are set"
         assert ge.config_args.get("import_today") == ["sensor.predbat_gecloud_battery001_grid_import_total", "sensor.predbat_gecloud_battery002_grid_import_total"], "import_today should use all batteries when split CT wins"
 
+        # Test 3h: standalone PV inverter present, ge_cloud_automatic_split_pv unset (default False) — PV inverter excluded
+        ge.config_args = {}
+        ge.settings = {"battery001": {"reg1": {"name": "Enable_Eco_Mode"}}}
+
+        devices = {"ems": None, "gateway": None, "battery": ["battery001"], "pv": ["pv001"]}
+
+        await ge.async_automatic_config(devices)
+
+        assert ge.config_args.get("pv_today") == ["sensor.predbat_gecloud_battery001_solar_total"], "pv_today should exclude standalone PV inverters by default"
+        assert ge.config_args.get("pv_power") == ["sensor.predbat_gecloud_battery001_solar_power"], "pv_power should exclude standalone PV inverters by default"
+
+        # Test 3i: standalone PV inverter present, ge_cloud_automatic_split_pv=True — PV inverter included
+        ge.config_args = {"ge_cloud_automatic_split_pv": True}
+        ge.settings = {"battery001": {"reg1": {"name": "Enable_Eco_Mode"}}}
+
+        devices = {"ems": None, "gateway": None, "battery": ["battery001"], "pv": ["pv001"]}
+
+        await ge.async_automatic_config(devices)
+
+        assert ge.config_args.get("pv_today") == ["sensor.predbat_gecloud_battery001_solar_total", "sensor.predbat_gecloud_pv001_solar_total"], "pv_today should include standalone PV inverters when ge_cloud_automatic_split_pv is set"
+        assert ge.config_args.get("pv_power") == ["sensor.predbat_gecloud_battery001_solar_power", "sensor.predbat_gecloud_pv001_solar_power"], "pv_power should include standalone PV inverters when ge_cloud_automatic_split_pv is set"
+
         # Test 3d: Three-phase alternative names should be auto-selected when default names do not exist
         ge.config_args = {}
         ge.settings = {

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -510,6 +510,9 @@ See also **ge_cloud_automatic_split_ct** which takes priority over this setting 
 Use this to override automatic shared-CT detection if Predbat incorrectly identifies your system as sharing a CT clamp (e.g. when duplicate meter serials are reported by the cloud API but the inverters actually have separate CT clamps).
 This setting takes priority over **ge_cloud_automatic_shared_ct** if both are set.
 
+- **ge_cloud_automatic_split_pv** - Optional, defaults to false. When set to `true`, Predbat will also include any standalone PV-only inverters (e.g. a GivEnergy AC-coupled PV inverter with no battery attached) in **pv_today** and **pv_power**, in addition to the battery inverters.
+Use this if you have a separate PV-only inverter alongside your battery inverter(s) and want its solar generation included in Predbat's totals. Leave this off (the default) if your battery inverters already report all of your solar generation, to avoid duplicating or including unwanted readings.
+
 ### SolaX Cloud Direct
 
 Predbat supports direct communication with the SolaX Cloud API to control SolaX inverters and batteries without requiring local integrations.

--- a/docs/components.md
+++ b/docs/components.md
@@ -218,6 +218,7 @@ Connects directly to the GivEnergy Cloud to control your GivEnergy inverter and 
 | `load_today_ignore` | Boolean | No | false | `ge_cloud_load_today_ignore` | Set to `true` to ignore GE Cloud load_today data and use the `load_today` sensor from `apps.yaml` instead |
 | `automatic_shared_ct` | Boolean | No | false | `ge_cloud_automatic_shared_ct` | Set to `true` to force shared CT clamp mode — only the first inverter's grid and load readings are used, preventing double-counting on multi-inverter systems with a single shared CT |
 | `automatic_split_ct` | Boolean | No | false | `ge_cloud_automatic_split_ct` | Set to `true` to force split CT clamp mode — each inverter's readings are summed independently. Takes priority over `ge_cloud_automatic_shared_ct` if both are set |
+| `automatic_split_pv` | Boolean | No | false | `ge_cloud_automatic_split_pv` | Set to `true` to also include standalone PV-only inverters' solar readings in `pv_today`/`pv_power`, in addition to battery inverters |
 
 #### How to get your API key (gecloud)
 


### PR DESCRIPTION
## Summary
- `pv_today`/`pv_power` now default to battery-inverter sensors only, instead of automatically including standalone PV-only inverters (`pv` devices) added in #4076.
- Adds `ge_cloud_automatic_split_pv` (default `false`) to opt in to summing standalone PV-only inverters alongside battery inverters, mirroring the existing `ge_cloud_automatic_split_ct` pattern.

## Test plan
- [x] `./run_all --test ge_cloud` — 66 passed, including new tests for the default-off and opt-in-on behavior with a standalone PV device present
- [x] `./run_pre_commit` — hooks (ruff, black, cspell, etc.) and quick test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)