### PR TITLE
feat(lattice): add durable schedule authority core

### DIFF
--- a/apps/predbat/lattice_schedule_authority.py
+++ b/apps/predbat/lattice_schedule_authority.py
@@ -31,8 +31,10 @@ VERIFICATION_DURABLE_STORE_READBACK = "DURABLE_STORE_READBACK"
 VERIFICATION_NATIVE_TARGET_READBACK = "NATIVE_TARGET_READBACK"
 MAX_SCHEDULE_SLOTS = 8
 _STATE_PENDING = "PENDING"
+_TRANSITION_REPLACE = "REPLACE"
+_TRANSITION_CANCEL = "CANCEL"
 _STORAGE_MODULE = "lattice_schedule_authority"
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 _MAX_EPOCH_MS = (1 << 53) - 1
 _MAX_UINT32 = (1 << 32) - 1
 _MAX_UINT64 = (1 << 64) - 1
@@ -67,9 +69,16 @@ _REJECTION_REASONS = (
     "VERIFICATION_FAILED",
     "INTERNAL",
     "SCOPE_BUSY",
+    "COMMAND_ID_COLLISION",
+    "NO_ACTIVE_SCHEDULE",
+    "PLAN_DIGEST_MISMATCH",
+    "AUTHORITY_RELEASE_UNCONFIRMED",
 )
+_CANCELLATION_REASONS = ("VALIDITY_END", "SUPERSEDED", "OPERATOR", "SAFETY")
 _COMMAND_IDENTITY_FIELDS = (
+    "transition_kind",
     "plan_digest",
+    "cancellation_reason",
     "slot_count",
     "valid_from_ts_ms",
     "valid_until_ts_ms",
@@ -267,7 +276,51 @@ class ScheduleCommand:
             "command_id": self.command_id,
             "doc_version": self.target.doc_version,
             "cap_ref": self.target.cap_ref,
-            "absolute_schedule_intent": self.schedule.to_wire(),
+            "schedule_transition": {"replacement": self.schedule.to_wire()},
+            "controller": {
+                "origin_id": self.lease.origin_id,
+                "controller_class": self.lease.controller_class,
+            },
+            "lease": {
+                "lease_id": self.lease.lease_id,
+                "scope_id": self.lease.scope_id,
+                "fencing_token": self.lease.fencing_token,
+                "expires_ts_ms": self.lease.expires_ts_ms,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class ScheduleCancellation:
+    """One digest-guarded request to end the installed schedule authority."""
+
+    expected_plan_digest: str
+    reason: str
+
+    def to_wire(self):
+        """Return the exact v0.4 conditional-cancellation field shape."""
+        return {
+            "expected_plan_digest": self.expected_plan_digest,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class ScheduleCancellationCommand:
+    """Protocol-neutral representation of one v0.4 cancellation command."""
+
+    command_id: str
+    target: ScheduleTarget
+    cancellation: ScheduleCancellation
+    lease: ScheduleLease
+
+    def to_wire(self):
+        """Return the exact v0.4 control-field shape for a protobuf adapter."""
+        return {
+            "command_id": self.command_id,
+            "doc_version": self.target.doc_version,
+            "cap_ref": self.target.cap_ref,
+            "schedule_transition": {"cancellation": self.cancellation.to_wire()},
             "controller": {
                 "origin_id": self.lease.origin_id,
                 "controller_class": self.lease.controller_class,
@@ -308,6 +361,8 @@ class ScheduleAck:
     durably_accepted: bool = False
     valid_from_ts_ms: int = 0
     valid_until_ts_ms: int = 0
+    cancelled_plan_digest: str = ""
+    writer_exclusion_released: bool = False
     verification: str = ""
     clamps: tuple[ScheduleClamp, ...] = ()
     clamp_count: int = 0
@@ -333,6 +388,8 @@ class ScheduleAck:
             self.durably_accepted,
             self.valid_from_ts_ms,
             self.valid_until_ts_ms,
+            self.cancelled_plan_digest,
+            self.writer_exclusion_released,
             self.verification,
             self.clamps,
             self.clamp_count,
@@ -351,6 +408,7 @@ class AuthorityDecision:
     state: str
     command_id: str = ""
     legacy_suppressed: bool = False
+    ending_transition_required: bool = False
     fallback_allowed: bool = False
     quarantined: bool = False
     detail: str = ""
@@ -657,6 +715,26 @@ def _valid_target(target, schedule, scope_id):
     )
 
 
+def _valid_cancellation_target(target, installed, scope_id):
+    """Return whether provider-local coordinates still bind the installed plan."""
+    return (
+        isinstance(target, ScheduleTarget)
+        and target.provider == "predbat-gateway"
+        and target.access_path == "gw-local"
+        and target.topology_version == "0.4.0"
+        and _is_int(target.doc_version)
+        and target.doc_version == installed["doc_version"]
+        and _is_int(target.cap_ref)
+        and target.cap_ref == installed["cap_ref"]
+        and target.node_id == installed["node_id"]
+        and target.altitude_id == installed["altitude_id"]
+        and target.scope_id == scope_id
+        and list(target.owned_node_ids) == installed["owned_node_ids"]
+        and isinstance(target.offer, ResolvedScheduleOffer)
+        and target.offer.fingerprint == installed["offer_fingerprint"]
+    )
+
+
 def _valid_lease(lease, scope_id, now_ts_ms):
     """Return whether the controller lease is well-formed and currently live."""
     return (
@@ -680,7 +758,9 @@ def _record_for(command):
     return {
         "command_id": command.command_id,
         "state": _STATE_PENDING,
+        "transition_kind": _TRANSITION_REPLACE,
         "plan_digest": command.schedule.plan_digest,
+        "cancellation_reason": "",
         "slot_count": len(command.schedule.slots),
         "valid_from_ts_ms": command.schedule.valid_from_ts_ms,
         "valid_until_ts_ms": command.schedule.valid_until_ts_ms,
@@ -696,6 +776,44 @@ def _record_for(command):
         "owned_node_ids": list(command.target.owned_node_ids),
         "offer_fingerprint": command.target.offer.fingerprint,
         "applied_plan_digest": "",
+        "cancelled_plan_digest": "",
+        "writer_exclusion_released": False,
+        "verification": "",
+        "clamps": [],
+        "clamp_count": 0,
+        "clamps_truncated": False,
+        "fallback": "",
+        "reason": "",
+        "durably_accepted": False,
+        "verified": False,
+    }
+
+
+def _cancellation_record_for(command, installed):
+    """Build a durable cancellation reservation bound to the installed plan."""
+    return {
+        "command_id": command.command_id,
+        "state": _STATE_PENDING,
+        "transition_kind": _TRANSITION_CANCEL,
+        "plan_digest": command.cancellation.expected_plan_digest,
+        "cancellation_reason": command.cancellation.reason,
+        "slot_count": installed["slot_count"],
+        "valid_from_ts_ms": installed["valid_from_ts_ms"],
+        "valid_until_ts_ms": installed["valid_until_ts_ms"],
+        "fencing_token": command.lease.fencing_token,
+        "lease_id": command.lease.lease_id,
+        "lease_expires_ts_ms": command.lease.expires_ts_ms,
+        "origin_id": command.lease.origin_id,
+        "controller_class": command.lease.controller_class,
+        "doc_version": command.target.doc_version,
+        "cap_ref": command.target.cap_ref,
+        "node_id": command.target.node_id,
+        "altitude_id": command.target.altitude_id,
+        "owned_node_ids": list(command.target.owned_node_ids),
+        "offer_fingerprint": command.target.offer.fingerprint,
+        "applied_plan_digest": "",
+        "cancelled_plan_digest": "",
+        "writer_exclusion_released": False,
         "verification": "",
         "clamps": [],
         "clamp_count": 0,
@@ -737,6 +855,8 @@ def _valid_ack_receipt(ack, expected):
         or not isinstance(ack.verified, bool)
         or ack.valid_from_ts_ms != expected["valid_from_ts_ms"]
         or ack.valid_until_ts_ms != expected["valid_until_ts_ms"]
+        or ack.cancelled_plan_digest != ""
+        or ack.writer_exclusion_released is not False
         or ack.verification not in (VERIFICATION_ACCEPTED_ONLY, VERIFICATION_DURABLE_STORE_READBACK, VERIFICATION_NATIVE_TARGET_READBACK)
         or not isinstance(ack.clamps, tuple)
         or len(ack.clamps) > MAX_SCHEDULE_SLOTS
@@ -752,14 +872,47 @@ def _valid_ack_receipt(ack, expected):
     return all(isinstance(clamp, ScheduleClamp) and _valid_clamp_values(clamp.slot_index, clamp.field, clamp.requested, clamp.applied, ack.accepted_slot_count) for clamp in ack.clamps)
 
 
+def _valid_ack_cancellation_receipt(ack, expected):
+    """Validate definite durable/native proof that writer exclusion was released."""
+    return (
+        ack.plan_digest == ""
+        and ack.accepted_slot_count == 0
+        and ack.durably_accepted is False
+        and ack.valid_from_ts_ms == 0
+        and ack.valid_until_ts_ms == 0
+        and ack.clamps == ()
+        and ack.clamp_count == 0
+        and ack.clamps_truncated is False
+        and ack.cancelled_plan_digest == expected["plan_digest"]
+        and ack.writer_exclusion_released is True
+        and ack.verification in (VERIFICATION_DURABLE_STORE_READBACK, VERIFICATION_NATIVE_TARGET_READBACK)
+        and ack.verified is True
+    )
+
+
 def _valid_stored_receipt(record):
-    """Validate a JSON-compatible durable copy of an applied receipt."""
+    """Validate a JSON-compatible durable copy of an APPLIED receipt."""
     verification = record.get("verification")
+    if record.get("transition_kind") == _TRANSITION_CANCEL:
+        return (
+            record.get("applied_plan_digest") == ""
+            and record.get("cancelled_plan_digest") == record.get("plan_digest")
+            and record.get("writer_exclusion_released") is True
+            and verification in (VERIFICATION_DURABLE_STORE_READBACK, VERIFICATION_NATIVE_TARGET_READBACK)
+            and record.get("verified") is True
+            and record.get("durably_accepted") is False
+            and record.get("clamps") == []
+            and record.get("clamp_count") == 0
+            and record.get("clamps_truncated") is False
+        )
     clamps = record.get("clamps")
     clamp_count = record.get("clamp_count")
     clamps_truncated = record.get("clamps_truncated")
     if (
         not _valid_digest(record.get("applied_plan_digest"))
+        or record.get("durably_accepted") is not True
+        or record.get("cancelled_plan_digest") != ""
+        or record.get("writer_exclusion_released") is not False
         or verification not in (VERIFICATION_ACCEPTED_ONLY, VERIFICATION_DURABLE_STORE_READBACK, VERIFICATION_NATIVE_TARGET_READBACK)
         or not isinstance(clamps, list)
         or len(clamps) > MAX_SCHEDULE_SLOTS
@@ -788,7 +941,12 @@ def _valid_command_record(record):
         return False
     if record.get("state") not in (_STATE_PENDING, RESULT_APPLIED, RESULT_NOT_APPLIED, RESULT_UNKNOWN):
         return False
+    if record.get("transition_kind") not in (_TRANSITION_REPLACE, _TRANSITION_CANCEL):
+        return False
     if not _valid_digest(record.get("plan_digest")):
+        return False
+    cancellation_reason = record.get("cancellation_reason")
+    if (record["transition_kind"] == _TRANSITION_REPLACE and cancellation_reason != "") or (record["transition_kind"] == _TRANSITION_CANCEL and cancellation_reason not in _CANCELLATION_REASONS):
         return False
     if not _valid_digest(record.get("offer_fingerprint")):
         return False
@@ -822,8 +980,16 @@ def _valid_command_record(record):
     if not isinstance(record.get("durably_accepted"), bool) or not isinstance(record.get("verified"), bool):
         return False
     if record["state"] == RESULT_APPLIED:
-        return record["durably_accepted"] and record["fallback"] == "" and record["reason"] == "" and _valid_stored_receipt(record)
-    if record.get("applied_plan_digest") != "" or record.get("verification") != "" or record.get("clamps") != [] or record.get("clamp_count") != 0 or record.get("clamps_truncated") is not False:
+        return record["fallback"] == "" and record["reason"] == "" and _valid_stored_receipt(record)
+    if (
+        record.get("applied_plan_digest") != ""
+        or record.get("cancelled_plan_digest") != ""
+        or record.get("writer_exclusion_released") is not False
+        or record.get("verification") != ""
+        or record.get("clamps") != []
+        or record.get("clamp_count") != 0
+        or record.get("clamps_truncated") is not False
+    ):
         return False
     if record["state"] == RESULT_NOT_APPLIED:
         return not record["durably_accepted"] and record["fallback"] in (FALLBACK_SAFE, FALLBACK_BLOCKED) and bool(record["reason"])
@@ -839,13 +1005,26 @@ def _valid_snapshot(snapshot, scope_id):
     high_water = snapshot.get("high_water_token")
     if not _is_int(high_water) or high_water < 0 or high_water > _MAX_UINT64:
         return False
+    quarantine_since_ts_ms = snapshot.get("quarantine_since_ts_ms")
+    if quarantine_since_ts_ms is not None and (not _is_int(quarantine_since_ts_ms) or quarantine_since_ts_ms <= 0 or quarantine_since_ts_ms > _MAX_EPOCH_MS):
+        return False
     command = snapshot.get("command")
     installed = snapshot.get("installed")
-    if installed is not None and (not _valid_command_record(installed) or installed["state"] != RESULT_APPLIED or installed["fencing_token"] > high_water):
+    if installed is not None and (not _valid_command_record(installed) or installed["state"] != RESULT_APPLIED or installed["transition_kind"] != _TRANSITION_REPLACE or installed["fencing_token"] > high_water):
         return False
     if command is None:
-        return installed is None
-    return _valid_command_record(command) and command["fencing_token"] <= high_water
+        return installed is None and quarantine_since_ts_ms is None
+    if not _valid_command_record(command) or command["fencing_token"] > high_water:
+        return False
+    if (command["state"] == RESULT_UNKNOWN) is not (quarantine_since_ts_ms is not None):
+        return False
+    if command["transition_kind"] == _TRANSITION_CANCEL:
+        if command["state"] == RESULT_APPLIED:
+            return installed is None
+        return installed is not None and command["plan_digest"] == installed["applied_plan_digest"]
+    if command["state"] == RESULT_APPLIED:
+        return installed is not None and _same_command_identity(command, installed)
+    return True
 
 
 def _same_command_identity(left, right):
@@ -857,21 +1036,34 @@ def _decision_from_record(record, now_ts_ms=None):
     """Derive legacy suppression and fallback from one validated record."""
     state = record["state"]
     if state == RESULT_APPLIED:
-        if now_ts_ms is not None and record["valid_until_ts_ms"] <= now_ts_ms:
-            return AuthorityDecision(RESULT_NOT_APPLIED, record["command_id"], detail="durable Lattice schedule validity has expired")
-        return AuthorityDecision(state, record["command_id"], legacy_suppressed=True)
+        return AuthorityDecision(
+            state,
+            record["command_id"],
+            legacy_suppressed=record["transition_kind"] == _TRANSITION_REPLACE,
+        )
     if state == RESULT_NOT_APPLIED:
         return AuthorityDecision(state, record["command_id"], fallback_allowed=record["fallback"] == FALLBACK_SAFE, detail=record["reason"])
-    return AuthorityDecision(RESULT_UNKNOWN, record["command_id"], quarantined=True, detail=record.get("reason") or "command result unresolved")
+    return AuthorityDecision(
+        RESULT_UNKNOWN,
+        record["command_id"],
+        legacy_suppressed=True,
+        quarantined=True,
+        detail=record.get("reason") or "command result unresolved",
+    )
 
 
 def _decision_from_snapshot(snapshot, now_ts_ms):
-    """Preserve suppression while a previously installed schedule may act."""
+    """Preserve suppression until a guarded ending transition proves release."""
     record = snapshot.get("command")
     decision = AuthorityDecision(RESULT_NOT_APPLIED, detail="no durable Lattice acceptance") if record is None else _decision_from_record(record, now_ts_ms)
     installed = snapshot.get("installed")
-    if installed is not None and installed["valid_until_ts_ms"] > now_ts_ms:
-        return replace(decision, legacy_suppressed=True, fallback_allowed=False)
+    if installed is not None:
+        return replace(
+            decision,
+            legacy_suppressed=True,
+            ending_transition_required=now_ts_ms >= installed["valid_until_ts_ms"],
+            fallback_allowed=False,
+        )
     return decision
 
 
@@ -962,23 +1154,27 @@ class LatticeScheduleAuthority:
         if any(value != absent and value != wanted for value, absent, wanted in optional_coordinates):
             return False
         if ack.state == RESULT_APPLIED:
-            return (
+            coordinates_match = (
                 ack.fencing_token == expected["fencing_token"]
                 and ack.lease_id == expected["lease_id"]
                 and ack.lease_expires_ts_ms == expected["lease_expires_ts_ms"]
                 and ack.origin_id == expected["origin_id"]
                 and ack.controller_class == expected["controller_class"]
-                and _valid_ack_receipt(ack, expected)
                 and ack.fallback == ""
                 and ack.reason == ""
                 and ack.detail == ""
             )
+            if expected["transition_kind"] == _TRANSITION_CANCEL:
+                return coordinates_match and _valid_ack_cancellation_receipt(ack, expected)
+            return coordinates_match and _valid_ack_receipt(ack, expected)
         receipt_absent = (
             ack.plan_digest == ""
             and ack.accepted_slot_count == 0
             and ack.durably_accepted is False
             and ack.valid_from_ts_ms == 0
             and ack.valid_until_ts_ms == 0
+            and ack.cancelled_plan_digest == ""
+            and ack.writer_exclusion_released is False
             and ack.verification == ""
             and ack.clamps == ()
             and ack.clamp_count == 0
@@ -994,6 +1190,10 @@ class LatticeScheduleAuthority:
             "SCOPE_MISMATCH",
             "SCOPE_QUARANTINED",
             "SCOPE_BUSY",
+            "COMMAND_ID_COLLISION",
+            "NO_ACTIVE_SCHEDULE",
+            "PLAN_DIGEST_MISMATCH",
+            "AUTHORITY_RELEASE_UNCONFIRMED",
             "EXECUTION_AMBIGUOUS",
             "INTERNAL",
         )
@@ -1054,6 +1254,8 @@ class LatticeScheduleAuthority:
             {
                 "state": ack.state,
                 "applied_plan_digest": ack.plan_digest,
+                "cancelled_plan_digest": ack.cancelled_plan_digest,
+                "writer_exclusion_released": ack.writer_exclusion_released,
                 "verification": ack.verification,
                 "clamps": [
                     {
@@ -1074,8 +1276,12 @@ class LatticeScheduleAuthority:
         )
         snapshot = dict(snapshot)
         snapshot["command"] = record
+        snapshot["quarantine_since_ts_ms"] = now_ts_ms if ack.state == RESULT_UNKNOWN else None
         if ack.state == RESULT_APPLIED:
-            snapshot["installed"] = dict(record)
+            if record["transition_kind"] == _TRANSITION_CANCEL:
+                snapshot["installed"] = None
+            else:
+                snapshot["installed"] = dict(record)
         if not await self._save(snapshot):
             return replace(
                 _decision_from_snapshot(previous_snapshot, now_ts_ms),
@@ -1101,6 +1307,7 @@ class LatticeScheduleAuthority:
         )
         updated = dict(snapshot)
         updated["command"] = record
+        updated["quarantine_since_ts_ms"] = snapshot.get("quarantine_since_ts_ms") or now_ts_ms
         await self._save(updated)
         return replace(
             _decision_from_snapshot(updated, now_ts_ms),
@@ -1124,12 +1331,17 @@ class LatticeScheduleAuthority:
         """Read the durable state used by a future legacy-suppression gate."""
         async with self._current_lock():
             if not _is_int(now_ts_ms) or now_ts_ms <= 0 or now_ts_ms > _MAX_EPOCH_MS:
-                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="now_ts_ms is invalid")
+                return AuthorityDecision(RESULT_UNKNOWN, legacy_suppressed=True, quarantined=True, detail="now_ts_ms is invalid")
             snapshot = await self._load()
             if snapshot is None:
                 return AuthorityDecision(RESULT_NOT_APPLIED, detail="no durable Lattice acceptance")
             if not _valid_snapshot(snapshot, self._scope_id):
-                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="corrupt persisted authority state")
+                return AuthorityDecision(
+                    RESULT_UNKNOWN,
+                    legacy_suppressed=True,
+                    quarantined=True,
+                    detail="corrupt persisted authority state",
+                )
             record = snapshot.get("command")
             if record is None:
                 return AuthorityDecision(RESULT_NOT_APPLIED, detail="no durable Lattice acceptance")
@@ -1139,12 +1351,17 @@ class LatticeScheduleAuthority:
         """Resume a pending/UNKNOWN command after restart without republishing."""
         async with self._current_lock():
             if not _is_int(now_ts_ms) or now_ts_ms <= 0 or now_ts_ms > _MAX_EPOCH_MS:
-                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="now_ts_ms is invalid")
+                return AuthorityDecision(RESULT_UNKNOWN, legacy_suppressed=True, quarantined=True, detail="now_ts_ms is invalid")
             snapshot = await self._load()
             if snapshot is None:
                 return AuthorityDecision(RESULT_NOT_APPLIED, detail="no command to reconcile")
             if not _valid_snapshot(snapshot, self._scope_id):
-                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="corrupt persisted authority state")
+                return AuthorityDecision(
+                    RESULT_UNKNOWN,
+                    legacy_suppressed=True,
+                    quarantined=True,
+                    detail="corrupt persisted authority state",
+                )
             record = snapshot.get("command")
             if record is None:
                 return AuthorityDecision(RESULT_NOT_APPLIED, detail="no command to reconcile")
@@ -1152,11 +1369,157 @@ class LatticeScheduleAuthority:
                 return await self._reconcile_snapshot(snapshot, now_ts_ms)
             return _decision_from_snapshot(snapshot, now_ts_ms)
 
+    async def cancel(self, target, lease, expected_plan_digest, reason, now_ts_ms, command_id=None):
+        """Guard and reconcile one definite installed-schedule ending transition."""
+        async with self._current_lock():
+            if not _is_int(now_ts_ms) or now_ts_ms <= 0 or now_ts_ms > _MAX_EPOCH_MS:
+                return AuthorityDecision(RESULT_UNKNOWN, legacy_suppressed=True, quarantined=True, detail="now_ts_ms is invalid")
+            snapshot = await self._load()
+            if snapshot is None:
+                return AuthorityDecision(RESULT_NOT_APPLIED, detail="no installed Lattice schedule")
+            if not _valid_snapshot(snapshot, self._scope_id):
+                return AuthorityDecision(
+                    RESULT_UNKNOWN,
+                    legacy_suppressed=True,
+                    quarantined=True,
+                    detail="corrupt persisted authority state",
+                )
+
+            previous = snapshot.get("command")
+            if previous and previous["state"] in (_STATE_PENDING, RESULT_UNKNOWN):
+                previous_decision = await self._reconcile_snapshot(snapshot, now_ts_ms)
+                if previous_decision.state == RESULT_UNKNOWN:
+                    return previous_decision
+                snapshot = await self._load()
+                if snapshot is None or not _valid_snapshot(snapshot, self._scope_id):
+                    return replace(
+                        previous_decision,
+                        state=RESULT_UNKNOWN,
+                        legacy_suppressed=True,
+                        fallback_allowed=False,
+                        quarantined=True,
+                        detail="reconciled state could not be reloaded",
+                    )
+                if previous["transition_kind"] == _TRANSITION_CANCEL and previous["plan_digest"] == expected_plan_digest and previous["cancellation_reason"] == reason and previous_decision.state == RESULT_APPLIED:
+                    return previous_decision
+
+            installed = snapshot.get("installed")
+            if installed is None:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="NO_ACTIVE_SCHEDULE",
+                )
+            if not _valid_digest(expected_plan_digest) or reason not in _CANCELLATION_REASONS:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="cancellation is invalid",
+                )
+            if expected_plan_digest != installed["applied_plan_digest"]:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="PLAN_DIGEST_MISMATCH",
+                )
+            if not _valid_cancellation_target(target, installed, self._scope_id):
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="unsafe topology cancellation target",
+                )
+            if not _valid_lease(lease, self._scope_id, now_ts_ms):
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="lease is invalid or expired",
+                )
+            try:
+                resolved_command_id = command_id or self._command_id_factory()
+            except Exception:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_UNKNOWN,
+                    fallback_allowed=False,
+                    quarantined=True,
+                    detail="command_id generation failed",
+                )
+            if not isinstance(resolved_command_id, str) or not resolved_command_id or _utf8_length(resolved_command_id) > 63:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="command_id is invalid",
+                )
+
+            command = ScheduleCancellationCommand(
+                resolved_command_id,
+                target,
+                ScheduleCancellation(expected_plan_digest, reason),
+                lease,
+            )
+            expected = _cancellation_record_for(command, installed)
+            previous = snapshot.get("command")
+            if previous and previous["command_id"] == resolved_command_id and not _same_command_identity(previous, expected):
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_UNKNOWN,
+                    command_id=resolved_command_id,
+                    fallback_allowed=False,
+                    quarantined=True,
+                    detail="command_id conflicts with durable command",
+                )
+            if previous and _same_command_identity(previous, expected):
+                return _decision_from_snapshot(snapshot, now_ts_ms)
+            if lease.fencing_token < snapshot["high_water_token"]:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    command_id=resolved_command_id,
+                    fallback_allowed=False,
+                    detail="STALE_FENCE",
+                )
+
+            previous_snapshot = snapshot
+            snapshot = {
+                "schema_version": _SCHEMA_VERSION,
+                "scope_id": self._scope_id,
+                "high_water_token": max(snapshot["high_water_token"], lease.fencing_token),
+                "command": expected,
+                "installed": installed,
+                "quarantine_since_ts_ms": None,
+            }
+            if not await self._save(snapshot):
+                return replace(
+                    _decision_from_snapshot(previous_snapshot, now_ts_ms),
+                    state=RESULT_UNKNOWN,
+                    command_id=resolved_command_id,
+                    fallback_allowed=False,
+                    quarantined=True,
+                    detail="cancellation reservation persistence failed",
+                )
+
+            result, conflict = await self._exchange(self._send, command, expected)
+            if conflict:
+                return await self._mark_unknown(snapshot, "conflicting cancellation result", now_ts_ms)
+            if result is None:
+                unknown = await self._mark_unknown(snapshot, "cancellation result unavailable", now_ts_ms)
+                reloaded = await self._load()
+                if reloaded is None or not _valid_snapshot(reloaded, self._scope_id):
+                    return unknown
+                return await self._reconcile_snapshot(reloaded, now_ts_ms)
+            return await self._persist_terminal(snapshot, result, now_ts_ms)
+
     async def dispatch(self, schedule, target, lease, now_ts_ms, command_id=None):
         """Reserve, send, and reconcile one schedule without any legacy write."""
         async with self._current_lock():
             if not _is_int(now_ts_ms) or now_ts_ms <= 0 or now_ts_ms > _MAX_EPOCH_MS:
-                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="now_ts_ms is invalid")
+                return AuthorityDecision(RESULT_UNKNOWN, legacy_suppressed=True, quarantined=True, detail="now_ts_ms is invalid")
             snapshot = await self._load()
             if snapshot is None:
                 snapshot = {
@@ -1165,9 +1528,15 @@ class LatticeScheduleAuthority:
                     "high_water_token": 0,
                     "command": None,
                     "installed": None,
+                    "quarantine_since_ts_ms": None,
                 }
             elif not _valid_snapshot(snapshot, self._scope_id):
-                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="corrupt persisted authority state")
+                return AuthorityDecision(
+                    RESULT_UNKNOWN,
+                    legacy_suppressed=True,
+                    quarantined=True,
+                    detail="corrupt persisted authority state",
+                )
             if not _valid_schedule_intent(schedule, now_ts_ms):
                 return replace(
                     _decision_from_snapshot(snapshot, now_ts_ms),
@@ -1253,6 +1622,7 @@ class LatticeScheduleAuthority:
                 "high_water_token": max(snapshot["high_water_token"], lease.fencing_token),
                 "command": expected,
                 "installed": snapshot.get("installed"),
+                "quarantine_since_ts_ms": None,
             }
             if not await self._save(snapshot):
                 return replace(

--- a/apps/predbat/lattice_schedule_authority.py
+++ b/apps/predbat/lattice_schedule_authority.py
@@ -1,0 +1,1276 @@
+"""Pure v0.4 schedule compilation and durable BatPred authority decisions.
+
+This module deliberately has no connection to ``PredBat.execute_plan`` or to a
+live transport.  A later, separately gated integration may adapt
+``ScheduleCommand.to_wire`` to the v0.4 protobuf and inject transport callbacks.
+"""
+
+# cspell:ignore READBACK readback
+
+import asyncio
+import hashlib
+import inspect
+import json
+import math
+import uuid
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+RESULT_APPLIED = "APPLIED"
+RESULT_NOT_APPLIED = "NOT_APPLIED"
+RESULT_UNKNOWN = "UNKNOWN"
+FALLBACK_SAFE = "SAFE"
+FALLBACK_BLOCKED = "BLOCKED"
+EXECUTION_NATIVE = "NATIVE"
+EXECUTION_CONTROLLER_STEPPED = "CONTROLLER_STEPPED"
+VERIFICATION_ACCEPTED_ONLY = "ACCEPTED_ONLY"
+VERIFICATION_DURABLE_STORE_READBACK = "DURABLE_STORE_READBACK"
+VERIFICATION_NATIVE_TARGET_READBACK = "NATIVE_TARGET_READBACK"
+MAX_SCHEDULE_SLOTS = 8
+_STATE_PENDING = "PENDING"
+_STORAGE_MODULE = "lattice_schedule_authority"
+_SCHEMA_VERSION = 1
+_MAX_EPOCH_MS = (1 << 53) - 1
+_MAX_UINT32 = (1 << 32) - 1
+_MAX_UINT64 = (1 << 64) - 1
+_LOAD_FAILED = object()
+_SCHEDULE_FIELDS = (
+    "TARGET_SOC",
+    "RESERVE_SOC",
+    "CHARGE_POWER_LIMIT",
+    "DISCHARGE_POWER_LIMIT",
+)
+_SLOT_FIELDS = (
+    "target_soc",
+    "reserve_soc",
+    "charge_power_limit",
+    "discharge_power_limit",
+    "enable",
+)
+_REJECTION_REASONS = (
+    "MALFORMED",
+    "STALE_DOCUMENT",
+    "UNSUPPORTED_OFFER",
+    "INVALID_SCHEDULE",
+    "UNSUPPORTED_MODE",
+    "AUTHENTICATED_ORIGIN_MISMATCH",
+    "LEASE_EXPIRED",
+    "STALE_FENCE",
+    "LEASE_CONFLICT",
+    "SCOPE_MISMATCH",
+    "SCOPE_QUARANTINED",
+    "EXECUTION_FAILED",
+    "EXECUTION_AMBIGUOUS",
+    "VERIFICATION_FAILED",
+    "INTERNAL",
+    "SCOPE_BUSY",
+)
+_COMMAND_IDENTITY_FIELDS = (
+    "plan_digest",
+    "slot_count",
+    "valid_from_ts_ms",
+    "valid_until_ts_ms",
+    "fencing_token",
+    "lease_id",
+    "lease_expires_ts_ms",
+    "origin_id",
+    "controller_class",
+    "doc_version",
+    "cap_ref",
+    "node_id",
+    "altitude_id",
+    "owned_node_ids",
+    "offer_fingerprint",
+)
+
+
+class ScheduleValidationError(ValueError):
+    """Reject a plan that cannot be represented as one safe v0.4 schedule."""
+
+
+@dataclass(frozen=True)
+class PlanWindow:
+    """One normalized segment of a complete plan at one topology altitude."""
+
+    altitude_id: str
+    start_minute: int
+    end_minute: int
+    mode: str
+    target_soc: Optional[float] = None
+    reserve_soc: Optional[float] = None
+    charge_power_limit: Optional[float] = None
+    discharge_power_limit: Optional[float] = None
+    enable: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class CompletePlan:
+    """A complete UTC timeline whose uncovered intervals use ``default_mode``."""
+
+    altitude_id: str
+    timeline_start_utc: datetime
+    horizon_minutes: int
+    diagnostic_timezone: str
+    windows: tuple[PlanWindow, ...]
+    default_mode: Optional[str] = "self_use"
+    execution: str = EXECUTION_CONTROLLER_STEPPED
+    is_complete: bool = True
+
+
+@dataclass(frozen=True)
+class AbsoluteScheduleSlot:
+    """One half-open v0.4 schedule slot expressed as UTC epoch milliseconds."""
+
+    start_ts_ms: int
+    end_ts_ms: int
+    mode: str
+    target_soc: Optional[float] = None
+    reserve_soc: Optional[float] = None
+    charge_power_limit: Optional[float] = None
+    discharge_power_limit: Optional[float] = None
+    enable: Optional[bool] = None
+
+    def to_wire(self):
+        """Return the v0.4 field names while preserving explicit zero and false."""
+        value = {
+            "start_ts_ms": self.start_ts_ms,
+            "end_ts_ms": self.end_ts_ms,
+            "mode": self.mode,
+        }
+        for field in ("target_soc", "reserve_soc", "charge_power_limit", "discharge_power_limit", "enable"):
+            field_value = getattr(self, field)
+            if field_value is not None:
+                value[field] = field_value
+        return value
+
+
+@dataclass(frozen=True)
+class AbsoluteScheduleIntent:
+    """One immutable v0.4 absolute schedule bound to a compiler altitude."""
+
+    altitude_id: str
+    slots: tuple[AbsoluteScheduleSlot, ...]
+    valid_from_ts_ms: int
+    valid_until_ts_ms: int
+    diagnostic_timezone: str
+    execution: str
+    default_mode: Optional[str] = None
+
+    def to_wire(self):
+        """Return the v0.4 ``absolute_schedule_intent`` object."""
+        value = {
+            "slots": [slot.to_wire() for slot in self.slots],
+            "valid_from_ts_ms": self.valid_from_ts_ms,
+            "valid_until_ts_ms": self.valid_until_ts_ms,
+            "diagnostic_timezone": self.diagnostic_timezone,
+            "execution": self.execution,
+        }
+        if self.default_mode is not None:
+            value["default_mode"] = self.default_mode
+        return value
+
+    @property
+    def plan_digest(self):
+        """Return the canonical SHA-256 digest used by applied receipts."""
+        encoded = json.dumps(self.to_wire(), sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class ResolvedScheduleOffer:
+    """Immutable constraints from the retained provider-local schedule offer."""
+
+    max_slots: int
+    supported_modes: tuple[str, ...]
+    slot_fields: tuple[str, ...]
+    execution_modes: tuple[str, ...]
+    gap_policy: str
+
+    def __post_init__(self):
+        """Normalize semantic sets and reject ambiguous duplicate constraints."""
+        fields = ("supported_modes", "slot_fields", "execution_modes")
+        for field in fields:
+            value = getattr(self, field)
+            if not isinstance(value, tuple) or any(not isinstance(item, str) for item in value):
+                raise ScheduleValidationError("{} must be an immutable string tuple".format(field))
+            if len(set(value)) != len(value):
+                raise ScheduleValidationError("{} contains duplicates".format(field))
+            object.__setattr__(self, field, tuple(sorted(value)))
+
+    @property
+    def fingerprint(self):
+        """Return a stable identity for the retained offer constraints."""
+        value = {
+            "max_slots": self.max_slots,
+            "supported_modes": list(self.supported_modes),
+            "slot_fields": list(self.slot_fields),
+            "execution_modes": list(self.execution_modes),
+            "gap_policy": self.gap_policy,
+        }
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class ScheduleTarget:
+    """Provider-local v0.4 schedule offer selected at one topology altitude."""
+
+    provider: str
+    node_id: str
+    access_path: str
+    topology_version: str
+    doc_version: int
+    cap_ref: int
+    altitude_id: str
+    scope_id: str
+    offer: ResolvedScheduleOffer
+    owned_node_ids: tuple[str, ...]
+
+    def __post_init__(self):
+        """Normalize and validate the exact provider-local owned target set."""
+        if not isinstance(self.owned_node_ids, tuple) or not self.owned_node_ids:
+            raise ScheduleValidationError("owned_node_ids must be a non-empty immutable tuple")
+        if any(not isinstance(node_id, str) or not node_id or _utf8_length(node_id) > 96 for node_id in self.owned_node_ids):
+            raise ScheduleValidationError("owned_node_ids contains an invalid node id")
+        if len(set(self.owned_node_ids)) != len(self.owned_node_ids):
+            raise ScheduleValidationError("owned_node_ids contains duplicates")
+        object.__setattr__(self, "owned_node_ids", tuple(sorted(self.owned_node_ids)))
+
+
+@dataclass(frozen=True)
+class ScheduleLease:
+    """Authenticated controller identity and its gateway-issued fence."""
+
+    origin_id: str
+    controller_class: str
+    lease_id: str
+    scope_id: str
+    fencing_token: int
+    expires_ts_ms: int
+
+
+@dataclass(frozen=True)
+class ScheduleCommand:
+    """Protocol-neutral representation of one v0.4 schedule command."""
+
+    command_id: str
+    target: ScheduleTarget
+    schedule: AbsoluteScheduleIntent
+    lease: ScheduleLease
+
+    def to_wire(self):
+        """Return the exact v0.4 control-field shape for a protobuf adapter."""
+        return {
+            "command_id": self.command_id,
+            "doc_version": self.target.doc_version,
+            "cap_ref": self.target.cap_ref,
+            "absolute_schedule_intent": self.schedule.to_wire(),
+            "controller": {
+                "origin_id": self.lease.origin_id,
+                "controller_class": self.lease.controller_class,
+            },
+            "lease": {
+                "lease_id": self.lease.lease_id,
+                "scope_id": self.lease.scope_id,
+                "fencing_token": self.lease.fencing_token,
+                "expires_ts_ms": self.lease.expires_ts_ms,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class ScheduleClamp:
+    """One bounded field clamp reported by the applied-schedule receipt."""
+
+    slot_index: int
+    field: str
+    requested: float
+    applied: float
+
+
+@dataclass(frozen=True)
+class ScheduleAck:
+    """Bounded terminal result returned by the gateway schedule ledger."""
+
+    command_id: str
+    state: str
+    scope_id: str
+    fencing_token: int = 0
+    lease_id: str = ""
+    lease_expires_ts_ms: int = 0
+    origin_id: str = ""
+    controller_class: str = ""
+    plan_digest: str = ""
+    accepted_slot_count: int = 0
+    durably_accepted: bool = False
+    valid_from_ts_ms: int = 0
+    valid_until_ts_ms: int = 0
+    verification: str = ""
+    clamps: tuple[ScheduleClamp, ...] = ()
+    clamp_count: int = 0
+    clamps_truncated: bool = False
+    verified: bool = False
+    reason: str = ""
+    fallback: str = ""
+    detail: str = ""
+
+    def canonical(self):
+        """Return stable content used to detect conflicting duplicate results."""
+        return (
+            self.command_id,
+            self.state,
+            self.scope_id,
+            self.fencing_token,
+            self.lease_id,
+            self.lease_expires_ts_ms,
+            self.origin_id,
+            self.controller_class,
+            self.plan_digest,
+            self.accepted_slot_count,
+            self.durably_accepted,
+            self.valid_from_ts_ms,
+            self.valid_until_ts_ms,
+            self.verification,
+            self.clamps,
+            self.clamp_count,
+            self.clamps_truncated,
+            self.verified,
+            self.reason,
+            self.fallback,
+            self.detail,
+        )
+
+
+@dataclass(frozen=True)
+class AuthorityDecision:
+    """Safety decision exposed to a future gated legacy/Lattice selector."""
+
+    state: str
+    command_id: str = ""
+    legacy_suppressed: bool = False
+    fallback_allowed: bool = False
+    quarantined: bool = False
+    detail: str = ""
+
+
+def _is_int(value):
+    """Return true only for an integer that is not a boolean."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _utf8_length(value):
+    """Return the encoded byte length used by the embedded profile."""
+    return len(value.encode("utf-8"))
+
+
+def _validate_text(value, label, max_bytes):
+    """Validate one required bounded UTF-8 string."""
+    if not isinstance(value, str) or not value:
+        raise ScheduleValidationError("{} is required".format(label))
+    if _utf8_length(value) > max_bytes:
+        raise ScheduleValidationError("{} exceeds {} UTF-8 bytes".format(label, max_bytes))
+
+
+def _epoch_ms(value, label):
+    """Convert an aware UTC datetime to one positive safe epoch millisecond."""
+    timezone_key = getattr(getattr(value, "tzinfo", None), "key", None)
+    is_utc_zone = getattr(value, "tzinfo", None) is timezone.utc or timezone_key in ("UTC", "Etc/UTC")
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() != timedelta(0) or not is_utc_zone:
+        raise ScheduleValidationError("{} must be a timezone-aware UTC datetime".format(label))
+    try:
+        milliseconds = int(value.timestamp() * 1000)
+    except (OverflowError, OSError, ValueError) as exc:
+        raise ScheduleValidationError("{} is outside the supported epoch range".format(label)) from exc
+    if milliseconds <= 0 or milliseconds > _MAX_EPOCH_MS:
+        raise ScheduleValidationError("{} must be a positive safe epoch millisecond".format(label))
+    return milliseconds
+
+
+def _validate_timezone(value):
+    """Validate an IANA diagnostic timezone without using it for conversion."""
+    _validate_text(value, "diagnostic_timezone", 47)
+    try:
+        ZoneInfo(value)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ScheduleValidationError("diagnostic_timezone must be an IANA timezone name") from exc
+
+
+def _validate_optional_number(value, label, minimum=None, maximum=None):
+    """Validate an optional finite numeric schedule refinement."""
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ScheduleValidationError("{} must be finite".format(label))
+    if minimum is not None and value < minimum:
+        raise ScheduleValidationError("{} is below {}".format(label, minimum))
+    if maximum is not None and value > maximum:
+        raise ScheduleValidationError("{} is above {}".format(label, maximum))
+
+
+def _same_slot_payload(left, right):
+    """Return true when adjacent slots can be losslessly coalesced."""
+    return (
+        left.mode,
+        left.target_soc,
+        left.reserve_soc,
+        left.charge_power_limit,
+        left.discharge_power_limit,
+        left.enable,
+    ) == (
+        right.mode,
+        right.target_soc,
+        right.reserve_soc,
+        right.charge_power_limit,
+        right.discharge_power_limit,
+        right.enable,
+    )
+
+
+def compile_absolute_schedule(plan, now_utc):
+    """Compile a complete plan into one ordered v0.4 UTC schedule.
+
+    Window offsets are elapsed minutes from ``timeline_start_utc``.  The
+    diagnostic timezone is validated but never used to reinterpret instants, so
+    midnight and DST gap/fold transitions cannot collapse distinct slots.
+    """
+    if not isinstance(plan, CompletePlan):
+        raise ScheduleValidationError("plan must be CompletePlan")
+    if plan.is_complete is not True:
+        raise ScheduleValidationError("partial plans cannot become an atomic schedule")
+    _validate_text(plan.altitude_id, "altitude_id", 96)
+    _validate_timezone(plan.diagnostic_timezone)
+    if plan.execution not in (EXECUTION_NATIVE, EXECUTION_CONTROLLER_STEPPED):
+        raise ScheduleValidationError("execution must be NATIVE or CONTROLLER_STEPPED")
+    if not _is_int(plan.horizon_minutes) or plan.horizon_minutes <= 0:
+        raise ScheduleValidationError("horizon_minutes must be a positive integer")
+    if plan.default_mode is not None:
+        _validate_text(plan.default_mode, "default_mode", 24)
+
+    valid_from_ts_ms = _epoch_ms(plan.timeline_start_utc, "timeline_start_utc")
+    try:
+        valid_until = plan.timeline_start_utc + timedelta(minutes=plan.horizon_minutes)
+    except (OverflowError, ValueError) as exc:
+        raise ScheduleValidationError("timeline end is outside the supported epoch range") from exc
+    valid_until_ts_ms = _epoch_ms(valid_until, "timeline end")
+    now_ts_ms = _epoch_ms(now_utc, "now_utc")
+    if valid_until_ts_ms <= now_ts_ms:
+        raise ScheduleValidationError("plan validity has expired")
+
+    if not isinstance(plan.windows, (tuple, list)):
+        raise ScheduleValidationError("windows must be a sequence")
+    slots = []
+    for index, window in enumerate(plan.windows):
+        if not isinstance(window, PlanWindow):
+            raise ScheduleValidationError("window {} must be PlanWindow".format(index))
+        if window.altitude_id != plan.altitude_id:
+            raise ScheduleValidationError("window {} crosses topology altitude".format(index))
+        if not _is_int(window.start_minute) or not _is_int(window.end_minute):
+            raise ScheduleValidationError("window {} offsets must be integers".format(index))
+        if window.start_minute < 0 or window.start_minute >= window.end_minute or window.end_minute > plan.horizon_minutes:
+            raise ScheduleValidationError("window {} is outside the non-empty plan horizon".format(index))
+        _validate_text(window.mode, "window {} mode".format(index), 24)
+        _validate_optional_number(window.target_soc, "window {} target_soc".format(index), 0, 100)
+        _validate_optional_number(window.reserve_soc, "window {} reserve_soc".format(index), 0, 100)
+        _validate_optional_number(window.charge_power_limit, "window {} charge_power_limit".format(index), 0)
+        _validate_optional_number(window.discharge_power_limit, "window {} discharge_power_limit".format(index), 0)
+        if window.enable is not None and not isinstance(window.enable, bool):
+            raise ScheduleValidationError("window {} enable must be boolean".format(index))
+
+        try:
+            start = plan.timeline_start_utc + timedelta(minutes=window.start_minute)
+            end = plan.timeline_start_utc + timedelta(minutes=window.end_minute)
+        except (OverflowError, ValueError) as exc:
+            raise ScheduleValidationError("window {} is outside the supported epoch range".format(index)) from exc
+        slots.append(
+            AbsoluteScheduleSlot(
+                _epoch_ms(start, "window {} start".format(index)),
+                _epoch_ms(end, "window {} end".format(index)),
+                window.mode,
+                window.target_soc,
+                window.reserve_soc,
+                window.charge_power_limit,
+                window.discharge_power_limit,
+                window.enable,
+            )
+        )
+
+    slots.sort(key=lambda item: (item.start_ts_ms, item.end_ts_ms))
+    coalesced = []
+    has_gap = False
+    previous_end = valid_from_ts_ms
+    for index, slot in enumerate(slots):
+        if slot.start_ts_ms < previous_end:
+            raise ScheduleValidationError("window {} overlaps another plan window".format(index))
+        if slot.start_ts_ms > previous_end:
+            has_gap = True
+        if coalesced and coalesced[-1].end_ts_ms == slot.start_ts_ms and _same_slot_payload(coalesced[-1], slot):
+            coalesced[-1] = replace(coalesced[-1], end_ts_ms=slot.end_ts_ms)
+        else:
+            coalesced.append(slot)
+        previous_end = slot.end_ts_ms
+    if previous_end < valid_until_ts_ms or not coalesced:
+        has_gap = True
+    if has_gap and plan.default_mode is None:
+        raise ScheduleValidationError("schedule gaps require default_mode")
+    if len(coalesced) > MAX_SCHEDULE_SLOTS:
+        raise ScheduleValidationError("schedule has {} slots; embedded maximum is {}".format(len(coalesced), MAX_SCHEDULE_SLOTS))
+
+    return AbsoluteScheduleIntent(
+        altitude_id=plan.altitude_id,
+        slots=tuple(coalesced),
+        valid_from_ts_ms=valid_from_ts_ms,
+        valid_until_ts_ms=valid_until_ts_ms,
+        diagnostic_timezone=plan.diagnostic_timezone,
+        execution=plan.execution,
+        default_mode=plan.default_mode if has_gap else None,
+    )
+
+
+def _valid_schedule_intent(schedule, now_ts_ms):
+    """Return whether a supplied intent satisfies the compiler's safe subset."""
+    if not isinstance(schedule, AbsoluteScheduleIntent):
+        return False
+    try:
+        _validate_text(schedule.altitude_id, "altitude_id", 96)
+        _validate_timezone(schedule.diagnostic_timezone)
+        if schedule.execution not in (EXECUTION_NATIVE, EXECUTION_CONTROLLER_STEPPED):
+            return False
+        if schedule.default_mode is not None:
+            _validate_text(schedule.default_mode, "default_mode", 24)
+    except ScheduleValidationError:
+        return False
+    if (
+        not _is_int(schedule.valid_from_ts_ms)
+        or not _is_int(schedule.valid_until_ts_ms)
+        or schedule.valid_from_ts_ms <= 0
+        or schedule.valid_from_ts_ms >= schedule.valid_until_ts_ms
+        or schedule.valid_until_ts_ms > _MAX_EPOCH_MS
+        or schedule.valid_until_ts_ms <= now_ts_ms
+        or not isinstance(schedule.slots, tuple)
+        or len(schedule.slots) > MAX_SCHEDULE_SLOTS
+    ):
+        return False
+
+    previous_end = schedule.valid_from_ts_ms
+    has_gap = not schedule.slots
+    for slot in schedule.slots:
+        if not isinstance(slot, AbsoluteScheduleSlot):
+            return False
+        try:
+            _validate_text(slot.mode, "slot mode", 24)
+            _validate_optional_number(slot.target_soc, "slot target_soc", 0, 100)
+            _validate_optional_number(slot.reserve_soc, "slot reserve_soc", 0, 100)
+            _validate_optional_number(slot.charge_power_limit, "slot charge_power_limit", 0)
+            _validate_optional_number(slot.discharge_power_limit, "slot discharge_power_limit", 0)
+        except ScheduleValidationError:
+            return False
+        if slot.enable is not None and not isinstance(slot.enable, bool):
+            return False
+        if not _is_int(slot.start_ts_ms) or not _is_int(slot.end_ts_ms) or slot.start_ts_ms < schedule.valid_from_ts_ms or slot.start_ts_ms >= slot.end_ts_ms or slot.end_ts_ms > schedule.valid_until_ts_ms or slot.start_ts_ms < previous_end:
+            return False
+        if slot.start_ts_ms > previous_end:
+            has_gap = True
+        previous_end = slot.end_ts_ms
+    if previous_end < schedule.valid_until_ts_ms:
+        has_gap = True
+    return not has_gap or schedule.default_mode is not None
+
+
+def _valid_resolved_offer(offer):
+    """Return whether retained offer constraints match the v0.4 safe subset."""
+    if (
+        not isinstance(offer, ResolvedScheduleOffer)
+        or not _is_int(offer.max_slots)
+        or not 1 <= offer.max_slots <= MAX_SCHEDULE_SLOTS
+        or not isinstance(offer.supported_modes, tuple)
+        or not offer.supported_modes
+        or any(not isinstance(mode, str) for mode in offer.supported_modes)
+        or len(set(offer.supported_modes)) != len(offer.supported_modes)
+        or not isinstance(offer.slot_fields, tuple)
+        or any(not isinstance(field, str) for field in offer.slot_fields)
+        or len(set(offer.slot_fields)) != len(offer.slot_fields)
+        or any(field not in _SLOT_FIELDS for field in offer.slot_fields)
+        or not isinstance(offer.execution_modes, tuple)
+        or not offer.execution_modes
+        or any(not isinstance(execution, str) for execution in offer.execution_modes)
+        or len(set(offer.execution_modes)) != len(offer.execution_modes)
+        or any(execution not in (EXECUTION_NATIVE, EXECUTION_CONTROLLER_STEPPED) for execution in offer.execution_modes)
+        or offer.gap_policy not in ("DEFAULT_MODE", "REJECT")
+    ):
+        return False
+    try:
+        for mode in offer.supported_modes:
+            _validate_text(mode, "supported mode", 24)
+    except ScheduleValidationError:
+        return False
+    return True
+
+
+def _offer_supports_schedule(offer, schedule):
+    """Check the complete intent against its retained provider-local offer."""
+    if not _valid_resolved_offer(offer) or len(schedule.slots) > offer.max_slots or schedule.execution not in offer.execution_modes:
+        return False
+    supported_modes = set(offer.supported_modes)
+    if schedule.default_mode is not None and schedule.default_mode not in supported_modes:
+        return False
+    previous_end = schedule.valid_from_ts_ms
+    has_gap = not schedule.slots
+    allowed_fields = set(offer.slot_fields)
+    for slot in schedule.slots:
+        if slot.mode not in supported_modes:
+            return False
+        if slot.start_ts_ms > previous_end:
+            has_gap = True
+        previous_end = slot.end_ts_ms
+        for field in _SLOT_FIELDS:
+            if getattr(slot, field) is not None and field not in allowed_fields:
+                return False
+    if previous_end < schedule.valid_until_ts_ms:
+        has_gap = True
+    if offer.gap_policy == "REJECT" and has_gap:
+        return False
+    if offer.gap_policy == "DEFAULT_MODE" and has_gap and schedule.default_mode is None:
+        return False
+    return True
+
+
+def _valid_target(target, schedule, scope_id):
+    """Return whether provider-local coordinates safely bind this schedule."""
+    return (
+        isinstance(target, ScheduleTarget)
+        and target.provider == "predbat-gateway"
+        and target.access_path == "gw-local"
+        and target.topology_version == "0.4.0"
+        and _is_int(target.doc_version)
+        and 0 < target.doc_version <= _MAX_UINT32
+        and _is_int(target.cap_ref)
+        and 0 < target.cap_ref <= _MAX_UINT32
+        and isinstance(target.node_id, str)
+        and bool(target.node_id)
+        and target.node_id in target.owned_node_ids
+        and target.altitude_id == schedule.altitude_id
+        and target.scope_id == scope_id
+        and _offer_supports_schedule(target.offer, schedule)
+    )
+
+
+def _valid_lease(lease, scope_id, now_ts_ms):
+    """Return whether the controller lease is well-formed and currently live."""
+    return (
+        isinstance(lease, ScheduleLease)
+        and isinstance(lease.origin_id, str)
+        and 0 < _utf8_length(lease.origin_id) <= 36
+        and lease.controller_class in ("AUTOMATION", "MANUAL", "SAFETY", "GRID")
+        and isinstance(lease.lease_id, str)
+        and 0 < _utf8_length(lease.lease_id) <= 36
+        and lease.scope_id == scope_id
+        and _is_int(lease.fencing_token)
+        and 0 < lease.fencing_token <= _MAX_UINT64
+        and _is_int(lease.expires_ts_ms)
+        and lease.expires_ts_ms > now_ts_ms
+        and lease.expires_ts_ms <= _MAX_EPOCH_MS
+    )
+
+
+def _record_for(command):
+    """Build the durable pre-dispatch reservation for one command."""
+    return {
+        "command_id": command.command_id,
+        "state": _STATE_PENDING,
+        "plan_digest": command.schedule.plan_digest,
+        "slot_count": len(command.schedule.slots),
+        "valid_from_ts_ms": command.schedule.valid_from_ts_ms,
+        "valid_until_ts_ms": command.schedule.valid_until_ts_ms,
+        "fencing_token": command.lease.fencing_token,
+        "lease_id": command.lease.lease_id,
+        "lease_expires_ts_ms": command.lease.expires_ts_ms,
+        "origin_id": command.lease.origin_id,
+        "controller_class": command.lease.controller_class,
+        "doc_version": command.target.doc_version,
+        "cap_ref": command.target.cap_ref,
+        "node_id": command.target.node_id,
+        "altitude_id": command.target.altitude_id,
+        "owned_node_ids": list(command.target.owned_node_ids),
+        "offer_fingerprint": command.target.offer.fingerprint,
+        "applied_plan_digest": "",
+        "verification": "",
+        "clamps": [],
+        "clamp_count": 0,
+        "clamps_truncated": False,
+        "fallback": "",
+        "reason": "",
+        "durably_accepted": False,
+        "verified": False,
+    }
+
+
+def _valid_digest(value):
+    """Return whether a receipt digest is exactly 32-byte lowercase hex."""
+    return isinstance(value, str) and len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
+def _valid_clamp_values(slot_index, field, requested, applied, slot_count):
+    """Validate one clamp against the bounded applied-schedule receipt."""
+    return (
+        _is_int(slot_index)
+        and 0 <= slot_index < slot_count
+        and field in _SCHEDULE_FIELDS
+        and not isinstance(requested, bool)
+        and isinstance(requested, (int, float))
+        and math.isfinite(requested)
+        and not isinstance(applied, bool)
+        and isinstance(applied, (int, float))
+        and math.isfinite(applied)
+    )
+
+
+def _valid_ack_receipt(ack, expected):
+    """Validate the complete bounded v0.4 applied-schedule receipt."""
+    if (
+        not _valid_digest(ack.plan_digest)
+        or not _is_int(ack.accepted_slot_count)
+        or ack.accepted_slot_count != expected["slot_count"]
+        or ack.durably_accepted is not True
+        or not isinstance(ack.verified, bool)
+        or ack.valid_from_ts_ms != expected["valid_from_ts_ms"]
+        or ack.valid_until_ts_ms != expected["valid_until_ts_ms"]
+        or ack.verification not in (VERIFICATION_ACCEPTED_ONLY, VERIFICATION_DURABLE_STORE_READBACK, VERIFICATION_NATIVE_TARGET_READBACK)
+        or not isinstance(ack.clamps, tuple)
+        or len(ack.clamps) > MAX_SCHEDULE_SLOTS
+        or not _is_int(ack.clamp_count)
+        or ack.clamp_count < len(ack.clamps)
+        or not isinstance(ack.clamps_truncated, bool)
+        or ack.clamps_truncated is not (ack.clamp_count > len(ack.clamps))
+    ):
+        return False
+    has_readback = ack.verification in (VERIFICATION_DURABLE_STORE_READBACK, VERIFICATION_NATIVE_TARGET_READBACK)
+    if ack.verified is not has_readback:
+        return False
+    return all(isinstance(clamp, ScheduleClamp) and _valid_clamp_values(clamp.slot_index, clamp.field, clamp.requested, clamp.applied, ack.accepted_slot_count) for clamp in ack.clamps)
+
+
+def _valid_stored_receipt(record):
+    """Validate a JSON-compatible durable copy of an applied receipt."""
+    verification = record.get("verification")
+    clamps = record.get("clamps")
+    clamp_count = record.get("clamp_count")
+    clamps_truncated = record.get("clamps_truncated")
+    if (
+        not _valid_digest(record.get("applied_plan_digest"))
+        or verification not in (VERIFICATION_ACCEPTED_ONLY, VERIFICATION_DURABLE_STORE_READBACK, VERIFICATION_NATIVE_TARGET_READBACK)
+        or not isinstance(clamps, list)
+        or len(clamps) > MAX_SCHEDULE_SLOTS
+        or not _is_int(clamp_count)
+        or clamp_count < len(clamps)
+        or not isinstance(clamps_truncated, bool)
+        or clamps_truncated is not (clamp_count > len(clamps))
+    ):
+        return False
+    has_readback = verification in (VERIFICATION_DURABLE_STORE_READBACK, VERIFICATION_NATIVE_TARGET_READBACK)
+    if record["verified"] is not has_readback:
+        return False
+    for clamp in clamps:
+        if not isinstance(clamp, dict) or set(clamp) != {"slot_index", "field", "requested", "applied"}:
+            return False
+        if not _valid_clamp_values(clamp["slot_index"], clamp["field"], clamp["requested"], clamp["applied"], record["slot_count"]):
+            return False
+    return True
+
+
+def _valid_command_record(record):
+    """Reject corrupt durable command state before it can influence a writer."""
+    if not isinstance(record, dict):
+        return False
+    if not isinstance(record.get("command_id"), str) or not record["command_id"]:
+        return False
+    if record.get("state") not in (_STATE_PENDING, RESULT_APPLIED, RESULT_NOT_APPLIED, RESULT_UNKNOWN):
+        return False
+    if not _valid_digest(record.get("plan_digest")):
+        return False
+    if not _valid_digest(record.get("offer_fingerprint")):
+        return False
+    if not _is_int(record.get("slot_count")) or record["slot_count"] < 0:
+        return False
+    for field in ("valid_from_ts_ms", "valid_until_ts_ms", "fencing_token", "lease_expires_ts_ms", "doc_version", "cap_ref"):
+        if not _is_int(record.get(field)) or record[field] <= 0:
+            return False
+    if record["valid_until_ts_ms"] > _MAX_EPOCH_MS or record["lease_expires_ts_ms"] > _MAX_EPOCH_MS or record["fencing_token"] > _MAX_UINT64:
+        return False
+    if record["doc_version"] > _MAX_UINT32 or record["cap_ref"] > _MAX_UINT32:
+        return False
+    if record["slot_count"] > MAX_SCHEDULE_SLOTS or record["valid_from_ts_ms"] >= record["valid_until_ts_ms"]:
+        return False
+    for field in ("lease_id", "origin_id", "controller_class", "node_id", "altitude_id"):
+        if not isinstance(record.get(field), str) or not record[field]:
+            return False
+    owned_node_ids = record.get("owned_node_ids")
+    if (
+        not isinstance(owned_node_ids, list)
+        or not owned_node_ids
+        or any(not isinstance(node_id, str) or not node_id or _utf8_length(node_id) > 96 for node_id in owned_node_ids)
+        or owned_node_ids != sorted(set(owned_node_ids))
+        or record["node_id"] not in owned_node_ids
+    ):
+        return False
+    if record.get("fallback") not in ("", FALLBACK_SAFE, FALLBACK_BLOCKED):
+        return False
+    if not isinstance(record.get("reason"), str):
+        return False
+    if not isinstance(record.get("durably_accepted"), bool) or not isinstance(record.get("verified"), bool):
+        return False
+    if record["state"] == RESULT_APPLIED:
+        return record["durably_accepted"] and record["fallback"] == "" and record["reason"] == "" and _valid_stored_receipt(record)
+    if record.get("applied_plan_digest") != "" or record.get("verification") != "" or record.get("clamps") != [] or record.get("clamp_count") != 0 or record.get("clamps_truncated") is not False:
+        return False
+    if record["state"] == RESULT_NOT_APPLIED:
+        return not record["durably_accepted"] and record["fallback"] in (FALLBACK_SAFE, FALLBACK_BLOCKED) and bool(record["reason"])
+    if record["state"] == RESULT_UNKNOWN:
+        return not record["durably_accepted"] and record["fallback"] == FALLBACK_BLOCKED and record["reason"] == "EXECUTION_AMBIGUOUS"
+    return not record["durably_accepted"] and record["fallback"] == "" and record["reason"] == ""
+
+
+def _valid_snapshot(snapshot, scope_id):
+    """Return whether the complete persisted scope snapshot is internally valid."""
+    if not isinstance(snapshot, dict) or snapshot.get("schema_version") != _SCHEMA_VERSION or snapshot.get("scope_id") != scope_id:
+        return False
+    high_water = snapshot.get("high_water_token")
+    if not _is_int(high_water) or high_water < 0 or high_water > _MAX_UINT64:
+        return False
+    command = snapshot.get("command")
+    installed = snapshot.get("installed")
+    if installed is not None and (not _valid_command_record(installed) or installed["state"] != RESULT_APPLIED or installed["fencing_token"] > high_water):
+        return False
+    if command is None:
+        return installed is None
+    return _valid_command_record(command) and command["fencing_token"] <= high_water
+
+
+def _same_command_identity(left, right):
+    """Return whether two durable records name the same exact command."""
+    return all(left[field] == right[field] for field in _COMMAND_IDENTITY_FIELDS)
+
+
+def _decision_from_record(record, now_ts_ms=None):
+    """Derive legacy suppression and fallback from one validated record."""
+    state = record["state"]
+    if state == RESULT_APPLIED:
+        if now_ts_ms is not None and record["valid_until_ts_ms"] <= now_ts_ms:
+            return AuthorityDecision(RESULT_NOT_APPLIED, record["command_id"], detail="durable Lattice schedule validity has expired")
+        return AuthorityDecision(state, record["command_id"], legacy_suppressed=True)
+    if state == RESULT_NOT_APPLIED:
+        return AuthorityDecision(state, record["command_id"], fallback_allowed=record["fallback"] == FALLBACK_SAFE, detail=record["reason"])
+    return AuthorityDecision(RESULT_UNKNOWN, record["command_id"], quarantined=True, detail=record.get("reason") or "command result unresolved")
+
+
+def _decision_from_snapshot(snapshot, now_ts_ms):
+    """Preserve suppression while a previously installed schedule may act."""
+    record = snapshot.get("command")
+    decision = AuthorityDecision(RESULT_NOT_APPLIED, detail="no durable Lattice acceptance") if record is None else _decision_from_record(record, now_ts_ms)
+    installed = snapshot.get("installed")
+    if installed is not None and installed["valid_until_ts_ms"] > now_ts_ms:
+        return replace(decision, legacy_suppressed=True, fallback_allowed=False)
+    return decision
+
+
+class LatticeScheduleAuthority:
+    """Serialize and durably reconcile one default-off schedule-control scope.
+
+    ``send`` and ``query_result`` are injected seams.  They may return a
+    ``ScheduleAck`` directly or deliver it synchronously through
+    :meth:`accept_result`.  The class never invokes a legacy or device writer.
+    """
+
+    def __init__(self, storage, send, query_result, scope_id, storage_key="schedule", command_id_factory=None):
+        """Create one single-process authority instance for a canonical scope."""
+        _validate_text(scope_id, "scope_id", 47)
+        _validate_text(storage_key, "storage_key", 96)
+        self._storage = storage
+        self._send = send
+        self._query_result = query_result
+        self._scope_id = scope_id
+        self._storage_key = storage_key
+        self._command_id_factory = command_id_factory or (lambda: str(uuid.uuid4()))
+        self._lock = None
+        self._lock_loop = None
+        self._expected = None
+        self._accepted_result = None
+        self._conflicting_result = False
+
+    def _current_lock(self):
+        """Return a lock bound to the active event loop.
+
+        PredBat may construct components before its async runner exists.  Tests
+        and lifecycle restarts may also use a new loop after the old one has
+        closed, so an idle lock is safely rebound when the loop changes.
+        """
+        loop = asyncio.get_running_loop()
+        if self._lock is None or self._lock_loop is not loop:
+            if self._lock is not None and self._lock.locked():
+                raise RuntimeError("schedule authority cannot move an active lock between event loops")
+            self._lock = asyncio.Lock()
+            self._lock_loop = loop
+        return self._lock
+
+    async def _load(self):
+        """Load this scope's durable snapshot."""
+        if self._storage is None:
+            return _LOAD_FAILED
+        try:
+            return await self._storage.load(_STORAGE_MODULE, self._storage_key)
+        except Exception:
+            return _LOAD_FAILED
+
+    async def _save(self, snapshot):
+        """Persist a full scope transition before exposing its consequence."""
+        if self._storage is None:
+            return False
+        try:
+            return bool(await self._storage.save(_STORAGE_MODULE, self._storage_key, snapshot, format="json", expiry=None))
+        except Exception:
+            return False
+
+    @staticmethod
+    async def _invoke(callback, *args):
+        """Invoke a synchronous or asynchronous injected seam."""
+        value = callback(*args)
+        if inspect.isawaitable(value):
+            return await value
+        return value
+
+    def _matches_expected(self, ack, expected):
+        """Validate exact correlation and v0.4 result-state invariants."""
+        if not isinstance(ack, ScheduleAck):
+            return False
+        if ack.command_id != expected["command_id"] or ack.scope_id != self._scope_id:
+            return False
+        if ack.fencing_token != 0 and (not _is_int(ack.fencing_token) or not 0 < ack.fencing_token <= _MAX_UINT64):
+            return False
+        if ack.lease_expires_ts_ms != 0 and (not _is_int(ack.lease_expires_ts_ms) or not 0 < ack.lease_expires_ts_ms <= _MAX_EPOCH_MS):
+            return False
+        if any(not isinstance(value, str) for value in (ack.lease_id, ack.origin_id, ack.controller_class)):
+            return False
+        optional_coordinates = (
+            (ack.fencing_token, 0, expected["fencing_token"]),
+            (ack.lease_id, "", expected["lease_id"]),
+            (ack.lease_expires_ts_ms, 0, expected["lease_expires_ts_ms"]),
+            (ack.origin_id, "", expected["origin_id"]),
+            (ack.controller_class, "", expected["controller_class"]),
+        )
+        if any(value != absent and value != wanted for value, absent, wanted in optional_coordinates):
+            return False
+        if ack.state == RESULT_APPLIED:
+            return (
+                ack.fencing_token == expected["fencing_token"]
+                and ack.lease_id == expected["lease_id"]
+                and ack.lease_expires_ts_ms == expected["lease_expires_ts_ms"]
+                and ack.origin_id == expected["origin_id"]
+                and ack.controller_class == expected["controller_class"]
+                and _valid_ack_receipt(ack, expected)
+                and ack.fallback == ""
+                and ack.reason == ""
+                and ack.detail == ""
+            )
+        receipt_absent = (
+            ack.plan_digest == ""
+            and ack.accepted_slot_count == 0
+            and ack.durably_accepted is False
+            and ack.valid_from_ts_ms == 0
+            and ack.valid_until_ts_ms == 0
+            and ack.verification == ""
+            and ack.clamps == ()
+            and ack.clamp_count == 0
+            and ack.clamps_truncated is False
+            and ack.verified is False
+        )
+        rejection_valid = receipt_absent and ack.reason in _REJECTION_REASONS and ack.fallback in (FALLBACK_SAFE, FALLBACK_BLOCKED) and isinstance(ack.detail, str) and 0 < _utf8_length(ack.detail) <= 96
+        blocked_reasons = (
+            "AUTHENTICATED_ORIGIN_MISMATCH",
+            "LEASE_EXPIRED",
+            "STALE_FENCE",
+            "LEASE_CONFLICT",
+            "SCOPE_MISMATCH",
+            "SCOPE_QUARANTINED",
+            "SCOPE_BUSY",
+            "EXECUTION_AMBIGUOUS",
+            "INTERNAL",
+        )
+        if ack.state == RESULT_NOT_APPLIED:
+            return rejection_valid and (ack.reason not in blocked_reasons or ack.fallback == FALLBACK_BLOCKED)
+        if ack.state == RESULT_UNKNOWN:
+            return rejection_valid and ack.reason == "EXECUTION_AMBIGUOUS" and ack.fallback == FALLBACK_BLOCKED
+        return False
+
+    def accept_result(self, ack):
+        """Accept an exact active result, tolerating only identical duplicates."""
+        expected = self._expected
+        if expected is None or not isinstance(ack, ScheduleAck) or ack.command_id != expected["command_id"]:
+            return False
+        if not self._matches_expected(ack, expected):
+            self._conflicting_result = True
+            return False
+        if self._accepted_result is None:
+            self._accepted_result = ack
+            return True
+        if self._accepted_result.canonical() == ack.canonical():
+            return True
+        self._conflicting_result = True
+        return False
+
+    def _begin_correlation(self, expected):
+        """Arm exact result correlation before invoking a transport seam."""
+        self._expected = expected
+        self._accepted_result = None
+        self._conflicting_result = False
+
+    def _end_correlation(self):
+        """Return the correlated result and clear transient correlation state."""
+        result = None if self._conflicting_result else self._accepted_result
+        conflict = self._conflicting_result
+        self._expected = None
+        self._accepted_result = None
+        self._conflicting_result = False
+        return result, conflict
+
+    async def _exchange(self, callback, argument, expected):
+        """Run one transport action with correlation armed before invocation."""
+        self._begin_correlation(expected)
+        try:
+            returned = await self._invoke(callback, argument)
+            if returned is not None:
+                self.accept_result(returned)
+        except Exception:
+            returned = None
+        result, conflict = self._end_correlation()
+        return result, conflict
+
+    async def _persist_terminal(self, snapshot, ack, now_ts_ms):
+        """Persist a validated terminal ACK and return its safe decision."""
+        previous_snapshot = snapshot
+        record = dict(snapshot["command"])
+        record.update(
+            {
+                "state": ack.state,
+                "applied_plan_digest": ack.plan_digest,
+                "verification": ack.verification,
+                "clamps": [
+                    {
+                        "slot_index": clamp.slot_index,
+                        "field": clamp.field,
+                        "requested": clamp.requested,
+                        "applied": clamp.applied,
+                    }
+                    for clamp in ack.clamps
+                ],
+                "clamp_count": ack.clamp_count,
+                "clamps_truncated": ack.clamps_truncated,
+                "fallback": ack.fallback,
+                "reason": ack.reason,
+                "durably_accepted": bool(ack.durably_accepted),
+                "verified": bool(ack.verified),
+            }
+        )
+        snapshot = dict(snapshot)
+        snapshot["command"] = record
+        if ack.state == RESULT_APPLIED:
+            snapshot["installed"] = dict(record)
+        if not await self._save(snapshot):
+            return replace(
+                _decision_from_snapshot(previous_snapshot, now_ts_ms),
+                state=RESULT_UNKNOWN,
+                command_id=record["command_id"],
+                fallback_allowed=False,
+                quarantined=True,
+                detail="terminal result persistence failed",
+            )
+        return _decision_from_snapshot(snapshot, now_ts_ms)
+
+    async def _mark_unknown(self, snapshot, detail, now_ts_ms):
+        """Durably quarantine an ambiguous command whenever storage permits."""
+        record = dict(snapshot["command"])
+        record.update(
+            {
+                "state": RESULT_UNKNOWN,
+                "fallback": FALLBACK_BLOCKED,
+                "reason": "EXECUTION_AMBIGUOUS",
+                "durably_accepted": False,
+                "verified": False,
+            }
+        )
+        updated = dict(snapshot)
+        updated["command"] = record
+        await self._save(updated)
+        return replace(
+            _decision_from_snapshot(updated, now_ts_ms),
+            state=RESULT_UNKNOWN,
+            command_id=record["command_id"],
+            quarantined=True,
+            detail=detail,
+        )
+
+    async def _reconcile_snapshot(self, snapshot, now_ts_ms):
+        """Query the gateway ledger by command ID without replaying the command."""
+        record = snapshot["command"]
+        result, conflict = await self._exchange(self._query_result, record["command_id"], record)
+        if conflict:
+            return await self._mark_unknown(snapshot, "conflicting reconciliation result", now_ts_ms)
+        if result is None:
+            return await self._mark_unknown(snapshot, "durable result unavailable", now_ts_ms)
+        return await self._persist_terminal(snapshot, result, now_ts_ms)
+
+    async def legacy_decision(self, now_ts_ms):
+        """Read the durable state used by a future legacy-suppression gate."""
+        async with self._current_lock():
+            if not _is_int(now_ts_ms) or now_ts_ms <= 0 or now_ts_ms > _MAX_EPOCH_MS:
+                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="now_ts_ms is invalid")
+            snapshot = await self._load()
+            if snapshot is None:
+                return AuthorityDecision(RESULT_NOT_APPLIED, detail="no durable Lattice acceptance")
+            if not _valid_snapshot(snapshot, self._scope_id):
+                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="corrupt persisted authority state")
+            record = snapshot.get("command")
+            if record is None:
+                return AuthorityDecision(RESULT_NOT_APPLIED, detail="no durable Lattice acceptance")
+            return _decision_from_snapshot(snapshot, now_ts_ms)
+
+    async def reconcile(self, now_ts_ms):
+        """Resume a pending/UNKNOWN command after restart without republishing."""
+        async with self._current_lock():
+            if not _is_int(now_ts_ms) or now_ts_ms <= 0 or now_ts_ms > _MAX_EPOCH_MS:
+                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="now_ts_ms is invalid")
+            snapshot = await self._load()
+            if snapshot is None:
+                return AuthorityDecision(RESULT_NOT_APPLIED, detail="no command to reconcile")
+            if not _valid_snapshot(snapshot, self._scope_id):
+                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="corrupt persisted authority state")
+            record = snapshot.get("command")
+            if record is None:
+                return AuthorityDecision(RESULT_NOT_APPLIED, detail="no command to reconcile")
+            if record["state"] in (_STATE_PENDING, RESULT_UNKNOWN):
+                return await self._reconcile_snapshot(snapshot, now_ts_ms)
+            return _decision_from_snapshot(snapshot, now_ts_ms)
+
+    async def dispatch(self, schedule, target, lease, now_ts_ms, command_id=None):
+        """Reserve, send, and reconcile one schedule without any legacy write."""
+        async with self._current_lock():
+            if not _is_int(now_ts_ms) or now_ts_ms <= 0 or now_ts_ms > _MAX_EPOCH_MS:
+                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="now_ts_ms is invalid")
+            snapshot = await self._load()
+            if snapshot is None:
+                snapshot = {
+                    "schema_version": _SCHEMA_VERSION,
+                    "scope_id": self._scope_id,
+                    "high_water_token": 0,
+                    "command": None,
+                    "installed": None,
+                }
+            elif not _valid_snapshot(snapshot, self._scope_id):
+                return AuthorityDecision(RESULT_UNKNOWN, quarantined=True, detail="corrupt persisted authority state")
+            if not _valid_schedule_intent(schedule, now_ts_ms):
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="schedule is invalid",
+                )
+            if not _valid_target(target, schedule, self._scope_id):
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="unsafe topology schedule target",
+                )
+            if not _valid_lease(lease, self._scope_id, now_ts_ms):
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="lease is invalid or expired",
+                )
+            try:
+                resolved_command_id = command_id or self._command_id_factory()
+            except Exception:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_UNKNOWN,
+                    fallback_allowed=False,
+                    quarantined=True,
+                    detail="command_id generation failed",
+                )
+            if not isinstance(resolved_command_id, str) or not resolved_command_id or _utf8_length(resolved_command_id) > 63:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    fallback_allowed=False,
+                    detail="command_id is invalid",
+                )
+            command = ScheduleCommand(resolved_command_id, target, schedule, lease)
+            expected = _record_for(command)
+
+            previous = snapshot.get("command")
+            if previous and previous["command_id"] == resolved_command_id:
+                if not _same_command_identity(previous, expected):
+                    return replace(
+                        _decision_from_snapshot(snapshot, now_ts_ms),
+                        state=RESULT_UNKNOWN,
+                        command_id=resolved_command_id,
+                        fallback_allowed=False,
+                        quarantined=True,
+                        detail="command_id conflicts with durable command",
+                    )
+            if previous and previous["state"] in (_STATE_PENDING, RESULT_UNKNOWN):
+                previous_decision = await self._reconcile_snapshot(snapshot, now_ts_ms)
+                if previous_decision.state == RESULT_UNKNOWN:
+                    return previous_decision
+                snapshot = await self._load()
+                if snapshot is None or not _valid_snapshot(snapshot, self._scope_id):
+                    return replace(
+                        previous_decision,
+                        state=RESULT_UNKNOWN,
+                        command_id=resolved_command_id,
+                        fallback_allowed=False,
+                        quarantined=True,
+                        detail="reconciled state could not be reloaded",
+                    )
+                previous = snapshot.get("command")
+            if previous and _same_command_identity(previous, expected):
+                return _decision_from_snapshot(snapshot, now_ts_ms)
+            if lease.fencing_token < snapshot["high_water_token"]:
+                return replace(
+                    _decision_from_snapshot(snapshot, now_ts_ms),
+                    state=RESULT_NOT_APPLIED,
+                    command_id=resolved_command_id,
+                    fallback_allowed=False,
+                    detail="STALE_FENCE",
+                )
+
+            previous_snapshot = snapshot
+            snapshot = {
+                "schema_version": _SCHEMA_VERSION,
+                "scope_id": self._scope_id,
+                "high_water_token": max(snapshot["high_water_token"], lease.fencing_token),
+                "command": expected,
+                "installed": snapshot.get("installed"),
+            }
+            if not await self._save(snapshot):
+                return replace(
+                    _decision_from_snapshot(previous_snapshot, now_ts_ms),
+                    state=RESULT_UNKNOWN,
+                    command_id=resolved_command_id,
+                    fallback_allowed=False,
+                    quarantined=True,
+                    detail="command reservation persistence failed",
+                )
+
+            result, conflict = await self._exchange(self._send, command, expected)
+            if conflict:
+                return await self._mark_unknown(snapshot, "conflicting command result", now_ts_ms)
+            if result is None:
+                unknown = await self._mark_unknown(snapshot, "command result unavailable", now_ts_ms)
+                reloaded = await self._load()
+                if reloaded is None or not _valid_snapshot(reloaded, self._scope_id):
+                    return unknown
+                return await self._reconcile_snapshot(reloaded, now_ts_ms)
+            return await self._persist_terminal(snapshot, result, now_ts_ms)

--- a/apps/predbat/tests/test_lattice_schedule_authority.py
+++ b/apps/predbat/tests/test_lattice_schedule_authority.py
@@ -1,0 +1,763 @@
+"""Tests for pure v0.4 plan compilation and durable schedule authority."""
+
+# cspell:ignore READBACK unsuppress
+
+import asyncio
+import copy
+import os
+import sys
+import unittest
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lattice_schedule_authority import (
+    EXECUTION_NATIVE,
+    FALLBACK_BLOCKED,
+    FALLBACK_SAFE,
+    RESULT_APPLIED,
+    RESULT_NOT_APPLIED,
+    RESULT_UNKNOWN,
+    VERIFICATION_ACCEPTED_ONLY,
+    VERIFICATION_DURABLE_STORE_READBACK,
+    AbsoluteScheduleIntent,
+    AbsoluteScheduleSlot,
+    CompletePlan,
+    LatticeScheduleAuthority,
+    PlanWindow,
+    ResolvedScheduleOffer,
+    ScheduleAck,
+    ScheduleClamp,
+    ScheduleLease,
+    ScheduleTarget,
+    ScheduleValidationError,
+    compile_absolute_schedule,
+)
+
+
+UTC = timezone.utc
+SCOPE = "site:GW-1:battery.mode"
+ALTITUDE = "site:GW-1"
+ORIGIN = datetime(2026, 7, 27, 22, 30, tzinfo=UTC)
+NOW_MS = int((ORIGIN - timedelta(minutes=5)).timestamp() * 1000)
+
+
+def plan(windows, horizon=180, timezone_name="Europe/London", default_mode="self_use", origin=ORIGIN, complete=True):
+    """Build a complete normalized plan fixture."""
+    return CompletePlan(
+        altitude_id=ALTITUDE,
+        timeline_start_utc=origin,
+        horizon_minutes=horizon,
+        diagnostic_timezone=timezone_name,
+        windows=tuple(windows),
+        default_mode=default_mode,
+        execution=EXECUTION_NATIVE,
+        is_complete=complete,
+    )
+
+
+def window(start, end, mode, altitude=ALTITUDE, **kwargs):
+    """Build one normalized plan window fixture."""
+    return PlanWindow(altitude, start, end, mode, **kwargs)
+
+
+def target(**overrides):
+    """Build exact provider-local topology coordinates."""
+    resolved_offer = ResolvedScheduleOffer(
+        max_slots=8,
+        supported_modes=("self_use", "force_charge", "force_export", "hold"),
+        slot_fields=("target_soc", "reserve_soc", "charge_power_limit", "discharge_power_limit", "enable"),
+        execution_modes=("NATIVE", "CONTROLLER_STEPPED"),
+        gap_policy="DEFAULT_MODE",
+    )
+    value = {
+        "provider": "predbat-gateway",
+        "node_id": "GW-1",
+        "access_path": "gw-local",
+        "topology_version": "0.4.0",
+        "doc_version": 12,
+        "cap_ref": 41,
+        "altitude_id": ALTITUDE,
+        "scope_id": SCOPE,
+        "offer": resolved_offer,
+        "owned_node_ids": ("GW-1",),
+    }
+    value.update(overrides)
+    return ScheduleTarget(**value)
+
+
+def lease(fence=10, expiry=NOW_MS + 3_600_000, **overrides):
+    """Build one currently valid controller lease."""
+    value = {
+        "origin_id": "predbat",
+        "controller_class": "AUTOMATION",
+        "lease_id": "lease-a",
+        "scope_id": SCOPE,
+        "fencing_token": fence,
+        "expires_ts_ms": expiry,
+    }
+    value.update(overrides)
+    return ScheduleLease(**value)
+
+
+def applied(command, verified=True, **overrides):
+    """Build an exact durably accepted schedule result."""
+    value = {
+        "command_id": command.command_id,
+        "state": RESULT_APPLIED,
+        "scope_id": command.lease.scope_id,
+        "fencing_token": command.lease.fencing_token,
+        "lease_id": command.lease.lease_id,
+        "lease_expires_ts_ms": command.lease.expires_ts_ms,
+        "origin_id": command.lease.origin_id,
+        "controller_class": command.lease.controller_class,
+        "plan_digest": command.schedule.plan_digest,
+        "accepted_slot_count": len(command.schedule.slots),
+        "durably_accepted": True,
+        "valid_from_ts_ms": command.schedule.valid_from_ts_ms,
+        "valid_until_ts_ms": command.schedule.valid_until_ts_ms,
+        "verification": VERIFICATION_DURABLE_STORE_READBACK if verified else VERIFICATION_ACCEPTED_ONLY,
+        "verified": verified,
+    }
+    value.update(overrides)
+    return ScheduleAck(**value)
+
+
+def rejected(command, fallback=FALLBACK_SAFE, reason="UNSUPPORTED_OFFER", **overrides):
+    """Build one definite NOT_APPLIED schedule result."""
+    value = {
+        "command_id": command.command_id,
+        "state": RESULT_NOT_APPLIED,
+        "scope_id": command.lease.scope_id,
+        "fencing_token": command.lease.fencing_token,
+        "reason": reason,
+        "fallback": fallback,
+        "detail": "schedule was not applied",
+    }
+    value.update(overrides)
+    return ScheduleAck(**value)
+
+
+def unknown(command, **overrides):
+    """Build one ambiguous result that must quarantine its scope."""
+    value = {
+        "command_id": command.command_id,
+        "state": RESULT_UNKNOWN,
+        "scope_id": command.lease.scope_id,
+        "fencing_token": command.lease.fencing_token,
+        "reason": "EXECUTION_AMBIGUOUS",
+        "fallback": FALLBACK_BLOCKED,
+        "detail": "write completion is ambiguous",
+    }
+    value.update(overrides)
+    return ScheduleAck(**value)
+
+
+class FakeStorage:
+    """In-memory asynchronous storage with controllable save failures."""
+
+    def __init__(self, snapshot=None, fail_saves=None, raise_load=False, raise_saves=None):
+        """Create a store with optional durable state and failing save numbers."""
+        self.snapshot = copy.deepcopy(snapshot)
+        self.fail_saves = set(fail_saves or ())
+        self.raise_load = raise_load
+        self.raise_saves = set(raise_saves or ())
+        self.save_count = 0
+
+    async def load(self, module, filename):
+        """Return a defensive snapshot copy."""
+        if self.raise_load:
+            raise OSError("load failed")
+        return copy.deepcopy(self.snapshot)
+
+    async def save(self, module, filename, data, **kwargs):
+        """Persist a defensive copy unless this save is scripted to fail."""
+        self.save_count += 1
+        if self.save_count in self.raise_saves:
+            raise OSError("save failed")
+        if self.save_count in self.fail_saves:
+            return False
+        self.snapshot = copy.deepcopy(data)
+        return True
+
+
+class Harness:
+    """Wire the authority to scripted send and ledger-query seams."""
+
+    def __init__(self, send_results=(), query_results=(), storage=None, command_id_factory=None):
+        """Create a deterministic harness."""
+        self.send_results = list(send_results)
+        self.query_results = list(query_results)
+        self.storage = storage or FakeStorage()
+        self.sent = []
+        self.queries = []
+        self.authority = LatticeScheduleAuthority(
+            self.storage,
+            self.send,
+            self.query,
+            SCOPE,
+            command_id_factory=command_id_factory or (lambda: "cmd-1"),
+        )
+
+    async def send(self, command):
+        """Capture a command and return the next scripted result."""
+        self.sent.append(command)
+        result = self.send_results.pop(0) if self.send_results else None
+        return result(command) if callable(result) else result
+
+    async def query(self, command_id):
+        """Capture a ledger lookup and return the next scripted result."""
+        self.queries.append(command_id)
+        result = self.query_results.pop(0) if self.query_results else None
+        if callable(result):
+            command = self.sent[-1] if self.sent else None
+            return result(command)
+        return result
+
+
+class TestAbsoluteScheduleCompiler(unittest.TestCase):
+    """Exercise calendar-correct atomic conversion."""
+
+    def test_midnight_and_multiple_days_remain_distinct_utc_instants(self):
+        """Elapsed offsets cross midnight and day two without HH:MM aliasing."""
+        compiled = compile_absolute_schedule(
+            plan(
+                [
+                    window(0, 90, "force_charge", target_soc=90),
+                    window(1500, 1530, "force_export", reserve_soc=20),
+                ],
+                horizon=1560,
+            ),
+            ORIGIN,
+        )
+        self.assertEqual(compiled.slots[0].start_ts_ms, int(ORIGIN.timestamp() * 1000))
+        self.assertEqual(compiled.slots[0].end_ts_ms, int((ORIGIN + timedelta(minutes=90)).timestamp() * 1000))
+        self.assertEqual(compiled.slots[1].start_ts_ms, int((ORIGIN + timedelta(minutes=1500)).timestamp() * 1000))
+        self.assertGreater(compiled.slots[1].start_ts_ms, compiled.slots[0].start_ts_ms + 24 * 60 * 60 * 1000)
+
+    def test_dst_timezone_is_diagnostic_only(self):
+        """The London spring gap cannot reinterpret producer-resolved UTC offsets."""
+        spring = datetime(2026, 3, 29, 0, 0, tzinfo=UTC)
+        london = compile_absolute_schedule(plan([window(60, 120, "force_charge")], horizon=180, origin=spring), spring)
+        utc = compile_absolute_schedule(plan([window(60, 120, "force_charge")], horizon=180, timezone_name="UTC", origin=spring), spring)
+        self.assertEqual(london.slots[0].start_ts_ms, utc.slots[0].start_ts_ms)
+        self.assertEqual(london.slots[0].end_ts_ms, utc.slots[0].end_ts_ms)
+        self.assertNotEqual(london.plan_digest, utc.plan_digest)
+
+    def test_adjacent_identical_slots_coalesce_and_preserve_zero_false(self):
+        """Lossless coalescing reduces slot pressure without dropping presence."""
+        compiled = compile_absolute_schedule(
+            plan(
+                [
+                    window(0, 30, "force_charge", charge_power_limit=0, enable=False),
+                    window(30, 60, "force_charge", charge_power_limit=0, enable=False),
+                ],
+                horizon=60,
+                default_mode=None,
+            ),
+            ORIGIN,
+        )
+        self.assertEqual(len(compiled.slots), 1)
+        self.assertEqual(compiled.slots[0].to_wire()["charge_power_limit"], 0)
+        self.assertIs(compiled.slots[0].to_wire()["enable"], False)
+        self.assertNotIn("default_mode", compiled.to_wire())
+
+    def test_overlap_rejects_the_entire_plan(self):
+        """No partial or last-writer-wins schedule escapes an overlap."""
+        with self.assertRaisesRegex(ScheduleValidationError, "overlaps"):
+            compile_absolute_schedule(plan([window(0, 60, "force_charge"), window(30, 90, "force_export")]), ORIGIN)
+
+    def test_gap_requires_an_explicit_default_mode(self):
+        """Uncovered validity is never assigned an implicit receiver behavior."""
+        with self.assertRaisesRegex(ScheduleValidationError, "gaps require"):
+            compile_absolute_schedule(plan([window(30, 60, "force_charge")], default_mode=None), ORIGIN)
+
+    def test_windows_cannot_cross_topology_altitudes(self):
+        """A plan cannot accidentally dispatch controls at two graph levels."""
+        with self.assertRaisesRegex(ScheduleValidationError, "crosses topology altitude"):
+            compile_absolute_schedule(plan([window(0, 60, "force_charge", altitude="site:other")]), ORIGIN)
+
+    def test_partial_and_expired_plans_are_rejected(self):
+        """Only a complete future-bearing plan can become an atomic command."""
+        with self.assertRaisesRegex(ScheduleValidationError, "partial"):
+            compile_absolute_schedule(plan([], complete=False), ORIGIN)
+        with self.assertRaisesRegex(ScheduleValidationError, "expired"):
+            compile_absolute_schedule(plan([], origin=ORIGIN - timedelta(hours=4)), ORIGIN)
+
+    def test_naive_time_and_invalid_timezone_are_rejected(self):
+        """Invalid time inputs fail closed before any epoch conversion."""
+        with self.assertRaisesRegex(ScheduleValidationError, "aware UTC"):
+            compile_absolute_schedule(plan([], origin=ORIGIN.replace(tzinfo=None)), ORIGIN)
+        with self.assertRaisesRegex(ScheduleValidationError, "aware UTC"):
+            compile_absolute_schedule(plan([], origin=datetime(2026, 1, 1, tzinfo=ZoneInfo("Europe/London"))), ORIGIN)
+        with self.assertRaisesRegex(ScheduleValidationError, "IANA"):
+            compile_absolute_schedule(plan([], timezone_name="../London"), ORIGIN)
+
+    def test_more_than_embedded_slot_limit_is_rejected(self):
+        """The compiler never truncates a complete plan to the embedded limit."""
+        windows = [window(index * 10, index * 10 + 5, "force_charge", target_soc=index) for index in range(9)]
+        with self.assertRaisesRegex(ScheduleValidationError, "embedded maximum"):
+            compile_absolute_schedule(plan(windows, horizon=100), ORIGIN)
+
+
+class TestLatticeScheduleAuthority(unittest.TestCase):
+    """Exercise durable dispatch, reconciliation, and legacy decisions."""
+
+    def setUp(self):
+        """Compile one representative schedule for each authority test."""
+        self.schedule = compile_absolute_schedule(
+            plan([window(0, 60, "force_charge", target_soc=90), window(60, 120, "self_use")], horizon=120, default_mode=None),
+            ORIGIN - timedelta(minutes=5),
+        )
+
+    def dispatch(self, harness, **kwargs):
+        """Run one deterministic dispatch."""
+        return asyncio.run(harness.authority.dispatch(self.schedule, kwargs.get("target", target()), kwargs.get("lease", lease()), kwargs.get("now_ts_ms", NOW_MS), kwargs.get("command_id")))
+
+    def test_applied_suppresses_legacy_only_after_local_durable_save(self):
+        """A durably accepted receipt plus local persistence activates suppression."""
+        harness = Harness(send_results=[applied])
+        decision = self.dispatch(harness)
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertFalse(decision.fallback_allowed)
+        durable = asyncio.run(harness.authority.legacy_decision(NOW_MS))
+        self.assertTrue(durable.legacy_suppressed)
+        self.assertEqual(len(harness.sent), 1)
+
+    def test_applied_receipt_save_failure_never_allows_fallback(self):
+        """Physical acceptance with failed local persistence remains ambiguous."""
+        harness = Harness(send_results=[applied], storage=FakeStorage(fail_saves={2}))
+        decision = self.dispatch(harness)
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertFalse(decision.legacy_suppressed)
+        self.assertFalse(decision.fallback_allowed)
+        self.assertTrue(decision.quarantined)
+
+    def test_clamped_applied_receipt_keeps_requested_and_applied_digests(self):
+        """A valid clamp may change the receiver's canonical applied digest."""
+        applied_digest = "a" * 64
+        clamp = ScheduleClamp(0, "TARGET_SOC", 101.0, 100.0)
+        harness = Harness(
+            send_results=[
+                lambda command: applied(
+                    command,
+                    plan_digest=applied_digest,
+                    clamps=(clamp,),
+                    clamp_count=1,
+                    clamps_truncated=False,
+                )
+            ]
+        )
+        decision = self.dispatch(harness)
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertEqual(harness.storage.snapshot["command"]["plan_digest"], self.schedule.plan_digest)
+        self.assertEqual(harness.storage.snapshot["command"]["applied_plan_digest"], applied_digest)
+        self.assertEqual(harness.storage.snapshot["command"]["clamps"][0]["field"], "TARGET_SOC")
+
+    def test_malformed_applied_receipts_quarantine(self):
+        """Invalid digest, verification, or clamp invariants never suppress legacy."""
+        valid_clamp = ScheduleClamp(0, "TARGET_SOC", 101.0, 100.0)
+        mutations = [
+            {"plan_digest": "bad"},
+            {"verification": "MAGIC"},
+            {"verification": VERIFICATION_ACCEPTED_ONLY, "verified": True},
+            {"clamps": [valid_clamp], "clamp_count": 1},
+            {"clamps": (valid_clamp,), "clamp_count": 1, "clamps_truncated": True},
+            {"clamps": (ScheduleClamp(2, "TARGET_SOC", 101.0, 100.0),), "clamp_count": 1},
+            {"clamps": (ScheduleClamp(0, "MAGIC", 101.0, 100.0),), "clamp_count": 1},
+            {"clamps": (ScheduleClamp(0, "TARGET_SOC", float("nan"), 100.0),), "clamp_count": 1},
+            {
+                "clamps": tuple(ScheduleClamp(0, "TARGET_SOC", 101.0, 100.0) for _ in range(9)),
+                "clamp_count": 9,
+                "clamps_truncated": False,
+            },
+        ]
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                harness = Harness(send_results=[lambda command, mutation=mutation: applied(command, **mutation)], query_results=[None])
+                decision = self.dispatch(harness)
+                self.assertEqual(decision.state, RESULT_UNKNOWN)
+                self.assertTrue(decision.quarantined)
+                self.assertFalse(decision.legacy_suppressed)
+                self.assertFalse(decision.fallback_allowed)
+
+    def test_truncated_clamp_detail_list_is_valid(self):
+        """A bounded receipt may report fewer details than its total clamp count."""
+        clamp = ScheduleClamp(0, "TARGET_SOC", 101.0, 100.0)
+        harness = Harness(
+            send_results=[
+                lambda command: applied(
+                    command,
+                    plan_digest="b" * 64,
+                    clamps=(clamp,),
+                    clamp_count=3,
+                    clamps_truncated=True,
+                )
+            ]
+        )
+        decision = self.dispatch(harness)
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertEqual(harness.storage.snapshot["command"]["clamp_count"], 3)
+        self.assertTrue(harness.storage.snapshot["command"]["clamps_truncated"])
+
+    def test_only_fallback_safe_not_applied_allows_fallback(self):
+        """Definite SAFE rejection is the sole fallback boundary."""
+        safe = Harness(send_results=[lambda command: rejected(command, FALLBACK_SAFE)])
+        blocked = Harness(send_results=[lambda command: rejected(command, FALLBACK_BLOCKED, "STALE_FENCE")])
+        self.assertTrue(self.dispatch(safe).fallback_allowed)
+        self.assertFalse(self.dispatch(blocked).fallback_allowed)
+
+    def test_rejected_replacement_cannot_unsuppress_installed_schedule(self):
+        """A failed replacement does not prove the prior device plan stopped."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        changed = compile_absolute_schedule(
+            plan([window(0, 30, "force_export")], horizon=120),
+            ORIGIN - timedelta(minutes=5),
+        )
+        replacement = Harness(storage=first.storage, send_results=[lambda command: rejected(command, FALLBACK_SAFE)])
+        decision = asyncio.run(replacement.authority.dispatch(changed, target(), lease(fence=11), NOW_MS, "cmd-2"))
+        self.assertEqual(decision.state, RESULT_NOT_APPLIED)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertFalse(decision.fallback_allowed)
+        self.assertEqual(first.storage.snapshot["installed"]["command_id"], "cmd-1")
+        self.assertEqual(first.storage.snapshot["command"]["command_id"], "cmd-2")
+
+    def test_unknown_quarantines_and_never_allows_fallback(self):
+        """UNKNOWN remains an explicit double-write barrier."""
+        harness = Harness(send_results=[unknown])
+        decision = self.dispatch(harness)
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertTrue(decision.quarantined)
+        self.assertFalse(decision.fallback_allowed)
+        self.assertFalse(decision.legacy_suppressed)
+
+    def test_lost_result_reconciles_by_id_without_republishing(self):
+        """An absent immediate result performs one ledger lookup only."""
+        harness = Harness(send_results=[None], query_results=[applied])
+        decision = self.dispatch(harness)
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        self.assertEqual(len(harness.sent), 1)
+        self.assertEqual(harness.queries, ["cmd-1"])
+
+    def test_restart_reconciles_pending_without_sending_again(self):
+        """A new authority instance resumes the durable command by ID."""
+        first = Harness(send_results=[None], query_results=[None])
+        self.assertEqual(self.dispatch(first).state, RESULT_UNKNOWN)
+        restarted = Harness(storage=first.storage, query_results=[lambda _command: applied(first.sent[0])])
+        decision = asyncio.run(restarted.authority.reconcile(NOW_MS))
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        self.assertEqual(restarted.sent, [])
+        self.assertEqual(restarted.queries, ["cmd-1"])
+
+    def test_identical_duplicate_result_is_idempotent(self):
+        """Two byte-equivalent logical results do not create a conflict."""
+        harness = Harness()
+
+        async def send(command):
+            """Deliver the same terminal result twice."""
+            result = applied(command)
+            self.assertTrue(harness.authority.accept_result(result))
+            self.assertTrue(harness.authority.accept_result(result))
+
+        harness._send = send
+        harness.authority._send = send
+        decision = self.dispatch(harness)
+        self.assertEqual(decision.state, RESULT_APPLIED)
+
+    def test_conflicting_duplicate_result_quarantines(self):
+        """Two terminal claims for one command are treated as ambiguous."""
+        harness = Harness()
+
+        async def send(command):
+            """Deliver mutually inconsistent terminal results."""
+            self.assertTrue(harness.authority.accept_result(applied(command)))
+            self.assertFalse(harness.authority.accept_result(unknown(command)))
+
+        harness.authority._send = send
+        decision = self.dispatch(harness)
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertTrue(decision.quarantined)
+
+    def test_result_digest_scope_fence_and_validity_mismatch_quarantine(self):
+        """Every applied receipt coordinate must match the admitted command."""
+        mutations = [
+            {"scope_id": "site:other"},
+            {"fencing_token": 11},
+            {"lease_id": "lease-other"},
+            {"lease_expires_ts_ms": NOW_MS + 7_200_000},
+            {"origin_id": "operator"},
+            {"controller_class": "MANUAL"},
+            {"valid_until_ts_ms": 1},
+            {"accepted_slot_count": 1},
+        ]
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                harness = Harness(send_results=[lambda command, mutation=mutation: applied(command, **mutation)], query_results=[None])
+                decision = self.dispatch(harness)
+                self.assertEqual(decision.state, RESULT_UNKNOWN)
+                self.assertFalse(decision.fallback_allowed)
+
+    def test_rejection_coordinates_may_be_absent_but_not_conflicting(self):
+        """Optional rejection echoes are checked whenever the protobuf carries them."""
+        absent = Harness(
+            send_results=[
+                lambda command: rejected(
+                    command,
+                    fencing_token=0,
+                    lease_id="",
+                    lease_expires_ts_ms=0,
+                    origin_id="",
+                    controller_class="",
+                )
+            ]
+        )
+        conflict = Harness(send_results=[lambda command: rejected(command, lease_id="lease-other")], query_results=[None])
+        blocked_claims_safe = Harness(
+            send_results=[lambda command: rejected(command, FALLBACK_SAFE, "STALE_FENCE")],
+            query_results=[None],
+        )
+        self.assertTrue(self.dispatch(absent).fallback_allowed)
+        self.assertEqual(self.dispatch(conflict).state, RESULT_UNKNOWN)
+        self.assertEqual(self.dispatch(blocked_claims_safe).state, RESULT_UNKNOWN)
+
+    def test_stale_fence_is_blocked_before_transport(self):
+        """A lower token cannot follow a durable high-water token."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first, lease=lease(fence=10)).state, RESULT_APPLIED)
+        second = Harness(storage=first.storage, send_results=[applied])
+        changed = compile_absolute_schedule(plan([window(0, 30, "force_export")], horizon=120), ORIGIN - timedelta(minutes=5))
+        decision = asyncio.run(second.authority.dispatch(changed, target(), lease(fence=9), NOW_MS, "cmd-2"))
+        self.assertEqual(decision.state, RESULT_NOT_APPLIED)
+        self.assertEqual(decision.detail, "STALE_FENCE")
+        self.assertFalse(decision.fallback_allowed)
+        self.assertEqual(second.sent, [])
+
+    def test_same_plan_and_fence_is_not_resent(self):
+        """A repeated accepted intent reuses durable acceptance after restart."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        restarted = Harness(storage=first.storage, send_results=[applied])
+        decision = self.dispatch(restarted, command_id="cmd-2")
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertEqual(restarted.sent, [])
+
+    def test_command_id_reuse_with_different_plan_quarantines(self):
+        """One command ID can never identify two plan digests."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        changed = compile_absolute_schedule(plan([window(0, 30, "force_export")], horizon=120), ORIGIN - timedelta(minutes=5))
+        restarted = Harness(storage=first.storage, send_results=[applied])
+        decision = asyncio.run(restarted.authority.dispatch(changed, target(), lease(), NOW_MS, "cmd-1"))
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertEqual(restarted.sent, [])
+
+    def test_same_command_id_with_changed_fence_quarantines(self):
+        """Command identity includes the accepted fence, not only the plan digest."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        restarted = Harness(storage=first.storage, send_results=[applied])
+        decision = self.dispatch(restarted, lease=lease(fence=11), command_id="cmd-1")
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertEqual(restarted.sent, [])
+
+    def test_same_command_id_with_changed_owned_set_quarantines(self):
+        """Command identity retains every provider-local node owned by the scope."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        restarted = Harness(storage=first.storage, send_results=[applied])
+        expanded = target(owned_node_ids=("GW-2", "GW-1"))
+        decision = self.dispatch(restarted, target=expanded, command_id="cmd-1")
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertEqual(restarted.sent, [])
+
+    def test_expired_ownership_no_longer_suppresses_legacy(self):
+        """Suppression ends only when the applied schedule validity ends."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        expired = asyncio.run(first.authority.legacy_decision(self.schedule.valid_until_ts_ms))
+        invalid_clock = asyncio.run(first.authority.legacy_decision(0))
+        self.assertEqual(expired.state, RESULT_NOT_APPLIED)
+        self.assertFalse(expired.legacy_suppressed)
+        self.assertFalse(expired.fallback_allowed)
+        self.assertEqual(invalid_clock.state, RESULT_UNKNOWN)
+        self.assertTrue(invalid_clock.quarantined)
+
+    def test_lease_expiry_does_not_unsuppress_an_installed_schedule(self):
+        """Lease expiry permits ownership change but does not cancel device effect."""
+        short_expiry = NOW_MS + 10 * 60 * 1000
+        harness = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(harness, lease=lease(expiry=short_expiry)).state, RESULT_APPLIED)
+        after_lease = asyncio.run(harness.authority.legacy_decision(short_expiry))
+        self.assertEqual(after_lease.state, RESULT_APPLIED)
+        self.assertTrue(after_lease.legacy_suppressed)
+        self.assertFalse(after_lease.fallback_allowed)
+
+    def test_empty_default_schedule_round_trips_durable_state(self):
+        """A zero-slot schedule with an explicit default remains restart-safe."""
+        empty_schedule = compile_absolute_schedule(plan([], horizon=120), ORIGIN - timedelta(minutes=5))
+        harness = Harness(send_results=[applied])
+        decision = asyncio.run(harness.authority.dispatch(empty_schedule, target(), lease(), NOW_MS, "cmd-empty"))
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        restarted = Harness(storage=harness.storage)
+        self.assertTrue(asyncio.run(restarted.authority.legacy_decision(NOW_MS)).legacy_suppressed)
+
+    def test_invalid_time_target_and_lease_never_send(self):
+        """Unsafe preconditions are rejected before durable reservation or send."""
+        cases = [
+            {"now_ts_ms": 0},
+            {"target": target(altitude_id="site:other")},
+            {"lease": lease(expiry=NOW_MS)},
+            {"lease": lease(scope_id="site:other")},
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                harness = Harness()
+                decision = self.dispatch(harness, **case)
+                self.assertFalse(decision.fallback_allowed)
+                self.assertEqual(harness.sent, [])
+
+    def test_retained_offer_constraints_are_enforced_before_send(self):
+        """BatPred never knowingly sends outside the selected offer surface."""
+        base_offer = target().offer
+        unsupported_targets = [
+            target(offer=replace(base_offer, max_slots=1)),
+            target(offer=replace(base_offer, supported_modes=("self_use",))),
+            target(offer=replace(base_offer, slot_fields=())),
+            target(offer=replace(base_offer, execution_modes=("CONTROLLER_STEPPED",))),
+            target(offer=replace(base_offer, max_slots=9)),
+        ]
+        for unsafe_target in unsupported_targets:
+            with self.subTest(offer=unsafe_target.offer):
+                harness = Harness()
+                decision = self.dispatch(harness, target=unsafe_target)
+                self.assertEqual(decision.state, RESULT_NOT_APPLIED)
+                self.assertEqual(harness.sent, [])
+
+        gapped = compile_absolute_schedule(
+            plan([window(30, 60, "force_charge", target_soc=90)], horizon=120),
+            ORIGIN - timedelta(minutes=5),
+        )
+        reject_gaps = target(offer=replace(base_offer, gap_policy="REJECT"))
+        harness = Harness()
+        decision = asyncio.run(harness.authority.dispatch(gapped, reject_gaps, lease(), NOW_MS, "cmd-gap"))
+        self.assertEqual(decision.state, RESULT_NOT_APPLIED)
+        self.assertEqual(harness.sent, [])
+
+    def test_offer_sets_are_canonical_and_duplicates_are_rejected(self):
+        """Equivalent tuple order has one fingerprint and duplicates are invalid."""
+        base_offer = target().offer
+        reordered = ResolvedScheduleOffer(
+            max_slots=base_offer.max_slots,
+            supported_modes=tuple(reversed(base_offer.supported_modes)),
+            slot_fields=tuple(reversed(base_offer.slot_fields)),
+            execution_modes=tuple(reversed(base_offer.execution_modes)),
+            gap_policy=base_offer.gap_policy,
+        )
+        self.assertEqual(reordered, base_offer)
+        self.assertEqual(reordered.fingerprint, base_offer.fingerprint)
+        with self.assertRaisesRegex(ScheduleValidationError, "duplicates"):
+            ResolvedScheduleOffer(8, ("self_use", "self_use"), (), ("NATIVE",), "DEFAULT_MODE")
+        with self.assertRaisesRegex(ScheduleValidationError, "duplicates"):
+            target(owned_node_ids=("GW-1", "GW-1"))
+
+    def test_fencing_token_uses_full_uint64_domain(self):
+        """Fence bounds follow protobuf uint64 rather than epoch-safe integers."""
+        max_fence = (1 << 64) - 1
+        accepted = Harness(send_results=[applied])
+        decision = self.dispatch(accepted, lease=lease(fence=max_fence))
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        self.assertEqual(accepted.storage.snapshot["high_water_token"], max_fence)
+
+        too_large = Harness()
+        rejected_decision = self.dispatch(too_large, lease=lease(fence=1 << 64))
+        self.assertEqual(rejected_decision.state, RESULT_NOT_APPLIED)
+        self.assertEqual(too_large.sent, [])
+
+    def test_manually_forged_schedule_is_revalidated_before_send(self):
+        """Public dataclasses cannot bypass the compiler's schedule invariants."""
+        valid_slot = self.schedule.slots[0]
+        forged = [
+            replace(self.schedule, valid_from_ts_ms=0),
+            replace(self.schedule, valid_until_ts_ms=(1 << 53)),
+            replace(self.schedule, execution="MAGIC"),
+            replace(self.schedule, diagnostic_timezone="../UTC"),
+            replace(self.schedule, altitude_id=""),
+            replace(self.schedule, slots=list(self.schedule.slots)),
+            replace(
+                self.schedule,
+                slots=(
+                    valid_slot,
+                    replace(valid_slot, start_ts_ms=valid_slot.start_ts_ms + 1),
+                ),
+            ),
+            replace(self.schedule, slots=(replace(valid_slot, mode="x" * 25),)),
+            replace(self.schedule, slots=(replace(valid_slot, target_soc=float("nan")),)),
+            AbsoluteScheduleIntent(
+                altitude_id=ALTITUDE,
+                slots=(),
+                valid_from_ts_ms=self.schedule.valid_from_ts_ms,
+                valid_until_ts_ms=self.schedule.valid_until_ts_ms,
+                diagnostic_timezone="UTC",
+                execution=EXECUTION_NATIVE,
+                default_mode=None,
+            ),
+            replace(
+                self.schedule,
+                slots=tuple(
+                    AbsoluteScheduleSlot(
+                        self.schedule.valid_from_ts_ms + index * 2,
+                        self.schedule.valid_from_ts_ms + index * 2 + 1,
+                        "self_use",
+                    )
+                    for index in range(9)
+                ),
+            ),
+        ]
+        for schedule in forged:
+            with self.subTest(schedule=schedule):
+                harness = Harness()
+                decision = asyncio.run(harness.authority.dispatch(schedule, target(), lease(), NOW_MS, "cmd-forged"))
+                self.assertEqual(decision.state, RESULT_NOT_APPLIED)
+                self.assertFalse(decision.fallback_allowed)
+                self.assertEqual(harness.sent, [])
+
+    def test_storage_and_command_id_exceptions_fail_closed(self):
+        """Infrastructure exceptions return UNKNOWN and cannot reach transport."""
+
+        def broken_command_id():
+            """Raise from the injected identifier source."""
+            raise RuntimeError("entropy unavailable")
+
+        harnesses = [
+            Harness(storage=FakeStorage(raise_load=True)),
+            Harness(storage=FakeStorage(raise_saves={1})),
+            Harness(command_id_factory=broken_command_id),
+        ]
+        for harness in harnesses:
+            with self.subTest(harness=harness):
+                decision = self.dispatch(harness)
+                self.assertEqual(decision.state, RESULT_UNKNOWN)
+                self.assertTrue(decision.quarantined)
+                self.assertFalse(decision.fallback_allowed)
+                self.assertEqual(harness.sent, [])
+
+    def test_corrupt_restart_state_fails_closed(self):
+        """Malformed persistence cannot activate either control path."""
+        storage = FakeStorage({"schema_version": 1, "scope_id": SCOPE, "high_water_token": 10, "command": {"state": RESULT_APPLIED}})
+        harness = Harness(storage=storage)
+        decision = asyncio.run(harness.authority.legacy_decision(NOW_MS))
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertTrue(decision.quarantined)
+        self.assertFalse(decision.legacy_suppressed)
+        self.assertFalse(decision.fallback_allowed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/predbat/tests/test_lattice_schedule_authority.py
+++ b/apps/predbat/tests/test_lattice_schedule_authority.py
@@ -125,6 +125,26 @@ def applied(command, verified=True, **overrides):
     return ScheduleAck(**value)
 
 
+def cancellation_applied(command, **overrides):
+    """Build exact durable/native proof that cancellation released authority."""
+    value = {
+        "command_id": command.command_id,
+        "state": RESULT_APPLIED,
+        "scope_id": command.lease.scope_id,
+        "fencing_token": command.lease.fencing_token,
+        "lease_id": command.lease.lease_id,
+        "lease_expires_ts_ms": command.lease.expires_ts_ms,
+        "origin_id": command.lease.origin_id,
+        "controller_class": command.lease.controller_class,
+        "cancelled_plan_digest": command.cancellation.expected_plan_digest,
+        "writer_exclusion_released": True,
+        "verification": VERIFICATION_DURABLE_STORE_READBACK,
+        "verified": True,
+    }
+    value.update(overrides)
+    return ScheduleAck(**value)
+
+
 def rejected(command, fallback=FALLBACK_SAFE, reason="UNSUPPORTED_OFFER", **overrides):
     """Build one definite NOT_APPLIED schedule result."""
     value = {
@@ -332,7 +352,7 @@ class TestLatticeScheduleAuthority(unittest.TestCase):
         harness = Harness(send_results=[applied], storage=FakeStorage(fail_saves={2}))
         decision = self.dispatch(harness)
         self.assertEqual(decision.state, RESULT_UNKNOWN)
-        self.assertFalse(decision.legacy_suppressed)
+        self.assertTrue(decision.legacy_suppressed)
         self.assertFalse(decision.fallback_allowed)
         self.assertTrue(decision.quarantined)
 
@@ -382,7 +402,7 @@ class TestLatticeScheduleAuthority(unittest.TestCase):
                 decision = self.dispatch(harness)
                 self.assertEqual(decision.state, RESULT_UNKNOWN)
                 self.assertTrue(decision.quarantined)
-                self.assertFalse(decision.legacy_suppressed)
+                self.assertTrue(decision.legacy_suppressed)
                 self.assertFalse(decision.fallback_allowed)
 
     def test_truncated_clamp_detail_list_is_valid(self):
@@ -435,7 +455,7 @@ class TestLatticeScheduleAuthority(unittest.TestCase):
         self.assertEqual(decision.state, RESULT_UNKNOWN)
         self.assertTrue(decision.quarantined)
         self.assertFalse(decision.fallback_allowed)
-        self.assertFalse(decision.legacy_suppressed)
+        self.assertTrue(decision.legacy_suppressed)
 
     def test_lost_result_reconciles_by_id_without_republishing(self):
         """An absent immediate result performs one ledger lookup only."""
@@ -578,16 +598,347 @@ class TestLatticeScheduleAuthority(unittest.TestCase):
         self.assertEqual(restarted.sent, [])
 
     def test_expired_ownership_no_longer_suppresses_legacy(self):
-        """Suppression ends only when the applied schedule validity ends."""
+        """Clock expiry requests an ending transition but cannot release authority."""
         first = Harness(send_results=[applied])
         self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
         expired = asyncio.run(first.authority.legacy_decision(self.schedule.valid_until_ts_ms))
         invalid_clock = asyncio.run(first.authority.legacy_decision(0))
-        self.assertEqual(expired.state, RESULT_NOT_APPLIED)
-        self.assertFalse(expired.legacy_suppressed)
+        self.assertEqual(expired.state, RESULT_APPLIED)
+        self.assertTrue(expired.legacy_suppressed)
+        self.assertTrue(expired.ending_transition_required)
         self.assertFalse(expired.fallback_allowed)
         self.assertEqual(invalid_clock.state, RESULT_UNKNOWN)
         self.assertTrue(invalid_clock.quarantined)
+
+    def test_guarded_verified_cancellation_is_the_only_authority_release(self):
+        """Matching durable readback proof ends exclusion after validity expiry."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        installed_digest = first.storage.snapshot["installed"]["applied_plan_digest"]
+
+        ending = Harness(storage=first.storage, send_results=[cancellation_applied])
+        decision = asyncio.run(
+            ending.authority.cancel(
+                target(),
+                lease(fence=11, expiry=self.schedule.valid_until_ts_ms + 3_600_000),
+                installed_digest,
+                "VALIDITY_END",
+                self.schedule.valid_until_ts_ms,
+                "cmd-end",
+            )
+        )
+
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        self.assertFalse(decision.legacy_suppressed)
+        self.assertFalse(decision.ending_transition_required)
+        self.assertFalse(decision.fallback_allowed)
+        self.assertIsNone(ending.storage.snapshot["installed"])
+        restarted = Harness(storage=ending.storage)
+        self.assertFalse(asyncio.run(restarted.authority.legacy_decision(self.schedule.valid_until_ts_ms + 1)).legacy_suppressed)
+        self.assertEqual(ending.sent[0].to_wire()["schedule_transition"]["cancellation"]["expected_plan_digest"], installed_digest)
+
+    def test_applied_replacement_holds_exclusion_continuously_after_expiry(self):
+        """A definite replacement swaps the installed digest without a write gap."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        transition_now = self.schedule.valid_until_ts_ms
+        new_origin = datetime.fromtimestamp(transition_now / 1000, UTC)
+        replacement_schedule = compile_absolute_schedule(
+            plan(
+                [window(0, 60, "force_export")],
+                horizon=120,
+                origin=new_origin,
+            ),
+            new_origin,
+        )
+        replacement = Harness(storage=first.storage)
+
+        async def send_with_old_authority_reserved(command):
+            """Observe that reservation preserves the old installed authority."""
+            self.assertEqual(replacement.storage.snapshot["installed"]["command_id"], "cmd-1")
+            return applied(command)
+
+        replacement.authority._send = send_with_old_authority_reserved
+        decision = asyncio.run(
+            replacement.authority.dispatch(
+                replacement_schedule,
+                target(),
+                lease(fence=11, expiry=transition_now + 3_600_000),
+                transition_now,
+                "cmd-replace",
+            )
+        )
+        self.assertEqual(decision.state, RESULT_APPLIED)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertFalse(decision.ending_transition_required)
+        self.assertEqual(
+            replacement.storage.snapshot["installed"]["command_id"],
+            "cmd-replace",
+        )
+
+    def test_bare_or_mismatched_applied_cancellation_cannot_release(self):
+        """APPLIED without exact durable/native release evidence quarantines."""
+        mutations = [
+            {"cancelled_plan_digest": "f" * 64},
+            {"writer_exclusion_released": False},
+            {
+                "verification": VERIFICATION_ACCEPTED_ONLY,
+                "verified": False,
+            },
+        ]
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                first = Harness(send_results=[applied])
+                self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+                installed_digest = first.storage.snapshot["installed"]["applied_plan_digest"]
+                ending = Harness(
+                    storage=first.storage,
+                    send_results=[lambda command, mutation=mutation: cancellation_applied(command, **mutation)],
+                )
+                decision = asyncio.run(
+                    ending.authority.cancel(
+                        target(),
+                        lease(fence=11),
+                        installed_digest,
+                        "OPERATOR",
+                        NOW_MS,
+                        "cmd-end",
+                    )
+                )
+                self.assertEqual(decision.state, RESULT_UNKNOWN)
+                self.assertTrue(decision.quarantined)
+                self.assertTrue(decision.legacy_suppressed)
+                self.assertEqual(
+                    ending.storage.snapshot["installed"]["applied_plan_digest"],
+                    installed_digest,
+                )
+
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        installed_digest = first.storage.snapshot["installed"]["applied_plan_digest"]
+        ending = Harness(
+            storage=first.storage,
+            send_results=[
+                lambda command: ScheduleAck(
+                    command_id=command.command_id,
+                    state=RESULT_APPLIED,
+                    scope_id=command.lease.scope_id,
+                )
+            ],
+        )
+        bare = asyncio.run(
+            ending.authority.cancel(
+                target(),
+                lease(fence=11),
+                installed_digest,
+                "OPERATOR",
+                NOW_MS,
+                "cmd-bare",
+            )
+        )
+        self.assertEqual(bare.state, RESULT_UNKNOWN)
+        self.assertTrue(bare.legacy_suppressed)
+        self.assertIsNotNone(ending.storage.snapshot["installed"])
+
+    def test_cancellation_digest_guard_rejects_before_transport(self):
+        """A delayed cancellation cannot remove a different installed digest."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        ending = Harness(storage=first.storage, send_results=[cancellation_applied])
+        decision = asyncio.run(
+            ending.authority.cancel(
+                target(),
+                lease(fence=11),
+                "e" * 64,
+                "SUPERSEDED",
+                NOW_MS,
+                "cmd-stale-cancel",
+            )
+        )
+        self.assertEqual(decision.state, RESULT_NOT_APPLIED)
+        self.assertEqual(decision.detail, "PLAN_DIGEST_MISMATCH")
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertEqual(ending.sent, [])
+
+    def test_cancellation_requires_the_installed_gateway_route(self):
+        """Provider/access hints cannot redirect an authority-ending command."""
+        for mutation in (
+            {"provider": "cloud-provider"},
+            {"access_path": "cloud-api"},
+        ):
+            with self.subTest(mutation=mutation):
+                first = Harness(send_results=[applied])
+                self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+                installed_digest = first.storage.snapshot["installed"]["applied_plan_digest"]
+                ending = Harness(storage=first.storage, send_results=[cancellation_applied])
+                decision = asyncio.run(
+                    ending.authority.cancel(
+                        target(**mutation),
+                        lease(fence=11),
+                        installed_digest,
+                        "OPERATOR",
+                        NOW_MS,
+                        "cmd-end",
+                    )
+                )
+                self.assertEqual(decision.state, RESULT_NOT_APPLIED)
+                self.assertTrue(decision.legacy_suppressed)
+                self.assertEqual(decision.detail, "unsafe topology cancellation target")
+                self.assertEqual(ending.sent, [])
+
+    def test_unknown_quarantine_timestamp_is_durable_and_paired(self):
+        """UNKNOWN keeps its first quarantine time and corrupt pairs fail closed."""
+        ambiguous = Harness(send_results=[unknown])
+        decision = self.dispatch(ambiguous)
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertEqual(ambiguous.storage.snapshot["quarantine_since_ts_ms"], NOW_MS)
+
+        restarted = Harness(storage=ambiguous.storage, query_results=[None])
+        reconciled = asyncio.run(restarted.authority.reconcile(NOW_MS + 1))
+        self.assertEqual(reconciled.state, RESULT_UNKNOWN)
+        self.assertEqual(restarted.storage.snapshot["quarantine_since_ts_ms"], NOW_MS)
+
+        missing_timestamp = copy.deepcopy(restarted.storage.snapshot)
+        missing_timestamp["quarantine_since_ts_ms"] = None
+        corrupt_unknown = Harness(storage=FakeStorage(missing_timestamp))
+        corrupt_decision = asyncio.run(corrupt_unknown.authority.legacy_decision(NOW_MS + 2))
+        self.assertEqual(corrupt_decision.state, RESULT_UNKNOWN)
+        self.assertTrue(corrupt_decision.quarantined)
+        self.assertTrue(corrupt_decision.legacy_suppressed)
+
+        stray_timestamp = copy.deepcopy(restarted.storage.snapshot)
+        stray_timestamp["command"]["state"] = RESULT_NOT_APPLIED
+        stray_timestamp["command"]["fallback"] = FALLBACK_BLOCKED
+        stray_timestamp["command"]["reason"] = "SCOPE_BUSY"
+        corrupt_terminal = Harness(storage=FakeStorage(stray_timestamp))
+        corrupt_decision = asyncio.run(corrupt_terminal.authority.legacy_decision(NOW_MS + 2))
+        self.assertEqual(corrupt_decision.state, RESULT_UNKNOWN)
+        self.assertTrue(corrupt_decision.quarantined)
+        self.assertTrue(corrupt_decision.legacy_suppressed)
+
+    def test_authority_release_rejections_are_always_blocked(self):
+        """Cancellation release failures never accept a SAFE fallback claim."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        installed_digest = first.storage.snapshot["installed"]["applied_plan_digest"]
+
+        blocked = Harness(
+            storage=first.storage,
+            send_results=[
+                lambda command: rejected(
+                    command,
+                    reason="AUTHORITY_RELEASE_UNCONFIRMED",
+                    fallback=FALLBACK_BLOCKED,
+                )
+            ],
+        )
+        decision = asyncio.run(
+            blocked.authority.cancel(
+                target(),
+                lease(fence=11),
+                installed_digest,
+                "OPERATOR",
+                NOW_MS,
+                "cmd-blocked",
+            )
+        )
+        self.assertEqual(decision.state, RESULT_NOT_APPLIED)
+        self.assertFalse(decision.quarantined)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertEqual(blocked.storage.snapshot["command"]["fallback"], FALLBACK_BLOCKED)
+
+        unsafe = Harness(
+            storage=blocked.storage,
+            send_results=[
+                lambda command: rejected(
+                    command,
+                    reason="PLAN_DIGEST_MISMATCH",
+                    fallback=FALLBACK_SAFE,
+                )
+            ],
+            query_results=[None],
+        )
+        decision = asyncio.run(
+            unsafe.authority.cancel(
+                target(),
+                lease(fence=12),
+                installed_digest,
+                "OPERATOR",
+                NOW_MS,
+                "cmd-unsafe",
+            )
+        )
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertTrue(decision.quarantined)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertEqual(unsafe.storage.snapshot["command"]["fallback"], FALLBACK_BLOCKED)
+
+    def test_restart_reconciles_unknown_cancellation_without_republishing(self):
+        """Power loss queries the exact cancellation ID and never sends twice."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        installed_digest = first.storage.snapshot["installed"]["applied_plan_digest"]
+        ending = Harness(
+            storage=first.storage,
+            send_results=[None],
+            query_results=[None],
+        )
+        unknown_decision = asyncio.run(
+            ending.authority.cancel(
+                target(),
+                lease(fence=11),
+                installed_digest,
+                "VALIDITY_END",
+                NOW_MS,
+                "cmd-end",
+            )
+        )
+        self.assertEqual(unknown_decision.state, RESULT_UNKNOWN)
+        self.assertTrue(unknown_decision.legacy_suppressed)
+        self.assertEqual(len(ending.sent), 1)
+
+        restarted = Harness(
+            storage=ending.storage,
+            query_results=[lambda _command: cancellation_applied(ending.sent[0])],
+        )
+        reconciled = asyncio.run(restarted.authority.reconcile(NOW_MS))
+        self.assertEqual(reconciled.state, RESULT_APPLIED)
+        self.assertFalse(reconciled.legacy_suppressed)
+        self.assertEqual(restarted.sent, [])
+        self.assertEqual(restarted.queries, ["cmd-end"])
+        self.assertIsNone(restarted.storage.snapshot["installed"])
+
+    def test_corrupt_pending_cancellation_snapshot_fails_closed(self):
+        """A restored cancellation must still name the installed plan exactly."""
+        first = Harness(send_results=[applied])
+        self.assertEqual(self.dispatch(first).state, RESULT_APPLIED)
+        installed_digest = first.storage.snapshot["installed"]["applied_plan_digest"]
+        ending = Harness(
+            storage=first.storage,
+            send_results=[None],
+            query_results=[None],
+        )
+        self.assertEqual(
+            asyncio.run(
+                ending.authority.cancel(
+                    target(),
+                    lease(fence=11),
+                    installed_digest,
+                    "VALIDITY_END",
+                    NOW_MS,
+                    "cmd-end",
+                )
+            ).state,
+            RESULT_UNKNOWN,
+        )
+        ending.storage.snapshot["command"]["plan_digest"] = "d" * 64
+
+        restarted = Harness(storage=ending.storage)
+        decision = asyncio.run(restarted.authority.legacy_decision(NOW_MS))
+        self.assertEqual(decision.state, RESULT_UNKNOWN)
+        self.assertTrue(decision.quarantined)
+        self.assertTrue(decision.legacy_suppressed)
+        self.assertEqual(restarted.sent, [])
 
     def test_lease_expiry_does_not_unsuppress_an_installed_schedule(self):
         """Lease expiry permits ownership change but does not cancel device effect."""
@@ -755,7 +1106,7 @@ class TestLatticeScheduleAuthority(unittest.TestCase):
         decision = asyncio.run(harness.authority.legacy_decision(NOW_MS))
         self.assertEqual(decision.state, RESULT_UNKNOWN)
         self.assertTrue(decision.quarantined)
-        self.assertFalse(decision.legacy_suppressed)
+        self.assertTrue(decision.legacy_suppressed)
         self.assertFalse(decision.fallback_allowed)
 
 


### PR DESCRIPTION
## Summary

Adds the pure BatPred-side v0.4 atomic schedule compiler and durable authority state machine.

- compiles a complete PredBat plan into an absolute UTC schedule with at most eight slots
- emits field-10 replacement and digest-guarded cancellation transitions
- validates retained gateway schedule capabilities and gateway-local coordinates before dispatch
- persists command identity, installed authority, terminal receipts, and UNKNOWN quarantine time for restart-safe reconciliation
- distinguishes requested, receiver-applied, and cancelled plan digests
- keeps writer exclusion after `valid_until`; only a proven replacement or cancellation ending transition can change/release it
- requires matching cancellation digest, release flag, and durable/native readback before cancellation `APPLIED` releases authority
- reconciles the original command ID without republishing after restart or uncertainty

## Safety

This tranche is deliberately disconnected from `PredBat.execute_plan`, `save_plan`, and all live transports. It cannot write to a gateway or inverter. Live wiring will be a separate, default-off stacked PR.

The implementation fails closed on:

- `UNKNOWN`, malformed/conflicting receipts, corrupt state, stale fencing, and storage/transport uncertainty
- bare or mismatched cancellation `APPLIED`
- wrong provider/access route for an ending transition
- command collisions, no-active-schedule, plan-digest mismatch, and unconfirmed authority release
- lease expiry or schedule `valid_until` without a proven ending transition

UNKNOWN and its first quarantine timestamp are durably paired; a corrupt or half-present pair suppresses the legacy writer.

## Verification

- 47/47 focused schedule-authority tests pass on Python 3.9 and Python 3.14
- Black, Ruff, cspell, pre-commit, and diff checks pass
- GitNexus staged audit: LOW risk, two files, zero affected existing execution flows
- independent review blockers were corrected before publication

## Stack

- Base: #4318
- Contract: Predictive-Cloud-Ltd/lattice-spec#38
- Tracking: Predictive-Cloud-Ltd/predbat-saas-infra#557
- Epic: Predictive-Cloud-Ltd/predbat-saas-infra#466
