### PR TITLE
fix(metrics): correct Data Age card's warning threshold on the metrics dashboard

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -843,6 +843,7 @@ class Fetch:
         m.export_today_kwh.set(self.export_today_now)
         m.pv_today_kwh.set(self.pv_today_now)
         m.data_age_days.set(self.load_minutes_age)
+        m.data_age_required_days.set(max(self.max_days_previous - 1, 0))
 
         if "rates_import_octopus_url" in self.args:
             # Fixed URL for rate import

--- a/apps/predbat/predbat_metrics.py
+++ b/apps/predbat/predbat_metrics.py
@@ -108,7 +108,8 @@ class PredbatMetrics:
         self.import_today_kwh = _gauge("predbat_import_today_kwh", "Import energy today in kWh")
         self.export_today_kwh = _gauge("predbat_export_today_kwh", "Export energy today in kWh")
         self.pv_today_kwh = _gauge("predbat_pv_today_kwh", "PV energy today in kWh")
-        self.data_age_days = _gauge("predbat_data_age_days", "Age of load data in days")
+        self.data_age_days = _gauge("predbat_data_age_days", "Days of load history successfully retrieved (depth, not staleness)")
+        self.data_age_required_days = _gauge("predbat_data_age_required_days", "Days of load history required by the configured days_previous")
 
         # -- Cost & savings ----------------------------------------------------
         self.cost_today = _gauge("predbat_cost_today", "Cost today in currency units")
@@ -212,6 +213,7 @@ class PredbatMetrics:
             "export_today_kwh": _val(self.export_today_kwh),
             "pv_today_kwh": _val(self.pv_today_kwh),
             "data_age_days": _val(self.data_age_days),
+            "data_age_required_days": _val(self.data_age_required_days),
             # Currency symbol
             "currency_symbol": self.currency_symbol,
             # Cost

--- a/apps/predbat/tests/test_predbat_metrics_data_age.py
+++ b/apps/predbat/tests/test_predbat_metrics_data_age.py
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Test the data_age_days / data_age_required_days metrics used by the "Data Age" card on the
+Metrics Dashboard. data_age_days is how many days of load history were actually retrieved
+(depth, not staleness) - see fetch.py's "Found N load_today datapoints going back N days" log
+line. The dashboard should only warn when the retrieved depth falls short of what the
+configured days_previous actually needs, not on a flat threshold.
+"""
+
+from predbat_metrics import metrics
+
+
+def test_data_age_metrics_round_trip(my_predbat):
+    """
+    data_age_days and data_age_required_days should round-trip through to_dict() with the
+    values fetch_sensor_data() would set: load_minutes_age, and max(max_days_previous - 1, 0).
+    """
+    print("**** test_data_age_metrics_round_trip ****")
+
+    m = metrics()
+
+    # Mirrors fetch.py's fetch_sensor_data(): m.data_age_days.set(self.load_minutes_age) and
+    # m.data_age_required_days.set(max(self.max_days_previous - 1, 0))
+    my_predbat.load_minutes_age = 8
+    my_predbat.max_days_previous = 8  # e.g. days_previous=[1, 7] -> max_days_previous = 8
+
+    m.data_age_days.set(my_predbat.load_minutes_age)
+    m.data_age_required_days.set(max(my_predbat.max_days_previous - 1, 0))
+
+    data = m.to_dict()
+
+    assert data["data_age_days"] == 8, f"Expected data_age_days=8, got {data['data_age_days']}"
+    assert data["data_age_required_days"] == 7, f"Expected data_age_required_days=7 (max_days_previous - 1), got {data['data_age_required_days']}"
+    print("✓ 8 days retrieved, 7 days required (days_previous up to 7) - dashboard should show OK")
+
+    # Insufficient history: only 2 days retrieved but 7 needed - dashboard should warn
+    my_predbat.load_minutes_age = 2
+    m.data_age_days.set(my_predbat.load_minutes_age)
+
+    data = m.to_dict()
+    assert data["data_age_days"] < data["data_age_required_days"], "Shortfall in retrieved history should be visible as data_age_days < data_age_required_days"
+    print("✓ 2 days retrieved, 7 required - shortfall correctly visible for the dashboard's warn condition")
+
+    print("✓ Test passed: data_age_days/data_age_required_days round-trip correctly")
+    return False

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -124,6 +124,7 @@ from tests.test_battery_curve_keys import run_battery_curve_keys_tests
 from tests.test_balance_inverters import run_balance_inverters_tests
 from tests.test_octopus_download_rates import test_octopus_download_rates_wrapper
 from tests.test_integer_config import test_integer_config_entities, test_expose_config_preserves_integer, test_config_item_range_clamp, test_config_item_step_min_max_types_consistent
+from tests.test_predbat_metrics_data_age import test_data_age_metrics_round_trip
 from tests.test_validate_config import test_validate_config
 from tests.test_plan_json_rate_adjust import run_test_plan_json_rate_adjust
 from tests.test_rate_replicate_missing_slots import test_rate_replicate
@@ -323,6 +324,7 @@ def main():
         ("expose_config_integer", test_expose_config_preserves_integer, "Expose config preserves integer tests", False),
         ("config_item_range_clamp", test_config_item_range_clamp, "Config item min/max range clamp tests", False),
         ("config_item_step_min_max_types", test_config_item_step_min_max_types_consistent, "Config item step/min/max type consistency tests", False),
+        ("data_age_metrics", test_data_age_metrics_round_trip, "Metrics dashboard data_age_days/data_age_required_days tests", False),
         ("plan_json_rate_adjust", run_test_plan_json_rate_adjust, "Plan JSON rate adjust type field tests", False),
         # Download tests
         ("download", test_download, "Predbat download/update comprehensive tests (GitHub API, SHA1, install check, file ops)", False),

--- a/apps/predbat/web_metrics_dashboard.py
+++ b/apps/predbat/web_metrics_dashboard.py
@@ -170,7 +170,7 @@ function mdRenderHealth(d) {
     {label:'Plan',        value: planOk ? 'Valid' : 'Stale',      cls: mdStatusClass(planOk),   sub: mdFmt(d.plan_age_minutes, 0) + ' min old'},
     {label:'Last Update', value: mdAgo(d.last_update_timestamp),  cls: '', sub: ''},
     {label:'Errors',      value: mdFmt(mdSumLabeled(d.errors_total), 0), cls: mdSumLabeled(d.errors_total) > 0 ? 'md-status-warn' : 'md-status-ok', sub: ''},
-    {label:'Data Age',    value: mdFmt(d.data_age_days, 1) + 'd', cls: d.data_age_days > 3 ? 'md-status-warn' : 'md-status-ok', sub: ''},
+    {label:'Data Age',    value: mdFmt(d.data_age_days, 1) + 'd', cls: d.data_age_days < d.data_age_required_days ? 'md-status-warn' : 'md-status-ok', sub: 'need ' + mdFmt(d.data_age_required_days, 0) + 'd'},
   ];
   var h = '';
   cards.forEach(function (c) {

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -193,6 +193,8 @@ These are intended for debugging and developer activities, in normal use you can
 
 The Metrics view gives a dashboard of Predbat's internal metrics, including application health, plan status, battery state, energy totals, costs, savings and API status.
 
+The System Health row includes a **Data Age** card, showing how many days of historical load data (`load_today`) Predbat was able to retrieve from Home Assistant, going back from now. This is a measure of how much history is *available*, not how stale the latest reading is - a higher number generally means better load forecasting, since day-of-week weighted forecasts (the `days_previous` setting) need enough history to match against. The card is only flagged as a warning when the retrieved depth falls short of what your `days_previous` configuration actually needs (shown in the "need Xd" sub-label) - for example, if `days_previous` includes `7`, Predbat needs at least 7 days of history, and a shortfall usually means Home Assistant's recorder purged old data before Predbat could read it, or a load sensor is newly added.
+
 ### Docs View
 
 Provides a quick link to the [Predbat documentation](https://springfall2008.github.io/batpred/).


### PR DESCRIPTION
## Summary

`data_age_days` measures how many days of load history Predbat successfully retrieved from Home Assistant (history depth, not staleness of the latest reading - see `fetch.py`'s `"Found N load_today datapoints going back N days"` log line). A higher value is generally better, not worse - it means more history is available for day-of-week weighted load forecasting (`days_previous`).

The Metrics Dashboard's "Data Age" card had the warning logic backwards: a flat `data_age_days > 3` threshold flags *more* history as a problem, when it should only warn on a genuine shortfall relative to what the configured `days_previous` actually needs.

## Changes

- `apps/predbat/predbat_metrics.py`: added a `data_age_required_days` gauge (exposed via `to_dict()`) alongside the existing `data_age_days`, and clarified the latter's docstring.
- `apps/predbat/fetch.py`: sets the new gauge to `max(max_days_previous - 1, 0)` right next to where `data_age_days` itself is set.
- `apps/predbat/web_metrics_dashboard.py`: the "Data Age" card now warns only when `data_age_days < data_age_required_days`, with a `need Xd` sub-label showing the comparison.
- `apps/predbat/tests/test_predbat_metrics_data_age.py`: new test covering both the "have enough history" and "shortfall" cases.
- `docs/web-interface.md`: the Metrics View section previously had no explanation of any dashboard card - added a paragraph explaining what Data Age actually measures and when the warning should fire.

## Test plan

- [x] `./run_all --test data_age_metrics` - new test passes
- [x] `./run_all --quick` - full quick suite passes (605 tests, 0 failures)
- [x] `./run_pre_commit` - clean (ruff, black, cspell, markdownlint)

🤖 Implemented with Claude Code, disclosed per repo convention.