### PR TITLE
fix(web): use configured currency minor unit in Rates chart legend

### DIFF
--- a/apps/predbat/tests/test_web_chart_currency.py
+++ b/apps/predbat/tests/test_web_chart_currency.py
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Test that the Rates chart's per-series legend names (WebInterface.get_chart, web.py) use the
+configured currency's minor unit rather than a hardcoded "p/kWh" - see issue #4153, where a
+user configured for NZ dollars/cents saw "p/kWh" (pence) in the chart legend regardless.
+"""
+
+
+def test_rates_chart_series_names_use_currency_symbol(my_predbat):
+    """
+    Directly mirrors the series-name formatting used in WebInterface.get_chart's "Rates"
+    branch (web.py) - get_chart itself requires a fully computed plan (soc_kw_best populated)
+    before it reaches this branch, so this tests the formatting logic directly rather than
+    standing up that heavier machinery.
+    """
+    print("**** test_rates_chart_series_names_use_currency_symbol ****")
+
+    for currency_symbols, expected_minor in [("£p", "p"), ("$c", "c"), ("€c", "c")]:
+        my_predbat.currency_symbols = currency_symbols
+        hourly_name = "Hourly {}/kWh".format(my_predbat.currency_symbols[1])
+        today_name = "Today {}/kWh".format(my_predbat.currency_symbols[1])
+
+        assert hourly_name == "Hourly {}/kWh".format(expected_minor), f"Expected 'Hourly {expected_minor}/kWh', got '{hourly_name}'"
+        assert today_name == "Today {}/kWh".format(expected_minor), f"Expected 'Today {expected_minor}/kWh', got '{today_name}'"
+        if expected_minor != "p":
+            assert "p/kWh" not in hourly_name and "p/kWh" not in today_name, f"Series name should not be hardcoded to pence for currency_symbols={currency_symbols}"
+
+    print("✓ Rates chart series names correctly follow currency_symbols[1] (£p, $c, €c all verified)")
+    print("✓ Test passed")
+    return False

--- a/apps/predbat/tests/test_web_chart_currency.py
+++ b/apps/predbat/tests/test_web_chart_currency.py
@@ -53,8 +53,8 @@ def test_rates_chart_series_names_use_currency_symbol(my_predbat):
     try:
         w = _make_web(my_predbat)
         my_predbat.dashboard_values = {
-            "predbat.soc_kw_best": {"attributes": {"results": {"2026-01-01T00:00:00+00:00": 5.0}}},
-            "predbat.rates": {"attributes": {"results": {"2026-01-01T00:00:00+00:00": 10.0}}},
+            my_predbat.prefix + ".soc_kw_best": {"attributes": {"results": {"2026-01-01T00:00:00+00:00": 5.0}}},
+            my_predbat.prefix + ".rates": {"attributes": {"results": {"2026-01-01T00:00:00+00:00": 10.0}}},
         }
         fake_history = [
             [

--- a/apps/predbat/tests/test_web_chart_currency.py
+++ b/apps/predbat/tests/test_web_chart_currency.py
@@ -14,26 +14,77 @@ configured currency's minor unit rather than a hardcoded "p/kWh" - see issue #41
 user configured for NZ dollars/cents saw "p/kWh" (pence) in the chart legend regardless.
 """
 
+import re
+
+from web import WebInterface
+
+
+def _make_web(my_predbat):
+    """
+    Build a minimal WebInterface bound to my_predbat, bypassing ComponentBase.__init__ (which
+    would stand up the real aiohttp app). currency_symbols/now_utc/minutes_now/etc are all
+    read-only properties on ComponentBase that delegate to self.base, so nothing else needs
+    setting here for get_chart() to run.
+    """
+    w = WebInterface.__new__(WebInterface)
+    w.base = my_predbat
+    w.log = my_predbat.log
+    w.prefix = my_predbat.prefix
+    return w
+
 
 def test_rates_chart_series_names_use_currency_symbol(my_predbat):
     """
-    Directly mirrors the series-name formatting used in WebInterface.get_chart's "Rates"
-    branch (web.py) - get_chart itself requires a fully computed plan (soc_kw_best populated)
-    before it reaches this branch, so this tests the formatting logic directly rather than
-    standing up that heavier machinery.
+    Calls the real WebInterface.get_chart("Rates") and checks the rendered series names,
+    rather than re-testing the formatting logic in isolation - a prior version of this test
+    only duplicated the format string inline, so it would still pass even if web.py regressed
+    back to a hardcoded "p/kWh" (Copilot review on PR #4288).
+
+    get_chart() gates on soc_kw_best being populated (dashboard_values) and reads the Hourly/
+    Today series from get_history_wrapper() - both are stubbed directly rather than trying to
+    reproduce realistic HA history formatting, since only the currency-dependent series *names*
+    are under test here, not the underlying rate data.
     """
     print("**** test_rates_chart_series_names_use_currency_symbol ****")
 
-    for currency_symbols, expected_minor in [("£p", "p"), ("$c", "c"), ("€c", "c")]:
-        my_predbat.currency_symbols = currency_symbols
-        hourly_name = "Hourly {}/kWh".format(my_predbat.currency_symbols[1])
-        today_name = "Today {}/kWh".format(my_predbat.currency_symbols[1])
+    original_currency_symbols = my_predbat.currency_symbols
+    original_dashboard_values = getattr(my_predbat, "dashboard_values", None)
 
-        assert hourly_name == "Hourly {}/kWh".format(expected_minor), f"Expected 'Hourly {expected_minor}/kWh', got '{hourly_name}'"
-        assert today_name == "Today {}/kWh".format(expected_minor), f"Expected 'Today {expected_minor}/kWh', got '{today_name}'"
-        if expected_minor != "p":
-            assert "p/kWh" not in hourly_name and "p/kWh" not in today_name, f"Series name should not be hardcoded to pence for currency_symbols={currency_symbols}"
+    try:
+        w = _make_web(my_predbat)
+        my_predbat.dashboard_values = {
+            "predbat.soc_kw_best": {"attributes": {"results": {"2026-01-01T00:00:00+00:00": 5.0}}},
+            "predbat.rates": {"attributes": {"results": {"2026-01-01T00:00:00+00:00": 10.0}}},
+        }
+        fake_history = [
+            [
+                {"state": 10.5, "last_updated": "2026-01-01T00:00:00+00:00"},
+                {"state": 12.3, "last_updated": "2026-01-01T00:30:00+00:00"},
+            ]
+        ]
+        w.get_history_wrapper = lambda *a, **kw: fake_history
 
-    print("✓ Rates chart series names correctly follow currency_symbols[1] (£p, $c, €c all verified)")
-    print("✓ Test passed")
-    return False
+        for currency_symbols, expected_minor in [("£p", "p"), ("$c", "c"), ("€c", "c")]:
+            my_predbat.currency_symbols = currency_symbols
+
+            result = w.get_chart("Rates")
+            series_names = re.findall(r"name: '([^']*)'", result)
+
+            expected_hourly = "Hourly {}/kWh".format(expected_minor)
+            expected_today = "Today {}/kWh".format(expected_minor)
+
+            assert expected_hourly in series_names, f"Expected series '{expected_hourly}' in {series_names} for currency_symbols={currency_symbols}"
+            assert expected_today in series_names, f"Expected series '{expected_today}' in {series_names} for currency_symbols={currency_symbols}"
+            if expected_minor != "p":
+                assert not any("p/kWh" in name for name in series_names), f"Series names should not be hardcoded to pence for currency_symbols={currency_symbols}, got {series_names}"
+
+        print("✓ Rates chart series names correctly follow currency_symbols[1] (£p, $c, €c all verified against the real get_chart() output)")
+        print("✓ Test passed")
+        return False
+    finally:
+        my_predbat.currency_symbols = original_currency_symbols
+        if original_dashboard_values is None:
+            if hasattr(my_predbat, "dashboard_values"):
+                del my_predbat.dashboard_values
+        else:
+            my_predbat.dashboard_values = original_dashboard_values

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -65,6 +65,7 @@ from tests.test_hainterface_service import run_hainterface_service_tests
 from tests.test_hainterface_lifecycle import run_hainterface_lifecycle_tests
 from tests.test_hainterface_websocket import run_hainterface_websocket_tests
 from tests.test_web_if import run_test_web_if
+from tests.test_web_chart_currency import test_rates_chart_series_names_use_currency_symbol
 from tests.test_web_functions import run_web_functions_tests
 from tests.test_web_history_table import run_web_history_table_tests
 from tests.test_web_charts import run_web_charts_tests
@@ -281,6 +282,7 @@ def main():
         ("manual_times", run_test_manual_times, "Manual times tests", False),
         ("manual_select", run_test_manual_select, "Manual select tests", False),
         ("web_if", run_test_web_if, "Web interface tests", False),
+        ("web_chart_currency", test_rates_chart_series_names_use_currency_symbol, "Rates chart series names follow currency_symbols tests", False),
         ("web_functions", run_web_functions_tests, "Web function unit tests", False),
         ("web_history_table", run_web_history_table_tests, "Web /entity history table bucketing tests", False),
         ("web_charts", run_web_charts_tests, "Web chart rendering tests (percent/special-character units)", False),

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -2964,8 +2964,8 @@ chart.render();
                 {"name": "Import", "data": rates, "opacity": "1.0", "stroke_width": "3", "stroke_curve": "stepline"},
                 {"name": "Export", "data": rates_export, "opacity": "0.2", "stroke_width": "2", "stroke_curve": "stepline", "chart_type": "area"},
                 {"name": "Gas", "data": rates_gas, "opacity": "0.2", "stroke_width": "2", "stroke_curve": "stepline", "chart_type": "area"},
-                {"name": "Hourly p/kWh", "data": cost_pkwh_hour, "opacity": "1.0", "stroke_width": "2", "stroke_curve": "stepline"},
-                {"name": "Today p/kWh", "data": cost_pkwh_today, "opacity": "1.0", "stroke_width": "2", "stroke_curve": "stepline"},
+                {"name": "Hourly {}/kWh".format(self.currency_symbols[1]), "data": cost_pkwh_hour, "opacity": "1.0", "stroke_width": "2", "stroke_curve": "stepline"},
+                {"name": "Today {}/kWh".format(self.currency_symbols[1]), "data": cost_pkwh_today, "opacity": "1.0", "stroke_width": "2", "stroke_curve": "stepline"},
             ]
             text += self.render_chart(series_data, self.currency_symbols[1], "Energy Rates", now_str)
         elif chart == "InDay":


### PR DESCRIPTION
## Summary

Fixes #4153. The Rates chart's "Hourly"/"Today" series legend names were hardcoded to `p/kWh` (pence) regardless of the user's configured `currency_symbols`, so non-GBP users (e.g. the reporter's NZD setup, configured as `$c`) saw `p/kWh` in the chart legend even though the surrounding chart title/axis already correctly used `self.currency_symbols[1]`.

Per the maintainer's own scoping comment on the issue: fix limited to `web.py`'s chart rendering. Left `config.py`'s CONFIG_ITEMS units and `output.py`'s HA entity attribute names untouched, since changing those affects existing HA entity definitions/history for all users.

Split out from #4288, which originally bundled this with two unrelated fixes.

## Changes

- `apps/predbat/web.py`: series names now use `"{}/kWh".format(self.currency_symbols[1])`, matching the pattern already used elsewhere in the same file.
- `apps/predbat/tests/test_web_chart_currency.py`: calls the real `WebInterface.get_chart("Rates")` (via a minimal instance bypassing `ComponentBase.__init__`) and checks the rendered series names, rather than re-testing the formatting logic in isolation. Verified this actually catches a regression: temporarily reintroducing the hardcoded `p/kWh` strings makes the test fail as expected.

## Test plan

- [x] `./run_all --test web_chart_currency` - new test passes
- [x] `./run_all --quick` - full quick suite passes (611 tests, 0 failures)
- [x] `./run_pre_commit` - clean (ruff, black, cspell, markdownlint)

🤖 Implemented with Claude Code, disclosed per repo convention.