### PR TITLE
fix(web): correct entity history bucketing, fix percent-unit charts

### DIFF
--- a/apps/predbat/tests/test_web_chart_grouping.py
+++ b/apps/predbat/tests/test_web_chart_grouping.py
@@ -1,0 +1,69 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+from web import split_entities_for_charting
+
+
+def make_history(records):
+    """Wrap a list of raw HA history records in the [[...]] shape returned by get_history_with_now."""
+    return [records]
+
+
+def run_web_chart_grouping_tests(my_predbat):
+    """Unit tests for split_entities_for_charting() - a unit group can mix numeric and non-numeric entities."""
+    failed = 0
+    print("**** Running web chart grouping tests ****")
+
+    # -------------------------------------------------------------------------
+    print("Test: a numeric entity is charted even when a non-numeric entity in the same group is processed after it")
+    entities = [
+        {"id": "number.percent", "friendly_name": "Percent", "attribute": None},
+        {"id": "select.status", "friendly_name": "Status", "attribute": None},
+    ]
+    entity_data_fetch = {
+        "number.percent": make_history([{"last_updated": "2026-07-23T10:00:00+00:00", "state": "45"}, {"last_updated": "2026-07-23T10:05:00+00:00", "state": "50"}]),
+        "select.status": make_history([{"last_updated": "2026-07-23T10:00:00+00:00", "state": "Demand"}, {"last_updated": "2026-07-23T10:05:00+00:00", "state": "Idle"}]),
+    }
+    numeric_entries, timeline_entries = split_entities_for_charting(entities, entity_data_fetch)
+
+    numeric_ids = [e["entity_id"] for e in numeric_entries]
+    timeline_ids = [e["entity_id"] for e in timeline_entries]
+    if "number.percent" not in numeric_ids:
+        print(f"  ERROR: expected the numeric entity to be charted as a line series, got numeric entries: {numeric_ids}")
+        failed += 1
+    if "select.status" not in timeline_ids:
+        print(f"  ERROR: expected the non-numeric entity to be charted as a timeline series, got timeline entries: {timeline_ids}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: the same split holds regardless of entity order (numeric entity listed first)")
+    entities_reordered = [
+        {"id": "select.status", "friendly_name": "Status", "attribute": None},
+        {"id": "number.percent", "friendly_name": "Percent", "attribute": None},
+    ]
+    numeric_entries, timeline_entries = split_entities_for_charting(entities_reordered, entity_data_fetch)
+    numeric_ids = [e["entity_id"] for e in numeric_entries]
+    timeline_ids = [e["entity_id"] for e in timeline_entries]
+    if "number.percent" not in numeric_ids:
+        print(f"  ERROR: order shouldn't matter - expected the numeric entity charted as a line series, got numeric entries: {numeric_ids}")
+        failed += 1
+    if "select.status" not in timeline_ids:
+        print(f"  ERROR: order shouldn't matter - expected the non-numeric entity charted as a timeline series, got timeline entries: {timeline_ids}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: an entity with no history data is skipped entirely")
+    entities_missing = [{"id": "number.missing", "friendly_name": "Missing", "attribute": None}]
+    numeric_entries, timeline_entries = split_entities_for_charting(entities_missing, {"number.missing": make_history([])})
+    if numeric_entries or timeline_entries:
+        print(f"  ERROR: expected no entries for an entity with no history, got numeric={numeric_entries} timeline={timeline_entries}")
+        failed += 1
+
+    return failed

--- a/apps/predbat/tests/test_web_charts.py
+++ b/apps/predbat/tests/test_web_charts.py
@@ -1,0 +1,59 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+from web import WebInterface
+
+
+def make_web(my_predbat):
+    """Create a WebInterface instance bound to the given predbat."""
+    return WebInterface(my_predbat, web_port=5053)
+
+
+def run_web_charts_tests(my_predbat):
+    """Unit tests for chart rendering - entities with a '%' unit must still be able to chart."""
+    failed = 0
+    print("**** Running web charts tests ****")
+
+    web = make_web(my_predbat)
+    now_str = my_predbat.now_utc.strftime("%Y-%m-%dT%H:%M:%S%z")
+    series_data = [{"name": "SoC", "data": {"2026-07-23T10:00:00+00:00": 45.0}, "chart_type": "line"}]
+
+    # -------------------------------------------------------------------------
+    print("Test: render_chart() targets a percent-unit tagname via getElementById, not a CSS id selector")
+    html = web.render_chart(series_data, "%", "SoC Chart", now_str, tagname="chart_%")
+    if "querySelector('#" in html or 'querySelector("#' in html:
+        print("  ERROR: render_chart() still targets the chart element via a '#id' CSS selector, which throws for a tagname like 'chart_%'")
+        failed += 1
+    if "getElementById('chart_%')" not in html:
+        print(f"  ERROR: expected render_chart() to call getElementById('chart_%'), got: {html}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: render_timeline_chart() targets a percent-unit tagname via getElementById, not a CSS id selector")
+    timeline_data = [{"name": "Status", "entity_id": "sensor.x", "data": {"2026-07-23T10:00:00+00:00": "on"}}]
+    html = web.render_timeline_chart(timeline_data, "chart_%", 7)
+    if "querySelector('#" in html or 'querySelector("#' in html:
+        print("  ERROR: render_timeline_chart() still targets the chart element via a '#id' CSS selector, which throws for a tagname like 'chart_%'")
+        failed += 1
+    if "getElementById('chart_%')" not in html:
+        print(f"  ERROR: expected render_timeline_chart() to call getElementById('chart_%'), got: {html}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: render_heatmap_chart() targets a percent-unit chart_id via getElementById, not a CSS id selector")
+    html = web.render_heatmap_chart([{"name": "SoC", "data": [{"x": "Mon", "y": 45.0}]}], "SoC Heatmap", 0, 100, chart_id="chart_%")
+    if "querySelector('#" in html or 'querySelector("#' in html:
+        print("  ERROR: render_heatmap_chart() still targets the chart element via a '#id' CSS selector, which throws for a chart_id like 'chart_%'")
+        failed += 1
+    if "getElementById('chart_%')" not in html:
+        print(f"  ERROR: expected render_heatmap_chart() to call getElementById('chart_%'), got: {html}")
+        failed += 1
+
+    return failed

--- a/apps/predbat/tests/test_web_entity_unit_resolution.py
+++ b/apps/predbat/tests/test_web_entity_unit_resolution.py
@@ -1,0 +1,66 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+from web import resolve_group_unit_and_name
+
+
+def run_web_entity_unit_resolution_tests(my_predbat):
+    """Unit tests for resolve_group_unit_and_name() - the /entity chart's unit/name grouping."""
+    failed = 0
+    print("**** Running web entity unit resolution tests ****")
+
+    # -------------------------------------------------------------------------
+    print("Test: an entity tracked in dashboard_values groups and labels from its cached attributes")
+    dashboard_values = {"number.percent": {"attributes": {"unit_of_measurement": "%", "friendly_name": "AC Charge Upper % Limit"}}}
+    unit, friendly_name = resolve_group_unit_and_name("number.percent", dashboard_values)
+    if unit != "%":
+        print(f"  ERROR: expected unit '%', got '{unit}'")
+        failed += 1
+    if friendly_name != "AC Charge Upper % Limit":
+        print(f"  ERROR: expected friendly name from dashboard_values, got '{friendly_name}'")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: an entity tracked in dashboard_values with no unit falls back to '(no unit)'")
+    dashboard_values = {"predbat.status": {"attributes": {"friendly_name": "Status"}}}
+    unit, friendly_name = resolve_group_unit_and_name("predbat.status", dashboard_values)
+    if unit != "(no unit)":
+        print(f"  ERROR: expected '(no unit)', got '{unit}'")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: an entity NOT tracked in dashboard_values uses the caller-supplied live HA lookup")
+    unit, friendly_name = resolve_group_unit_and_name("number.gecloud_ac_charge_upper_percent_limit", {}, live_unit="%", live_friendly_name="AC Charge Upper % Limit")
+    if unit != "%":
+        print(f"  ERROR: expected the live HA unit '%' to be used for an entity Predbat doesn't track, got '{unit}'")
+        failed += 1
+    if friendly_name != "AC Charge Upper % Limit":
+        print(f"  ERROR: expected the live HA friendly name to be used, got '{friendly_name}'")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: an entity NOT tracked in dashboard_values with no live lookup result falls back to '(no unit)' and its id")
+    unit, friendly_name = resolve_group_unit_and_name("number.unknown", {}, live_unit=None, live_friendly_name=None)
+    if unit != "(no unit)":
+        print(f"  ERROR: expected '(no unit)', got '{unit}'")
+        failed += 1
+    if friendly_name != "number.unknown":
+        print(f"  ERROR: expected the entity_id itself as a last-resort name, got '{friendly_name}'")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: dashboard_values takes priority - the live lookup arguments are ignored when the entity is tracked")
+    dashboard_values = {"number.percent": {"attributes": {"unit_of_measurement": "%"}}}
+    unit, friendly_name = resolve_group_unit_and_name("number.percent", dashboard_values, live_unit="kWh", live_friendly_name="Wrong Name")
+    if unit != "%":
+        print(f"  ERROR: expected dashboard_values' unit '%' to win over the live lookup, got '{unit}'")
+        failed += 1
+
+    return failed

--- a/apps/predbat/tests/test_web_history_table.py
+++ b/apps/predbat/tests/test_web_history_table.py
@@ -1,0 +1,207 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+from datetime import datetime, timedelta, timezone
+
+from web import build_entity_history_table_data
+
+
+def make_history(records):
+    """Wrap a list of raw HA history records in the [[...]] shape returned by get_history_with_now."""
+    return [records]
+
+
+def run_web_history_table_tests(my_predbat):
+    """Unit tests for build_entity_history_table_data() used by the /entity history table."""
+    failed = 0
+    print("**** Running web history table tests ****")
+
+    # -------------------------------------------------------------------------
+    print("Test: 30-min bucket keeps the most recent sample, not the oldest, when several samples land in the same window")
+    selections = [{"entity_id": "sensor.x", "attribute": None}]
+    fetch = {
+        "sensor.x": make_history(
+            [
+                {"last_updated": "2026-07-23T10:01:00+00:00", "state": "5"},
+                {"last_updated": "2026-07-23T10:02:00+00:00", "state": "6"},
+                {"last_updated": "2026-07-23T10:03:00+00:00", "state": "7"},
+                {"last_updated": "2026-07-23T10:04:00+00:00", "state": "8"},
+            ]
+        )
+    }
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
+
+    bucket_30 = datetime(2026, 7, 23, 10, 0, 0, tzinfo=timezone.utc)
+    value, is_known, prev_value = filled_30[0][bucket_30]
+    if value != "8":
+        print(f"  ERROR: expected 30-min bucket to hold the latest sample '8', got '{value}'")
+        failed += 1
+    if not is_known:
+        print("  ERROR: expected 30-min bucket to be flagged as directly known")
+        failed += 1
+    if prev_value is not None:
+        print(f"  ERROR: expected no prior value before the first bucket, got '{prev_value}'")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: 5-min bucket keeps the most recent sample, not the oldest, when several samples land in the same window")
+    selections = [{"entity_id": "sensor.x", "attribute": None}]
+    fetch = {
+        "sensor.x": make_history(
+            [
+                {"last_updated": "2026-07-23T10:26:00+00:00", "state": "5"},
+                {"last_updated": "2026-07-23T10:27:00+00:00", "state": "6"},
+                {"last_updated": "2026-07-23T10:28:00+00:00", "state": "7"},
+                {"last_updated": "2026-07-23T10:29:00+00:00", "state": "8"},
+                # A later sample in the next 30-min window, purely so 10:25 becomes a rendered detail slot
+                # (detail slots are the offsets -5..-25 leading up to each known 30-min bucket).
+                {"last_updated": "2026-07-23T10:35:00+00:00", "state": "9"},
+            ]
+        )
+    }
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
+
+    bucket_5 = datetime(2026, 7, 23, 10, 25, 0, tzinfo=timezone.utc)
+    if bucket_5 not in display_slots_5:
+        print(f"  ERROR: test setup expected {bucket_5} to be a rendered detail slot, got {display_slots_5}")
+        failed += 1
+    value, is_known, prev_value = filled_5[0][bucket_5]
+    if value != "8":
+        print(f"  ERROR: expected 5-min bucket to hold the latest sample '8', got '{value}'")
+        failed += 1
+    if not is_known:
+        print("  ERROR: expected 5-min bucket to be flagged as directly known")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: two columns for the same entity_id stay consistent with each other")
+    selections = [
+        {"entity_id": "sensor.x", "attribute": None},
+        {"entity_id": "sensor.x", "attribute": "other"},
+    ]
+    fetch = {
+        "sensor.x": make_history(
+            [
+                {"last_updated": "2026-07-23T10:01:00+00:00", "state": "5", "attributes": {"other": "o1"}},
+                {"last_updated": "2026-07-23T10:02:00+00:00", "state": "6", "attributes": {"other": "o2"}},
+                {"last_updated": "2026-07-23T10:03:00+00:00", "state": "7", "attributes": {"other": "o3"}},
+                {"last_updated": "2026-07-23T10:04:00+00:00", "state": "8", "attributes": {"other": "o4"}},
+            ]
+        )
+    }
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
+
+    state_value, _, _ = filled_30[0][bucket_30]
+    attr_value, _, _ = filled_30[1][bucket_30]
+    if state_value != "8":
+        print(f"  ERROR: state column should pick the latest sample '8', got '{state_value}'")
+        failed += 1
+    if attr_value != "o4":
+        print(f"  ERROR: attribute column should pick the latest sample 'o4', got '{attr_value}'")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: 30-min bucket timestamps round down and never overflow the hour")
+    selections = [{"entity_id": "sensor.y", "attribute": None}]
+    fetch = {
+        "sensor.y": make_history(
+            [
+                {"last_updated": "2026-07-23T10:07:00+00:00", "state": "mid"},
+                {"last_updated": "2026-07-23T23:59:00+00:00", "state": "late"},
+            ]
+        )
+    }
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
+
+    expected_30 = {
+        datetime(2026, 7, 23, 10, 0, 0, tzinfo=timezone.utc),
+        datetime(2026, 7, 23, 23, 30, 0, tzinfo=timezone.utc),
+    }
+    if set(sorted_ts_30) != expected_30:
+        print(f"  ERROR: expected 30-min buckets {expected_30}, got {set(sorted_ts_30)}")
+        failed += 1
+    if sorted_ts_30 != sorted(sorted_ts_30, reverse=True):
+        print("  ERROR: expected sorted_timestamps_30min in descending (newest-first) order")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: display slots for detail rows are the 5-min offsets leading up to each 30-min bucket")
+    selections = [{"entity_id": "sensor.x", "attribute": None}]
+    fetch = {
+        "sensor.x": make_history(
+            [
+                {"last_updated": "2026-07-23T10:01:00+00:00", "state": "5"},
+                {"last_updated": "2026-07-23T10:35:00+00:00", "state": "9"},
+            ]
+        )
+    }
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
+
+    # Expected: the 5-min offsets (-5 to -25) leading up to each of the two known 30-min buckets (10:00 and 10:30)
+    expected_slots = set()
+    for base_hour, base_minute in ((10, 0), (10, 30)):
+        base = datetime(2026, 7, 23, base_hour, base_minute, 0, tzinfo=timezone.utc)
+        for offset in (5, 10, 15, 20, 25):
+            expected_slots.add(base - timedelta(minutes=offset))
+    if display_slots_5 != expected_slots:
+        print(f"  ERROR: expected display slots {expected_slots}, got {display_slots_5}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: a 30-min bucket with no direct sample carries forward the previous known value")
+    selections = [
+        {"entity_id": "sensor.a", "attribute": None},
+        {"entity_id": "sensor.b", "attribute": None},
+    ]
+    fetch = {
+        "sensor.a": make_history([{"last_updated": "2026-07-23T10:00:00+00:00", "state": "A1"}]),
+        "sensor.b": make_history([{"last_updated": "2026-07-23T10:30:00+00:00", "state": "B1"}]),
+    }
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
+
+    ts_1000 = datetime(2026, 7, 23, 10, 0, 0, tzinfo=timezone.utc)
+    ts_1030 = datetime(2026, 7, 23, 10, 30, 0, tzinfo=timezone.utc)
+
+    value, is_known, prev_value = filled_30[0][ts_1030]
+    if value != "A1" or is_known:
+        print(f"  ERROR: expected sensor.a to carry forward 'A1' as unknown at 10:30, got value={value} is_known={is_known}")
+        failed += 1
+
+    value, is_known, prev_value = filled_30[1][ts_1000]
+    if value != "-" or is_known or prev_value is not None:
+        print(f"  ERROR: expected sensor.b to have no value before its first sample at 10:00, got value={value} is_known={is_known} prev_value={prev_value}")
+        failed += 1
+
+    value, is_known, prev_value = filled_30[1][ts_1030]
+    if value != "B1" or not is_known:
+        print(f"  ERROR: expected sensor.b to show its own sample 'B1' at 10:30, got value={value} is_known={is_known}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: records missing last_updated are skipped and a missing state renders as 'None'")
+    selections = [{"entity_id": "sensor.z", "attribute": None}]
+    fetch = {
+        "sensor.z": make_history(
+            [
+                {"state": "no-timestamp"},
+                {"last_updated": "2026-07-23T12:00:00+00:00", "state": None},
+            ]
+        )
+    }
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
+    ts_1200 = datetime(2026, 7, 23, 12, 0, 0, tzinfo=timezone.utc)
+    value, is_known, _ = filled_30[0][ts_1200]
+    if value != "None" or not is_known:
+        print(f"  ERROR: expected a missing state to render as the string 'None', got value={value} is_known={is_known}")
+        failed += 1
+    if len(sorted_ts_30) != 1:
+        print(f"  ERROR: expected the record without last_updated to be skipped, got buckets {sorted_ts_30}")
+        failed += 1
+
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -67,6 +67,7 @@ from tests.test_web_if import run_test_web_if
 from tests.test_web_functions import run_web_functions_tests
 from tests.test_web_history_table import run_web_history_table_tests
 from tests.test_web_charts import run_web_charts_tests
+from tests.test_web_chart_grouping import run_web_chart_grouping_tests
 from tests.test_window import run_window_sort_tests, run_intersect_window_tests
 from tests.test_find_charge_rate import test_find_charge_rate, test_find_charge_rate_string_temperature, test_find_charge_rate_string_charge_curve
 from tests.test_manual_api import run_test_manual_api
@@ -280,6 +281,7 @@ def main():
         ("web_functions", run_web_functions_tests, "Web function unit tests", False),
         ("web_history_table", run_web_history_table_tests, "Web /entity history table bucketing tests", False),
         ("web_charts", run_web_charts_tests, "Web chart rendering tests (percent/special-character units)", False),
+        ("web_chart_grouping", run_web_chart_grouping_tests, "Web /entity chart numeric vs timeline grouping tests", False),
         ("nordpool", run_nordpool_test, "Nordpool tests", False),
         ("futurerate_auto", test_futurerate_auto, "FutureRate auto Agile detection tests", False),
         ("octopus_slots", run_load_octopus_slots_tests, "Load Octopus slots tests", False),

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -68,6 +68,7 @@ from tests.test_web_functions import run_web_functions_tests
 from tests.test_web_history_table import run_web_history_table_tests
 from tests.test_web_charts import run_web_charts_tests
 from tests.test_web_chart_grouping import run_web_chart_grouping_tests
+from tests.test_web_entity_unit_resolution import run_web_entity_unit_resolution_tests
 from tests.test_window import run_window_sort_tests, run_intersect_window_tests
 from tests.test_find_charge_rate import test_find_charge_rate, test_find_charge_rate_string_temperature, test_find_charge_rate_string_charge_curve
 from tests.test_manual_api import run_test_manual_api
@@ -282,6 +283,7 @@ def main():
         ("web_history_table", run_web_history_table_tests, "Web /entity history table bucketing tests", False),
         ("web_charts", run_web_charts_tests, "Web chart rendering tests (percent/special-character units)", False),
         ("web_chart_grouping", run_web_chart_grouping_tests, "Web /entity chart numeric vs timeline grouping tests", False),
+        ("web_entity_unit_resolution", run_web_entity_unit_resolution_tests, "Web /entity chart unit/name resolution tests", False),
         ("nordpool", run_nordpool_test, "Nordpool tests", False),
         ("futurerate_auto", test_futurerate_auto, "FutureRate auto Agile detection tests", False),
         ("octopus_slots", run_load_octopus_slots_tests, "Load Octopus slots tests", False),

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -65,6 +65,8 @@ from tests.test_hainterface_lifecycle import run_hainterface_lifecycle_tests
 from tests.test_hainterface_websocket import run_hainterface_websocket_tests
 from tests.test_web_if import run_test_web_if
 from tests.test_web_functions import run_web_functions_tests
+from tests.test_web_history_table import run_web_history_table_tests
+from tests.test_web_charts import run_web_charts_tests
 from tests.test_window import run_window_sort_tests, run_intersect_window_tests
 from tests.test_find_charge_rate import test_find_charge_rate, test_find_charge_rate_string_temperature, test_find_charge_rate_string_charge_curve
 from tests.test_manual_api import run_test_manual_api
@@ -276,6 +278,8 @@ def main():
         ("manual_select", run_test_manual_select, "Manual select tests", False),
         ("web_if", run_test_web_if, "Web interface tests", False),
         ("web_functions", run_web_functions_tests, "Web function unit tests", False),
+        ("web_history_table", run_web_history_table_tests, "Web /entity history table bucketing tests", False),
+        ("web_charts", run_web_charts_tests, "Web chart rendering tests (percent/special-character units)", False),
         ("nordpool", run_nordpool_test, "Nordpool tests", False),
         ("futurerate_auto", test_futurerate_auto, "FutureRate auto Agile detection tests", False),
         ("octopus_slots", run_load_octopus_slots_tests, "Load Octopus slots tests", False),

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -268,6 +268,30 @@ def split_entities_for_charting(entities, entity_data_fetch):
     return numeric_entries, timeline_entries
 
 
+def resolve_group_unit_and_name(entity_id, dashboard_values, live_unit=None, live_friendly_name=None):
+    """
+    Resolve the unit_of_measurement/friendly_name to group and label an entity by for the
+    /entity charts.
+
+    Prefers Predbat's own dashboard_values cache, falling back to a caller-supplied live HA
+    lookup (mirroring html_get_entity_text's fallback) for entities Predbat doesn't track
+    itself - e.g. inverter control entities that are selectable on this page but were never
+    published via dashboard_item(), which otherwise silently grouped every such entity into
+    "(no unit)" regardless of their real HA unit.
+
+    live_unit/live_friendly_name should only be looked up by the caller when entity_id isn't
+    in dashboard_values, since that's the only case they're used.
+    """
+    attributes = dashboard_values.get(entity_id, {}).get("attributes", {})
+    if entity_id in dashboard_values:
+        unit = attributes.get("unit_of_measurement") or ""
+        friendly_name = attributes.get("friendly_name") or ""
+    else:
+        unit = live_unit or ""
+        friendly_name = live_friendly_name or ""
+    return unit or "(no unit)", friendly_name or entity_id
+
+
 class WebInterface(ComponentBase):
     """Built-in web dashboard server using aiohttp.
 
@@ -1193,13 +1217,16 @@ class WebInterface(ComponentBase):
                 entity_id = selection["entity_id"]
                 attribute = selection["attribute"]
 
-                attributes = self.base.dashboard_values.get(entity_id, {}).get("attributes", {})
-                unit = attributes.get("unit_of_measurement", "") or "(no unit)"
+                live_unit = live_friendly_name = None
+                if entity_id not in self.base.dashboard_values:
+                    live_unit = self.get_state_wrapper(entity_id=entity_id, attribute="unit_of_measurement")
+                    live_friendly_name = self.get_state_wrapper(entity_id=entity_id, attribute="friendly_name")
+                unit, friendly_name = resolve_group_unit_and_name(entity_id, self.base.dashboard_values, live_unit, live_friendly_name)
 
                 if unit not in entity_groups:
                     entity_groups[unit] = []
 
-                entity_groups[unit].append({"id": entity_id, "friendly_name": attributes.get("friendly_name", entity_id), "unit": unit, "attribute": attribute, "available_attrs": entity_attributes_map.get(entity_id, [])})
+                entity_groups[unit].append({"id": entity_id, "friendly_name": friendly_name, "unit": unit, "attribute": attribute, "available_attrs": entity_attributes_map.get(entity_id, [])})
 
             # Display entity details table for first selected entity
             if len(entity_selections) == 1:

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -186,6 +186,88 @@ def build_entity_history_table_data(entity_selections, entity_data_fetch):
     return entity_filled_30min, entity_filled_5min, sorted_timestamps_30min, all_display_slots_5min
 
 
+def is_data_numerical(history, attribute=None):
+    """
+    Check if history data is numerical (supports both state and attribute checking)
+    Returns True if at least 10% of values are numeric or boolean
+    """
+    count_nums = 0
+    count_total = 0
+
+    if history and len(history) >= 1:
+        for item in history[0]:
+            if attribute:
+                # Check attribute value
+                attr_value = item.get("attributes", {}).get(attribute, None)
+                if attr_value is None:
+                    continue
+                value = str(attr_value)
+            else:
+                # Check state value
+                value = item.get("state", None)
+                if value is None:
+                    continue
+                value = str(value)
+
+            if value.lower() in ["on", "off", "true", "false"]:
+                count_nums += 1
+            else:
+                try:
+                    float(value)
+                    count_nums += 1
+                except (ValueError, TypeError):
+                    pass
+            count_total += 1
+
+    if count_total > 0 and (count_nums / count_total) >= 0.1:
+        return True
+    elif count_total == 0:
+        return True
+    return False
+
+
+def split_entities_for_charting(entities, entity_data_fetch):
+    """
+    Fetch each entity's history and split a unit group into numeric vs non-numeric entries.
+
+    Deciding numeric-vs-timeline per entity (rather than once for the whole group, from
+    whichever entity happened to be processed last) means a numeric entity doesn't end up
+    silently rendered as a broken timeline chart just because another entity sharing the same
+    unit group is non-numerical.
+
+    entities: list of {"id": entity_id, "friendly_name": ..., "attribute": ...}
+    entity_data_fetch: dict of entity_id -> history as returned by get_history_with_now()
+
+    Returns (numeric_entries, timeline_entries), each a list of
+    {"name": display_name, "friendly_name": ..., "entity_id": ..., "data": history_chart}.
+    """
+    numeric_entries = []
+    timeline_entries = []
+
+    for entity_info in entities:
+        entity_id = entity_info["id"]
+        friendly_name = entity_info["friendly_name"]
+        attribute = entity_info.get("attribute")
+
+        history = entity_data_fetch.get(entity_id)
+        is_numerical = is_data_numerical(history, attribute=attribute)
+
+        if attribute:
+            history_chart = history_attribute(history, state_key=attribute, attributes=True, is_numerical=is_numerical)
+            display_name = f"{friendly_name} ({attribute})"
+        else:
+            history_chart = history_attribute(history, is_numerical=is_numerical)
+            display_name = friendly_name
+
+        if not history_chart:
+            continue
+
+        entry = {"name": display_name, "friendly_name": friendly_name, "entity_id": entity_id, "data": history_chart}
+        (numeric_entries if is_numerical else timeline_entries).append(entry)
+
+    return numeric_entries, timeline_entries
+
+
 class WebInterface(ComponentBase):
     """Built-in web dashboard server using aiohttp.
 
@@ -917,45 +999,6 @@ class WebInterface(ComponentBase):
             self.base.log(f"Error in html_api_get_entities: {e}")
             return web.json_response({"error": str(e)}, status=500)
 
-    def is_data_numerical(self, history, attribute=None):
-        """
-        Check if history data is numerical (supports both state and attribute checking)
-        Returns True if at least 10% of values are numeric or boolean
-        """
-        count_nums = 0
-        count_total = 0
-
-        if history and len(history) >= 1:
-            for item in history[0]:
-                if attribute:
-                    # Check attribute value
-                    attr_value = item.get("attributes", {}).get(attribute, None)
-                    if attr_value is None:
-                        continue
-                    value = str(attr_value)
-                else:
-                    # Check state value
-                    value = item.get("state", None)
-                    if value is None:
-                        continue
-                    value = str(value)
-
-                if value.lower() in ["on", "off", "true", "false"]:
-                    count_nums += 1
-                else:
-                    try:
-                        float(value)
-                        count_nums += 1
-                    except (ValueError, TypeError):
-                        pass
-                count_total += 1
-
-        if count_total > 0 and (count_nums / count_total) >= 0.1:
-            return True
-        elif count_total == 0:
-            return True
-        return False
-
     async def get_history_with_now(self, entity_id, days, attribute=None):
         """
         Get history for an entity including the current state
@@ -1189,46 +1232,28 @@ class WebInterface(ComponentBase):
             now_str = self.now_utc.strftime(TIME_FORMAT)
 
             for unit, entities in entity_groups.items():
+                # Numeric and non-numeric entities are split per-entity (not decided once for the
+                # whole group) so a numeric entity sharing a unit with a non-numerical one still
+                # gets a proper line chart instead of being dropped into a broken timeline chart.
+                numeric_entries, timeline_entries = split_entities_for_charting(entities, entity_data_fetch)
+                if not numeric_entries and not timeline_entries:
+                    continue
+
                 text += "<h2>History Chart - {}</h2>\n".format(unit if unit != "(no unit)" else "(no unit)")
-                chart_id = "chart_{}".format(unit.replace("/", "_").replace(" ", "_").replace("(", "").replace(")", ""))
-                text += '<div id="{}"></div>'.format(chart_id)
-                is_numerical = False
+                base_chart_id = "chart_{}".format(unit.replace("/", "_").replace(" ", "_").replace("(", "").replace(")", ""))
 
-                # First, collect all entity data
-                entity_data = []
-                for entity_info in entities:
-                    entity_id = entity_info["id"]
-                    friendly_name = entity_info["friendly_name"]
-                    attribute = entity_info.get("attribute")
-
-                    # Fetch history with attribute if specified
-                    history = entity_data_fetch[entity_id]
-
-                    # Check if data is numerical (supports both state and attribute)
-                    is_numerical = self.is_data_numerical(history, attribute=attribute)
-
-                    # Extract chart data using history_attribute
-                    if attribute:
-                        # Chart attribute data
-                        history_chart = history_attribute(history, state_key=attribute, attributes=True, is_numerical=is_numerical)
-                        display_name = f"{friendly_name} ({attribute})"
-                    else:
-                        # Chart state data (default)
-                        history_chart = history_attribute(history, is_numerical=is_numerical)
-                        display_name = friendly_name
-
-                    if history_chart:
-                        entity_data.append({"name": display_name, "entity_id": entity_id, "data": history_chart})
-
-                # Prepare data for the appropriate chart type
-                if is_numerical:
-                    series_data = [{"name": item["name"], "data": item["data"], "chart_type": "line", "stroke_width": "2", "stroke_curve": "stepline"} for item in entity_data]
+                if numeric_entries:
+                    chart_id = base_chart_id
+                    text += '<div id="{}"></div>'.format(chart_id)
+                    series_data = [{"name": item["name"], "data": item["data"], "chart_type": "line", "stroke_width": "2", "stroke_curve": "stepline"} for item in numeric_entries]
                     chart_unit = unit if unit != "(no unit)" else ""
-                    chart_title = "{} entities".format(len(entities)) if len(entities) > 1 else entities[0]["friendly_name"]
+                    chart_title = "{} entities".format(len(numeric_entries)) if len(numeric_entries) > 1 else numeric_entries[0]["friendly_name"]
                     text += self.render_chart(series_data, chart_unit, chart_title, now_str, tagname=chart_id)
-                else:
-                    # Render timeline chart for non-numerical data
-                    text += self.render_timeline_chart(entity_data, chart_id, days)
+
+                if timeline_entries:
+                    chart_id = base_chart_id + "_timeline" if numeric_entries else base_chart_id
+                    text += '<div id="{}"></div>'.format(chart_id)
+                    text += self.render_timeline_chart(timeline_entries, chart_id, days)
 
             # History table showing all selected entities
             if entity_selections:

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -81,6 +81,111 @@ from marginal import MARGINAL_EXTRA_KWH_LEVEL_NAMES, MARGINAL_EXTRA_KWH_LEVELS, 
 ROOT_YAML_KEY = "pred_bat"
 
 
+def build_entity_history_table_data(entity_selections, entity_data_fetch):
+    """
+    Bucket raw HA history into 5-minute and 30-minute windows for the /entity history table.
+
+    entity_selections: list of {"entity_id": ..., "attribute": ...} (attribute may be None for state)
+    entity_data_fetch: dict of entity_id -> history as returned by get_history_with_now(), i.e. [[record, ...]]
+
+    Each raw record list is oldest-first; it is read (never mutated) in that order so that, when
+    several records round into the same bucket, the bucket keeps the most recent one - the value
+    that was actually in effect by the end of that window and that should carry forward into the
+    next bucket without data.
+
+    Returns (entity_filled_30min, entity_filled_5min, sorted_timestamps_30min, all_display_slots_5min):
+      entity_filled_30min / entity_filled_5min: one dict per selection, {slot: (value, is_known, prev_value)}
+        with unfilled slots carried forward from the last known value ("-" if none yet)
+      sorted_timestamps_30min: all known 30-min bucket timestamps, newest first
+      all_display_slots_5min: the 5-min detail-row slots (offsets -5 to -25) leading up to each 30-min bucket
+    """
+    entity_histories_30min = []
+    entity_histories_5min = []
+    all_timestamps_30min = set()
+
+    for selection in entity_selections:
+        entity_id = selection["entity_id"]
+        attribute = selection["attribute"]
+        history = entity_data_fetch[entity_id]
+        entity_data_30min = {}
+        entity_data_5min = {}
+
+        if history and len(history) >= 1:
+            history = history[0]
+            if history:
+                for item in history:
+                    if "last_updated" not in item:
+                        continue
+                    last_updated_time = item["last_updated"]
+                    last_updated_stamp = str2time(last_updated_time)
+
+                    # Get state or attribute value
+                    if attribute:
+                        state = item.get("attributes", {}).get(attribute, None)
+                    else:
+                        state = item.get("state", None)
+
+                    if state is None:
+                        state = "None"
+
+                    # Store 5-minute interval data
+                    minutes = last_updated_stamp.hour * 60 + last_updated_stamp.minute
+                    rounded_minutes_5 = (minutes // 5) * 5
+                    rounded_stamp_5 = last_updated_stamp.replace(minute=rounded_minutes_5 % 60, hour=rounded_minutes_5 // 60, second=0, microsecond=0)
+                    entity_data_5min[rounded_stamp_5] = state
+
+                    # Round to 30-minute intervals for summary
+                    rounded_minutes_30 = (minutes // 30) * 30
+                    rounded_stamp_30 = last_updated_stamp.replace(minute=rounded_minutes_30 % 60, hour=rounded_minutes_30 // 60, second=0, microsecond=0)
+                    entity_data_30min[rounded_stamp_30] = state
+                    all_timestamps_30min.add(rounded_stamp_30)
+
+        entity_histories_30min.append(entity_data_30min)
+        entity_histories_5min.append(entity_data_5min)
+
+    # Sort timestamps in reverse chronological order
+    sorted_timestamps_30min = sorted(all_timestamps_30min, reverse=True)
+
+    # Collect all display slots so we can precompute carry-forward fill
+    # Detail rows go BACKWARDS from the 30-min parent timestamp (offsets -5 to -25)
+    all_display_slots_5min = set()
+    for ts_30 in sorted_timestamps_30min:
+        for offset in range(-5, -30, -5):
+            all_display_slots_5min.add(ts_30 + timedelta(minutes=offset))
+
+    # Precompute filled dicts: {slot: (value, is_known, prev_value)} per entity using carry-forward
+    entity_filled_30min = []
+    entity_filled_5min = []
+    for data_30min, data_5min in zip(entity_histories_30min, entity_histories_5min):
+        # --- 30-min fill ---
+        sorted_known_30 = sorted(data_30min.keys())
+        filled_30 = {}
+        last_val = None
+        ki = 0
+        for slot in sorted(sorted_timestamps_30min):
+            prev_val = last_val
+            while ki < len(sorted_known_30) and sorted_known_30[ki] <= slot:
+                last_val = data_30min[sorted_known_30[ki]]
+                ki += 1
+            filled_30[slot] = (last_val if last_val is not None else "-", slot in data_30min, prev_val)
+        entity_filled_30min.append(filled_30)
+
+        # --- 5-min fill ---
+        sorted_known_5 = sorted(data_5min.keys())
+        filled_5 = {}
+        last_val = None
+        ki = 0
+        for slot in sorted(all_display_slots_5min):
+            prev_val = last_val
+            while ki < len(sorted_known_5) and sorted_known_5[ki] <= slot:
+                last_val = data_5min[sorted_known_5[ki]]
+                ki += 1
+            filled_5[slot] = (last_val if last_val is not None else "-", slot in data_5min, prev_val)
+        entity_filled_5min.append(filled_5)
+
+    return entity_filled_30min, entity_filled_5min, sorted_timestamps_30min, all_display_slots_5min
+
+
 class WebInterface(ComponentBase):
     """Built-in web dashboard server using aiohttp.
 
@@ -942,51 +1047,16 @@ class WebInterface(ComponentBase):
         days = int(request.query.get("days", 7))  # Default to 7 days if not specified
 
         text = self.get_header("Predbat Entity", refresh=0)
-        text += """
-<script>
-(function() {
-    // Restore scroll position and expanded rows saved before last reload
-    window.addEventListener('load', function() {
-        var savedPos = sessionStorage.getItem('entityScrollPos');
-        if (savedPos) {
-            savedPos = JSON.parse(savedPos);
-            sessionStorage.removeItem('entityScrollPos');
-            window.scrollTo(savedPos.x, savedPos.y);
-        }
-        var savedExpanded = sessionStorage.getItem('entityExpandedRows');
-        if (savedExpanded) {
-            sessionStorage.removeItem('entityExpandedRows');
-            JSON.parse(savedExpanded).forEach(function(rowIndex) {
-                var mainRow = document.getElementById('row_' + rowIndex);
-                if (mainRow) {
-                    var detailRows = document.querySelectorAll('#detail_' + rowIndex);
-                    detailRows.forEach(function(row) { row.style.display = 'table-row'; });
-                    mainRow.classList.add('expanded');
-                    var timeCell = mainRow.cells[0];
-                    timeCell.innerHTML = timeCell.innerHTML.replace('\u25b6', '\u25bc');
-                }
-            });
-        }
-    });
-    // Schedule reload, saving scroll position and expanded rows first
-    setTimeout(function() {
-        var expandedRows = [];
-        document.querySelectorAll('tr.history-row.expanded').forEach(function(row) {
-            expandedRows.push(row.id.replace('row_', ''));
-        });
-        sessionStorage.setItem('entityExpandedRows', JSON.stringify(expandedRows));
-        sessionStorage.setItem('entityScrollPos', JSON.stringify({x: window.scrollX, y: window.scrollY}));
-        location.reload();
-    }, 60000);
-})();
-</script>
-"""
 
-        # Include a back button to return the previous page
+        # Include a back button to return the previous page, and a reload button in case the
+        # entities selected weren't available yet when the page was first loaded
         text += """<div style="margin-bottom: 15px;">
             <a href="{}" class="button" style="display: inline-block; padding: 8px 15px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 4px; font-weight: bold;">
                 <span class="mdi mdi-arrow-left" style="margin-right: 5px;"></span>Back
             </a>
+            <button onclick="location.reload()" style="display: inline-block; margin-left: 10px; padding: 8px 15px; background-color: #2196F3; color: white; border: none; text-decoration: none; border-radius: 4px; font-weight: bold; cursor: pointer;">
+                <span class="mdi mdi-refresh" style="margin-right: 5px;"></span>Reload
+            </button>
         </div>""".format(
             self.default_page
         )
@@ -1192,91 +1262,8 @@ class WebInterface(ComponentBase):
                     text += f"<th>{friendly_name}{attr_display}{unit_display}</th>"
                 text += "</tr>\n"
 
-                # Collect history data for all entities (both 30-min summary and 5-min detail)
-                entity_histories_30min = []
-                entity_histories_5min = []
-                all_timestamps_30min = set()
-
-                for selection in entity_selections:
-                    entity_id = selection["entity_id"]
-                    attribute = selection["attribute"]
-                    history = entity_data_fetch[entity_id]
-                    entity_data_30min = {}
-                    entity_data_5min = {}
-
-                    if history and len(history) >= 1:
-                        history = history[0]
-                        if history:
-                            history.reverse()
-                            for item in history:
-                                if "last_updated" not in item:
-                                    continue
-                                last_updated_time = item["last_updated"]
-                                last_updated_stamp = str2time(last_updated_time)
-
-                                # Get state or attribute value
-                                if attribute:
-                                    state = item.get("attributes", {}).get(attribute, None)
-                                else:
-                                    state = item.get("state", None)
-
-                                if state is None:
-                                    state = "None"
-
-                                # Store 5-minute interval data
-                                minutes = last_updated_stamp.hour * 60 + last_updated_stamp.minute
-                                rounded_minutes_5 = (minutes // 5) * 5
-                                rounded_stamp_5 = last_updated_stamp.replace(minute=rounded_minutes_5 % 60, hour=rounded_minutes_5 // 60, second=0, microsecond=0)
-                                entity_data_5min[rounded_stamp_5] = state
-
-                                # Round to 30-minute intervals for summary
-                                rounded_minutes_30 = (minutes // 30) * 30
-                                rounded_stamp_30 = last_updated_stamp.replace(minute=rounded_minutes_30 % 60, hour=rounded_minutes_30 // 60, second=0, microsecond=0)
-                                entity_data_30min[rounded_stamp_30] = state
-                                all_timestamps_30min.add(rounded_stamp_30)
-
-                    entity_histories_30min.append(entity_data_30min)
-                    entity_histories_5min.append(entity_data_5min)
-
-                # Sort timestamps in reverse chronological order
-                sorted_timestamps_30min = sorted(all_timestamps_30min, reverse=True)
-
-                # Collect all display slots so we can precompute carry-forward fill
-                # Detail rows go BACKWARDS from the 30-min parent timestamp (offsets -5 to -25)
-                all_display_slots_5min = set()
-                for ts_30 in sorted_timestamps_30min:
-                    for offset in range(-5, -30, -5):
-                        all_display_slots_5min.add(ts_30 + timedelta(minutes=offset))
-
-                # Precompute filled dicts: {slot: (value, is_changed, prev_value)} per entity using carry-forward
-                entity_filled_30min = []
-                entity_filled_5min = []
-                for data_30min, data_5min in zip(entity_histories_30min, entity_histories_5min):
-                    # --- 30-min fill ---
-                    sorted_known_30 = sorted(data_30min.keys())
-                    filled_30 = {}
-                    last_val = None
-                    ki = 0
-                    for slot in sorted(sorted_timestamps_30min):
-                        prev_val = last_val
-                        while ki < len(sorted_known_30) and sorted_known_30[ki] <= slot:
-                            last_val = data_30min[sorted_known_30[ki]]
-                            ki += 1
-                        filled_30[slot] = (last_val if last_val is not None else "-", slot in data_30min, prev_val)
-                    entity_filled_30min.append(filled_30)
-
-                    # --- 5-min fill ---
-                    sorted_known_5 = sorted(data_5min.keys())
-                    filled_5 = {}
-                    last_val = None
-                    ki = 0
-                    for slot in sorted(all_display_slots_5min):
-                        prev_val = last_val
-                        while ki < len(sorted_known_5) and sorted_known_5[ki] <= slot:
-                            last_val = data_5min[sorted_known_5[ki]]
-                            ki += 1
-                        filled_5[slot] = (last_val if last_val is not None else "-", slot in data_5min, prev_val)
-                    entity_filled_5min.append(filled_5)
+                # Collect and bucket history data for all entities (both 30-min summary and 5-min detail)
+                entity_filled_30min, entity_filled_5min, sorted_timestamps_30min, _ = build_entity_history_table_data(entity_selections, entity_data_fetch)
 
                 # Pre-compute per-row cell classes so we can decide which rows to show
                 num_cols = len(entity_selections)
@@ -1768,7 +1755,9 @@ var options = {
         text += "   ]\n"
         text += "  }\n"
         text += "}\n"
-        text += "var chart = new ApexCharts(document.querySelector('#{}'), options);\n".format(tagname)
+        # getElementById (not a '#id' CSS selector) - tagname can be unit-derived (e.g. "chart_%")
+        # and '%' is not a valid unescaped CSS identifier character, which would throw in querySelector
+        text += "var chart = new ApexCharts(document.getElementById('{}'), options);\n".format(tagname)
         text += "chart.render();\n"
         text += "</script>\n"
         return text
@@ -1836,7 +1825,9 @@ var options = {
         text += "  title: {{ text: '{}' }},\n".format(title)
         text += "  tooltip: { y: { formatter: function(val) { return val !== null ? val.toFixed(2) : 'N/A'; } } }\n"
         text += "};\n"
-        text += "var chart_{cid} = new ApexCharts(document.querySelector('#{cid}'), options);\n".format(cid=chart_id)
+        # getElementById, not a '#id' CSS selector - chart_id may contain characters (e.g. "%") that
+        # are invalid in an unescaped CSS identifier and would throw in querySelector
+        text += "var chart_{cid} = new ApexCharts(document.getElementById('{cid}'), options);\n".format(cid=chart_id)
         text += "chart_{}.render();\n".format(chart_id)
         text += "</script>\n"
         return text
@@ -2030,7 +2021,7 @@ var options = {
   }
 };
 
-var chart = new ApexCharts(document.querySelector('#"""
+var chart = new ApexCharts(document.getElementById('"""
             + tagname
             + """'), options);
 chart.render();

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -179,8 +179,16 @@ def get_entity_js(selected_entities_json, entity_attributes_json):
         // Initialise entity data
 
         document.addEventListener('DOMContentLoaded', function() {
+            // Restore the "Show All" preference across page loads (e.g. after submitting the
+            // entity form to add another entity, which is a full page navigation, not an
+            // in-place update)
+            var showAll = localStorage.getItem('entityShowAllEntities') === 'true';
+            var showAllCheckbox = document.getElementById('showAllEntities');
+            if (showAllCheckbox) {
+                showAllCheckbox.checked = showAll;
+            }
             // Load entity data from API
-            loadEntityData(false);
+            loadEntityData(showAll);
         });
 
         async function loadEntityData(showAll) {
@@ -203,6 +211,7 @@ def get_entity_js(selected_entities_json, entity_attributes_json):
         }
 
         function toggleShowAll(checked) {
+            localStorage.setItem('entityShowAllEntities', checked ? 'true' : 'false');
             loadEntityData(checked).then(function() {
                 if (isDropdownVisible) {
                     filterEntityOptions();


### PR DESCRIPTION
## Summary
- **History table bug**: bucketing a raw sample into its 5-/30-min window was keeping the *oldest* sample in that window instead of the newest, due to a stray `history.reverse()` combined with an in-place overwrite on a history list that's shared across columns for the same entity (selecting an entity with two attributes made the two columns pick inconsistent samples). Extracted the logic into `build_entity_history_table_data()` and fixed the ordering so each bucket carries the most recent sample - consistent with the carry-forward fill that already assumed that.
- **Percent-unit charts not rendering**: chart element ids on the `/entity` page are derived from the unit of measurement (e.g. `chart_%` for a battery SOC sensor), but were targeted via `document.querySelector('#chart_%')`. `%` isn't a valid unescaped CSS identifier character, so `querySelector` throws and the chart script aborts before rendering. Switched all three chart-render call sites (`render_chart`, `render_timeline_chart`, `render_heatmap_chart`) to `document.getElementById(id)`, which has no such restriction.
- **Entity page usability**: removed the page's disruptive 60-second auto-`location.reload()` (and the scroll/expanded-row restore plumbing that only existed to survive it), and added a manual "Reload" button next to "Back" for when the entities you wanted weren't available yet at page load.

## Test plan
- [x] `tests/test_web_history_table.py` (new, registered as `web_history_table`): bucket keeps the latest sample in-window, two columns for the same entity stay consistent, bucket-time rounding/hour-boundary correctness, detail-row display slots, carry-forward fill, missing-`last_updated`/`None`-state handling. Verified RED against the old `history.reverse()` behaviour, GREEN after the fix.
- [x] `tests/test_web_charts.py` (new, registered as `web_charts`): each render function targets a `%`-containing id via `getElementById`, never via a `#id` selector. Verified RED against the old `querySelector` code, GREEN after the fix.
- [x] `./run_all -k web` - all web tests pass
- [x] `./run_pre_commit` - all hooks pass, full `run_all --quick` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)