### PR TITLE
fix(history): skip update entity restoration

### DIFF
--- a/apps/predbat/tests/test_integer_config.py
+++ b/apps/predbat/tests/test_integer_config.py
@@ -279,6 +279,37 @@ def test_config_item_range_clamp(my_predbat):
     my_predbat.expose_config("metric_min_improvement_plan", int_item.get("default"), force_ha=True)
     my_predbat.expose_config("expert_mode", original_expert_mode, force_ha=True)
 
+    # Test 5: update entities are synthesised after release discovery and must not be
+    # restored from history. An empty lookup gets registered by HAHistory and retried
+    # every two minutes, causing repeated wide-window history queries.
+    update_item = None
+    for config_item in my_predbat.CONFIG_ITEMS:
+        if config_item.get("type") == "update":
+            update_item = config_item
+            break
+
+    assert update_item is not None, "Update config item not found"
+    original_update_value = update_item.get("value")
+    original_history_loader = my_predbat.load_previous_value_from_ha
+    history_requests = []
+
+    def track_history_request(entity, attribute=None):
+        history_requests.append(entity)
+        return original_history_loader(entity, attribute=attribute)
+
+    update_item["value"] = None
+    my_predbat.load_previous_value_from_ha = track_history_request
+    try:
+        my_predbat.load_user_config()
+    finally:
+        my_predbat.load_previous_value_from_ha = original_history_loader
+        update_item["value"] = original_update_value
+
+    update_entity = "update.{}_{}".format(my_predbat.prefix, update_item["name"])
+    assert update_entity not in history_requests, f"{update_entity} must not be restored from history"
+    assert my_predbat.prefix + ".status" in history_requests, "Non-update history fallback should remain active"
+    print("✓ Update config entity skips history restore while normal fallback remains active")
+
     # Restore original state
     my_predbat.args = original_args
     my_predbat.had_errors = original_had_errors

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -964,7 +964,10 @@ class UserInterface:
 
             # Get from current state, if not from HA directly
             ha_value = item.get("value", None)
-            if ha_value is None:
+            # The update entity is synthesised after release discovery and is explicitly
+            # non-restorable. Looking in history when its current state is absent registers
+            # an empty 30-day query with HAHistory, which then retries every two minutes.
+            if ha_value is None and type != "update":
                 ha_value = self.load_previous_value_from_ha(entity)
 
             # Update drop down menu


### PR DESCRIPTION
## Summary

- skip HA history restoration for update entities, which are synthesised after release discovery and are non-restorable
- prevent an absent update state from registering an empty long-range HAHistory lookup that is retried periodically
- retain the existing history fallback for ordinary entities

## Problem

Update entities are generated at runtime and explicitly non-restorable. When an update entity has no current state during startup, attempting to restore it from entity history adds an empty lookup to HAHistory tracking. The tracker then retries that unnecessary lookup, producing avoidable backend load and timeout noise.

## Tests

- `config_item_range_clamp`
- `plugin_startup`
- `hahistory`
- pre-commit: whitespace, EOF, Ruff, Black, cspell

## Risk

`load_user_config` is a central startup path, but the behaviour change is restricted to `type == "update"`. Regression coverage verifies normal history fallback remains active.