### PR TITLE
fix(web): stop the /entity page reporting a status it never held

### DIFF
--- a/apps/predbat/tests/test_web_charts.py
+++ b/apps/predbat/tests/test_web_charts.py
@@ -8,12 +8,92 @@
 # pylint: disable=line-too-long
 # pylint: disable=attribute-defined-outside-init
 
+import re
+from datetime import datetime, timedelta, timezone
+
 from web import WebInterface
 
 
 def make_web(my_predbat):
     """Create a WebInterface instance bound to the given predbat."""
     return WebInterface(my_predbat, web_port=5053)
+
+
+def parse_timeline_ranges(html):
+    """Extract the rendered timeline ranges as a list of (category, label, start_ms, end_ms)."""
+    pattern = r"x: '([^']*)',\s*\n\s*y: \[(\d+), (\d+)\],\s*\n\s*fillColor: '[^']*',\s*\n\s*label: '([^']*)'"
+    return [(m.group(1), m.group(4), int(m.group(2)), int(m.group(3))) for m in re.finditer(pattern, html)]
+
+
+def run_web_timeline_fidelity_tests(web):
+    """A flapping state must not be erased from the timeline chart, and same-named entities must not share a row."""
+    failed = 0
+
+    # -------------------------------------------------------------------------
+    # A status sensor that alternates Normal/Lost every minute for six days. The chart used to
+    # downsample the raw samples by array index, so whenever the step landed on one phase of the
+    # flap the other state vanished entirely and the chart claimed one continuous multi-day run -
+    # contradicting the history table, which samples the same data per 5/30-minute bucket.
+    print("Test: render_timeline_chart() does not erase a state when downsampling a long flapping history")
+    now = datetime(2026, 7, 25, 14, 0, 0, tzinfo=timezone.utc)
+    samples = 8640
+    flapping = {}
+    stamp = now - timedelta(minutes=samples)
+    for index in range(samples):
+        flapping[stamp.strftime("%Y-%m-%dT%H:%M:%S%z")] = "Lost" if index % 2 else "Normal"
+        stamp += timedelta(minutes=1)
+
+    html = web.render_timeline_chart([{"name": "Status", "entity_id": "sensor.inverter_one_status", "data": flapping}], "chart_status", 7)
+    ranges = parse_timeline_ranges(html)
+    covered = {}
+    for _, label, start, end in ranges:
+        covered[label] = covered.get(label, 0) + (end - start)
+    span = sum(covered.values())
+    lost_share = covered.get("Lost", 0) / span if span else 0
+    if lost_share < 0.25:
+        print(f"  ERROR: 'Lost' holds half the history but the timeline chart gives it {lost_share:.1%} of the span - the other state was aliased over it")
+        failed += 1
+    longest = max(((end - start) / 60000 for _, label, start, end in ranges if label == "Normal"), default=0)
+    if longest > 60:
+        print(f"  ERROR: timeline chart reports a continuous {longest:.0f} minute 'Normal' run, but the state never stayed Normal for more than a minute")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    # Two inverters both publish a status sensor whose friendly name is "Status", so using the
+    # display name as the rangeBar category collapsed both onto a single y-axis row, making it
+    # impossible to tell which bar belonged to which inverter.
+    print("Test: render_timeline_chart() gives same-named entities distinct rows")
+    both = [
+        {"name": "Status", "entity_id": "sensor.inverter_one_status", "data": {"2026-07-23T10:00:00+00:00": "Normal"}},
+        {"name": "Status", "entity_id": "sensor.inverter_two_status", "data": {"2026-07-23T10:00:00+00:00": "Lost"}},
+    ]
+    html = web.render_timeline_chart(both, "chart_status", 7)
+    categories = {category for category, _, _, _ in parse_timeline_ranges(html)}
+    if len(categories) < 2:
+        print(f"  ERROR: two entities sharing the friendly name 'Status' collapsed onto one timeline row: {sorted(categories)}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    # get_history_with_now() appends the current state stamped in local time while HA/DB history
+    # is UTC, so sorting the raw timestamp strings orders records by their text, not their instant.
+    print("Test: render_timeline_chart() orders records by instant, not by raw timestamp string")
+    mixed = {
+        "2026-07-23T09:00:00+0000": "Normal",
+        "2026-07-23T11:30:00+0200": "Lost",  # 09:30 UTC - sorts after "11:00" as text
+        "2026-07-23T10:00:00+0000": "Normal",
+    }
+    html = web.render_timeline_chart([{"name": "Status", "entity_id": "sensor.inverter_one_status", "data": mixed}], "chart_status", 7)
+    mixed_ranges = parse_timeline_ranges(html)
+    latest_ms = int(datetime(2026, 7, 23, 10, 0, 0, tzinfo=timezone.utc).timestamp() * 1000)
+    covered_to = max((end for _, _, _, end in mixed_ranges), default=0)
+    if covered_to != latest_ms:
+        print(f"  ERROR: timeline stops at {datetime.fromtimestamp(covered_to / 1000, timezone.utc)} instead of the newest record at 10:00 UTC - the 11:30+0200 record sorted last as text")
+        failed += 1
+    if [label for _, label, _, _ in mixed_ranges][:2] != ["Normal", "Lost"]:
+        print(f"  ERROR: expected the 09:30 UTC 'Lost' record to sort between the 09:00 and 10:00 UTC records, got range labels {[label for _, label, _, _ in mixed_ranges]}")
+        failed += 1
+
+    return failed
 
 
 def run_web_charts_tests(my_predbat):
@@ -68,5 +148,7 @@ def run_web_charts_tests(my_predbat):
     if "chart_chart__.render()" not in html:
         print(f"  ERROR: expected render_heatmap_chart() to render via a sanitised 'chart_chart__' variable, got: {html}")
         failed += 1
+
+    failed += run_web_timeline_fidelity_tests(web)
 
     return failed

--- a/apps/predbat/tests/test_web_history_table.py
+++ b/apps/predbat/tests/test_web_history_table.py
@@ -17,13 +17,70 @@ def make_history(records):
     return [records]
 
 
+def utc(hour, minute, day=23):
+    """Build a UTC timestamp on 2026-07-<day>."""
+    return datetime(2026, 7, day, hour, minute, 0, tzinfo=timezone.utc)
+
+
 def run_web_history_table_tests(my_predbat):
     """Unit tests for build_entity_history_table_data() used by the /entity history table."""
     failed = 0
     print("**** Running web history table tests ****")
 
     # -------------------------------------------------------------------------
-    print("Test: 30-min bucket keeps the most recent sample, not the oldest, when several samples land in the same window")
+    # A row used to report the last sample taken inside its window, so a single momentary reading
+    # stood for the whole half hour and then carried forward into every later slot without a sample
+    # of its own - the /entity table showed a GivEnergy Cloud inverter "Lost" for hours off one blip.
+    print("Test: a momentary sample inside a window does not become the whole row's value")
+    selections = [{"entity_id": "sensor.status", "attribute": None}]
+    records = []
+    stamp = utc(20, 0, day=24)
+    while stamp < utc(23, 0, day=24):
+        records.append({"last_updated": stamp.strftime("%Y-%m-%dT%H:%M:%S%z"), "state": "Normal"})
+        stamp += timedelta(minutes=5)
+    records.append({"last_updated": utc(21, 57, day=24).strftime("%Y-%m-%dT%H:%M:%S%z"), "state": "Lost"})
+    records.sort(key=lambda record: record["last_updated"])
+
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, {"sensor.status": make_history(records)})
+    reported_lost = [ts for ts in sorted_ts_30 if filled_30[0][ts][0] == "Lost"]
+    if reported_lost:
+        print(f"  ERROR: the sensor read Normal at every 30-min mark but these rows report 'Lost': {[ts.strftime('%H:%M') for ts in reported_lost]}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    # Detail rows used to be the offsets -5..-25, i.e. the half hour BEFORE the row, so expanding a
+    # row described a different window and could contradict the row it sat under.
+    print("Test: detail slots belong to the row's own half hour, not the one before it")
+    row_2130 = utc(21, 30, day=24)
+    expected_slots = {ts + timedelta(minutes=offset) for ts in sorted_ts_30 for offset in range(0, 30, 5)}
+    if display_slots_5 != expected_slots:
+        print(f"  ERROR: detail slots should be each row's own half hour; {len(expected_slots - display_slots_5)} of them are missing and {len(display_slots_5 - expected_slots)} belong to another window")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: a genuine transition is reported by the row it happened in, and by that row's detail slots")
+    selections = [{"entity_id": "sensor.status", "attribute": None}]
+    records = []
+    stamp = utc(20, 0, day=24)
+    while stamp < utc(23, 0, day=24):
+        records.append({"last_updated": stamp.strftime("%Y-%m-%dT%H:%M:%S%z"), "state": "Normal" if stamp < row_2130 else "Lost"})
+        stamp += timedelta(minutes=5)
+    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, {"sensor.status": make_history(records)})
+
+    value, changed, prev_value = filled_30[0][row_2130]
+    if value != "Lost" or not changed or prev_value != "Normal":
+        print(f"  ERROR: expected the 21:30 row to flag the Normal->Lost change, got value={value} changed={changed} prev={prev_value}")
+        failed += 1
+    if filled_30[0][utc(21, 0, day=24)][0] != "Normal":
+        print(f"  ERROR: expected the 21:00 row to still read 'Normal', got '{filled_30[0][utc(21, 0, day=24)][0]}'")
+        failed += 1
+    detail_values = {filled_5[0].get(row_2130 + timedelta(minutes=offset), ("-", False, None))[0] for offset in range(5, 30, 5)}
+    if detail_values != {"Lost"}:
+        print(f"  ERROR: expected the 21:30 row to expand to its own window (all 'Lost'), got {sorted(detail_values)}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: a slot reports the state as of its own timestamp, not a reading taken later")
     selections = [{"entity_id": "sensor.x", "attribute": None}]
     fetch = {
         "sensor.x": make_history(
@@ -37,46 +94,16 @@ def run_web_history_table_tests(my_predbat):
     }
     filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
 
-    bucket_30 = datetime(2026, 7, 23, 10, 0, 0, tzinfo=timezone.utc)
-    value, is_known, prev_value = filled_30[0][bucket_30]
-    if value != "8":
-        print(f"  ERROR: expected 30-min bucket to hold the latest sample '8', got '{value}'")
-        failed += 1
-    if not is_known:
-        print("  ERROR: expected 30-min bucket to be flagged as directly known")
+    value, changed, prev_value = filled_30[0][utc(10, 0)]
+    if value != "-":
+        print(f"  ERROR: nothing had been recorded by 10:00, so the row should read '-', got '{value}'")
         failed += 1
     if prev_value is not None:
-        print(f"  ERROR: expected no prior value before the first bucket, got '{prev_value}'")
+        print(f"  ERROR: expected no prior value before the first row, got '{prev_value}'")
         failed += 1
-
-    # -------------------------------------------------------------------------
-    print("Test: 5-min bucket keeps the most recent sample, not the oldest, when several samples land in the same window")
-    selections = [{"entity_id": "sensor.x", "attribute": None}]
-    fetch = {
-        "sensor.x": make_history(
-            [
-                {"last_updated": "2026-07-23T10:26:00+00:00", "state": "5"},
-                {"last_updated": "2026-07-23T10:27:00+00:00", "state": "6"},
-                {"last_updated": "2026-07-23T10:28:00+00:00", "state": "7"},
-                {"last_updated": "2026-07-23T10:29:00+00:00", "state": "8"},
-                # A later sample in the next 30-min window, purely so 10:25 becomes a rendered detail slot
-                # (detail slots are the offsets -5..-25 leading up to each known 30-min bucket).
-                {"last_updated": "2026-07-23T10:35:00+00:00", "state": "9"},
-            ]
-        )
-    }
-    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
-
-    bucket_5 = datetime(2026, 7, 23, 10, 25, 0, tzinfo=timezone.utc)
-    if bucket_5 not in display_slots_5:
-        print(f"  ERROR: test setup expected {bucket_5} to be a rendered detail slot, got {display_slots_5}")
-        failed += 1
-    value, is_known, prev_value = filled_5[0][bucket_5]
-    if value != "8":
-        print(f"  ERROR: expected 5-min bucket to hold the latest sample '8', got '{value}'")
-        failed += 1
-    if not is_known:
-        print("  ERROR: expected 5-min bucket to be flagged as directly known")
+    value, changed, _ = filled_5[0].get(utc(10, 5), ("-", False, None))
+    if value != "8" or not changed:
+        print(f"  ERROR: expected the 10:05 slot to report the latest reading '8' as a change, got value={value} changed={changed}")
         failed += 1
 
     # -------------------------------------------------------------------------
@@ -97,17 +124,17 @@ def run_web_history_table_tests(my_predbat):
     }
     filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
 
-    state_value, _, _ = filled_30[0][bucket_30]
-    attr_value, _, _ = filled_30[1][bucket_30]
+    state_value, _, _ = filled_5[0].get(utc(10, 5), ("-", False, None))
+    attr_value, _, _ = filled_5[1].get(utc(10, 5), ("-", False, None))
     if state_value != "8":
-        print(f"  ERROR: state column should pick the latest sample '8', got '{state_value}'")
+        print(f"  ERROR: state column should report the reading in effect at 10:05 ('8'), got '{state_value}'")
         failed += 1
     if attr_value != "o4":
-        print(f"  ERROR: attribute column should pick the latest sample 'o4', got '{attr_value}'")
+        print(f"  ERROR: attribute column should report the value in effect at 10:05 ('o4'), got '{attr_value}'")
         failed += 1
 
     # -------------------------------------------------------------------------
-    print("Test: 30-min bucket timestamps round down and never overflow the hour")
+    print("Test: 30-min row timestamps round down and never overflow the hour")
     selections = [{"entity_id": "sensor.y", "attribute": None}]
     fetch = {
         "sensor.y": make_history(
@@ -119,42 +146,16 @@ def run_web_history_table_tests(my_predbat):
     }
     filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
 
-    expected_30 = {
-        datetime(2026, 7, 23, 10, 0, 0, tzinfo=timezone.utc),
-        datetime(2026, 7, 23, 23, 30, 0, tzinfo=timezone.utc),
-    }
+    expected_30 = {utc(10, 0), utc(23, 30)}
     if set(sorted_ts_30) != expected_30:
-        print(f"  ERROR: expected 30-min buckets {expected_30}, got {set(sorted_ts_30)}")
+        print(f"  ERROR: expected 30-min rows {expected_30}, got {set(sorted_ts_30)}")
         failed += 1
     if sorted_ts_30 != sorted(sorted_ts_30, reverse=True):
         print("  ERROR: expected sorted_timestamps_30min in descending (newest-first) order")
         failed += 1
 
     # -------------------------------------------------------------------------
-    print("Test: display slots for detail rows are the 5-min offsets leading up to each 30-min bucket")
-    selections = [{"entity_id": "sensor.x", "attribute": None}]
-    fetch = {
-        "sensor.x": make_history(
-            [
-                {"last_updated": "2026-07-23T10:01:00+00:00", "state": "5"},
-                {"last_updated": "2026-07-23T10:35:00+00:00", "state": "9"},
-            ]
-        )
-    }
-    filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
-
-    # Expected: the 5-min offsets (-5 to -25) leading up to each of the two known 30-min buckets (10:00 and 10:30)
-    expected_slots = set()
-    for base_hour, base_minute in ((10, 0), (10, 30)):
-        base = datetime(2026, 7, 23, base_hour, base_minute, 0, tzinfo=timezone.utc)
-        for offset in (5, 10, 15, 20, 25):
-            expected_slots.add(base - timedelta(minutes=offset))
-    if display_slots_5 != expected_slots:
-        print(f"  ERROR: expected display slots {expected_slots}, got {display_slots_5}")
-        failed += 1
-
-    # -------------------------------------------------------------------------
-    print("Test: a 30-min bucket with no direct sample carries forward the previous known value")
+    print("Test: a row with no sample of its own carries forward the previous known value")
     selections = [
         {"entity_id": "sensor.a", "attribute": None},
         {"entity_id": "sensor.b", "attribute": None},
@@ -165,43 +166,40 @@ def run_web_history_table_tests(my_predbat):
     }
     filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
 
-    ts_1000 = datetime(2026, 7, 23, 10, 0, 0, tzinfo=timezone.utc)
-    ts_1030 = datetime(2026, 7, 23, 10, 30, 0, tzinfo=timezone.utc)
-
-    value, is_known, prev_value = filled_30[0][ts_1030]
-    if value != "A1" or is_known:
-        print(f"  ERROR: expected sensor.a to carry forward 'A1' as unknown at 10:30, got value={value} is_known={is_known}")
+    value, changed, _ = filled_30[0][utc(10, 30)]
+    if value != "A1" or changed:
+        print(f"  ERROR: expected sensor.a to carry 'A1' forward unchanged at 10:30, got value={value} changed={changed}")
         failed += 1
 
-    value, is_known, prev_value = filled_30[1][ts_1000]
-    if value != "-" or is_known or prev_value is not None:
-        print(f"  ERROR: expected sensor.b to have no value before its first sample at 10:00, got value={value} is_known={is_known} prev_value={prev_value}")
+    value, changed, prev_value = filled_30[1][utc(10, 0)]
+    if value != "-" or changed or prev_value is not None:
+        print(f"  ERROR: expected sensor.b to have no value before its first sample, got value={value} changed={changed} prev={prev_value}")
         failed += 1
 
-    value, is_known, prev_value = filled_30[1][ts_1030]
-    if value != "B1" or not is_known:
-        print(f"  ERROR: expected sensor.b to show its own sample 'B1' at 10:30, got value={value} is_known={is_known}")
+    value, changed, _ = filled_30[1][utc(10, 30)]
+    if value != "B1" or not changed:
+        print(f"  ERROR: expected sensor.b to report its own sample 'B1' at 10:30 as a change, got value={value} changed={changed}")
         failed += 1
 
     # -------------------------------------------------------------------------
-    print("Test: records missing last_updated are skipped and a missing state renders as 'None'")
+    print("Test: records with a missing or unparseable last_updated are skipped and a missing state renders as 'None'")
     selections = [{"entity_id": "sensor.z", "attribute": None}]
     fetch = {
         "sensor.z": make_history(
             [
                 {"state": "no-timestamp"},
+                {"last_updated": "not-a-timestamp", "state": "unparseable"},
                 {"last_updated": "2026-07-23T12:00:00+00:00", "state": None},
             ]
         )
     }
     filled_30, filled_5, sorted_ts_30, display_slots_5 = build_entity_history_table_data(selections, fetch)
-    ts_1200 = datetime(2026, 7, 23, 12, 0, 0, tzinfo=timezone.utc)
-    value, is_known, _ = filled_30[0][ts_1200]
-    if value != "None" or not is_known:
-        print(f"  ERROR: expected a missing state to render as the string 'None', got value={value} is_known={is_known}")
+    value, changed, _ = filled_30[0][utc(12, 0)]
+    if value != "None" or not changed:
+        print(f"  ERROR: expected a missing state to render as the string 'None', got value={value} changed={changed}")
         failed += 1
     if len(sorted_ts_30) != 1:
-        print(f"  ERROR: expected the record without last_updated to be skipped, got buckets {sorted_ts_30}")
+        print(f"  ERROR: expected the unusable records to be skipped, got rows {sorted_ts_30}")
         failed += 1
 
     return failed

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -81,34 +81,55 @@ from marginal import MARGINAL_EXTRA_KWH_LEVEL_NAMES, MARGINAL_EXTRA_KWH_LEVELS, 
 ROOT_YAML_KEY = "pred_bat"
 
 
+def state_as_of_slots(records, slots):
+    """
+    Resolve each slot to the state in effect at it - the most recent record at or before the slot.
+
+    records must be a list of (timestamp, value) ordered oldest first. Returns
+    {slot: (value, changed, prev_value)} where value is "-" for slots preceding the first record and
+    changed marks a slot whose value differs from the one shown at the previous slot.
+    """
+    filled = {}
+    last_value = None
+    previous = None
+    index = 0
+
+    for slot in sorted(slots):
+        while index < len(records) and records[index][0] <= slot:
+            last_value = records[index][1]
+            index += 1
+        value = last_value if last_value is not None else "-"
+        filled[slot] = (value, value != "-" and value != previous, previous)
+        previous = value
+
+    return filled
+
+
 def build_entity_history_table_data(entity_selections, entity_data_fetch):
     """
-    Bucket raw HA history into 5-minute and 30-minute windows for the /entity history table.
+    Resolve the /entity history table's 30-minute rows and their 5-minute detail slots.
 
     entity_selections: list of {"entity_id": ..., "attribute": ...} (attribute may be None for state)
     entity_data_fetch: dict of entity_id -> history as returned by get_history_with_now(), i.e. [[record, ...]]
 
-    Each raw record list is oldest-first; it is read (never mutated) in that order so that, when
-    several records round into the same bucket, the bucket keeps the most recent one - the value
-    that was actually in effect by the end of that window and that should carry forward into the
-    next bucket without data.
+    Every slot reports the state as of its own timestamp. Summarising a window by the last sample
+    taken inside it instead let a momentary blip stand for the whole window - one stray "Lost"
+    record at 21:57 made the entire 21:30 row read "Lost" - and that value then carried forward
+    into every later slot that had no sample of its own, turning a blip into hours of downtime.
 
     Returns (entity_filled_30min, entity_filled_5min, sorted_timestamps_30min, all_display_slots_5min):
-      entity_filled_30min / entity_filled_5min: one dict per selection, {slot: (value, is_known, prev_value)}
-        with unfilled slots carried forward from the last known value ("-" if none yet)
-      sorted_timestamps_30min: all known 30-min bucket timestamps, newest first
-      all_display_slots_5min: the 5-min detail-row slots (offsets -5 to -25) leading up to each 30-min bucket
+      entity_filled_30min / entity_filled_5min: one dict per selection, {slot: (value, changed, prev_value)}
+      sorted_timestamps_30min: the 30-min row timestamps, newest first
+      all_display_slots_5min: the 5-min slots covering each 30-min row's own window (offsets 0 to +25)
     """
-    entity_histories_30min = []
-    entity_histories_5min = []
+    entity_records = []
     all_timestamps_30min = set()
 
     for selection in entity_selections:
         entity_id = selection["entity_id"]
         attribute = selection["attribute"]
         history = entity_data_fetch[entity_id]
-        entity_data_30min = {}
-        entity_data_5min = {}
+        records = []
 
         if history and len(history) >= 1:
             history = history[0]
@@ -116,8 +137,10 @@ def build_entity_history_table_data(entity_selections, entity_data_fetch):
                 for item in history:
                     if "last_updated" not in item:
                         continue
-                    last_updated_time = item["last_updated"]
-                    last_updated_stamp = str2time(last_updated_time)
+                    try:
+                        last_updated_stamp = str2time(item["last_updated"])
+                    except (ValueError, TypeError):
+                        continue
 
                     # Get state or attribute value
                     if attribute:
@@ -128,60 +151,33 @@ def build_entity_history_table_data(entity_selections, entity_data_fetch):
                     if state is None:
                         state = "None"
 
-                    # Store 5-minute interval data
+                    records.append((last_updated_stamp, state))
+
+                    # A record makes the window it landed in a row, so activity is always on screen
                     minutes = last_updated_stamp.hour * 60 + last_updated_stamp.minute
-                    rounded_minutes_5 = (minutes // 5) * 5
-                    rounded_stamp_5 = last_updated_stamp.replace(minute=rounded_minutes_5 % 60, hour=rounded_minutes_5 // 60, second=0, microsecond=0)
-                    entity_data_5min[rounded_stamp_5] = state
-
-                    # Round to 30-minute intervals for summary
                     rounded_minutes_30 = (minutes // 30) * 30
-                    rounded_stamp_30 = last_updated_stamp.replace(minute=rounded_minutes_30 % 60, hour=rounded_minutes_30 // 60, second=0, microsecond=0)
-                    entity_data_30min[rounded_stamp_30] = state
-                    all_timestamps_30min.add(rounded_stamp_30)
+                    all_timestamps_30min.add(last_updated_stamp.replace(minute=rounded_minutes_30 % 60, hour=rounded_minutes_30 // 60, second=0, microsecond=0))
 
-        entity_histories_30min.append(entity_data_30min)
-        entity_histories_5min.append(entity_data_5min)
+        # str2time is only reliable for ordering once parsed - the raw strings mix UTC history with
+        # the local-time "now" record get_history_with_now() appends
+        records.sort(key=lambda record: record[0])
+        entity_records.append(records)
 
     # Sort timestamps in reverse chronological order
     sorted_timestamps_30min = sorted(all_timestamps_30min, reverse=True)
 
-    # Collect all display slots so we can precompute carry-forward fill
-    # Detail rows go BACKWARDS from the 30-min parent timestamp (offsets -5 to -25)
+    # Detail slots are the 5-min marks INSIDE each row's own half hour, so expanding a row explains
+    # that row rather than describing the preceding half hour
     all_display_slots_5min = set()
     for ts_30 in sorted_timestamps_30min:
-        for offset in range(-5, -30, -5):
+        for offset in range(0, 30, 5):
             all_display_slots_5min.add(ts_30 + timedelta(minutes=offset))
 
-    # Precompute filled dicts: {slot: (value, is_known, prev_value)} per entity using carry-forward
     entity_filled_30min = []
     entity_filled_5min = []
-    for data_30min, data_5min in zip(entity_histories_30min, entity_histories_5min):
-        # --- 30-min fill ---
-        sorted_known_30 = sorted(data_30min.keys())
-        filled_30 = {}
-        last_val = None
-        ki = 0
-        for slot in sorted(sorted_timestamps_30min):
-            prev_val = last_val
-            while ki < len(sorted_known_30) and sorted_known_30[ki] <= slot:
-                last_val = data_30min[sorted_known_30[ki]]
-                ki += 1
-            filled_30[slot] = (last_val if last_val is not None else "-", slot in data_30min, prev_val)
-        entity_filled_30min.append(filled_30)
-
-        # --- 5-min fill ---
-        sorted_known_5 = sorted(data_5min.keys())
-        filled_5 = {}
-        last_val = None
-        ki = 0
-        for slot in sorted(all_display_slots_5min):
-            prev_val = last_val
-            while ki < len(sorted_known_5) and sorted_known_5[ki] <= slot:
-                last_val = data_5min[sorted_known_5[ki]]
-                ki += 1
-            filled_5[slot] = (last_val if last_val is not None else "-", slot in data_5min, prev_val)
-        entity_filled_5min.append(filled_5)
+    for records in entity_records:
+        entity_filled_30min.append(state_as_of_slots(records, sorted_timestamps_30min))
+        entity_filled_5min.append(state_as_of_slots(records, all_display_slots_5min))
 
     return entity_filled_30min, entity_filled_5min, sorted_timestamps_30min, all_display_slots_5min
 
@@ -1326,18 +1322,16 @@ class WebInterface(ComponentBase):
                     for filled_30, filled_5 in zip(entity_filled_30min, entity_filled_5min):
                         value, is_changed, prev_value = filled_30.get(timestamp_30, ("-", False, None))
                         if is_changed:
-                            if prev_value is None or value != prev_value:
-                                cell_class = ' class="changed-cell"'
+                            cell_class = ' class="changed-cell"'
+                            has_highlight = True
+                        else:
+                            # Flag a row that held its value at both ends but moved somewhere inside its own half hour
+                            sub_vals = [filled_5.get(timestamp_30 + timedelta(minutes=off), ("-", False, None))[0] for off in range(5, 30, 5)]
+                            if any(v != value for v in sub_vals):
+                                cell_class = ' class="reverted-cell"'
                                 has_highlight = True
                             else:
-                                sub_vals = [filled_5.get(timestamp_30 + timedelta(minutes=off), ("-", False, None))[0] for off in range(-5, -26, -5)]
-                                if any(v != value for v in sub_vals):
-                                    cell_class = ' class="reverted-cell"'
-                                    has_highlight = True
-                                else:
-                                    cell_class = ""
-                        else:
-                            cell_class = ""
+                                cell_class = ""
                         cells.append((value, cell_class))
                     row_data.append((timestamp_30, cells, has_highlight))
 
@@ -1376,17 +1370,15 @@ class WebInterface(ComponentBase):
                         text += f"<td{cell_class}>{value}</td>"
                     text += "</tr>\n"
 
-                    # Detail rows: 5-minute slots leading UP TO the parent timestamp
-                    for offset in range(-5, -26, -5):
+                    # Detail rows: the remaining 5-minute slots inside this row's own half hour,
+                    # newest first to match the table's ordering (the row itself covers offset 0)
+                    for offset in range(25, 0, -5):
                         detail_time = timestamp_30 + timedelta(minutes=offset)
                         text += f'<tr class="detail-row" id="detail_{row_index}">'
                         text += f"<td>  {detail_time.strftime(TIME_FORMAT)}</td>"
                         for filled in entity_filled_5min:
                             value, is_changed, prev_value = filled.get(detail_time, ("-", False, None))
-                            if is_changed and (prev_value is None or value != prev_value):
-                                cell_class = ' class="changed-cell"'
-                            else:
-                                cell_class = ""
+                            cell_class = ' class="changed-cell"' if is_changed else ""
                             text += f"<td{cell_class}>{value}</td>"
                         text += "</tr>\n"
 
@@ -1946,47 +1938,44 @@ var options = {
         first_series = True
         all_states = set()
 
+        # A rangeBar data point's "x" is the y-axis category, so entities whose friendly names
+        # collide (every GivEnergy Cloud inverter publishes a "Status" sensor, for instance) would
+        # otherwise share a single unlabelled row with no way to tell which bar is which inverter.
+        name_counts = {}
+        for entity_timeline in timeline_data:
+            name_counts[entity_timeline["name"]] = name_counts.get(entity_timeline["name"], 0) + 1
+
         for entity_timeline in timeline_data:
             entity_name = entity_timeline["name"]
+            if name_counts.get(entity_name, 0) > 1:
+                entity_name = "{} ({})".format(entity_name, entity_timeline.get("entity_id", ""))
             history_chart = entity_timeline["data"]  # Dict with timestamp keys and state values
 
-            # Convert history data to timeline ranges
+            # Sort by the instant each record represents rather than by its raw timestamp text:
+            # HA/DB history is UTC while get_history_with_now() appends the current state stamped
+            # in local time, so a string sort can order records by their offset instead of by time.
+            sorted_items = []
+            for timestamp_str, state in history_chart.items():
+                try:
+                    sorted_items.append((int(str2time(timestamp_str).timestamp() * 1000), str(state)))
+                except (ValueError, TypeError):
+                    continue
+            sorted_items.sort(key=lambda item: item[0])
+
+            # Convert history data to timeline ranges. Every sample is folded into a range: unlike a
+            # numerical series, thinning a state series does not merely lower the resolution, it
+            # rewrites history. Sampling the records by array index used to alias a flapping state
+            # away entirely whenever the step kept landing on one phase of the flap, leaving the
+            # chart asserting a single multi-day run that the history table flatly contradicted.
+            # Only transitions produce a range, so an entity that rarely changes stays cheap.
             ranges = []
             current_state = None
             start_time = None
-
-            # Sort by timestamp - history_chart is a dict
-            sorted_items = sorted(history_chart.items(), key=lambda x: x[0])
-
-            # Downsample if needed - keep max 288 data points
-            max_points = 288
-            if len(sorted_items) > max_points:
-                # Calculate step size to keep approximately max_points
-                step = len(sorted_items) // max_points
-                if step < 1:
-                    step = 1
-                # Keep every Nth item, but always keep first and last
-                downsampled = [sorted_items[0]]  # Always keep first
-                # Add items at regular intervals
-                for i in range(step, len(sorted_items) - 1, step):
-                    downsampled.append(sorted_items[i])
-                # Always keep last if it's not already included
-                if len(sorted_items) > 1 and sorted_items[-1] not in downsampled:
-                    downsampled.append(sorted_items[-1])
-                sorted_items = downsampled
-
             last_timestamp_ms = None
-            for timestamp_str, state in sorted_items:
-                state = str(state)
-                all_states.add(state)
 
-                # Convert timestamp string to milliseconds for ApexCharts
-                try:
-                    timestamp_dt = str2time(timestamp_str)
-                    timestamp_ms = int(timestamp_dt.timestamp() * 1000)
-                    last_timestamp_ms = timestamp_ms  # Track the last valid timestamp
-                except (ValueError, TypeError):
-                    continue
+            for timestamp_ms, state in sorted_items:
+                all_states.add(state)
+                last_timestamp_ms = timestamp_ms
 
                 if current_state is None:
                     # First point


### PR DESCRIPTION
## Problem

Selecting two GivEnergy Cloud inverters' status sensors on `/entity` produced three contradictions at once: the timeline chart drew one continuous `Normal` bar while the history table reported `Lost` over the same hours; a table row reported `Lost` while every 5-minute slot listed under it read `Normal`; and both inverters shared a single unlabelled `Status` row on the chart.

Both views were wrong, in different ways.

## History table

`build_entity_history_table_data()` had two defects:

- **A row reported the last sample taken inside its window, not the state across it.** One momentary `Lost` record at 21:57 made the whole 21:30 row read `Lost`, and carry-forward then repeated that value into every later slot with no sample of its own — turning a blip into hours of apparent downtime. Every 30-minute row and 5-minute slot now reports the state **as of its own timestamp** (the most recent record at or before it), via a new `state_as_of_slots()` helper.

  This is the rule 7248a75a (#4291) established when it fixed buckets keeping the oldest sample rather than the newest — the bucket-summary idea itself was the problem.

- **Detail rows were the offsets `-5..-25`** — the half hour *before* the row — so expanding a row described a different window and contradicted the row it sat under. They are now the 5-minute marks inside the row's own window.

Same data, before and after:

```
Normal all evening, one 'Lost' record at 21:57
  before:  row 21:30 shows 'Lost'    expands to 21:25 21:20 21:15 21:10 21:05 = Normal
  after:   row 21:30 shows 'Normal'  expands to 21:55 21:50 21:45 21:40 21:35 = Normal
```

## Timeline chart

`render_timeline_chart()` had three:

- **State records were downsampled by array index** (every Nth, max 288) before being folded into ranges. For a categorical series that does not lower the resolution, it rewrites history: whenever the step kept landing on one phase of a flapping signal, every occurrence of the other state was erased and the survivors merged into one long run. 8640 records alternating `Normal`/`Lost` every minute rendered as a single 8639-minute `Normal` bar. Ranges are now built from every record — only transitions emit a range, so an entity that rarely changes stays cheap.
- **Records were sorted by raw timestamp string.** HA/DB history is UTC while `get_history_with_now()` appends the current state stamped in local time, so a string sort ordered records by their offset text and could truncate the timeline early. Timestamps are parsed once and sorted by instant.
- **A rangeBar point's `x` is the y-axis category**, and every GivEnergy Cloud inverter publishes a status sensor named `Status` (`gecloud.py:173`), so both inverters collapsed onto one unlabelled row. Colliding names are disambiguated with the entity_id.

## Trade-offs worth reviewing

- A blip falling between two 5-minute marks is no longer visible in the table. That is inherent to sampling a state at fixed timestamps — it can no longer claim `Lost` when it wasn't, but it also won't show a 3-minute dropout that fell between samples. The chart is where every transition shows.
- The oldest table row can read `-` where nothing had been recorded by that timestamp, instead of borrowing a reading taken later in that window.
- The chart no longer caps at 288 points. A genuinely fast-flapping entity now emits one point per transition, which is more work for the browser. I tried a range-count cap first and dropped it: every thinning scheme reintroduced a fabricated run when the data is uniformly short.

## Testing

`tests/test_web_history_table.py` and `tests/test_web_charts.py` extended. Each new assertion was confirmed to fail against the unfixed code, including reproducing the reported symptom directly (`rows report 'Lost': ['21:30']`). `./run_all --quick` and `./run_pre_commit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
