### PR TITLE
docs: small clarifications for Sigenergy, Kraken, and multi-array PV setups

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -935,7 +935,8 @@ On first run the component queries your account for active meter point agreement
 - **EDF and E.ON Next only** — this component uses the Kraken GraphQL schema specific to those providers and will not work with Octopus Energy (use the `octopus` component instead)
 - The component automatically sets `metric_octopus_import` and `metric_standing_charge` in Predbat, and will also set `metric_octopus_export` **when an export tariff is discovered** — no manual `apps.yaml` edits are needed for those settings once the relevant tariffs have been detected and the component is running
 - E.ON Next customers who have solar export may have their import and export on **separate account numbers** — in this case the component will attempt to discover the export account automatically via an address-matching strategy, or you can provide `export_account_id` explicitly
-- For OSS (self-hosted) installations you need to supply credentials — either an API key (`api_key` auth method) or email/password (`email` auth method). SaaS/cloud-managed installations use OAuth and have credentials managed automatically
+- For OSS (self-hosted) installations you need to supply credentials — either an API key (`api_key` auth method) or email/password (`email` auth method). SaaS/cloud-managed installations use OAuth and have credentials managed automatically. If you can't find a way to generate a separate API key for your provider, use the `email` auth method with the same email/password you use to sign into your normal EDF or E.ON Next online account — no separate key is required for that method
+- For accounts with a SmartFlex-managed EV device, an `intelligent_dispatch` binary sensor is published per device (see [Published entities](#published-entities-kraken)) and automatically wired into `octopus_intelligent_slot`, exactly like Octopus Intelligent Go — no manual `apps.yaml` configuration is needed for this. Make sure **switch.predbat_octopus_intelligent_charging** (see [car charging docs](car-charging.md)) is turned On so Predbat actually uses the dispatch slots for planning
 
 #### Configuration Options (kraken)
 
@@ -1007,6 +1008,7 @@ All entities use the pattern `sensor.predbat_kraken_{account_id}_{suffix}` (acco
 | `sensor.predbat_kraken_a_12345678_import_rates` | Import rate periods — consumed by Predbat automatically |
 | `sensor.predbat_kraken_a_12345678_import_standing` | Daily standing charge in £/day |
 | `sensor.predbat_kraken_a_12345678_export_rates` | Export rate periods — only present when an export tariff is found |
+| `binary_sensor.predbat_kraken_a_12345678_intelligent_dispatch[_N]` | On when a SmartFlex dispatch slot is active for device `N` — only present for accounts with a SmartFlex-managed EV device |
 
 Predbat is automatically configured to use these energy rates once Kraken is enabled.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -117,6 +117,30 @@ To reverse the direction of your [grid power entity](apps-yaml.md#power-data) in
 
 If this is your situation, create a template sensor in Home Assistant that combines the two into one signed value (e.g. `export - import`, or `-import` when only importing) and point **grid_power** at that combined template instead of either sensor directly.
 
+## I have a second solar array that Predbat doesn't manage as an inverter - how do I include its generation?
+
+The [Power Data](apps-yaml.md#power-data) **pv_power**/**pv_today** lists take one entry per inverter Predbat is actually configured to manage (`num_inverters`) - you can't just add an extra line for a second array that has no corresponding managed inverter (e.g. a separate FIT-metered string, or a second hybrid system Predbat isn't controlling), Predbat will still only look for as many sensors as it has inverters defined.
+
+Instead, create a template sensor in Home Assistant that adds the extra array's generation into the same total, and point your managed inverter's **pv_power**/**pv_today** entry at that combined sensor instead of the raw inverter sensor. For example, combining a managed inverter's PV power with a separate FIT array's:
+
+```yaml
+# Combined PV power sensor, updated every 5 minutes instead of the default of every sensor state change
+- trigger:
+    - platform: time_pattern
+      minutes: "/5"
+  sensor:
+    - name: "Combined PV Power"
+      unique_id: "combined_pv_power"
+      unit_of_measurement: W
+      device_class: power
+      state_class: measurement
+      state: >
+        {{ (states('sensor.givtcp_xxx_pv_power') | float(0)
+          + states('sensor.fit_array_pv_power') | float(0)) | round(0) }}
+```
+
+Use a `time_pattern` trigger template (rather than a plain templated sensor in the UI) so it updates on a fixed schedule instead of firing on every state change of either underlying sensor, which generates unnecessary extra state history. The same pattern works for **pv_today** (summing the two daily energy totals instead of instantaneous power).
+
 ## My plan is freeze charging or holding at 100% battery a lot
 
 **Round trip losses**

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -1580,8 +1580,8 @@ To integrate your Sigenergy Sigenstor inverter with Predbat, you will need to fo
     - number.sigen_plant_ess_backup_state_of_charge
     - number.sigen_plant_ess_charge_cut_off_state_of_charge
     - number.sigen_plant_ess_discharge_cut_off_state_of_charge
-    - sensor.sigen_plant_ess_max_charging_limit
-    - sensor.sigen_plant_ess_max_discharging_limit
+    - number.sigen_plant_ess_max_charging_limit
+    - number.sigen_plant_ess_max_discharging_limit
     - sensor.sigen_plant_max_active_power
 
 - The following additions are needed to facilitate integration with Predbat and need to be put into Home Assistant's `configuration.yaml` or configured via the HA user interface:


### PR DESCRIPTION
## Summary
Batch of three independent, small docs-only fixes, each addressing a separate open issue - one commit per issue for traceability:

- **`bf8b3c1c`** Fixes #4102 (in part) - `sensor.sigen_plant_ess_max_charging_limit`/`max_discharging_limit` in the "needs enabling" list should be `number.*`, matching how they're actually referenced in the automations further down the same section. (The other two entity-name variants raised in #4102 are already covered by the existing note later in that section - not re-documented here.)
- **`d7b1d71a`** Fixes #4261 (in part) - clarifies that Kraken's `email` auth method just uses your normal EDF/E.ON Next online account login (no separate API key needed), and documents the per-device `intelligent_dispatch` binary_sensor that Kraken auto-wires into `octopus_intelligent_slot` for SmartFlex EV accounts, which wasn't mentioned anywhere. (The stale-rate-during-dispatch part of #4261 is being tracked separately via #4267 - not touched here.)
- **`0b80487b`** Fixes #3971 - adds a FAQ entry explaining how to fold a second, separately-metered PV array (that Predbat isn't managing as an inverter) into an existing `pv_power`/`pv_today` sensor via a template sensor, since the per-inverter list can't just take an extra unmanaged entry. Based on the working solution from that issue's comment thread.

## Test plan
- [x] `pre-commit` (markdownlint-fix, cspell, trailing-whitespace/EOF) run against all three changed files, all passed
- [ ] Reporters to confirm each resolves their reported confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)