### PR TITLE
feat(lattice): compose partial provider projections

### DIFF
--- a/apps/predbat/lattice_autoconfig.py
+++ b/apps/predbat/lattice_autoconfig.py
@@ -11,7 +11,7 @@ invalidate their monotonically increasing generations.  A later, separately
 gated runtime component can supply a materializer.
 """
 
-# cspell:ignore autoconfig
+# cspell:ignore autoconfig popleft
 
 import copy
 import hashlib
@@ -423,6 +423,8 @@ class ProjectionCandidate:
     cardinality: str
     required: bool
     values: tuple
+    slot_indexes: tuple
+    target_count: int
     value_kinds: tuple
     capabilities: tuple
     identity_selectors: tuple
@@ -956,11 +958,11 @@ def _projection_override_value(override, candidate):
     if candidate.cardinality == ProjectionCardinality.PER_INDEX.value:
         if not isinstance(value, tuple):
             raise AutoConfigCompileError("override {} must be an ordered per-index sequence".format(override.argument))
-        if len(value) != len(candidate.values):
+        if len(value) != candidate.target_count:
             raise AutoConfigCompileError(
                 "override {} cardinality mismatch: expected {}, got {}".format(
                     override.argument,
-                    len(candidate.values),
+                    candidate.target_count,
                     len(value),
                 )
             )
@@ -976,6 +978,111 @@ def _projection_override_value(override, candidate):
     if candidate.required and any(item is None for item in values):
         raise AutoConfigCompileError("override {} leaves a required slot empty".format(override.argument))
     return value
+
+
+def _projection_slot_indexes(projection, snapshot, targets, canonical_by_node):
+    """Map provider-local projection values onto aggregate target slots."""
+    if projection.cardinality is ProjectionCardinality.SCALAR:
+        canonical_node_id = canonical_by_node[
+            (
+                snapshot.provider_id,
+                projection.values[0].node_id,
+            )
+        ]
+        target = targets[0]
+        if canonical_node_id != target.node_id:
+            raise AutoConfigCompileError(
+                "projection {} slot 0 is unrelated to selected canonical target {}".format(
+                    projection.argument,
+                    target.node_id,
+                )
+            )
+        return (0,)
+
+    targets_by_index = {target.index: target for target in targets}
+    owned_by_local_node = {}
+    for assignment in sorted(
+        snapshot.role_assignments,
+        key=lambda item: (
+            item.group,
+            item.role.value,
+            item.index,
+            item.node_id,
+        ),
+    ):
+        if assignment.role is not projection.role or assignment.group != projection.group:
+            continue
+        target = targets_by_index.get(assignment.index)
+        if target is None:
+            continue
+        canonical_node_id = canonical_by_node[
+            (
+                snapshot.provider_id,
+                assignment.node_id,
+            )
+        ]
+        if target.node_id == canonical_node_id:
+            owned_by_local_node.setdefault(
+                assignment.node_id,
+                deque(),
+            ).append(assignment.index)
+
+    available_by_node = {}
+    for target in targets:
+        available_by_node.setdefault(target.node_id, deque()).append(target.index)
+    unowned_value_counts = {}
+    for value in projection.values:
+        if value.node_id in owned_by_local_node:
+            continue
+        canonical_node_id = canonical_by_node[
+            (
+                snapshot.provider_id,
+                value.node_id,
+            )
+        ]
+        unowned_value_counts[canonical_node_id] = unowned_value_counts.get(canonical_node_id, 0) + 1
+
+    slot_indexes = []
+    used_slots = set()
+    for value in projection.values:
+        canonical_node_id = canonical_by_node[
+            (
+                snapshot.provider_id,
+                value.node_id,
+            )
+        ]
+        available = owned_by_local_node.get(value.node_id)
+        if available is None:
+            available = available_by_node.get(canonical_node_id)
+            while available and available[0] in used_slots:
+                available.popleft()
+            if available and unowned_value_counts[canonical_node_id] != len(available):
+                raise AutoConfigCompileError(
+                    "projection {} value for {} is ambiguous across aggregate slots {}".format(
+                        projection.argument,
+                        value.node_id,
+                        tuple(available),
+                    )
+                )
+            unowned_value_counts[canonical_node_id] -= 1
+        if not available:
+            raise AutoConfigCompileError(
+                "projection {} value for {} is unrelated to an available selected target".format(
+                    projection.argument,
+                    value.node_id,
+                )
+            )
+        target_index = available.popleft()
+        if target_index in used_slots:
+            raise AutoConfigCompileError(
+                "projection {} repeats aggregate slot {}".format(
+                    projection.argument,
+                    target_index,
+                )
+            )
+        slot_indexes.append(target_index)
+        used_slots.add(target_index)
+    return tuple(slot_indexes)
 
 
 def _compile_config_projections(
@@ -1026,22 +1133,9 @@ def _compile_config_projections(
                         projection.group,
                     )
                 )
-            if projection.cardinality is ProjectionCardinality.PER_INDEX and len(projection.values) != len(targets):
-                raise AutoConfigCompileError(
-                    "projection {} cardinality mismatch: expected {}, got {}".format(
-                        projection.argument,
-                        len(targets),
-                        len(projection.values),
-                    )
-                )
             if projection.routing is ProjectionRouting.COORDINATOR and len({target.node_id for target in targets}) != 1:
                 raise AutoConfigCompileError("coordinator projection {} requires one canonical target".format(projection.argument))
-
-            values = []
-            kinds = []
-            specificities = []
-            provenance = []
-            for value_index, value in enumerate(projection.values):
+            for value in projection.values:
                 if value.node_id not in provider_nodes[snapshot.provider_id]:
                     raise AutoConfigCompileError(
                         "projection {} targets unknown provider-local node {}".format(
@@ -1049,6 +1143,18 @@ def _compile_config_projections(
                             value.node_id,
                         )
                     )
+            slot_indexes = _projection_slot_indexes(
+                projection,
+                snapshot,
+                targets,
+                canonical_by_node,
+            )
+
+            values = []
+            kinds = []
+            specificities = []
+            provenance = []
+            for value_index, value in enumerate(projection.values):
                 if value.kind is ProjectionValueKind.ENTITY:
                     matching_capabilities = {
                         access_path_id
@@ -1075,17 +1181,7 @@ def _compile_config_projections(
                                 value.access_path_id,
                             )
                         )
-                target_index = value_index if projection.cardinality is ProjectionCardinality.PER_INDEX else 0
-                canonical_node_id = canonical_by_node[(snapshot.provider_id, value.node_id)]
-                target = targets[target_index]
-                if canonical_node_id != target.node_id:
-                    raise AutoConfigCompileError(
-                        "projection {} slot {} is unrelated to selected canonical target {}".format(
-                            projection.argument,
-                            target_index,
-                            target.node_id,
-                        )
-                    )
+                target_index = slot_indexes[value_index]
 
                 specificity = 0
                 if value.identity_kind is not None:
@@ -1150,6 +1246,8 @@ def _compile_config_projections(
                 cardinality=projection.cardinality.value,
                 required=projection.required,
                 values=tuple(values),
+                slot_indexes=slot_indexes,
+                target_count=(len(targets) if projection.cardinality is ProjectionCardinality.PER_INDEX else 1),
                 value_kinds=tuple(kinds),
                 capabilities=tuple(value.capability for value in projection.values),
                 identity_selectors=tuple(
@@ -1199,7 +1297,7 @@ def _compile_config_projections(
                 candidate.cardinality,
                 candidate.required,
                 candidate.transforms,
-                len(candidate.values),
+                candidate.target_count,
             )
             for candidate in candidates
         }
@@ -1211,10 +1309,28 @@ def _compile_config_projections(
         selected_values = []
         selected_provenance = []
         if override is None:
-            for index in range(len(first.values)):
-                highest_specificity = max(candidate.specificities[index] for candidate in candidates)
-                selected = tuple(candidate for candidate in candidates if candidate.specificities[index] == highest_specificity)
-                kinds = {candidate.value_kinds[index] for candidate in selected}
+            for index in range(first.target_count):
+                slot_candidates = tuple(
+                    (
+                        candidate,
+                        candidate.slot_indexes.index(index),
+                    )
+                    for candidate in candidates
+                    if index in candidate.slot_indexes
+                )
+                if not slot_candidates:
+                    if first.required:
+                        raise AutoConfigCompileError(
+                            "projection {} cardinality mismatch: required slot {} has no provider candidate".format(
+                                argument,
+                                index,
+                            )
+                        )
+                    selected_values.append(None)
+                    continue
+                highest_specificity = max(candidate.specificities[value_index] for candidate, value_index in slot_candidates)
+                selected = tuple((candidate, value_index) for candidate, value_index in slot_candidates if candidate.specificities[value_index] == highest_specificity)
+                kinds = {candidate.value_kinds[value_index] for candidate, value_index in selected}
                 if len(kinds) != 1:
                     raise AutoConfigCompileError(
                         "projection {} type mismatch at slot {}".format(
@@ -1222,7 +1338,7 @@ def _compile_config_projections(
                             index,
                         )
                     )
-                canonical_values = {_canonical_json(candidate.values[index]) for candidate in selected}
+                canonical_values = {_canonical_json(candidate.values[value_index]) for candidate, value_index in selected}
                 if len(canonical_values) != 1:
                     raise AutoConfigCompileError(
                         "ambiguous multi-provider projection {} at slot {}".format(
@@ -1230,8 +1346,8 @@ def _compile_config_projections(
                             index,
                         )
                     )
-                selected_values.append(selected[0].values[index])
-                selected_provenance.extend(source for candidate in selected for source in candidate.provenance[index])
+                selected_values.append(selected[0][0].values[selected[0][1]])
+                selected_provenance.extend(source for candidate, value_index in selected for source in candidate.provenance[value_index])
             if first.cardinality == ProjectionCardinality.PER_INDEX.value:
                 effective_value = tuple(selected_values)
             else:

--- a/apps/predbat/tests/test_lattice_autoconfig.py
+++ b/apps/predbat/tests/test_lattice_autoconfig.py
@@ -165,6 +165,40 @@ def projection_value(
     )
 
 
+def partial_projection_snapshot(
+    provider,
+    node_id,
+    index,
+    argument,
+    value,
+    required=True,
+    identity_aliases=(),
+):
+    """Build one provider-owned aggregate slot and local projection value."""
+    roles = tuple(
+        ProviderRoleAssignment(
+            role,
+            "inverters",
+            index,
+            node_id,
+        )
+        for role in (AliasRole.PRIMARY, AliasRole.CONTROL)
+    )
+    return projection_snapshot(
+        provider,
+        (node_id,),
+        roles,
+        (
+            config_projection(
+                argument,
+                (value,),
+                required=required,
+            ),
+        ),
+        identity_aliases=identity_aliases,
+    )
+
+
 def config_projection(
     argument,
     values,
@@ -523,6 +557,362 @@ class TestPlanCompilation(unittest.TestCase):
 
 class TestConfigProjectionCompilation(unittest.TestCase):
     """Provider contracts project selected indexed capabilities into config."""
+
+    def test_disjoint_providers_compose_partial_indexed_slots(self):
+        """Each provider can fill its own slot without publishing aggregate width."""
+        gateway = partial_projection_snapshot(
+            "gateway",
+            "GW1",
+            0,
+            "battery_power",
+            projection_value(
+                "GW1",
+                ProjectionValueKind.ENTITY,
+                "sensor.gateway_battery_power",
+            ),
+        )
+        cloud = partial_projection_snapshot(
+            "cloud",
+            "CLOUD1",
+            1,
+            "battery_power",
+            projection_value(
+                "CLOUD1",
+                ProjectionValueKind.ENTITY,
+                "sensor.cloud_battery_power",
+            ),
+        )
+
+        left = compile_auto_config((gateway, cloud))
+        right = compile_auto_config((cloud, gateway))
+        argument = left.config_arguments[0]
+
+        self.assertEqual(left.digest, right.digest)
+        self.assertEqual(
+            left.projected_config["battery_power"],
+            (
+                "sensor.gateway_battery_power",
+                "sensor.cloud_battery_power",
+            ),
+        )
+        self.assertEqual(
+            {
+                candidate.provider_id: (
+                    candidate.slot_indexes,
+                    candidate.target_count,
+                    candidate.values,
+                )
+                for candidate in argument.candidates
+            },
+            {
+                "gateway": (
+                    (0,),
+                    2,
+                    ("sensor.gateway_battery_power",),
+                ),
+                "cloud": (
+                    (1,),
+                    2,
+                    ("sensor.cloud_battery_power",),
+                ),
+            },
+        )
+        self.assertEqual(
+            [
+                (
+                    source.field_path,
+                    source.provider_id,
+                )
+                for source in argument.provenance
+            ],
+            [
+                ("/projected_config/battery_power/0", "gateway"),
+                ("/projected_config/battery_power/1", "cloud"),
+            ],
+        )
+        self.assertFalse(left.materialization_readiness.ready)
+        self.assertEqual(
+            left.materialization_readiness.blockers,
+            ("atomic_materializer_missing",),
+        )
+
+    def test_provider_owned_slot_disambiguates_repeated_canonical_node(self):
+        """Explicit roles place correlated providers in their owned slots."""
+        identity = "SER-SHARED"
+        gateway = partial_projection_snapshot(
+            "gateway",
+            "GW1",
+            0,
+            "battery_power",
+            projection_value(
+                "GW1",
+                ProjectionValueKind.ENTITY,
+                "sensor.gateway_battery_power",
+            ),
+            identity_aliases=(
+                ProviderIdentityAlias(
+                    "serial",
+                    identity,
+                    "GW1",
+                ),
+            ),
+        )
+        cloud = partial_projection_snapshot(
+            "cloud",
+            "CLOUD1",
+            1,
+            "battery_power",
+            projection_value(
+                "CLOUD1",
+                ProjectionValueKind.ENTITY,
+                "sensor.cloud_battery_power",
+            ),
+            identity_aliases=(
+                ProviderIdentityAlias(
+                    "serial",
+                    identity,
+                    "CLOUD1",
+                ),
+            ),
+        )
+
+        plan = compile_auto_config((gateway, cloud))
+
+        self.assertEqual(
+            plan.projected_config["battery_power"],
+            (
+                "sensor.gateway_battery_power",
+                "sensor.cloud_battery_power",
+            ),
+        )
+        self.assertEqual(
+            {candidate.provider_id: candidate.slot_indexes for candidate in plan.config_arguments[0].candidates},
+            {
+                "gateway": (0,),
+                "cloud": (1,),
+            },
+        )
+
+    def test_repeated_node_projection_ignores_role_declaration_order(self):
+        """Role tuple order cannot swap values between repeated node slots."""
+        roles = tuple(
+            ProviderRoleAssignment(
+                role,
+                "inverters",
+                index,
+                "GW1",
+            )
+            for index in (0, 1)
+            for role in (AliasRole.PRIMARY, AliasRole.CONTROL)
+        )
+        projection = config_projection(
+            "battery_power",
+            (
+                projection_value(
+                    "GW1",
+                    ProjectionValueKind.ENTITY,
+                    "sensor.gateway_slot_0",
+                ),
+                projection_value(
+                    "GW1",
+                    ProjectionValueKind.ENTITY,
+                    "sensor.gateway_slot_1",
+                ),
+            ),
+        )
+        left = projection_snapshot(
+            "gateway",
+            ("GW1",),
+            roles,
+            (projection,),
+        )
+        right = projection_snapshot(
+            "gateway",
+            ("GW1",),
+            tuple(reversed(roles)),
+            (projection,),
+        )
+
+        left_plan = compile_auto_config((left,))
+        right_plan = compile_auto_config((right,))
+
+        self.assertEqual(left_plan.digest, right_plan.digest)
+        self.assertEqual(
+            left_plan.projected_config["battery_power"],
+            (
+                "sensor.gateway_slot_0",
+                "sensor.gateway_slot_1",
+            ),
+        )
+
+    def test_unowned_value_cannot_guess_between_repeated_canonical_slots(self):
+        """A correlated observer must not guess which repeated slot it fills."""
+        identity = "SER-AMBIGUOUS"
+
+        def target_provider(provider, node_id, index):
+            """Build one indexed target without a config projection."""
+            roles = tuple(
+                ProviderRoleAssignment(
+                    role,
+                    "inverters",
+                    index,
+                    node_id,
+                )
+                for role in (AliasRole.PRIMARY, AliasRole.CONTROL)
+            )
+            return projection_snapshot(
+                provider,
+                (node_id,),
+                roles,
+                (),
+                identity_aliases=(
+                    ProviderIdentityAlias(
+                        "serial",
+                        identity,
+                        node_id,
+                    ),
+                ),
+            )
+
+        observer = projection_snapshot(
+            "observer",
+            ("OBS1",),
+            (),
+            (
+                config_projection(
+                    "battery_power",
+                    (
+                        projection_value(
+                            "OBS1",
+                            ProjectionValueKind.ENTITY,
+                            "sensor.observer_battery_power",
+                        ),
+                    ),
+                ),
+            ),
+            identity_aliases=(
+                ProviderIdentityAlias(
+                    "serial",
+                    identity,
+                    "OBS1",
+                ),
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            AutoConfigCompileError,
+            "ambiguous across aggregate slots",
+        ):
+            compile_auto_config(
+                (
+                    target_provider("gateway", "GW1", 0),
+                    target_provider("cloud", "CLOUD1", 1),
+                    observer,
+                )
+            )
+
+    def test_partial_indexed_user_override_covers_aggregate_shape(self):
+        """A user override resolves the complete array and retains candidates."""
+        gateway = partial_projection_snapshot(
+            "gateway",
+            "GW1",
+            0,
+            "battery_power",
+            projection_value(
+                "GW1",
+                ProjectionValueKind.ENTITY,
+                "sensor.gateway_candidate",
+            ),
+        )
+        cloud = partial_projection_snapshot(
+            "cloud",
+            "CLOUD1",
+            1,
+            "battery_power",
+            projection_value(
+                "CLOUD1",
+                ProjectionValueKind.ENTITY,
+                "sensor.cloud_candidate",
+            ),
+        )
+        override = UserConfigOverride(
+            "battery_power",
+            [
+                "sensor.user_slot_0",
+                "sensor.user_slot_1",
+            ],
+            "/apps.yaml/battery_power",
+        )
+
+        plan = compile_auto_config(
+            (gateway, cloud),
+            user_overrides=(override,),
+        )
+        argument = plan.config_arguments[0]
+
+        self.assertEqual(
+            plan.projected_config["battery_power"],
+            (
+                "sensor.user_slot_0",
+                "sensor.user_slot_1",
+            ),
+        )
+        self.assertEqual(
+            {source.provider_id for source in argument.candidate_provenance},
+            {"gateway", "cloud"},
+        )
+        self.assertEqual(
+            [source.provider_id for source in argument.provenance],
+            ["user_override"],
+        )
+
+    def test_optional_partial_projection_preserves_aggregate_hole(self):
+        """An absent optional slot remains explicit None in the final array."""
+        cloud_roles = tuple(
+            ProviderRoleAssignment(
+                role,
+                "inverters",
+                1,
+                "CLOUD1",
+            )
+            for role in (AliasRole.PRIMARY, AliasRole.CONTROL)
+        )
+        gateway = partial_projection_snapshot(
+            "gateway",
+            "GW1",
+            0,
+            "pause_mode",
+            projection_value(
+                "GW1",
+                ProjectionValueKind.NONE,
+            ),
+            required=False,
+        )
+        cloud = projection_snapshot(
+            "cloud",
+            ("CLOUD1",),
+            cloud_roles,
+            (),
+        )
+
+        plan = compile_auto_config((gateway, cloud))
+
+        self.assertEqual(
+            plan.projected_config["pause_mode"],
+            (None, None),
+        )
+        self.assertEqual(
+            {
+                (
+                    source.field_path,
+                    source.provider_id,
+                )
+                for source in plan.config_arguments[0].candidate_provenance
+            },
+            {
+                ("/projected_config/pause_mode/0", "gateway"),
+            },
+        )
 
     def test_gateway_multi_aio_projects_ordered_leaf_arrays(self):
         """Two Gateway-like AIO nodes produce deterministic per-index arrays."""


### PR DESCRIPTION
## Summary

- let disjoint provider fragments contribute only the indexed auto-config slots they own
- keep aggregate target width and final array assembly in the Lattice compiler
- preserve deterministic provider/role ordering, provenance, scalar behavior, and user overrides
- reject ambiguous correlated values instead of guessing between repeated canonical slots
- keep materialization fail-closed with `atomic_materializer_missing`

## Safety properties

- required aggregate gaps reject the whole candidate
- optional gaps become explicit `None`
- user overrides must match the compiler-owned aggregate width
- explicit provider role ownership disambiguates repeated canonical nodes
- unowned correlated projections fail closed when more than one aggregate slot could match
- fragment/provider order does not affect the semantic digest or projected output
- no production registration, configuration write, or materializer is added

## Verification

- 64 focused and adjacent tests passed on Python 3.9, 3.11, and 3.14
- Black, Ruff, cspell, and pre-commit checks passed
- GitNexus staged change detection: LOW, two files, zero affected existing symbols or flows

Tracks Predictive-Cloud-Ltd/predbat-saas-infra#561 and #466.
