### PR TITLE
fix(web): sanitise render_heatmap_chart()'s chart_id before using it as a JS variable name

### DIFF
--- a/apps/predbat/tests/test_web_charts.py
+++ b/apps/predbat/tests/test_web_charts.py
@@ -56,4 +56,17 @@ def run_web_charts_tests(my_predbat):
         print(f"  ERROR: expected render_heatmap_chart() to call getElementById('chart_%'), got: {html}")
         failed += 1
 
+    # -------------------------------------------------------------------------
+    print("Test: render_heatmap_chart() sanitises chart_id before using it as a JS variable name")
+    for bad_variable_name in ("height_chart_%", "chart_chart_%"):
+        if bad_variable_name in html:
+            print(f"  ERROR: render_heatmap_chart() interpolated an unsanitised chart_id into a JS identifier ('{bad_variable_name}'), which is a syntax error")
+            failed += 1
+    if "height_chart__" not in html:
+        print(f"  ERROR: expected render_heatmap_chart() to declare a sanitised 'height_chart__' variable, got: {html}")
+        failed += 1
+    if "chart_chart__.render()" not in html:
+        print(f"  ERROR: expected render_heatmap_chart() to render via a sanitised 'chart_chart__' variable, got: {html}")
+        failed += 1
+
     return failed

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -1844,6 +1844,11 @@ var options = {
             points_js = ", ".join("{{ x: '{}', y: {} }}".format(p["x"], "null" if p["y"] is None else p["y"]) for p in data_points)
             series_js += "    {{ name: '{}', data: [{}] }},\n".format(name, points_js)
 
+        # chart_id is only safe to interpolate as a *string* (DOM id, inside quotes) - it may
+        # contain characters (e.g. "%") that are invalid in a JS identifier, so a separate
+        # sanitised name is used anywhere it needs to appear as a variable name
+        js_id = re.sub(r"[^0-9A-Za-z_]", "_", chart_id)
+
         text = ""
         text += "<script>\n"
         text += "window.onresize = function(){ location.reload(); };\n"
@@ -1852,12 +1857,12 @@ var options = {
         text += "if (width < 400) { width = 400; }\n"
         text += "width = width - 50;\n"
         if fixed_height is not None:
-            text += "var height_{} = {};\n".format(chart_id, fixed_height)
+            text += "var height_{} = {};\n".format(js_id, fixed_height)
         else:
             num_rows = max(len(series_data), 1)
-            text += "var height_{} = {};\n".format(chart_id, num_rows * 80 + 80)
+            text += "var height_{} = {};\n".format(js_id, num_rows * 80 + 80)
         text += "var options = {\n"
-        text += "  chart: {{ type: 'heatmap', width: width, height: height_{}, animations: {{ enabled: false }} }},\n".format(chart_id)
+        text += "  chart: {{ type: 'heatmap', width: width, height: height_{}, animations: {{ enabled: false }} }},\n".format(js_id)
         text += "  plotOptions: {\n"
         text += "    heatmap: {\n"
         text += "      radius: 2,\n"
@@ -1879,8 +1884,8 @@ var options = {
         text += "};\n"
         # getElementById, not a '#id' CSS selector - chart_id may contain characters (e.g. "%") that
         # are invalid in an unescaped CSS identifier and would throw in querySelector
-        text += "var chart_{cid} = new ApexCharts(document.getElementById('{cid}'), options);\n".format(cid=chart_id)
-        text += "chart_{}.render();\n".format(chart_id)
+        text += "var chart_{jid} = new ApexCharts(document.getElementById('{cid}'), options);\n".format(jid=js_id, cid=chart_id)
+        text += "chart_{}.render();\n".format(js_id)
         text += "</script>\n"
         return text
 


### PR DESCRIPTION
## Summary
Follow-up to #4291 addressing a Copilot review comment on that PR.

`render_heatmap_chart()` was fixed to target its chart element via `document.getElementById()` instead of a `#id` CSS selector, but `chart_id` was still interpolated directly into JS *variable name* positions (`var height_<chart_id> = ...`, `var chart_<chart_id> = ...`). A `chart_id` containing characters invalid in a JS identifier (e.g. `%`, the exact case #4291 was fixing for DOM ids) makes the generated `<script>` a syntax error, so the whole block silently fails and the heatmap never renders - even with `getElementById()` in place.

`chart_id` is now only used as a quoted string for the DOM id; a separate `js_id` (chart_id with any non `[0-9A-Za-z_]` character replaced by `_`) is used everywhere it needs to appear as a JS identifier.

## Test plan
- [x] `tests/test_web_charts.py` - extended to assert `render_heatmap_chart()` never emits an unsanitised `chart_id` as a JS identifier, and does declare/use the sanitised `height_<js_id>` / `chart_<js_id>` names. Verified RED against the pre-fix code (`var chart_chart_% = ...` - literal syntax error), GREEN after the fix.
- [x] `./run_all --test web_charts` passes
- [x] `./run_pre_commit` hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)