### PR TITLE
fix(compare): restore config: overrides between tariffs, not just after the whole run

### DIFF
--- a/apps/predbat/compare.py
+++ b/apps/predbat/compare.py
@@ -567,6 +567,15 @@ class Compare:
             my_predbat.battery_rate_max_charge_dc = save_battery_rate_max_charge_dc
             my_predbat.battery_rate_max_discharge = save_battery_rate_max_discharge
             my_predbat.inverter_limit = save_inverter_limit
+            # Restore config: overrides after each tariff too, for the same reason - otherwise a
+            # tariff's config override stays applied to config_index for every subsequent tariff,
+            # even ones with no config block of their own (issue #4156)
+            if config_snapshot:
+                for key, orig_value in config_snapshot.items():
+                    item = my_predbat.config_index.get(key)
+                    if item is not None:
+                        item["value"] = orig_value
+                my_predbat.fetch_config_options()
             # Save and update comparisons as we go so it is updated in HA
             self.select_best(compare_list, results)
             self.comparisons = results

--- a/apps/predbat/tests/test_compare.py
+++ b/apps/predbat/tests/test_compare.py
@@ -344,6 +344,31 @@ def test_compare(my_predbat):
         print("ERROR T11: apply_hardware_overrides raised on bad input: {}".format(e))
         failed += 1
 
+    # ------------------------------------------------------------------
+    # T12: run_all() source actually contains the mid-loop config restore
+    #      (T9/T10 above only prove the pattern works in isolation - this
+    #      closes the gap by checking it's genuinely wired into run_all()
+    #      itself, not just demonstrated as a standalone snippet - #4156)
+    # ------------------------------------------------------------------
+    import inspect
+
+    run_all_source = inspect.getsource(Compare.run_all)
+    # The restore block must appear between the "restore hardware settings" comment (which is
+    # inside the per-tariff loop) and the loop's closing use of publish_data(), otherwise it's
+    # not actually running once per tariff.
+    hardware_restore_idx = run_all_source.find("Restore hardware settings after each tariff")
+    publish_data_idx = run_all_source.find("self.publish_data()")
+    config_restore_idx = run_all_source.find("config_snapshot", hardware_restore_idx + 1) if hardware_restore_idx >= 0 else -1
+
+    if hardware_restore_idx < 0 or publish_data_idx < 0:
+        print("ERROR T12: could not locate expected markers in run_all() source - test may need updating")
+        failed += 1
+    elif not (hardware_restore_idx < config_restore_idx < publish_data_idx):
+        print("ERROR T12: config_snapshot restore is not positioned inside the per-tariff loop in run_all() - the #4156 leak is not actually fixed")
+        failed += 1
+    else:
+        print("PASS T12: run_all() restores config: overrides inside the per-tariff loop, not just once at the end")
+
     if failed:
         print("**** compare tests FAILED: {} errors ****\n".format(failed))
     else:


### PR DESCRIPTION
## Summary

Fixes #4156. `Compare.run_all()` snapshotted `config_index` values overridden by any tariff's `config:` block once before the comparison loop, but only restored them once after the *entire* loop finished. A tariff's `config:` override stayed applied to `config_index` for every subsequent tariff in the list, even ones defining no `config:` block of their own - so a tariff's simulated result depended on its position in `compare_list`, not just its own settings, making the comparison not a fair like-for-like.

This was inconsistent with the hardware overrides (`soc_max`, `battery_rate_max_charge`, `battery_rate_max_charge_dc`, `battery_rate_max_discharge`, `inverter_limit`), which were already correctly restored after each individual tariff *inside* the loop - exactly as the issue's own analysis pointed out.

## Changes

- `apps/predbat/compare.py`: `config:` overrides now follow the same per-iteration restore pattern as the hardware overrides, applied right alongside them inside the loop. The existing final restore after the loop is kept too (matching how the hardware overrides also get a final restore - presumably a safety net for the rest of Predbat's live operation after the whole comparison finishes, not just between tariffs).
- `apps/predbat/tests/test_compare.py`: added T12. The existing T9/T10 already proved the snapshot/restore pattern works correctly *in isolation* (as a standalone simulation copied into the test), but didn't check it was actually wired into `run_all()` itself, where the real bug lived. T12 closes that gap with a source-level check confirming the restore genuinely runs inside the per-tariff loop, not just once at the end.

## Test plan

- [x] `./run_all --test compare` - all 12 subtests pass (T1-T11 existing, T12 new)
- [x] `./run_all --quick` - full quick suite passes (604 tests, 0 failures)
- [x] `./run_pre_commit` - clean (ruff, black, cspell, markdownlint)

🤖 Implemented with Claude Code, disclosed per repo convention.