### PR TITLE
feat(lattice): publish durable compiled config

### DIFF
--- a/apps/predbat/lattice_compiled_publication.py
+++ b/apps/predbat/lattice_compiled_publication.py
@@ -1,0 +1,756 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System - compiled Lattice publication
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+"""Durable immutable publication for compiled Lattice auto-configuration.
+
+The component in this module is deliberately additive and shadow-only.  It
+uses the pure compiler's existing single-flight invalidation state machine,
+but replaces its future materializer hand-off with one atomic publication.
+It has no integration registry, MQTT, Home Assistant, configuration-write, or
+other production runtime dependency.
+"""
+
+# cspell:ignore autoconfig
+
+import hashlib
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from lattice_autoconfig import (
+    AutoConfigCompileError,
+    AutoConfigPlan,
+    CompileIssue,
+    CompileRun,
+    CompileStatus,
+    LatticeAutoConfigCompiler,
+    MaterializationReadiness,
+    UserConfigOverride,
+    _canonical_json,
+    _plain,
+    compile_auto_config,
+)
+from lattice_topology import TopologyValidationError
+
+
+@dataclass(frozen=True)
+class CompilationInvalidation:
+    """One accepted input cause retained until a successful compile."""
+
+    source_type: str
+    source_id: str
+    generation: int
+    reason: str
+
+    def __post_init__(self):
+        """Validate and normalize one auditable invalidation cause."""
+        if self.source_type not in ("provider", "user_override"):
+            raise ValueError("invalidation source_type must be provider or user_override")
+        if not isinstance(self.source_id, str) or not self.source_id.strip():
+            raise ValueError("invalidation source_id must be a non-empty string")
+        if not isinstance(self.generation, int) or isinstance(self.generation, bool) or self.generation < 0:
+            raise ValueError("invalidation generation must be a non-negative integer")
+        if not isinstance(self.reason, str) or not self.reason.strip():
+            raise ValueError("invalidation reason must be a non-empty string")
+        object.__setattr__(self, "source_id", self.source_id.strip())
+        object.__setattr__(self, "reason", self.reason.strip())
+
+
+@dataclass(frozen=True)
+class UserOverrideSnapshot:
+    """One durable generation of explicit runtime user overrides."""
+
+    generation: int
+    overrides: tuple
+
+    def __post_init__(self):
+        """Detach ordering from the reader and reject ambiguous arguments."""
+        if not isinstance(self.generation, int) or isinstance(self.generation, bool) or self.generation < 0:
+            raise ValueError("override generation must be a non-negative integer")
+        if isinstance(self.overrides, (str, bytes)):
+            raise ValueError("overrides must be an iterable of UserConfigOverride values")
+        try:
+            overrides = tuple(self.overrides)
+        except TypeError as exc:
+            raise ValueError("overrides must be an iterable of UserConfigOverride values") from exc
+        if any(not isinstance(item, UserConfigOverride) for item in overrides):
+            raise ValueError("overrides must contain UserConfigOverride values")
+        arguments = [item.argument for item in overrides]
+        if len(arguments) != len(set(arguments)):
+            raise ValueError("override arguments must be unique")
+        object.__setattr__(
+            self,
+            "overrides",
+            tuple(sorted(overrides, key=lambda item: item.argument)),
+        )
+
+
+@dataclass(frozen=True)
+class CompiledLatticeDiagnostics:
+    """Immutable status and diagnostics for one compiler observation."""
+
+    status: CompileStatus
+    stale: bool
+    degraded: bool
+    issues: tuple
+    readiness: Optional[MaterializationReadiness]
+
+    def __post_init__(self):
+        """Reject contradictory status flags or mutable diagnostic inputs."""
+        if not isinstance(self.status, CompileStatus):
+            raise ValueError("diagnostic status must be a CompileStatus")
+        if not isinstance(self.stale, bool) or not isinstance(self.degraded, bool):
+            raise ValueError("diagnostic flags must be booleans")
+        if self.stale != (self.status is CompileStatus.STALE):
+            raise ValueError("stale flag must match STALE status")
+        if self.degraded != (self.status is CompileStatus.DEGRADED):
+            raise ValueError("degraded flag must match DEGRADED status")
+        issues = tuple(self.issues)
+        if any(not isinstance(issue, CompileIssue) for issue in issues):
+            raise ValueError("diagnostic issues must contain CompileIssue values")
+        if self.readiness is not None and not isinstance(
+            self.readiness,
+            MaterializationReadiness,
+        ):
+            raise ValueError("diagnostic readiness must be MaterializationReadiness or None")
+        object.__setattr__(self, "issues", issues)
+
+
+@dataclass(frozen=True)
+class CompiledLatticePublication:
+    """One immutable version with its full durable provider input cursor."""
+
+    lattice_version: int
+    digest: str
+    provider_generations: tuple
+    provider_fingerprints: tuple
+    provider_requested_generations: tuple
+    user_override_generation: Optional[int]
+    user_override_fingerprint: Optional[str]
+    user_override_requested_generation: Optional[int]
+    invalidation_causes: tuple
+    feedback_token: str
+    diagnostics: CompiledLatticeDiagnostics
+    plan: AutoConfigPlan
+
+    def __post_init__(self):
+        """Validate publication integrity and normalize deterministic tuples."""
+        if not isinstance(self.lattice_version, int) or isinstance(self.lattice_version, bool) or self.lattice_version < 1:
+            raise ValueError("lattice_version must be a positive integer")
+        if not isinstance(self.digest, str) or not self.digest:
+            raise ValueError("publication digest must be a non-empty string")
+        if not isinstance(self.plan, AutoConfigPlan):
+            raise ValueError("publication plan must be an AutoConfigPlan")
+        if self.plan.digest != self.digest:
+            raise ValueError("publication digest must match its plan")
+
+        provider_generations = tuple(self.provider_generations)
+        if any(not isinstance(provider_id, str) or not provider_id or not isinstance(generation, int) or isinstance(generation, bool) or generation < 0 for provider_id, generation in provider_generations):
+            raise ValueError("publication provider generations are invalid")
+        if provider_generations != tuple(sorted(set(provider_generations))):
+            raise ValueError("publication provider generations must be unique and sorted")
+        durable_generations = dict(provider_generations)
+        plan_generations = tuple(self.plan.provider_generations)
+        if any(durable_generations.get(provider_id) != generation for provider_id, generation in plan_generations):
+            raise ValueError("plan provider generations must be a consistent subset of the durable cursor")
+
+        provider_fingerprints = tuple(self.provider_fingerprints)
+        fingerprint_keys = []
+        for item in provider_fingerprints:
+            if not isinstance(item, tuple) or len(item) != 3:
+                raise ValueError("provider fingerprints must contain provider/generation/digest tuples")
+            provider_id, generation, fingerprint = item
+            if not isinstance(provider_id, str) or not provider_id or not isinstance(generation, int) or isinstance(generation, bool) or generation < 0 or not isinstance(fingerprint, str) or not fingerprint:
+                raise ValueError("publication provider fingerprint is invalid")
+            fingerprint_keys.append((provider_id, generation))
+        if tuple(fingerprint_keys) != provider_generations:
+            raise ValueError("publication provider fingerprints must match provider generations")
+
+        provider_requested_generations = tuple(self.provider_requested_generations)
+        if any(not isinstance(provider_id, str) or not provider_id or not isinstance(generation, int) or isinstance(generation, bool) or generation < 0 for provider_id, generation in provider_requested_generations):
+            raise ValueError("publication provider requested generations are invalid")
+        if provider_requested_generations != tuple(sorted(set(provider_requested_generations))):
+            raise ValueError("publication provider requested generations must be unique and sorted")
+        requested_by_provider = dict(provider_requested_generations)
+        if any(requested_by_provider.get(provider_id, -1) < generation for provider_id, generation in provider_generations):
+            raise ValueError("provider requested generations must cover the observed cursor")
+
+        if (self.user_override_generation is None) != (self.user_override_fingerprint is None):
+            raise ValueError("override generation and fingerprint must both be present or absent")
+        if self.user_override_generation is not None:
+            if not isinstance(self.user_override_generation, int) or isinstance(self.user_override_generation, bool) or self.user_override_generation < 0 or not isinstance(self.user_override_fingerprint, str) or not self.user_override_fingerprint:
+                raise ValueError("publication override generation is invalid")
+        if self.user_override_generation is not None and self.user_override_requested_generation is None:
+            raise ValueError("observed override cursor requires a requested generation")
+        if self.user_override_requested_generation is not None:
+            if not isinstance(self.user_override_requested_generation, int) or isinstance(self.user_override_requested_generation, bool) or self.user_override_requested_generation < 0:
+                raise ValueError("publication override requested generation is invalid")
+            if self.user_override_generation is not None and self.user_override_requested_generation < self.user_override_generation:
+                raise ValueError("override requested generation must cover the observed cursor")
+
+        causes = tuple(sorted(set(self.invalidation_causes), key=_cause_sort_key))
+        if any(not isinstance(cause, CompilationInvalidation) for cause in causes):
+            raise ValueError("publication invalidation causes must contain CompilationInvalidation values")
+        if not isinstance(self.feedback_token, str) or not self.feedback_token.strip():
+            raise ValueError("publication feedback_token must be a non-empty string")
+        if not isinstance(self.diagnostics, CompiledLatticeDiagnostics):
+            raise ValueError("publication diagnostics must be CompiledLatticeDiagnostics")
+        if self.diagnostics.status not in (
+            CompileStatus.FRESH,
+            CompileStatus.DEGRADED,
+        ):
+            raise ValueError("only successful compile diagnostics may be published")
+        if self.diagnostics.stale:
+            raise ValueError("a successful immutable publication cannot be stale")
+        if self.diagnostics.readiness != getattr(
+            self.plan,
+            "materialization_readiness",
+            None,
+        ):
+            raise ValueError("publication readiness must match its plan")
+
+        object.__setattr__(self, "provider_generations", provider_generations)
+        object.__setattr__(self, "provider_fingerprints", provider_fingerprints)
+        object.__setattr__(self, "provider_requested_generations", provider_requested_generations)
+        object.__setattr__(self, "invalidation_causes", causes)
+        object.__setattr__(self, "feedback_token", self.feedback_token.strip())
+
+
+@dataclass(frozen=True)
+class CompiledLatticeRun(CompileRun):
+    """One drain result plus durable publication and live diagnostics."""
+
+    publication: Optional[CompiledLatticePublication]
+    published: bool
+    diagnostics: CompiledLatticeDiagnostics
+    causes: tuple
+
+    def __post_init__(self):
+        """Validate the additive publication-specific run fields."""
+        if self.publication is not None and not isinstance(
+            self.publication,
+            CompiledLatticePublication,
+        ):
+            raise ValueError("run publication must be CompiledLatticePublication or None")
+        if not isinstance(self.published, bool):
+            raise ValueError("run published flag must be a boolean")
+        if not isinstance(self.diagnostics, CompiledLatticeDiagnostics):
+            raise ValueError("run diagnostics must be CompiledLatticeDiagnostics")
+        causes = tuple(sorted(set(self.causes), key=_cause_sort_key))
+        if any(not isinstance(cause, CompilationInvalidation) for cause in causes):
+            raise ValueError("run causes must contain CompilationInvalidation values")
+        object.__setattr__(self, "causes", causes)
+
+
+class CompiledLatticeStateStore:
+    """Injected durable compare-and-swap publication store contract."""
+
+    def load(self):
+        """Return the current CompiledLatticePublication or None."""
+        raise NotImplementedError
+
+    def compare_and_publish(self, expected_version, publication):
+        """Atomically publish when the durable version equals expected_version."""
+        raise NotImplementedError
+
+
+class InMemoryCompiledLatticeStateStore(CompiledLatticeStateStore):
+    """Thread-safe reference store for tests; deliberately not durable."""
+
+    def __init__(self, publication=None):
+        """Create a store optionally seeded with a validated publication."""
+        if publication is not None and not isinstance(
+            publication,
+            CompiledLatticePublication,
+        ):
+            raise ValueError("initial publication must be CompiledLatticePublication or None")
+        self._lock = threading.RLock()
+        self._publication = publication
+        self._writes = 0
+
+    @property
+    def writes(self):
+        """Return the number of successful atomic publications."""
+        with self._lock:
+            return self._writes
+
+    def load(self):
+        """Return the immutable current publication."""
+        with self._lock:
+            return self._publication
+
+    def compare_and_publish(self, expected_version, publication):
+        """Atomically publish exactly the next monotonic version."""
+        if not isinstance(expected_version, int) or isinstance(expected_version, bool) or expected_version < 0:
+            raise ValueError("expected_version must be a non-negative integer")
+        if not isinstance(publication, CompiledLatticePublication):
+            raise ValueError("publication must be a CompiledLatticePublication")
+        if publication.lattice_version != expected_version + 1:
+            raise ValueError("publication version must be exactly expected_version + 1")
+        with self._lock:
+            current_version = self._publication.lattice_version if self._publication is not None else 0
+            if current_version != expected_version:
+                return False
+            self._publication = publication
+            self._writes += 1
+            return True
+
+
+def _cause_sort_key(cause):
+    """Return deterministic ordering for generic compiler invalidations."""
+    return (
+        cause.source_type,
+        cause.source_id,
+        cause.generation,
+        cause.reason,
+    )
+
+
+def _fingerprint_overrides(snapshot):
+    """Bind one override generation to its exact immutable contents."""
+    payload = {
+        "generation": snapshot.generation,
+        "overrides": [
+            {
+                "argument": item.argument,
+                "value": _plain(item.value),
+                "source_path": item.source_path,
+            }
+            for item in snapshot.overrides
+        ],
+    }
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _same_durable_input(left, right):
+    """Compare successful durable input cursors and observable diagnostics."""
+    return (
+        left.digest == right.digest
+        and left.provider_generations == right.provider_generations
+        and left.provider_fingerprints == right.provider_fingerprints
+        and left.provider_requested_generations == right.provider_requested_generations
+        and left.user_override_generation == right.user_override_generation
+        and left.user_override_fingerprint == right.user_override_fingerprint
+        and left.user_override_requested_generation == right.user_override_requested_generation
+        and left.diagnostics == right.diagnostics
+    )
+
+
+def _causes_represented(causes, publication):
+    """Return whether one publication already audits every local cause."""
+    return set(causes).issubset(set(publication.invalidation_causes))
+
+
+class CompiledLatticeCompiler(LatticeAutoConfigCompiler):
+    """Dedicated shadow compiler that owns durable Lattice publication."""
+
+    _OVERRIDE_SOURCE_ID = "user-overrides"
+
+    def __init__(
+        self,
+        readers=None,
+        state_store=None,
+        override_reader=None,
+    ):
+        """Create a publisher over registered fragment and override readers."""
+        if state_store is None:
+            raise ValueError("a durable compiled-Lattice state_store is required")
+        if not callable(getattr(state_store, "load", None)) or not callable(getattr(state_store, "compare_and_publish", None)):
+            raise ValueError("state_store must provide load and compare_and_publish")
+        if override_reader is not None and not callable(override_reader):
+            raise ValueError("override_reader must be callable")
+
+        super().__init__(readers=readers, materializer=None)
+        self._state_store = state_store
+        self._override_reader = override_reader
+        self._override_requested_generation = -1
+        self._override_observed_generation = -1
+        self._override_generation_fingerprints = {}
+        self._pending_causes = set()
+        self._candidate_issues = ()
+        self._candidate_override_generation = None
+        self._candidate_override_fingerprint = None
+        self._publication = None
+        self._drain_local = threading.local()
+
+        loaded = self._state_store.load()
+        if loaded is not None and not isinstance(
+            loaded,
+            CompiledLatticePublication,
+        ):
+            raise ValueError("state_store.load must return CompiledLatticePublication or None")
+        if loaded is not None:
+            if (loaded.user_override_generation is not None or loaded.user_override_requested_generation is not None) and self._override_reader is None:
+                raise ValueError("a published user-override input requires override_reader")
+            with self._lock:
+                self._install_publication(loaded)
+
+    @property
+    def publication(self):
+        """Return the last durable immutable compiled-Lattice publication."""
+        with self._lock:
+            return self._publication
+
+    @property
+    def diagnostics(self):
+        """Return current live diagnostics without mutating the publication."""
+        with self._lock:
+            readiness = self._publication.plan.materialization_readiness if self._publication is not None else None
+            return CompiledLatticeDiagnostics(
+                status=self._status,
+                stale=self._status is CompileStatus.STALE,
+                degraded=self._status is CompileStatus.DEGRADED,
+                issues=self._issues,
+                readiness=readiness,
+            )
+
+    def invalidate(
+        self,
+        provider_id,
+        generation,
+        reason,
+        feedback_token=None,
+    ):
+        """Invalidate any registered provider and retain its audit cause."""
+        with self._lock:
+            accepted = super().invalidate(
+                provider_id,
+                generation,
+                reason,
+                feedback_token,
+            )
+            if accepted:
+                self._pending_causes.add(
+                    CompilationInvalidation(
+                        "provider",
+                        provider_id,
+                        generation,
+                        reason,
+                    )
+                )
+            return accepted
+
+    def invalidate_user_overrides(
+        self,
+        generation,
+        reason,
+        feedback_token=None,
+    ):
+        """Invalidate the durable user-override input monotonically."""
+        if self._override_reader is None:
+            raise RuntimeError("user override reader is not configured")
+        if not isinstance(generation, int) or isinstance(generation, bool) or generation < 0:
+            raise ValueError("generation must be a non-negative integer")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("reason must be a non-empty string")
+        with self._lock:
+            if feedback_token is not None and feedback_token in self._feedback_tokens:
+                return False
+            previous = max(
+                self._override_requested_generation,
+                self._override_observed_generation,
+            )
+            if generation <= previous:
+                return False
+            self._override_requested_generation = generation
+            self._pending_causes.add(
+                CompilationInvalidation(
+                    "user_override",
+                    self._OVERRIDE_SOURCE_ID,
+                    generation,
+                    reason,
+                )
+            )
+            if self._compiling:
+                self._follow_up = True
+            else:
+                self._pending = True
+            return True
+
+    def _read_user_overrides(self):
+        """Fresh-read and validate the complete optional override snapshot."""
+        if self._override_reader is None:
+            self._candidate_override_generation = None
+            self._candidate_override_fingerprint = None
+            return (), ()
+        try:
+            snapshot = self._override_reader()
+            if not isinstance(snapshot, UserOverrideSnapshot):
+                raise ValueError("override reader must return UserOverrideSnapshot")
+            fingerprint = _fingerprint_overrides(snapshot)
+            with self._lock:
+                required_generation = self._override_requested_generation
+                previous_generation = self._override_observed_generation
+                previous_fingerprint = self._override_generation_fingerprints.get(snapshot.generation)
+                if snapshot.generation < previous_generation:
+                    raise ValueError(
+                        "override generation {} regressed from {}".format(
+                            snapshot.generation,
+                            previous_generation,
+                        )
+                    )
+                if previous_fingerprint is not None and previous_fingerprint != fingerprint:
+                    raise ValueError("override generation {} was reused with different content".format(snapshot.generation))
+                if snapshot.generation < required_generation:
+                    raise ValueError(
+                        "override generation {} is behind invalidation {}".format(
+                            snapshot.generation,
+                            required_generation,
+                        )
+                    )
+                self._override_observed_generation = snapshot.generation
+                self._override_requested_generation = max(
+                    required_generation,
+                    snapshot.generation,
+                )
+                self._override_generation_fingerprints[snapshot.generation] = fingerprint
+                self._candidate_override_generation = snapshot.generation
+                self._candidate_override_fingerprint = fingerprint
+            return snapshot.overrides, ()
+        except (TypeError, ValueError) as exc:
+            return (), (
+                CompileIssue(
+                    "user_overrides_invalid",
+                    str(exc),
+                    self._OVERRIDE_SOURCE_ID,
+                ),
+            )
+        except Exception as exc:
+            return (), (
+                CompileIssue(
+                    "user_overrides_read_failed",
+                    "{}: {}".format(type(exc).__name__, exc),
+                    self._OVERRIDE_SOURCE_ID,
+                ),
+            )
+
+    def _compile_attempt(self):
+        """Fresh-read every input and compile exactly one candidate plan."""
+        snapshots, provider_issues = self._read_all()
+        overrides, override_issues = self._read_user_overrides()
+        issues = provider_issues + override_issues
+        if override_issues:
+            detail = "durable user overrides are unavailable or invalid"
+            self._candidate_issues = issues + (CompileIssue("compile_failed", detail),)
+            return None, self._candidate_issues
+
+        with self._lock:
+            active_providers = set(dict(self._active_plan.provider_generations)) if self._active_plan is not None else set()
+        usable_providers = {snapshot.provider_id for snapshot in snapshots}
+        unavailable_active = sorted(active_providers - usable_providers)
+        if unavailable_active:
+            detail = "previously active provider(s) unavailable: {}".format(", ".join(unavailable_active))
+            self._candidate_issues = issues + (
+                CompileIssue("active_provider_unavailable", detail),
+                CompileIssue("compile_failed", detail),
+            )
+            return None, self._candidate_issues
+
+        try:
+            plan = compile_auto_config(snapshots, overrides)
+        except (
+            AutoConfigCompileError,
+            TopologyValidationError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            self._candidate_issues = issues + (CompileIssue("compile_failed", str(exc)),)
+            return None, self._candidate_issues
+        self._candidate_issues = issues
+        return plan, issues
+
+    def _materialize_if_changed(self, plan):
+        """Publish each changed durable input cursor without materializing."""
+        with self._lock:
+            causes = tuple(sorted(self._pending_causes, key=_cause_sort_key))
+            self._drain_local.hook_called = True
+            self._drain_local.causes = causes
+
+            expected_version = self._publication.lattice_version if self._publication is not None else 0
+            lattice_version = expected_version + 1
+            feedback_token = "lattice-publication-{}-{}".format(
+                lattice_version,
+                plan.digest[:16],
+            )
+            status = CompileStatus.DEGRADED if self._candidate_issues else CompileStatus.FRESH
+            provider_generations, provider_fingerprints, provider_requested_generations = self._durable_provider_cursor()
+            diagnostics = CompiledLatticeDiagnostics(
+                status=status,
+                stale=False,
+                degraded=status is CompileStatus.DEGRADED,
+                issues=self._candidate_issues,
+                readiness=plan.materialization_readiness,
+            )
+            publication = CompiledLatticePublication(
+                lattice_version=lattice_version,
+                digest=plan.digest,
+                provider_generations=provider_generations,
+                provider_fingerprints=provider_fingerprints,
+                provider_requested_generations=provider_requested_generations,
+                user_override_generation=self._candidate_override_generation,
+                user_override_fingerprint=self._candidate_override_fingerprint,
+                user_override_requested_generation=(self._override_requested_generation if self._override_reader is not None and self._override_requested_generation >= 0 else None),
+                invalidation_causes=causes,
+                feedback_token=feedback_token,
+                diagnostics=diagnostics,
+                plan=plan,
+            )
+            if self._publication is not None and _same_durable_input(self._publication, publication) and _causes_represented(causes, self._publication):
+                self._active_plan = self._publication.plan
+                self._pending_causes.clear()
+                return 0, ()
+            self._feedback_tokens.append(feedback_token)
+
+            try:
+                committed = self._state_store.compare_and_publish(
+                    expected_version,
+                    publication,
+                )
+            except Exception as exc:
+                recovered = self._recover_ambiguous_publication(publication)
+                if recovered:
+                    self._pending_causes.clear()
+                    self._drain_local.published = True
+                    return 0, ()
+                detail = "{}: {}".format(type(exc).__name__, exc)
+                return 0, (
+                    CompileIssue("publication_failed", detail),
+                    CompileIssue(
+                        "compile_failed",
+                        "compiled-Lattice publication failed",
+                    ),
+                )
+
+            if committed is not True:
+                try:
+                    current = self._load_current_publication()
+                except Exception as exc:
+                    detail = "{}: {}".format(type(exc).__name__, exc)
+                    return 0, (
+                        CompileIssue("publication_failed", detail),
+                        CompileIssue(
+                            "compile_failed",
+                            "compiled-Lattice publication state could not be reloaded",
+                        ),
+                    )
+                if current is not None and _same_durable_input(current, publication):
+                    if _causes_represented(causes, current):
+                        self._pending_causes.clear()
+                    else:
+                        self._pending = True
+                    return 0, ()
+                return 0, (
+                    CompileIssue(
+                        "publication_conflict",
+                        "durable lattice_version changed before atomic publication",
+                    ),
+                    CompileIssue(
+                        "compile_failed",
+                        "compiled-Lattice publication conflicted",
+                    ),
+                )
+
+            self._install_publication(publication)
+            self._pending_causes.clear()
+            self._drain_local.published = True
+            return 0, ()
+
+    def _recover_ambiguous_publication(self, candidate):
+        """Recover only when the store contains the exact attempted publication."""
+        try:
+            current = self._load_current_publication()
+        except Exception:
+            return False
+        return current == candidate
+
+    def _durable_provider_cursor(self):
+        """Return prior-or-fresh fingerprints for current registered readers."""
+        provider_generations = []
+        provider_fingerprints = []
+        provider_requested_generations = []
+        for provider_id in sorted(self._readers):
+            generation = self._observed_generations.get(provider_id)
+            if generation is not None:
+                fingerprint = self._generation_fingerprints.get((provider_id, generation))
+                if fingerprint is not None:
+                    provider_generations.append((provider_id, generation))
+                    provider_fingerprints.append((provider_id, generation, fingerprint))
+            requested_generation = self._requested_generations.get(provider_id)
+            if requested_generation is not None and requested_generation >= 0:
+                provider_requested_generations.append((provider_id, requested_generation))
+        return (
+            tuple(provider_generations),
+            tuple(provider_fingerprints),
+            tuple(provider_requested_generations),
+        )
+
+    def _load_current_publication(self):
+        """Load and install the durable publication after a CAS conflict."""
+        current = self._state_store.load()
+        if current is not None and not isinstance(
+            current,
+            CompiledLatticePublication,
+        ):
+            raise ValueError("state_store.load must return CompiledLatticePublication or None")
+        if current is not None:
+            self._install_publication(current)
+        return current
+
+    def _install_publication(self, publication):
+        """Restore one validated publication into compiler safety state."""
+        self._publication = publication
+        self._active_plan = publication.plan
+        self._status = publication.diagnostics.status
+        self._issues = publication.diagnostics.issues
+        for provider_id, generation, fingerprint in publication.provider_fingerprints:
+            self._observed_generations[provider_id] = generation
+            self._generation_fingerprints[(provider_id, generation)] = fingerprint
+        for provider_id, generation in publication.provider_requested_generations:
+            self._requested_generations[provider_id] = generation
+        if publication.user_override_generation is not None:
+            generation = publication.user_override_generation
+            self._override_observed_generation = generation
+            self._override_generation_fingerprints[generation] = publication.user_override_fingerprint
+        if publication.user_override_requested_generation is not None:
+            self._override_requested_generation = publication.user_override_requested_generation
+        self._feedback_tokens.append(publication.feedback_token)
+
+    def drain(self):
+        """Drain once, preserving publication-plan identity in the result."""
+        self._drain_local.published = False
+        self._drain_local.hook_called = False
+        with self._lock:
+            self._drain_local.causes = tuple(sorted(self._pending_causes, key=_cause_sort_key))
+        run = super().drain()
+        if not self._drain_local.hook_called:
+            with self._lock:
+                self._drain_local.causes = tuple(sorted(self._pending_causes, key=_cause_sort_key))
+        with self._lock:
+            publication = self._publication
+            if publication is not None:
+                self._active_plan = publication.plan
+                active_plan = publication.plan
+            else:
+                active_plan = run.plan
+        diagnostics = CompiledLatticeDiagnostics(
+            status=run.status,
+            stale=run.status is CompileStatus.STALE,
+            degraded=run.status is CompileStatus.DEGRADED,
+            issues=run.issues,
+            readiness=(publication.plan.materialization_readiness if publication is not None else None),
+        )
+        return CompiledLatticeRun(
+            run.attempts,
+            run.status,
+            active_plan,
+            run.issues,
+            run.invalidations,
+            run.materializations,
+            run.pending,
+            publication,
+            bool(getattr(self._drain_local, "published", False)),
+            diagnostics,
+            tuple(getattr(self._drain_local, "causes", ())),
+        )

--- a/apps/predbat/tests/test_lattice_compiled_publication.py
+++ b/apps/predbat/tests/test_lattice_compiled_publication.py
@@ -1,0 +1,1017 @@
+"""Tests for immutable durable publication of compiled Lattice state."""
+
+# cspell:ignore autoconfig
+
+import os
+import sys
+import threading
+import unittest
+from dataclasses import FrozenInstanceError, replace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lattice_autoconfig import (  # noqa: E402
+    AliasRole,
+    CompileStatus,
+    ProjectionCardinality,
+    ProjectionValueKind,
+    ProviderHealth,
+    ProviderSnapshot,
+    UserConfigOverride,
+)
+from lattice_compiled_publication import (  # noqa: E402
+    CompilationInvalidation,
+    CompiledLatticeCompiler,
+    InMemoryCompiledLatticeStateStore,
+    UserOverrideSnapshot,
+)
+from tests.test_lattice_autoconfig import (  # noqa: E402
+    MutableReader,
+    config_projection,
+    fragment,
+    indexed_roles,
+    projection_snapshot,
+    projection_value,
+    snapshot,
+)
+
+
+class MutableOverrideReader:
+    """Mutable complete override snapshot reader with a call counter."""
+
+    def __init__(self, value):
+        """Store the first immutable override generation."""
+        self.value = value
+        self.calls = 0
+
+    def __call__(self):
+        """Return the current override generation and count the fresh read."""
+        self.calls += 1
+        return self.value
+
+
+class RejectOnceStore(InMemoryCompiledLatticeStateStore):
+    """Reference store that rejects its first atomic publication."""
+
+    def __init__(self):
+        """Create one rejecting reference store."""
+        super().__init__()
+        self.reject = True
+
+    def compare_and_publish(self, expected_version, publication):
+        """Reject once, then delegate to the atomic reference store."""
+        if self.reject:
+            self.reject = False
+            return False
+        return super().compare_and_publish(expected_version, publication)
+
+
+class AmbiguousDifferentCursorStore(InMemoryCompiledLatticeStateStore):
+    """Store that commits a different same-version publication, then raises."""
+
+    def compare_and_publish(self, expected_version, publication):
+        """Expose ambiguous-write recovery to a same-digest cursor collision."""
+        conflicting = replace(
+            publication,
+            provider_generations=publication.provider_generations + (("offline", 7),),
+            provider_fingerprints=publication.provider_fingerprints + (("offline", 7, "f" * 64),),
+            provider_requested_generations=publication.provider_requested_generations + (("offline", 7),),
+            invalidation_causes=publication.invalidation_causes
+            + (
+                CompilationInvalidation(
+                    "provider",
+                    "offline",
+                    7,
+                    "different committed cursor",
+                ),
+            ),
+        )
+        with self._lock:
+            self._publication = conflicting
+            self._writes += 1
+        raise RuntimeError("connection lost after another cursor committed")
+
+
+class AmbiguousExactStore(InMemoryCompiledLatticeStateStore):
+    """Store that commits the exact candidate and then loses acknowledgement."""
+
+    def compare_and_publish(self, expected_version, publication):
+        """Commit the exact publication before raising an ambiguous error."""
+        with self._lock:
+            self._publication = publication
+            self._writes += 1
+        raise RuntimeError("connection lost after exact commit")
+
+
+def override_projection_snapshot(generation=1):
+    """Build one provider projection suitable for explicit override tests."""
+    return projection_snapshot(
+        "gateway",
+        ("GW1",),
+        indexed_roles(("GW1",)),
+        (
+            config_projection(
+                "battery_rate_max",
+                (
+                    projection_value(
+                        "GW1",
+                        ProjectionValueKind.CONSTANT,
+                        5,
+                    ),
+                ),
+                role=AliasRole.PRIMARY,
+                cardinality=ProjectionCardinality.PER_INDEX,
+            ),
+        ),
+        generation=generation,
+    )
+
+
+def overrides(generation, value):
+    """Build one complete immutable user override generation."""
+    return UserOverrideSnapshot(
+        generation,
+        (
+            UserConfigOverride(
+                "battery_rate_max",
+                [value],
+                "user.battery_rate_max",
+            ),
+        ),
+    )
+
+
+class TestCompiledLatticePublication(unittest.TestCase):
+    """Publication versions each changed durable successful input cursor."""
+
+    def test_generation_cursor_and_changed_digest_each_publish_once(
+        self,
+    ):
+        """Generation-only and semantic changes each advance lattice_version."""
+        reader = MutableReader(snapshot("gateway", generation=1))
+        store = InMemoryCompiledLatticeStateStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": reader},
+            state_store=store,
+        )
+
+        first = compiler.drain()
+
+        self.assertTrue(first.published)
+        self.assertEqual(first.publication.lattice_version, 1)
+        self.assertEqual(store.writes, 1)
+
+        reader.value = snapshot("gateway", generation=2)
+        self.assertTrue(compiler.invalidate("gateway", 2, "generation bookkeeping"))
+        unchanged = compiler.drain()
+
+        self.assertTrue(unchanged.published)
+        self.assertEqual(unchanged.publication.lattice_version, 2)
+        self.assertEqual(unchanged.publication.digest, first.publication.digest)
+        self.assertEqual(store.writes, 2)
+        self.assertEqual(
+            dict(unchanged.plan.provider_generations),
+            {"gateway": 2},
+        )
+        self.assertIs(compiler.active_plan, unchanged.publication.plan)
+
+        exact_repeat = compiler.drain()
+
+        self.assertEqual(exact_repeat.attempts, 0)
+        self.assertFalse(exact_repeat.published)
+        self.assertIs(exact_repeat.publication, unchanged.publication)
+        self.assertIs(exact_repeat.plan, unchanged.publication.plan)
+        self.assertIs(compiler.active_plan, unchanged.publication.plan)
+        self.assertEqual(store.writes, 2)
+
+        reader.value = snapshot(
+            "gateway",
+            generation=3,
+            node_id="INV2",
+        )
+        self.assertTrue(compiler.invalidate("gateway", 3, "new inverter identity"))
+        changed = compiler.drain()
+
+        self.assertTrue(changed.published)
+        self.assertEqual(changed.publication.lattice_version, 3)
+        self.assertEqual(store.writes, 3)
+        self.assertNotEqual(
+            changed.publication.digest,
+            first.publication.digest,
+        )
+        self.assertEqual(
+            changed.publication.invalidation_causes,
+            (
+                CompilationInvalidation(
+                    "provider",
+                    "gateway",
+                    3,
+                    "new inverter identity",
+                ),
+            ),
+        )
+
+    def test_generation_only_publication_restores_reuse_protection(self):
+        """Restart restores the newest cursor even when its digest was unchanged."""
+        reader = MutableReader(snapshot("gateway", generation=1))
+        store = InMemoryCompiledLatticeStateStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": reader},
+            state_store=store,
+        )
+        compiler.drain()
+
+        reader.value = snapshot("gateway", generation=2)
+        self.assertTrue(compiler.invalidate("gateway", 2, "heartbeat cursor"))
+        second = compiler.drain()
+
+        self.assertTrue(second.published)
+        self.assertEqual(second.publication.lattice_version, 2)
+        self.assertEqual(
+            dict(second.publication.provider_generations),
+            {"gateway": 2},
+        )
+
+        restarted = CompiledLatticeCompiler(
+            {"gateway": reader},
+            state_store=store,
+        )
+        reader.value = snapshot(
+            "gateway",
+            generation=2,
+            node_id="MUTATED",
+        )
+        failed = restarted.drain()
+
+        self.assertEqual(failed.status, CompileStatus.STALE)
+        self.assertIs(failed.publication, second.publication)
+        self.assertIs(restarted.active_plan, second.publication.plan)
+        self.assertIn(
+            "provider_invalid",
+            {issue.code for issue in failed.issues},
+        )
+
+    def test_offline_provider_cursor_is_durable_but_not_a_plan_contributor(self):
+        """Offline inputs advance the cursor and retain restart reuse safety."""
+        gateway = MutableReader(snapshot("gateway", generation=1))
+        cloud = MutableReader(
+            snapshot(
+                "cloud",
+                generation=1,
+                node_id="CLOUD1",
+                health=ProviderHealth.OFFLINE,
+            )
+        )
+        store = InMemoryCompiledLatticeStateStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": gateway, "cloud": cloud},
+            state_store=store,
+        )
+        first = compiler.drain()
+
+        self.assertEqual(
+            dict(first.publication.provider_generations),
+            {"cloud": 1, "gateway": 1},
+        )
+        self.assertEqual(
+            dict(first.publication.plan.provider_generations),
+            {"gateway": 1},
+        )
+        self.assertLessEqual(
+            set(first.publication.plan.provider_generations),
+            set(first.publication.provider_generations),
+        )
+
+        cloud.value = snapshot(
+            "cloud",
+            generation=2,
+            node_id="CLOUD1",
+            health=ProviderHealth.OFFLINE,
+        )
+        self.assertTrue(compiler.invalidate("cloud", 2, "offline heartbeat"))
+        second = compiler.drain()
+
+        self.assertTrue(second.published)
+        self.assertEqual(second.publication.lattice_version, 2)
+        self.assertEqual(second.publication.digest, first.publication.digest)
+        self.assertEqual(
+            dict(second.publication.provider_generations),
+            {"cloud": 2, "gateway": 1},
+        )
+        durable_fingerprints = second.publication.provider_fingerprints
+
+        exact_repeat = compiler.drain()
+        self.assertEqual(exact_repeat.attempts, 0)
+        self.assertFalse(exact_repeat.published)
+        self.assertEqual(store.writes, 2)
+
+        restarted = CompiledLatticeCompiler(
+            {"gateway": gateway, "cloud": cloud},
+            state_store=store,
+        )
+        cloud.value = snapshot(
+            "cloud",
+            generation=2,
+            node_id="MUTATED",
+            health=ProviderHealth.OFFLINE,
+        )
+        rejected = restarted.drain()
+
+        self.assertEqual(rejected.status, CompileStatus.DEGRADED)
+        self.assertTrue(rejected.published)
+        self.assertEqual(rejected.publication.lattice_version, 3)
+        self.assertEqual(
+            rejected.publication.provider_fingerprints,
+            durable_fingerprints,
+        )
+        self.assertIn(
+            "provider_invalid",
+            {issue.code for issue in rejected.issues},
+        )
+        self.assertIs(restarted.active_plan, rejected.publication.plan)
+
+    def test_reader_failure_preserves_prior_cursor_and_requested_generation(self):
+        """A reader failure cannot erase its cursor or acknowledged invalidation."""
+        gateway = MutableReader(snapshot("gateway", generation=1))
+        state = {
+            "fail": False,
+            "value": snapshot(
+                "cloud",
+                generation=1,
+                health=ProviderHealth.OFFLINE,
+            ),
+        }
+
+        def cloud_reader():
+            """Return the cloud snapshot unless the simulated API is down."""
+            if state["fail"]:
+                raise RuntimeError("cloud API unavailable")
+            return state["value"]
+
+        store = InMemoryCompiledLatticeStateStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": gateway, "cloud": cloud_reader},
+            state_store=store,
+        )
+        first = compiler.drain()
+        first_cloud_fingerprint = first.publication.provider_fingerprints[0]
+
+        state["fail"] = True
+        self.assertTrue(compiler.invalidate("cloud", 2, "cloud generation announced"))
+        degraded = compiler.drain()
+
+        self.assertTrue(degraded.published)
+        self.assertEqual(
+            dict(degraded.publication.provider_generations),
+            {"cloud": 1, "gateway": 1},
+        )
+        self.assertEqual(
+            degraded.publication.provider_fingerprints[0],
+            first_cloud_fingerprint,
+        )
+        self.assertIn(
+            "provider_read_failed",
+            {issue.code for issue in degraded.issues},
+        )
+        self.assertEqual(
+            dict(degraded.publication.provider_requested_generations),
+            {"cloud": 2, "gateway": 1},
+        )
+
+        gateway.value = snapshot("gateway", generation=2)
+        self.assertTrue(compiler.invalidate("gateway", 2, "unrelated gateway cursor"))
+        later = compiler.drain()
+
+        self.assertTrue(later.published)
+        self.assertEqual(later.publication.lattice_version, 3)
+        self.assertEqual(
+            dict(later.publication.provider_requested_generations),
+            {"cloud": 2, "gateway": 2},
+        )
+        self.assertNotIn(
+            CompilationInvalidation(
+                "provider",
+                "cloud",
+                2,
+                "cloud generation announced",
+            ),
+            later.publication.invalidation_causes,
+        )
+
+        state["fail"] = False
+        restarted = CompiledLatticeCompiler(
+            {"gateway": gateway, "cloud": cloud_reader},
+            state_store=store,
+        )
+        behind = restarted.drain()
+
+        self.assertIn(
+            "provider_invalid",
+            {issue.code for issue in behind.issues},
+        )
+        self.assertIn(
+            "behind invalidation 2",
+            " ".join(issue.detail for issue in behind.issues),
+        )
+
+    def test_restart_filters_publication_only_unregistered_provider_cursor(self):
+        """Removed readers are not misreported as freshly observed inputs."""
+        gateway = MutableReader(snapshot("gateway", generation=1))
+        cloud = MutableReader(
+            snapshot(
+                "cloud",
+                generation=1,
+                health=ProviderHealth.OFFLINE,
+            )
+        )
+        store = InMemoryCompiledLatticeStateStore()
+        CompiledLatticeCompiler(
+            {"gateway": gateway, "cloud": cloud},
+            state_store=store,
+        ).drain()
+
+        restarted = CompiledLatticeCompiler(
+            {"gateway": gateway},
+            state_store=store,
+        )
+        filtered = restarted.drain()
+
+        self.assertTrue(filtered.published)
+        self.assertEqual(filtered.publication.lattice_version, 2)
+        self.assertEqual(
+            dict(filtered.publication.provider_generations),
+            {"gateway": 1},
+        )
+        self.assertEqual(
+            filtered.publication.provider_generations,
+            filtered.publication.plan.provider_generations,
+        )
+
+    def test_any_provider_or_override_invalidation_fresh_reads_every_input(
+        self,
+    ):
+        """Every accepted cause reads all fragments and the complete overrides."""
+        gateway = MutableReader(snapshot("gateway", generation=1))
+        cloud = MutableReader(snapshot("cloud", generation=1))
+        override_reader = MutableOverrideReader(UserOverrideSnapshot(1, ()))
+        compiler = CompiledLatticeCompiler(
+            {"gateway": gateway, "cloud": cloud},
+            state_store=InMemoryCompiledLatticeStateStore(),
+            override_reader=override_reader,
+        )
+        compiler.drain()
+
+        gateway.value = snapshot("gateway", generation=2)
+        self.assertTrue(compiler.invalidate("gateway", 2, "gateway discovery"))
+        compiler.drain()
+
+        override_reader.value = UserOverrideSnapshot(2, ())
+        self.assertTrue(compiler.invalidate_user_overrides(2, "user config saved"))
+        override_run = compiler.drain()
+
+        self.assertEqual((gateway.calls, cloud.calls), (3, 3))
+        self.assertEqual(override_reader.calls, 3)
+        self.assertIn(
+            CompilationInvalidation(
+                "user_override",
+                "user-overrides",
+                2,
+                "user config saved",
+            ),
+            override_run.causes,
+        )
+
+    def test_override_is_public_durable_input_and_reuse_fails_closed(self):
+        """Override cursors publish even before an effective value changes."""
+        provider = MutableReader(override_projection_snapshot())
+        override_reader = MutableOverrideReader(overrides(1, 7))
+        store = InMemoryCompiledLatticeStateStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": provider},
+            state_store=store,
+            override_reader=override_reader,
+        )
+
+        first = compiler.drain()
+        self.assertEqual(
+            first.publication.plan.projected_config["battery_rate_max"],
+            (7,),
+        )
+        self.assertEqual(first.publication.user_override_generation, 1)
+
+        override_reader.value = overrides(2, 7)
+        self.assertTrue(compiler.invalidate_user_overrides(2, "override cursor changed"))
+        second = compiler.drain()
+
+        self.assertTrue(second.published)
+        self.assertEqual(second.publication.lattice_version, 2)
+        self.assertEqual(second.publication.digest, first.publication.digest)
+        self.assertEqual(second.publication.user_override_generation, 2)
+        self.assertEqual(
+            second.publication.plan.projected_config["battery_rate_max"],
+            (7,),
+        )
+
+        override_reader.value = overrides(3, 8)
+        self.assertTrue(compiler.invalidate_user_overrides(3, "override value changed"))
+        third = compiler.drain()
+
+        self.assertTrue(third.published)
+        self.assertEqual(third.publication.lattice_version, 3)
+        self.assertNotEqual(third.publication.digest, second.publication.digest)
+        self.assertEqual(
+            third.publication.plan.projected_config["battery_rate_max"],
+            (8,),
+        )
+
+        override_reader.value = overrides(3, 9)
+        provider.value = override_projection_snapshot(generation=2)
+        self.assertTrue(compiler.invalidate("gateway", 2, "provider refresh"))
+        failed = compiler.drain()
+
+        self.assertEqual(failed.status, CompileStatus.STALE)
+        self.assertIs(failed.publication, third.publication)
+        self.assertIn(
+            "user_overrides_invalid",
+            {issue.code for issue in failed.issues},
+        )
+
+    def test_failed_compile_retains_lkg_and_causes_until_recovery(self):
+        """A failed candidate never publishes and its causes survive retry."""
+        reader = MutableReader(snapshot("gateway", generation=1))
+        compiler = CompiledLatticeCompiler(
+            {"gateway": reader},
+            state_store=InMemoryCompiledLatticeStateStore(),
+        )
+        first = compiler.drain()
+
+        bad = fragment("gateway", 2)
+        bad["nodes"].append(dict(bad["nodes"][0]))
+        reader.value = ProviderSnapshot(
+            "gateway",
+            2,
+            ProviderHealth.HEALTHY,
+            bad,
+        )
+        self.assertTrue(compiler.invalidate("gateway", 2, "conflicting rediscovery"))
+        failed = compiler.drain()
+
+        self.assertEqual(failed.status, CompileStatus.STALE)
+        self.assertFalse(failed.published)
+        self.assertIs(failed.publication, first.publication)
+        self.assertEqual(first.publication.lattice_version, 1)
+
+        reader.value = snapshot(
+            "gateway",
+            generation=3,
+            node_id="INV2",
+        )
+        self.assertTrue(compiler.invalidate("gateway", 3, "corrected rediscovery"))
+        recovered = compiler.drain()
+
+        self.assertTrue(recovered.published)
+        self.assertEqual(recovered.publication.lattice_version, 2)
+        self.assertEqual(
+            set(recovered.publication.invalidation_causes),
+            {
+                CompilationInvalidation(
+                    "provider",
+                    "gateway",
+                    2,
+                    "conflicting rediscovery",
+                ),
+                CompilationInvalidation(
+                    "provider",
+                    "gateway",
+                    3,
+                    "corrected rediscovery",
+                ),
+            },
+        )
+
+    def test_second_attempt_supersede_retains_all_causes(self):
+        """A bounded follow-up superseded again publishes nothing until retry."""
+        entered_first = threading.Event()
+        release_first = threading.Event()
+        entered_second = threading.Event()
+        release_second = threading.Event()
+        state = {
+            "value": snapshot("gateway", generation=1),
+            "calls": 0,
+        }
+
+        def reader():
+            """Block the first two post-baseline reads after capturing state."""
+            state["calls"] += 1
+            value = state["value"]
+            if state["calls"] == 2:
+                entered_first.set()
+                release_first.wait(5)
+            elif state["calls"] == 3:
+                entered_second.set()
+                release_second.wait(5)
+            return value
+
+        compiler = CompiledLatticeCompiler(
+            {"gateway": reader},
+            state_store=InMemoryCompiledLatticeStateStore(),
+        )
+        baseline = compiler.drain().publication
+
+        state["value"] = snapshot(
+            "gateway",
+            generation=2,
+            node_id="INV2",
+        )
+        self.assertTrue(compiler.invalidate("gateway", 2, "generation two"))
+        result = {}
+        worker = threading.Thread(target=lambda: result.setdefault("run", compiler.drain()))
+        worker.start()
+        self.assertTrue(entered_first.wait(5))
+        state["value"] = snapshot(
+            "gateway",
+            generation=3,
+            node_id="INV3",
+        )
+        self.assertTrue(compiler.invalidate("gateway", 3, "generation three"))
+        release_first.set()
+        self.assertTrue(entered_second.wait(5))
+        state["value"] = snapshot(
+            "gateway",
+            generation=4,
+            node_id="INV4",
+        )
+        self.assertTrue(compiler.invalidate("gateway", 4, "generation four"))
+        release_second.set()
+        worker.join(5)
+
+        superseded = result["run"]
+        self.assertEqual(superseded.status, CompileStatus.STALE)
+        self.assertFalse(superseded.published)
+        self.assertIs(superseded.publication, baseline)
+        self.assertTrue(superseded.pending)
+
+        recovered = compiler.drain()
+        self.assertTrue(recovered.published)
+        self.assertEqual(
+            {(cause.generation, cause.reason) for cause in recovered.publication.invalidation_causes},
+            {
+                (2, "generation two"),
+                (3, "generation three"),
+                (4, "generation four"),
+            },
+        )
+
+    def test_store_conflict_is_fail_closed_and_retryable(self):
+        """A rejected CAS keeps the LKG and retries the same next version."""
+        store = RejectOnceStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": MutableReader(snapshot("gateway"))},
+            state_store=store,
+        )
+
+        rejected = compiler.drain()
+
+        self.assertEqual(rejected.status, CompileStatus.STALE)
+        self.assertIsNone(rejected.publication)
+        self.assertIn(
+            "publication_conflict",
+            {issue.code for issue in rejected.issues},
+        )
+        self.assertTrue(rejected.pending)
+
+        accepted = compiler.drain()
+
+        self.assertTrue(accepted.published)
+        self.assertEqual(accepted.publication.lattice_version, 1)
+        self.assertEqual(store.writes, 1)
+
+    def test_concurrent_same_input_cas_installs_exact_durable_plan(self):
+        """A CAS loser adopts the winner's publication and exact plan object."""
+        store = InMemoryCompiledLatticeStateStore()
+        first_compiler = CompiledLatticeCompiler(
+            {"gateway": MutableReader(snapshot("gateway"))},
+            state_store=store,
+        )
+        second_compiler = CompiledLatticeCompiler(
+            {"gateway": MutableReader(snapshot("gateway"))},
+            state_store=store,
+        )
+
+        winner = first_compiler.drain()
+        concurrent = second_compiler.drain()
+
+        self.assertTrue(winner.published)
+        self.assertFalse(concurrent.published)
+        self.assertEqual(concurrent.status, CompileStatus.FRESH)
+        self.assertIs(concurrent.publication, winner.publication)
+        self.assertIs(concurrent.plan, winner.publication.plan)
+        self.assertIs(second_compiler.active_plan, winner.publication.plan)
+        self.assertEqual(store.writes, 1)
+
+    def test_concurrent_same_input_retains_each_compiler_cause_once(self):
+        """A CAS loser publishes a missing local cause in one follow-up version."""
+        store = InMemoryCompiledLatticeStateStore()
+        seed_reader = MutableReader(snapshot("gateway", generation=1))
+        CompiledLatticeCompiler(
+            {"gateway": seed_reader},
+            state_store=store,
+        ).drain()
+
+        first_reader = MutableReader(snapshot("gateway", generation=2))
+        second_reader = MutableReader(snapshot("gateway", generation=2))
+        first_compiler = CompiledLatticeCompiler(
+            {"gateway": first_reader},
+            state_store=store,
+        )
+        second_compiler = CompiledLatticeCompiler(
+            {"gateway": second_reader},
+            state_store=store,
+        )
+        self.assertTrue(first_compiler.invalidate("gateway", 2, "compiler A discovery"))
+        self.assertTrue(second_compiler.invalidate("gateway", 2, "compiler B discovery"))
+
+        winner = first_compiler.drain()
+        adopted = second_compiler.drain()
+
+        self.assertTrue(winner.published)
+        self.assertEqual(winner.publication.lattice_version, 2)
+        self.assertIn(
+            CompilationInvalidation(
+                "provider",
+                "gateway",
+                2,
+                "compiler A discovery",
+            ),
+            winner.publication.invalidation_causes,
+        )
+        self.assertFalse(adopted.published)
+        self.assertTrue(adopted.pending)
+        self.assertIs(adopted.publication, winner.publication)
+
+        retained = second_compiler.drain()
+
+        self.assertTrue(retained.published)
+        self.assertFalse(retained.pending)
+        self.assertEqual(retained.publication.lattice_version, 3)
+        self.assertEqual(retained.publication.digest, winner.publication.digest)
+        self.assertEqual(
+            retained.publication.provider_generations,
+            winner.publication.provider_generations,
+        )
+        self.assertEqual(
+            retained.publication.invalidation_causes,
+            (
+                CompilationInvalidation(
+                    "provider",
+                    "gateway",
+                    2,
+                    "compiler B discovery",
+                ),
+            ),
+        )
+
+        exact_repeat = second_compiler.drain()
+
+        self.assertEqual(exact_repeat.attempts, 0)
+        self.assertFalse(exact_repeat.published)
+        self.assertFalse(exact_repeat.pending)
+        self.assertIs(exact_repeat.publication, retained.publication)
+        self.assertEqual(store.writes, 3)
+
+    def test_ambiguous_write_recovery_requires_exact_publication(self):
+        """Same version, digest, and token cannot alias a different cursor."""
+        store = AmbiguousDifferentCursorStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": MutableReader(snapshot("gateway"))},
+            state_store=store,
+        )
+
+        rejected = compiler.drain()
+
+        self.assertEqual(rejected.status, CompileStatus.STALE)
+        self.assertFalse(rejected.published)
+        self.assertTrue(rejected.pending)
+        self.assertEqual(
+            dict(rejected.publication.provider_generations),
+            {"gateway": 1, "offline": 7},
+        )
+        self.assertIn(
+            "publication_failed",
+            {issue.code for issue in rejected.issues},
+        )
+        self.assertIs(compiler.active_plan, rejected.publication.plan)
+
+    def test_ambiguous_write_recovers_only_the_exact_publication(self):
+        """Exact durable equality safely resolves a lost acknowledgement."""
+        store = AmbiguousExactStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": MutableReader(snapshot("gateway"))},
+            state_store=store,
+        )
+
+        recovered = compiler.drain()
+
+        self.assertEqual(recovered.status, CompileStatus.FRESH)
+        self.assertTrue(recovered.published)
+        self.assertFalse(recovered.pending)
+        self.assertIs(recovered.publication, store.load())
+        self.assertIs(compiler.active_plan, recovered.publication.plan)
+
+    def test_restart_restores_generation_fingerprint_and_feedback_safety(self):
+        """Durable state rejects replay, content reuse, and write feedback."""
+        provider = MutableReader(override_projection_snapshot())
+        override_reader = MutableOverrideReader(overrides(1, 7))
+        store = InMemoryCompiledLatticeStateStore()
+        first_compiler = CompiledLatticeCompiler(
+            {"gateway": provider},
+            state_store=store,
+            override_reader=override_reader,
+        )
+        publication = first_compiler.drain().publication
+
+        restarted = CompiledLatticeCompiler(
+            {"gateway": provider},
+            state_store=store,
+            override_reader=override_reader,
+        )
+
+        self.assertFalse(restarted.invalidate("gateway", 1, "replayed generation"))
+        self.assertFalse(
+            restarted.invalidate(
+                "gateway",
+                2,
+                "publication feedback",
+                publication.feedback_token,
+            )
+        )
+        self.assertFalse(
+            restarted.invalidate_user_overrides(
+                2,
+                "publication feedback",
+                publication.feedback_token,
+            )
+        )
+
+        provider.value = snapshot(
+            "gateway",
+            generation=1,
+            node_id="DIFFERENT",
+        )
+        failed = restarted.drain()
+
+        self.assertEqual(failed.status, CompileStatus.STALE)
+        self.assertIs(failed.publication, publication)
+        self.assertIn(
+            "provider_invalid",
+            {issue.code for issue in failed.issues},
+        )
+
+    def test_restart_cannot_silently_drop_durable_override_input(self):
+        """Observed or requested override state requires its reader on restart."""
+        provider = MutableReader(override_projection_snapshot())
+        override_reader = MutableOverrideReader(overrides(1, 7))
+        store = InMemoryCompiledLatticeStateStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": provider},
+            state_store=store,
+            override_reader=override_reader,
+        )
+        compiler.drain()
+
+        with self.assertRaisesRegex(ValueError, "requires override_reader"):
+            CompiledLatticeCompiler(
+                {"gateway": provider},
+                state_store=store,
+            )
+
+        plain_store = InMemoryCompiledLatticeStateStore()
+        plain_publication = (
+            CompiledLatticeCompiler(
+                {"gateway": MutableReader(snapshot("gateway"))},
+                state_store=plain_store,
+            )
+            .drain()
+            .publication
+        )
+        requested_only = replace(
+            plain_publication,
+            user_override_requested_generation=2,
+            invalidation_causes=(
+                CompilationInvalidation(
+                    "user_override",
+                    "user-overrides",
+                    2,
+                    "override generation announced",
+                ),
+            ),
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires override_reader"):
+            CompiledLatticeCompiler(
+                {"gateway": MutableReader(snapshot("gateway"))},
+                state_store=InMemoryCompiledLatticeStateStore(requested_only),
+            )
+
+    def test_publication_is_deeply_immutable(self):
+        """The public snapshot and its compiled plan cannot be mutated."""
+        compiler = CompiledLatticeCompiler(
+            {"gateway": MutableReader(snapshot("gateway"))},
+            state_store=InMemoryCompiledLatticeStateStore(),
+        )
+        publication = compiler.drain().publication
+
+        with self.assertRaises(FrozenInstanceError):
+            publication.lattice_version = 9
+        with self.assertRaises(TypeError):
+            publication.plan.topology["scope"] = "site"
+
+    def test_live_stale_diagnostics_do_not_mutate_durable_degraded_snapshot(
+        self,
+    ):
+        """A later failure reports STALE beside the unchanged LKG snapshot."""
+        gateway = MutableReader(snapshot("gateway", generation=1))
+        offline = MutableReader(
+            snapshot(
+                "cloud",
+                generation=1,
+                health=ProviderHealth.OFFLINE,
+            )
+        )
+        compiler = CompiledLatticeCompiler(
+            {"gateway": gateway, "cloud": offline},
+            state_store=InMemoryCompiledLatticeStateStore(),
+        )
+        first = compiler.drain()
+
+        self.assertEqual(first.status, CompileStatus.DEGRADED)
+        self.assertTrue(first.publication.diagnostics.degraded)
+        self.assertFalse(first.publication.diagnostics.stale)
+
+        gateway.value = snapshot(
+            "gateway",
+            generation=2,
+            health=ProviderHealth.OFFLINE,
+        )
+        self.assertTrue(compiler.invalidate("gateway", 2, "gateway unavailable"))
+        failed = compiler.drain()
+
+        self.assertEqual(failed.status, CompileStatus.STALE)
+        self.assertTrue(failed.diagnostics.stale)
+        self.assertFalse(failed.diagnostics.degraded)
+        self.assertIs(failed.publication, first.publication)
+        self.assertEqual(
+            failed.publication.diagnostics.status,
+            CompileStatus.DEGRADED,
+        )
+
+    def test_publication_feedback_never_loops_for_any_input(self):
+        """Published feedback tokens suppress provider and override causes."""
+        provider = MutableReader(override_projection_snapshot())
+        override_reader = MutableOverrideReader(overrides(1, 7))
+        holder = {}
+
+        class FeedbackStore(InMemoryCompiledLatticeStateStore):
+            """Store that echoes publication feedback synchronously."""
+
+            def compare_and_publish(self, expected_version, publication):
+                """Commit, then echo the token through both invalidation APIs."""
+                committed = super().compare_and_publish(
+                    expected_version,
+                    publication,
+                )
+                compiler = holder["compiler"]
+                holder["feedback"] = (
+                    compiler.invalidate(
+                        "gateway",
+                        2,
+                        "published config observed",
+                        publication.feedback_token,
+                    ),
+                    compiler.invalidate_user_overrides(
+                        2,
+                        "published config observed",
+                        publication.feedback_token,
+                    ),
+                )
+                return committed
+
+        store = FeedbackStore()
+        compiler = CompiledLatticeCompiler(
+            {"gateway": provider},
+            state_store=store,
+            override_reader=override_reader,
+        )
+        holder["compiler"] = compiler
+
+        run = compiler.drain()
+
+        self.assertTrue(run.published)
+        self.assertEqual(holder["feedback"], (False, False))
+        self.assertFalse(run.pending)
+        self.assertEqual(provider.calls, 1)
+        self.assertEqual(override_reader.calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an additive, shadow-only compiled-Lattice publication coordinator
- let any registered fragment integration or durable user-override source invalidate the aggregate compiler
- fresh-read every registered input through the existing single-flight/bounded-follow-up compiler
- atomically publish immutable versions with semantic digest, full observed provider cursor,
  requested-generation high-water marks, fingerprints, diagnostics, readiness, causes, and plan
- preserve last-known-good state across failures, restarts, ambiguous writes, and multi-writer CAS races
- keep configuration materialization absent and default-off

## Safety properties

- generation/fingerprint or diagnostic changes advance `lattice_version` even when the projected
  values are unchanged
- exact identical input is a no-op; later materialization remains separately digest-gated
- OFFLINE, DEGRADED, and fingerprinted-invalid registered inputs remain in the durable input cursor
  even when they do not contribute to the usable plan
- accepted-but-unobserved generations survive later publications and restarts
- same-generation semantic mutation is rejected after restart
- CAS recovery requires the exact attempted publication; a losing compiler retains any missing
  accepted cause in one bounded follow-up version
- no production registry, MQTT, Home Assistant, configuration writer, or materializer is wired

## Verification

- `python3.9 -m unittest apps/predbat/tests/test_lattice_compiled_publication.py apps/predbat/tests/test_lattice_autoconfig.py` — 72 passed on the stacked branch
- the publication tranche also passed its pre-stack suite on Python 3.14
- Black, Ruff, cspell, and pre-commit checks passed
- GitNexus staged change detection: LOW, exactly two files, zero affected existing symbols or flows

Tracks Predictive-Cloud-Ltd/predbat-saas-infra#561 and #466.
