### PR TITLE
docs(inverter-setup): fix Sigenergy predbat_requested_mode_action template whitespace bug

### DIFF
--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -1637,13 +1637,15 @@ Add the following automations to `automations.yaml` (or configure via the UI):
       target:
         entity_id: select.sigen_plant_remote_ems_control_mode
       data:
-        option: >
-          {% if is_state('input_select.predbat_requested_mode', "Demand") %}Maximum Self Consumption
-          {% elif is_state('input_select.predbat_requested_mode', "Charging") %}Command Charging (PV First)
-          {% elif is_state('input_select.predbat_requested_mode', "Freeze Charging") %}Maximum Self Consumption
-          {% elif is_state('input_select.predbat_requested_mode', "Discharging") %}Command Discharging (PV First)
-          {% elif is_state('input_select.predbat_requested_mode', "Freeze Discharging") %}Maximum Self Consumption
-          {% endif %}
+        # Rendered as a single Jinja expression (not a folded if/elif block) so there's no
+        # embedded literal newline/whitespace in the result - select.select_option requires an
+        # exact match against the target entity's options list.
+        option: >-
+          {{ "Maximum Self Consumption" if is_state('input_select.predbat_requested_mode', "Demand")
+             else "Command Charging (PV First)" if is_state('input_select.predbat_requested_mode', "Charging")
+             else "Maximum Self Consumption" if is_state('input_select.predbat_requested_mode', "Freeze Charging")
+             else "Command Discharging (PV First)" if is_state('input_select.predbat_requested_mode', "Discharging")
+             else "Maximum Self Consumption" }}
     - choose:
         # Freeze Charging
         # Docs:


### PR DESCRIPTION
## Summary
- The documented Sigenergy `predbat_requested_mode_action` automation used a folded YAML block scalar (`>`) around an if/elif chain, which renders a trailing space and newline (e.g. `"Maximum Self Consumption \n"`) for the matched branch.
- `select.select_option` requires an exact match against the target entity's `options` list, so the call silently failed to ever change `select.sigen_plant_remote_ems_control_mode` - HA doesn't surface this loudly in the trace, so it went unnoticed.
- Rewritten as a single Jinja expression (`>-` + `{{ ... if ... else ... }}`) instead of a mixed literal-text/control-flow block, so there's no embedded newline in the output.
- Checked the other per-brand example automations in this doc (Solax, Sunsynk, SolarEdge) for the same pattern - none of them mix multi-line if/elif with literal text inside a folded scalar, so this appears isolated to the Sigenergy section rather than a repeated bug.

Fixes #4297

## Test plan
- [x] `./run_pre_commit` equivalent (`markdownlint-fix`, `cspell`, trailing-whitespace/EOF checks) run against the changed file, all passed
- [ ] Reporter (@a-teece) to confirm the rewritten template renders and applies correctly against their live Sigenergy install

🤖 Generated with [Claude Code](https://claude.com/claude-code)