### PR TITLE
fix(deye): repair SaaS OAuth and correct telemetry keys against a live inverter

### DIFF
--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -264,6 +264,9 @@ COMPONENT_LIST = {
             "inverter_sn": {"required": False, "config": "deye_inverter_sn"},
             "automatic": {"required": False, "default": False, "config": "deye_automatic"},
             "automatic_ignore_pv": {"required": False, "default": False, "config": "deye_automatic_ignore_pv"},
+            # config/battery reports capacity in Ah; the default suits 48 V low-voltage
+            # hybrids. High-voltage stacks must override this or soc_max is several-fold out.
+            "battery_nominal_voltage": {"required": False, "config": "deye_battery_nominal_voltage"},
         },
         # Gate activation on having at least one auth path — app credentials (app_id,
         # self-hosted add-on) OR an injected SaaS access token (key). Without this the

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -250,6 +250,10 @@ COMPONENT_LIST = {
         "args": {
             "app_id": {"required": False, "config": "deye_app_id"},
             "app_secret": {"required": False, "config": "deye_app_secret"},
+            # In oauth mode OAuthMixin treats 'key' as the access token (see
+            # oauth_mixin._init_oauth). Predbat.com injects it as deye_key; without this
+            # entry the token is dropped and DEYE rejects every call as "auth invalid token".
+            "key": {"required": False, "config": "deye_key"},
             "username": {"required": False, "config": "deye_username"},
             "password": {"required": False, "config": "deye_password"},
             "data_center": {"required": False, "default": "eu", "config": "deye_data_center"},
@@ -262,10 +266,12 @@ COMPONENT_LIST = {
             "automatic_ignore_pv": {"required": False, "default": False, "config": "deye_automatic_ignore_pv"},
         },
         # Gate activation on having at least one auth path — app credentials (app_id,
-        # self-hosted add-on) OR an injected SaaS token (token_hash). Without this the
+        # self-hosted add-on) OR an injected SaaS access token (key). Without this the
         # component would start for every instance since all individual args are
-        # optional to allow either auth mode.
-        "required_or": ["app_id", "token_hash"],
+        # optional to allow either auth mode. Gate on key, not token_hash: the hash is
+        # only a refresh dedup handle, so gating on it starts the component for an
+        # instance that has no usable token and fails on every API call instead.
+        "required_or": ["app_id", "key"],
         "phase": 1,
     },
     "enphase": {

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -48,7 +48,22 @@ class DeyeAPI(ComponentBase, OAuthMixin):
     """DEYE Cloud API component."""
 
     def initialize(
-        self, app_id="", app_secret="", username="", password="", key="", data_center="eu", company_id="", auth_method="app_credentials", token_expires_at=None, token_hash="", inverter_sn=None, automatic=False, automatic_ignore_pv=False, **kwargs
+        self,
+        app_id="",
+        app_secret="",
+        username="",
+        password="",
+        key="",
+        data_center="eu",
+        company_id="",
+        auth_method="app_credentials",
+        token_expires_at=None,
+        token_hash="",
+        inverter_sn=None,
+        automatic=False,
+        automatic_ignore_pv=False,
+        battery_nominal_voltage=None,
+        **kwargs,
     ):
         """Initialise the DEYE component from its resolved config args.
 
@@ -79,8 +94,19 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         self.applied_payload = {}
         self.control_active = set()
         self.cached_values = {}
+        self.battery_nominal_voltage = self._as_float(battery_nominal_voltage, DEYE_NOMINAL_BATTERY_VOLTAGE) or DEYE_NOMINAL_BATTERY_VOLTAGE
         self._telemetry_keys_reported = set()
         self._battery_config_reported = set()
+        self._nominal_voltage_warned = set()
+        self._energy_keys_seen = {}
+        # auth_method defaults to app_credentials, but an injected access token with no
+        # developer app credentials can only be oauth — and in app_credentials mode
+        # _init_oauth() throws the key away, so a host that forgets deye_auth_method gets
+        # a component that authenticates with nothing. Infer the mode from what was
+        # actually supplied rather than trusting the default.
+        if key and not app_id and auth_method != "oauth":
+            self.log("Info: DEYE inferring auth_method 'oauth' - an access token was injected without app credentials")
+            auth_method = "oauth"
         # _init_oauth() assigns key to self.access_token in oauth mode, so key must be the
         # injected access token (deye_key) — NOT token_hash, which is only the dedup handle
         # echoed back to oauth-refresh. Passing the hash here made every DEYE call fail with
@@ -246,6 +272,28 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         self._telemetry_keys_reported.add(sn)
         self.log(f"Warn: DEYE device/latest for {sn} returned none of {missing} - correct DEYE_TELEMETRY_KEYS to the keys actually present: {sorted(flat.keys())}")
 
+    def _daily_energy(self, sn, flat):
+        """Return today's cumulative energy counters, resolving an absent key correctly.
+
+        Absence means two different things. A model that has never reported a
+        counter should not publish that sensor at all - Predbat must not be wired
+        to a permanently missing entity. But a counter that HAS been seen and then
+        disappears is the midnight rollover, where the true value is zero; leaving
+        the sensor at its last state would feed yesterday's total back to Predbat
+        as today's load until DEYE starts reporting again.
+        """
+        if not hasattr(self, "_energy_keys_seen"):
+            self._energy_keys_seen = {}
+        seen = self._energy_keys_seen.setdefault(sn, set())
+        values = {}
+        for name, key in DEYE_ENERGY_KEYS.items():
+            if key in flat:
+                seen.add(name)
+                values[name] = self._as_float(flat[key])
+            elif name in seen:
+                values[name] = 0.0
+        return values
+
     async def fetch_device_data(self, sn):
         """Fetch and normalise the latest telemetry for one inverter."""
         data = await self._post("device_latest", {DEYE_LATEST_BODY_KEY: [sn]})
@@ -258,10 +306,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         flat = self._datalist_to_dict(rows[0].get("dataList"))
         self._report_unmatched_telemetry(sn, flat)
         result = {name: self._as_float(flat.get(key)) for name, key in DEYE_TELEMETRY_KEYS.items()}
-        # Daily counters are only present once the inverter has reported today, so
-        # omit rather than zero them - a spurious 0.0 load_today would look like a
-        # real reading and skew the load model.
-        result.update({name: self._as_float(flat[key]) for name, key in DEYE_ENERGY_KEYS.items() if key in flat})
+        result.update(self._daily_energy(sn, flat))
         self.device_values[sn] = result
         return result
 
@@ -294,8 +339,24 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         entry BatteryRatedCapacity, unit "Ah"), but Predbat's soc_max is kWh --
         publishing the raw figure advertised a 1200 kWh battery. Convert against
         the nominal pack voltage, never the resting voltage, which rises with SOC.
+
+        The default suits low-voltage 48 V hybrids, which is the only hardware this
+        has been confirmed against. DEYE also ship high-voltage stacks where that
+        default would understate capacity several-fold, so warn when the measured
+        pack voltage is inconsistent with it and let deye_battery_nominal_voltage
+        override rather than silently publishing a wrong soc_max.
         """
-        return round(self._battery_config_value(sn, "capacity") * DEYE_NOMINAL_BATTERY_VOLTAGE / 1000.0, 2)
+        capacity_ah = self._battery_config_value(sn, "capacity")
+        if not capacity_ah:
+            return 0.0
+        nominal = getattr(self, "battery_nominal_voltage", None) or DEYE_NOMINAL_BATTERY_VOLTAGE
+        if not hasattr(self, "_nominal_voltage_warned"):
+            self._nominal_voltage_warned = set()
+        measured = self._as_float(getattr(self, "device_values", {}).get(sn, {}).get("battery_voltage"))
+        if measured and not 0.8 * nominal <= measured <= 1.3 * nominal and sn not in self._nominal_voltage_warned:
+            self._nominal_voltage_warned.add(sn)
+            self.log(f"Warn: DEYE {sn} pack reads {measured} V but capacity is being converted at {nominal} V nominal - set deye_battery_nominal_voltage or soc_max will be wrong")
+        return round(capacity_ah * nominal / 1000.0, 2)
 
     def derive_control_state(self, schedule, current_soc):
         """Map Predbat's schedule intent to a DEYE control state (see design spec table)."""
@@ -499,7 +560,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         """Publish monitoring sensors for each inverter."""
         for sn in self.device_list:
             values = self.device_values.get(sn, {})
-            units = {"soc": "%", "battery_power": "W", "grid_power": "W", "pv_power": "W", "load_power": "W", "temperature": "°C"}
+            units = {"soc": "%", "battery_power": "W", "grid_power": "W", "pv_power": "W", "load_power": "W", "temperature": "°C", "battery_voltage": "V"}
             units.update({leaf: "kWh" for leaf in DEYE_ENERGY_KEYS})
             for leaf, unit in units.items():
                 if leaf in values:

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -25,13 +25,31 @@ import os
 from datetime import datetime
 from component_base import ComponentBase
 from oauth_mixin import OAuthMixin
-from deye_const import DEYE_BASE_URLS, DEYE_ENDPOINTS, DEYE_TIMEOUT, DEYE_RETRIES, DEYE_TELEMETRY_KEYS, DEYE_LATEST_BODY_KEY, DEYE_WORKMODE, FREEZE_EXPORT_SOC, TOU_FIELD, TOU_SLOT_COUNT, TOU_FILLER_TIMES, DEYE_ORDER_MAX_POLLS, CONFIG_BATTERY_KEYS
+from deye_const import (
+    DEYE_BASE_URLS,
+    DEYE_ENDPOINTS,
+    DEYE_TIMEOUT,
+    DEYE_RETRIES,
+    DEYE_TELEMETRY_KEYS,
+    DEYE_ENERGY_KEYS,
+    DEYE_NOMINAL_BATTERY_VOLTAGE,
+    DEYE_LATEST_BODY_KEY,
+    DEYE_WORKMODE,
+    FREEZE_EXPORT_SOC,
+    TOU_FIELD,
+    TOU_SLOT_COUNT,
+    TOU_FILLER_TIMES,
+    DEYE_ORDER_MAX_POLLS,
+    CONFIG_BATTERY_KEYS,
+)
 
 
 class DeyeAPI(ComponentBase, OAuthMixin):
     """DEYE Cloud API component."""
 
-    def initialize(self, app_id="", app_secret="", username="", password="", data_center="eu", company_id="", auth_method="app_credentials", token_expires_at=None, token_hash="", inverter_sn=None, automatic=False, automatic_ignore_pv=False, **kwargs):
+    def initialize(
+        self, app_id="", app_secret="", username="", password="", key="", data_center="eu", company_id="", auth_method="app_credentials", token_expires_at=None, token_hash="", inverter_sn=None, automatic=False, automatic_ignore_pv=False, **kwargs
+    ):
         """Initialise the DEYE component from its resolved config args.
 
         ComponentBase.__init__ calls initialize(**kwargs); the Components
@@ -61,9 +79,16 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         self.applied_payload = {}
         self.control_active = set()
         self.cached_values = {}
+        self._telemetry_keys_reported = set()
+        self._battery_config_reported = set()
+        # _init_oauth() assigns key to self.access_token in oauth mode, so key must be the
+        # injected access token (deye_key) — NOT token_hash, which is only the dedup handle
+        # echoed back to oauth-refresh. Passing the hash here made every DEYE call fail with
+        # "auth invalid token", and token_expires_at being far in the future meant the
+        # refresh that would have replaced it never ran.
         self._init_oauth(
             auth_method=auth_method,
-            key=app_secret or token_hash,
+            key=key or app_secret,
             token_expires_at=token_expires_at,
             provider_name="deye",
         )
@@ -94,6 +119,15 @@ class DeyeAPI(ComponentBase, OAuthMixin):
 
     async def fetch_token(self):
         """Fetch an access token using app credentials (app_credentials mode)."""
+        # Every app_credentials arg is optional in COMPONENT_LIST (the component also
+        # accepts the SaaS token_hash path), so a mis-configured instance can reach here
+        # with them unset. Fail soft: the callers already treat False as "skip this run",
+        # whereas hashing a None password raises AttributeError out of run() and buries
+        # the real problem under a traceback on every cycle.
+        missing = [name for name in ("app_id", "app_secret", "username", "password") if not getattr(self, name, None)]
+        if missing:
+            self.log(f"Warn: DEYE app_credentials login is missing {', '.join(missing)} - set deye_auth_method to 'oauth' if this is a Predbat.com instance")
+            return False
         url = f"{self.base_url}{DEYE_ENDPOINTS['token']}?appId={self.app_id}"
         body = {"appSecret": self.app_secret, "password": self._sha256(self.password), **self._login_payload(self.username)}
         if self.company_id:
@@ -193,6 +227,25 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         except (TypeError, ValueError):
             return default
 
+    def _report_unmatched_telemetry(self, sn, flat):
+        """Log the keys DEYE actually returned when DEYE_TELEMETRY_KEYS does not match.
+
+        _as_float() coerces an absent key to 0.0, so a wrong spelling in
+        DEYE_TELEMETRY_KEYS publishes a full set of plausible-looking zeros
+        (SOC 0%, temperature 0C) rather than failing. That is indistinguishable
+        from a flat battery on a cold night, so surface the real key names once
+        per serial instead of silently zeroing.
+        """
+        missing = sorted(key for key in DEYE_TELEMETRY_KEYS.values() if key not in flat)
+        # Test doubles build DeyeAPI via __new__ without initialize(), so create the
+        # seen-set lazily rather than requiring every caller to pre-seed it.
+        if not hasattr(self, "_telemetry_keys_reported"):
+            self._telemetry_keys_reported = set()
+        if not missing or sn in self._telemetry_keys_reported:
+            return
+        self._telemetry_keys_reported.add(sn)
+        self.log(f"Warn: DEYE device/latest for {sn} returned none of {missing} - correct DEYE_TELEMETRY_KEYS to the keys actually present: {sorted(flat.keys())}")
+
     async def fetch_device_data(self, sn):
         """Fetch and normalise the latest telemetry for one inverter."""
         data = await self._post("device_latest", {DEYE_LATEST_BODY_KEY: [sn]})
@@ -203,7 +256,12 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         if not rows:
             return {}
         flat = self._datalist_to_dict(rows[0].get("dataList"))
+        self._report_unmatched_telemetry(sn, flat)
         result = {name: self._as_float(flat.get(key)) for name, key in DEYE_TELEMETRY_KEYS.items()}
+        # Daily counters are only present once the inverter has reported today, so
+        # omit rather than zero them - a spurious 0.0 load_today would look like a
+        # real reading and skew the load model.
+        result.update({name: self._as_float(flat[key]) for name, key in DEYE_ENERGY_KEYS.items() if key in flat})
         self.device_values[sn] = result
         return result
 
@@ -214,12 +272,30 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             self.log(f"Warn: DEYE config/battery failed for {sn}: {data.get('msg', 'unknown')}")
             return {}
         self.device_battery_config[sn] = data
+        # CONFIG_BATTERY_KEYS was never confirmed against a live response (units in
+        # particular), so record the raw payload once per serial - a capacity that is
+        # really Ah or Wh silently becomes a nonsense soc_max otherwise.
+        if not hasattr(self, "_battery_config_reported"):
+            self._battery_config_reported = set()
+        if sn not in self._battery_config_reported:
+            self._battery_config_reported.add(sn)
+            self.log(f"Info: DEYE config/battery raw payload for {sn}: {json.dumps(data, default=str)}")
         return data
 
     def _battery_config_value(self, sn, key, default=0.0):
         """Read a config_battery field for one inverter via CONFIG_BATTERY_KEYS (spike-confirmable), safely coerced."""
         raw = self.device_battery_config.get(sn, {}).get(CONFIG_BATTERY_KEYS[key])
         return self._as_float(raw, default)
+
+    def _battery_capacity_kwh(self, sn):
+        """Return rated battery capacity in kWh, converting DEYE's amp-hours.
+
+        config/battery battCapacity is AMP-HOURS (corroborated by the dataList
+        entry BatteryRatedCapacity, unit "Ah"), but Predbat's soc_max is kWh --
+        publishing the raw figure advertised a 1200 kWh battery. Convert against
+        the nominal pack voltage, never the resting voltage, which rises with SOC.
+        """
+        return round(self._battery_config_value(sn, "capacity") * DEYE_NOMINAL_BATTERY_VOLTAGE / 1000.0, 2)
 
     def derive_control_state(self, schedule, current_soc):
         """Map Predbat's schedule intent to a DEYE control state (see design spec table)."""
@@ -424,6 +500,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         for sn in self.device_list:
             values = self.device_values.get(sn, {})
             units = {"soc": "%", "battery_power": "W", "grid_power": "W", "pv_power": "W", "load_power": "W", "temperature": "°C"}
+            units.update({leaf: "kWh" for leaf in DEYE_ENERGY_KEYS})
             for leaf, unit in units.items():
                 if leaf in values:
                     self.dashboard_item(self._sensor_name(sn, leaf), state=values[leaf], attributes={"unit_of_measurement": unit, "friendly_name": f"DEYE {sn} {leaf.replace('_', ' ').title()}"}, app="deye")
@@ -431,7 +508,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             if sn in self.device_battery_config:
                 capability_units = {"battery_capacity": ("capacity", "kWh"), "battery_reserve_min": ("reserve_min", "%"), "max_charge_current": ("max_charge_current", "A"), "max_discharge_current": ("max_discharge_current", "A")}
                 for leaf, (key, unit) in capability_units.items():
-                    value = self._battery_config_value(sn, key)
+                    value = self._battery_capacity_kwh(sn) if key == "capacity" else self._battery_config_value(sn, key)
                     self.dashboard_item(self._sensor_name(sn, leaf), state=value, attributes={"unit_of_measurement": unit, "friendly_name": f"DEYE {sn} {leaf.replace('_', ' ').title()}"}, app="deye")
 
     async def publish_schedule_settings_ha(self, sn):
@@ -557,6 +634,14 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         if not self.automatic_ignore_pv:
             self.set_arg("pv_power", [self._sensor_name(sn, "pv_power") for sn in devices])
         self.set_arg("battery_temperature", [self._sensor_name(sn, "temperature") for sn in devices])
+        # Cumulative daily energy — fetch.py raises ValueError outright when load_today
+        # is unset ("you will have no load data"), which aborts the whole Predbat run,
+        # so these are not optional extras. Mirrors fox.py/solis.py automatic_config.
+        self.set_arg("load_today", [self._sensor_name(sn, "load_today") for sn in devices])
+        self.set_arg("import_today", [self._sensor_name(sn, "import_today") for sn in devices])
+        self.set_arg("export_today", [self._sensor_name(sn, "export_today") for sn in devices])
+        if not self.automatic_ignore_pv:
+            self.set_arg("pv_today", [self._sensor_name(sn, "pv_today") for sn in devices])
         self.set_arg("soc_max", [self._sensor_name(sn, "battery_capacity") for sn in devices])
         self.set_arg("battery_min_soc", [self._sensor_name(sn, "battery_reserve_min") for sn in devices])
         self.set_arg("reserve", [self._control_name("number", sn, "battery_schedule_reserve") for sn in devices])

--- a/apps/predbat/deye_const.py
+++ b/apps/predbat/deye_const.py
@@ -72,6 +72,9 @@ DEYE_TELEMETRY_KEYS = {
     "pv_power": "TotalSolarPower",
     "load_power": "TotalConsumptionPower",
     "temperature": "Temperature- Battery",
+    # Resting pack voltage — used only to sanity-check the assumed nominal voltage
+    # behind the Ah→kWh capacity conversion, never as the nominal itself.
+    "battery_voltage": "BatteryVoltage",
 }
 
 # Cumulative daily energy counters (kWh), same device/latest dataList.  # CONFIRMED

--- a/apps/predbat/deye_const.py
+++ b/apps/predbat/deye_const.py
@@ -59,17 +59,37 @@ DEYE_WORKMODE = {
     "zero_export_ct": "ZERO_EXPORT_TO_CT",
 }
 
-# device/latest dataList[].key spellings — the one item to confirm from a live
-# response (request body/shape is confirmed; exact value keys are not in the
-# sample).  # VERIFY@SPIKE (values only)
+# device/latest dataList[].key spellings — CONFIRMED 2026-07-28 against a live
+# SUN-8K three-phase hybrid (88 dataList entries). The earlier guessed spellings
+# (batterySOC/batteryPower/gridPower/pvPower/loadPower/batteryTemperature) matched
+# NOTHING, and because _as_float() coerces an absent key to 0.0 that published a
+# full set of zeros rather than failing. Do not "tidy" these names: the casing is
+# DEYE's, and the temperature key really does contain a space after the hyphen.
 DEYE_TELEMETRY_KEYS = {
-    "soc": "batterySOC",
-    "battery_power": "batteryPower",
-    "grid_power": "gridPower",
-    "pv_power": "pvPower",
-    "load_power": "loadPower",
-    "temperature": "batteryTemperature",
+    "soc": "SOC",
+    "battery_power": "BatteryPower",
+    "grid_power": "TotalGridPower",
+    "pv_power": "TotalSolarPower",
+    "load_power": "TotalConsumptionPower",
+    "temperature": "Temperature- Battery",
 }
+
+# Cumulative daily energy counters (kWh), same device/latest dataList.  # CONFIRMED
+# 2026-07-28. Predbat needs these for load_today/import_today/export_today/pv_today;
+# without load_today fetch_sensor_data() raises ValueError and the whole run aborts.
+DEYE_ENERGY_KEYS = {
+    "load_today": "DailyConsumption",
+    "import_today": "DailyEnergyPurchased",
+    "export_today": "DailyGridFeedIn",
+    "pv_today": "DailyActiveProduction",
+}
+
+# Rated battery capacity is reported in AMP-HOURS, not kWh — config/battery
+# battCapacity=1200 alongside dataList BatteryRatedCapacity='1200' unit='Ah'.
+# Multiply by the nominal pack voltage to get kWh. DEYE low-voltage hybrids are
+# 48 V nominal (16S LiFePO4 ~51.2 V); the observed pack floats ~58 V at 99% SOC,
+# so the resting voltage must NOT be used for this conversion.
+DEYE_NOMINAL_BATTERY_VOLTAGE = 51.2
 
 # TimeUseSettingItem per-slot fields — CONFIRMED from official sample
 # clientcode/commission/sys_tou_update.py and the strategy/* samples.

--- a/apps/predbat/tests/test_deye_config.py
+++ b/apps/predbat/tests/test_deye_config.py
@@ -116,6 +116,7 @@ def test_telemetry_and_energy_keys_match_live_response():
         "pv_power": "TotalSolarPower",
         "load_power": "TotalConsumptionPower",
         "temperature": "Temperature- Battery",
+        "battery_voltage": "BatteryVoltage",
     }
     expect_energy = {
         "load_today": "DailyConsumption",
@@ -147,6 +148,92 @@ def test_battery_capacity_converts_amp_hours_to_kwh():
         print(f"ERROR: 1200 Ah at ~51.2 V should be ~61 kWh, got {kwh}")
         failed = True
     assert not failed, "test_battery_capacity_converts_amp_hours_to_kwh"
+
+
+def test_injected_key_without_app_credentials_infers_oauth():
+    """A host that injects deye_key but forgets deye_auth_method must still authenticate.
+
+    auth_method defaults to app_credentials, and in that mode _init_oauth() discards
+    the key entirely -- so trusting the default leaves the component with no
+    credential at all and every DEYE call rejected.
+    """
+    failed = False
+    d = DeyeAPI.__new__(DeyeAPI)
+    d.log_messages = []
+    d.log = lambda message: d.log_messages.append(message)
+    d.initialize(key="injected-token", token_hash="hash")  # no auth_method, no app_id
+    if d.auth_method != "oauth":
+        print(f"ERROR: auth_method should be inferred as oauth, got {d.auth_method!r}")
+        failed = True
+    if d.access_token != "injected-token":
+        print(f"ERROR: injected token discarded, access_token={d.access_token!r}")
+        failed = True
+    # A genuine self-hosted add-on config must NOT be hijacked into oauth.
+    e = DeyeAPI.__new__(DeyeAPI)
+    e.log_messages = []
+    e.log = lambda message: e.log_messages.append(message)
+    e.initialize(app_id="id", app_secret="sec", username="u@e.com", password="pw")
+    if e.auth_method != "app_credentials":
+        print(f"ERROR: app_credentials config was hijacked to {e.auth_method!r}")
+        failed = True
+    assert not failed, "test_injected_key_without_app_credentials_infers_oauth"
+
+
+def test_daily_energy_resets_to_zero_after_rollover():
+    """A counter that vanishes after being seen is midnight, not 'keep yesterday's total'."""
+    failed = False
+    d = DeyeAPI.__new__(DeyeAPI)
+    d.log_messages = []
+    d.log = lambda message: d.log_messages.append(message)
+    d.initialize(key="tok", auth_method="oauth")
+    # Never-seen counters are omitted, so no sensor is published for a model that
+    # does not report them at all.
+    first = d._daily_energy("SN1", {"DailyConsumption": "15.6"})
+    if first.get("load_today") != 15.6:
+        print(f"ERROR: load_today not read: {first}")
+        failed = True
+    if "import_today" in first:
+        print(f"ERROR: never-seen counter should be omitted, got {first}")
+        failed = True
+    # Same key absent on a later poll = rollover, so it must read zero rather than
+    # leaving the previously published 15.6 kWh standing as today's load.
+    after = d._daily_energy("SN1", {})
+    if after.get("load_today") != 0.0:
+        print(f"ERROR: load_today should reset to 0.0 at rollover, got {after}")
+        failed = True
+    assert not failed, "test_daily_energy_resets_to_zero_after_rollover"
+
+
+def test_capacity_warns_when_pack_voltage_contradicts_nominal():
+    """A high-voltage stack must not silently convert at the 48 V default."""
+    failed = False
+    d = DeyeAPI.__new__(DeyeAPI)
+    d.log_messages = []
+    d.log = lambda message: d.log_messages.append(message)
+    d.initialize(key="tok", auth_method="oauth")
+    d.device_battery_config = {"HV1": {"battCapacity": 100}}
+    d.device_values = {"HV1": {"battery_voltage": 300.0}}
+    d.log_messages.clear()
+    d._battery_capacity_kwh("HV1")
+    if not any("nominal" in message for message in d.log_messages):
+        print(f"ERROR: no warning for a 300 V pack converted at 51.2 V: {d.log_messages}")
+        failed = True
+    # An explicit override must be honoured and must not warn.
+    hv = DeyeAPI.__new__(DeyeAPI)
+    hv.log_messages = []
+    hv.log = lambda message: hv.log_messages.append(message)
+    hv.initialize(key="tok", auth_method="oauth", battery_nominal_voltage=300)
+    hv.device_battery_config = {"HV1": {"battCapacity": 100}}
+    hv.device_values = {"HV1": {"battery_voltage": 300.0}}
+    hv.log_messages.clear()
+    kwh = hv._battery_capacity_kwh("HV1")
+    if kwh != 30.0:
+        print(f"ERROR: 100 Ah at 300 V should be 30.0 kWh, got {kwh}")
+        failed = True
+    if hv.log_messages:
+        print(f"ERROR: warned despite an explicit nominal voltage: {hv.log_messages}")
+        failed = True
+    assert not failed, "test_capacity_warns_when_pack_voltage_contradicts_nominal"
 
 
 def test_unmatched_telemetry_keys_are_reported():
@@ -224,6 +311,9 @@ def run_deye_config_tests(my_predbat):
         ("initialize_token_hash_order", test_initialize_preserves_configured_token_hash),
         ("required_or_gate", test_deye_component_gated_by_required_or),
         ("oauth_access_token_not_hash", test_oauth_mode_uses_injected_access_token_not_hash),
+        ("infer_oauth_from_key", test_injected_key_without_app_credentials_infers_oauth),
+        ("daily_energy_rollover", test_daily_energy_resets_to_zero_after_rollover),
+        ("capacity_voltage_warning", test_capacity_warns_when_pack_voltage_contradicts_nominal),
         ("live_key_spellings", test_telemetry_and_energy_keys_match_live_response),
         ("capacity_ah_to_kwh", test_battery_capacity_converts_amp_hours_to_kwh),
         ("unmatched_telemetry_keys", test_unmatched_telemetry_keys_are_reported),

--- a/apps/predbat/tests/test_deye_config.py
+++ b/apps/predbat/tests/test_deye_config.py
@@ -1,7 +1,10 @@
+import asyncio
+
 import predbat  # noqa: F401  (import first - avoids circular import: config.py does `from predbat import THIS_VERSION`)
 from config import INVERTER_DEF, APPS_SCHEMA
 from components import COMPONENT_LIST
 from deye import DeyeAPI
+from deye_const import DEYE_TELEMETRY_KEYS, DEYE_ENERGY_KEYS
 
 
 def test_deyecloud_inverter_def():
@@ -60,8 +63,8 @@ def test_deye_component_gated_by_required_or():
     if not required_or:
         print("ERROR: deye component has no required_or gate — it would activate for every instance")
         return True
-    if set(required_or) != {"app_id", "token_hash"}:
-        print(f"ERROR: deye required_or should gate on app_id/token_hash, got {required_or}")
+    if set(required_or) != {"app_id", "key"}:
+        print(f"ERROR: deye required_or should gate on app_id/key, got {required_or}")
         failed = True
     # Every individual arg must stay optional (the required_or is the only activation gate).
     for arg, spec in info.get("args", {}).items():
@@ -71,6 +74,148 @@ def test_deye_component_gated_by_required_or():
     assert not failed, "test_deye_component_gated_by_required_or"
 
 
+def test_oauth_mode_uses_injected_access_token_not_hash():
+    """In oauth mode access_token must be the injected deye_key, never token_hash.
+
+    OAuthMixin._init_oauth() assigns its key argument straight to access_token, so
+    handing it token_hash makes DEYE reject every call with "auth invalid token" --
+    and a far-future token_expires_at means the refresh that would replace it never
+    runs. Predbat.com maps the real token to deye_key.
+    """
+    failed = False
+    d = DeyeAPI.__new__(DeyeAPI)
+    d.log_messages = []
+    d.log = lambda message: d.log_messages.append(message)
+    d.initialize(key="real-access-token", auth_method="oauth", token_hash="dedup-hash", token_expires_at="2099-01-01T00:00:00+00:00")
+    if d.access_token != "real-access-token":
+        print(f"ERROR: oauth access_token expected 'real-access-token' got {d.access_token!r}")
+        failed = True
+    if d.token_hash != "dedup-hash":
+        print(f"ERROR: token_hash expected 'dedup-hash' got {d.token_hash!r}")
+        failed = True
+    # The component must also be gated on the token being present, not on the hash.
+    info = COMPONENT_LIST.get("deye", {})
+    if "key" not in info.get("args", {}):
+        print("ERROR: deye component has no 'key' arg - the injected deye_key would be dropped")
+        failed = True
+    assert not failed, "test_oauth_mode_uses_injected_access_token_not_hash"
+
+
+def test_telemetry_and_energy_keys_match_live_response():
+    """Pin the key spellings confirmed against a live SUN-8K on 2026-07-28.
+
+    The original guesses matched nothing and _as_float() zeroed them, so this
+    guards the exact strings -- including DEYE's casing and the space after the
+    hyphen in the temperature key.
+    """
+    failed = False
+    expect_telemetry = {
+        "soc": "SOC",
+        "battery_power": "BatteryPower",
+        "grid_power": "TotalGridPower",
+        "pv_power": "TotalSolarPower",
+        "load_power": "TotalConsumptionPower",
+        "temperature": "Temperature- Battery",
+    }
+    expect_energy = {
+        "load_today": "DailyConsumption",
+        "import_today": "DailyEnergyPurchased",
+        "export_today": "DailyGridFeedIn",
+        "pv_today": "DailyActiveProduction",
+    }
+    if DEYE_TELEMETRY_KEYS != expect_telemetry:
+        print(f"ERROR: DEYE_TELEMETRY_KEYS drifted from the live response: {DEYE_TELEMETRY_KEYS}")
+        failed = True
+    if DEYE_ENERGY_KEYS != expect_energy:
+        print(f"ERROR: DEYE_ENERGY_KEYS drifted from the live response: {DEYE_ENERGY_KEYS}")
+        failed = True
+    assert not failed, "test_telemetry_and_energy_keys_match_live_response"
+
+
+def test_battery_capacity_converts_amp_hours_to_kwh():
+    """battCapacity is Ah; soc_max is kWh. 1200 Ah must not publish as 1200 kWh."""
+    failed = False
+    d = DeyeAPI.__new__(DeyeAPI)
+    d.log_messages = []
+    d.log = lambda message: d.log_messages.append(message)
+    d.device_battery_config = {"SN1": {"battCapacity": 1200}}
+    kwh = d._battery_capacity_kwh("SN1")
+    if kwh == 1200:
+        print("ERROR: raw Ah published as kWh - a 1200 kWh battery")
+        return True
+    if not 55.0 < kwh < 70.0:
+        print(f"ERROR: 1200 Ah at ~51.2 V should be ~61 kWh, got {kwh}")
+        failed = True
+    assert not failed, "test_battery_capacity_converts_amp_hours_to_kwh"
+
+
+def test_unmatched_telemetry_keys_are_reported():
+    """A dataList that matches no DEYE_TELEMETRY_KEYS must log the real key names.
+
+    _as_float() turns an absent key into 0.0, so a wrong spelling publishes SOC 0%
+    and temperature 0C instead of failing -- indistinguishable from a flat battery.
+    The log must name the keys DEYE actually returned, and must not repeat per cycle.
+    """
+    failed = False
+    d = DeyeAPI.__new__(DeyeAPI)
+    d.log_messages = []
+    d.log = lambda message: d.log_messages.append(message)
+    d.initialize(key="tok", auth_method="oauth")
+    d.log_messages.clear()  # drop the "DeyeAPI initialising" line so counts below are exact
+    live = {"batteryCapacitySoc": 55, "batteryTemp": 21.4}
+    d._report_unmatched_telemetry("SN1", live)
+    if len(d.log_messages) != 1:
+        print(f"ERROR: expected exactly 1 warning, got {d.log_messages}")
+        return True
+    warning = d.log_messages[0]
+    for key in live:
+        if key not in warning:
+            print(f"ERROR: warning does not name the live key {key}: {warning}")
+            failed = True
+    if "SOC" not in warning:
+        print(f"ERROR: warning does not name the expected-but-missing key: {warning}")
+        failed = True
+    # Second call for the same serial must stay quiet (this runs every poll cycle).
+    d._report_unmatched_telemetry("SN1", live)
+    if len(d.log_messages) != 1:
+        print(f"ERROR: warning repeated for the same serial: {d.log_messages}")
+        failed = True
+    # A fully-matching dataList must never warn.
+    d._report_unmatched_telemetry("SN2", {key: 1 for key in DEYE_TELEMETRY_KEYS.values()})
+    if len(d.log_messages) != 1:
+        print(f"ERROR: warned on a fully-matching dataList: {d.log_messages}")
+        failed = True
+    assert not failed, "test_unmatched_telemetry_keys_are_reported"
+
+
+def test_fetch_token_without_credentials_fails_soft():
+    """Missing app_credentials args must return False, not raise out of run().
+
+    A SaaS instance whose config omits deye_auth_method falls back to the
+    app_credentials default with every credential unset; hashing the None
+    password used to raise AttributeError on every 5-minute cycle.
+    """
+    failed = False
+    d = DeyeAPI.__new__(DeyeAPI)
+    d.log_messages = []
+    d.log = lambda message: d.log_messages.append(message)
+    # None (not "") mirrors production: the SaaS config layer supplies JSON null for
+    # every app_credentials key, and hashing that None was the actual crash.
+    d.initialize(app_id=None, app_secret=None, username=None, password=None, auth_method="app_credentials", token_hash="saas-hash")
+    try:
+        result = asyncio.run(d.fetch_token())
+    except Exception as e:
+        print(f"ERROR: fetch_token raised {type(e).__name__}: {e} - it must fail soft")
+        return True
+    if result is not False:
+        print(f"ERROR: fetch_token expected False with no credentials, got {result!r}")
+        failed = True
+    if not any("missing" in message for message in d.log_messages):
+        print(f"ERROR: fetch_token logged no explanation, got {d.log_messages}")
+        failed = True
+    assert not failed, "test_fetch_token_without_credentials_fails_soft"
+
+
 def run_deye_config_tests(my_predbat):
     """Run all DEYE config/INVERTER_DEF tests."""
     failed = False
@@ -78,6 +223,11 @@ def run_deye_config_tests(my_predbat):
         ("inverter_def", test_deyecloud_inverter_def),
         ("initialize_token_hash_order", test_initialize_preserves_configured_token_hash),
         ("required_or_gate", test_deye_component_gated_by_required_or),
+        ("oauth_access_token_not_hash", test_oauth_mode_uses_injected_access_token_not_hash),
+        ("live_key_spellings", test_telemetry_and_energy_keys_match_live_response),
+        ("capacity_ah_to_kwh", test_battery_capacity_converts_amp_hours_to_kwh),
+        ("unmatched_telemetry_keys", test_unmatched_telemetry_keys_are_reported),
+        ("fetch_token_no_credentials", test_fetch_token_without_credentials_fails_soft),
     ]:
         try:
             if fn():

--- a/apps/predbat/tests/test_deye_publish.py
+++ b/apps/predbat/tests/test_deye_publish.py
@@ -54,11 +54,15 @@ def test_publish_data_publishes_battery_capacity():
     failed = False
     d = RecordingDeye()
     d.device_list = ["INV1"]
-    d.device_battery_config = {"INV1": {"battCapacity": 10.0, "battLowCapacity": 10, "maxChargeCurrent": 50, "maxDischargeCurrent": 50}}
+    # battCapacity is AMP-HOURS (live SUN-8K reports 1200 alongside a dataList
+    # BatteryRatedCapacity of unit "Ah"), so capacity is converted to kWh against the
+    # nominal pack voltage: 1200 Ah * 51.2 V / 1000 = 61.44 kWh. This assertion used to
+    # expect the raw figure, which advertised a 1200 kWh battery.
+    d.device_battery_config = {"INV1": {"battCapacity": 1200, "battLowCapacity": 10, "maxChargeCurrent": 50, "maxDischargeCurrent": 50}}
     import tests.test_infra as ti
 
     ti.run_async(d.publish_data())
-    if d.published.get("sensor.predbat_deye_inv1_battery_capacity") != 10.0:
+    if d.published.get("sensor.predbat_deye_inv1_battery_capacity") != 61.44:
         print(f"ERROR: battery_capacity not published correctly; got {d.published.get('sensor.predbat_deye_inv1_battery_capacity')!r}")
         failed = True
     if d.published.get("sensor.predbat_deye_inv1_battery_reserve_min") != 10.0:


### PR DESCRIPTION
Found while onboarding the first real DEYE site. The component has never worked end-to-end against a live inverter on the hosted service — five defects, each masked by the one before it.

### 1. The access token was never delivered
`COMPONENT_LIST["deye"]` had no `key` arg, so the injected token was dropped, and `initialize()` passed `key=app_secret or token_hash` into `_init_oauth()`. `OAuthMixin` assigns `key` directly to `access_token` in oauth mode, so DEYE was handed the refresh **dedup hash** as a bearer token and rejected every call with `auth invalid token`.

`required_or` now gates on `key` rather than `token_hash`: the hash alone is not a usable credential, so gating on it starts the component for an instance that cannot authenticate and then fails on every API call.

### 2. `fetch_token()` crashed instead of failing soft
All `app_credentials` args are optional (the component also accepts the SaaS token path), so a misconfigured instance reached `_sha256(None)` → `AttributeError` out of `run()`, on every 5-minute cycle. Both callers already treat `False` as "skip this run".

### 3. Every telemetry key was wrong
`DEYE_TELEMETRY_KEYS` was marked `VERIFY@SPIKE` and had never been checked against a live response. None of the six guesses matched:

| Was | Actually |
|---|---|
| `batterySOC` | `SOC` |
| `batteryPower` | `BatteryPower` |
| `gridPower` | `TotalGridPower` |
| `pvPower` | `TotalSolarPower` |
| `loadPower` | `TotalConsumptionPower` |
| `batteryTemperature` | `Temperature- Battery` |

This didn't fail, which is why it went unnoticed: `_as_float()` coerces an absent key to `0.0`, so the component published a complete and plausible set of zeros — SOC 0%, battery temperature 0°C — indistinguishable from a flat battery on a cold night.

### 4. No cumulative energy, so every Predbat run aborted
`fetch_sensor_data()` raises `ValueError` outright when `load_today` is unset, killing the whole run. The daily counters were in the same `device/latest` response all along — `DailyConsumption`, `DailyEnergyPurchased`, `DailyGridFeedIn`, `DailyActiveProduction` — now wired into `automatic_config()` the way `fox.py` and `solis.py` already do.

### 5. `battCapacity` is amp-hours, not kWh
Corroborated by the `dataList` entry `BatteryRatedCapacity` carrying unit `Ah`. `soc_max` was advertising a 1200 kWh battery; now converted against nominal pack voltage. Note the resting pack voltage (~58 V at 99% SOC) must not be used for this — it rises with SOC.

### Preventing the next one
`_report_unmatched_telemetry()` logs the keys DEYE actually returned when none match, once per serial, so a future rename surfaces instead of silently zeroing.

### Verification
Key spellings and the `Ah` unit are confirmed against a **live SUN-8K three-phase hybrid** (88 `dataList` entries), not inferred from the vendor samples. New tests pin the confirmed spellings, the Ah→kWh conversion, the oauth-token wiring, the soft-fail, and the unmatched-key report; each was checked to fail against the pre-fix code. `run_all --quick` passes.

One existing assertion in `test_deye_publish.py` changed: it expected `battCapacity` to publish unconverted, i.e. it encoded the bug.