### PR TITLE
docs(inverter-setup): document Victron's target-SoC-only control model

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -50,6 +50,7 @@ cadata
 calib
 Cantarell
 cdn
+Cerbo
 cexxxx
 ceyyyy
 chargedischarge

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -3067,6 +3067,10 @@ rest_command:
 
 This is at an early stage of development, see GitHub discussion [#789](https://github.com/springfall2008/batpred/discussions/798) and [#2846](https://github.com/springfall2008/batpred/issues/2846)
 
+The Victron inverter type is configured with `has_charge_enable_time: false` and `has_discharge_enable_time: false` (only `has_target_soc: true`) - Predbat has no way to enable or disable a charge/discharge window on a Victron/Cerbo system, in any Predbat mode. All it can do is write a target SoC percentage.
+
+This means Predbat can only actually cause charging or discharging if a charge/discharge schedule is already permanently enabled on the Victron/Cerbo side (e.g. covering all day, or whatever hours you want available) - Predbat then just moves the target SoC up or down within that always-open window: raising the target causes charging, lowering it causes discharging, and leaving it at the current SoC holds. There's currently no way to have Predbat also switch a schedule on and off for you.
+
 ## I want to add an unsupported inverter to Predbat
 
 - First copy one of the template configurations that is close to your system and try to configure it to match the sensors you have


### PR DESCRIPTION
## Summary
- The Victron section of the inverter setup docs was just two lines pointing at an open discussion/issue - expanded it with a concrete, verified explanation of why Predbat can't enable/disable charging on Victron/Cerbo systems.
- Confirmed directly against the debug.yaml attached to #4337: the Victron inverter type has `has_charge_enable_time: false` / `has_discharge_enable_time: false` (only `has_target_soc: true`), so no Predbat mode (`Control SoC only`, `Control charge`, etc.) can toggle a charge/discharge window for this inverter - Predbat only ever writes a target SoC.
- Documents the practical implication: a charge/discharge schedule needs to be left permanently enabled on the Victron/Cerbo side so Predbat's target-SoC changes actually result in charging/discharging.

Related to #4337 (not auto-closing it - the underlying report there was already a mode-selection misunderstanding the reporter found themselves; this just documents the deeper "why" they asked about in a follow-up comment).

## Test plan
- [x] `pre-commit` (markdownlint-fix, cspell, trailing-whitespace/EOF) run against the changed files, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)