### PR TITLE
fix(gateway): ignore blank inverter serial filters

### DIFF
--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -217,7 +217,7 @@ class GatewayMQTT(ComponentBase):
                     serials = [serial_value]
             else:
                 serials = [serial_value]
-self.gateway_inverter_serial = [serial for value in serials if value is not None and (serial := str(value).strip())]
+        self.gateway_inverter_serial = [serial for value in serials if value is not None and (serial := str(value).strip())]
         self.mqtt_token_expires_at = 0
 
         # MQTT topic strings

--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -217,7 +217,7 @@ class GatewayMQTT(ComponentBase):
                     serials = [serial_value]
             else:
                 serials = [serial_value]
-        self.gateway_inverter_serial = [serial for value in serials if (serial := str(value).strip())]
+self.gateway_inverter_serial = [serial for value in serials if value is not None and (serial := str(value).strip())]
         self.mqtt_token_expires_at = 0
 
         # MQTT topic strings

--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -197,23 +197,27 @@ class GatewayMQTT(ComponentBase):
         self.mqtt_port = mqtt_port
         self.mqtt_token = mqtt_token
 
-        # Normalise serial filter to a list (or None if not set)
+        # Normalise the serial filter to a list. Whitespace-only values are
+        # equivalent to an unset filter, including when they arrive inside a
+        # list or a JSON-encoded list.
         if gateway_inverter_serial is None:
-            self.gateway_inverter_serial = []
+            serials = []
         elif isinstance(gateway_inverter_serial, list):
-            self.gateway_inverter_serial = gateway_inverter_serial
+            serials = gateway_inverter_serial
         else:
-            if isinstance(gateway_inverter_serial, str) and (gateway_inverter_serial.startswith("{") or gateway_inverter_serial.startswith("[")):
+            serial_value = gateway_inverter_serial.strip() if isinstance(gateway_inverter_serial, str) else gateway_inverter_serial
+            if isinstance(serial_value, str) and (serial_value.startswith("{") or serial_value.startswith("[")):
                 try:
-                    parsed = json.loads(gateway_inverter_serial)
+                    parsed = json.loads(serial_value)
                     if isinstance(parsed, list):
-                        self.gateway_inverter_serial = [str(s) for s in parsed]
+                        serials = parsed
                     else:
-                        self.gateway_inverter_serial = [str(parsed)]
+                        serials = [parsed]
                 except json.JSONDecodeError:
-                    self.gateway_inverter_serial = [str(gateway_inverter_serial)]
+                    serials = [serial_value]
             else:
-                self.gateway_inverter_serial = [gateway_inverter_serial]
+                serials = [serial_value]
+        self.gateway_inverter_serial = [serial for value in serials if (serial := str(value).strip())]
         self.mqtt_token_expires_at = 0
 
         # MQTT topic strings

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -1744,6 +1744,55 @@ class TestAutomaticConfig:
         gw.initialize(gateway_device_id="pbgw_test", mqtt_host="mqtt.example.com", mqtt_token="tok", gateway_inverter_serial=None)
         assert gw.gateway_inverter_serial == []
 
+    def test_serial_filter_blank_strings_become_empty_list(self):
+        """Empty and whitespace-only serials are treated as an unset filter."""
+        from gateway import GatewayMQTT
+        from unittest.mock import MagicMock
+
+        for value in ("", " ", "   ", "\t\r\n"):
+            gw = GatewayMQTT.__new__(GatewayMQTT)
+            gw.base = MagicMock()
+            gw.args = {}
+            gw.initialize(
+                gateway_device_id="pbgw_test",
+                mqtt_host="mqtt.example.com",
+                mqtt_token="tok",
+                gateway_inverter_serial=value,
+            )
+            assert gw.gateway_inverter_serial == []
+
+    def test_serial_filter_list_drops_blanks_and_trims_values(self):
+        """Blank list entries are discarded while valid serials are trimmed."""
+        from gateway import GatewayMQTT
+        from unittest.mock import MagicMock
+
+        gw = GatewayMQTT.__new__(GatewayMQTT)
+        gw.base = MagicMock()
+        gw.args = {}
+        gw.initialize(
+            gateway_device_id="pbgw_test",
+            mqtt_host="mqtt.example.com",
+            mqtt_token="tok",
+            gateway_inverter_serial=["", "  ", " CE000000AA1 ", "\t"],
+        )
+        assert gw.gateway_inverter_serial == ["CE000000AA1"]
+
+    def test_serial_filter_json_array_drops_blanks_and_trims_values(self):
+        """JSON-encoded lists receive the same blank filtering and trimming."""
+        from gateway import GatewayMQTT
+        from unittest.mock import MagicMock
+
+        gw = GatewayMQTT.__new__(GatewayMQTT)
+        gw.base = MagicMock()
+        gw.args = {}
+        gw.initialize(
+            gateway_device_id="pbgw_test",
+            mqtt_host="mqtt.example.com",
+            mqtt_token="tok",
+            gateway_inverter_serial=' [ "", "  ", " CE000000AA1 " ] ',
+        )
+        assert gw.gateway_inverter_serial == ["CE000000AA1"]
+
     def test_serial_filter_json_array_string_expanded_to_list(self):
         """A JSON-encoded array string is parsed and expanded into a list of serials."""
         from gateway import GatewayMQTT

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -1773,7 +1773,7 @@ class TestAutomaticConfig:
             gateway_device_id="pbgw_test",
             mqtt_host="mqtt.example.com",
             mqtt_token="tok",
-            gateway_inverter_serial=["", "  ", " CE000000AA1 ", "\t"],
+            gateway_inverter_serial=["", None, "  ", " CE000000AA1 ", "\t"],
         )
         assert gw.gateway_inverter_serial == ["CE000000AA1"]
 


### PR DESCRIPTION
## Summary

- trim configured gateway inverter serials before applying the filter
- treat empty and whitespace-only values as an unset filter
- drop blank entries from list and JSON-list inputs while preserving valid serials
- add regression coverage for plain strings, lists, and JSON-encoded lists

## Why

A blank inverter selection can be persisted as `[""]`. Because that list is truthy, PredBat tries to match an empty serial against discovered inverters, aborts gateway auto-configuration, and repeats the error on every telemetry update. Normalising blanks to an empty list makes the configuration behave as no filter.

## Verification

- `pytest apps/predbat/tests/test_gateway.py -k serial_filter -q` — 14 passed
- `ruff check apps/predbat/gateway.py apps/predbat/tests/test_gateway.py`
- `python -m py_compile apps/predbat/gateway.py apps/predbat/tests/test_gateway.py`
- all pre-commit hooks passed