### PR TITLE
fix(config): raise charge_low_power_margin max from 30 to 60 minutes

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -875,7 +875,7 @@ CONFIG_ITEMS = [
         "friendly_name": "Low power mode margin",
         "type": "input_number",
         "min": 0,
-        "max": 30,
+        "max": 60,
         "step": 5,
         "unit": "minutes",
         "icon": "mdi:seatbelt",


### PR DESCRIPTION
## Summary
- `charge_low_power_margin`'s declared max (`config.py`) has been 30 minutes since the setting was added - no correctness reason for the cap, `find_charge_rate` (`utils.py`) handles a margin exceeding the charge window safely (falls back to max-rate charging for that window rather than erroring).
- This became a real regression for anyone who'd previously set a higher value (e.g. 60) directly in `apps.yaml`: before `013558e7` (`fix(config): clamp input_number config items to their declared min/max`), an apps.yaml override bypassed the HA input_number entity's own min/max entirely, so an out-of-range value passed straight through unclamped. After that patch landed, the same apps.yaml value now gets silently clamped down to the declared max on every config load - which is exactly what #4320 reports (worked before, capped at 30 now).
- Raises the declared max to 60 so that range is actually supported rather than relying on the (now-closed) unclamped-override loophole.

Fixes #4320

## Test plan
- [x] `./run_all --test find_charge_rate --test integer_config --test config_item_range_clamp --test validate_config` - all pass
- [x] `pre-commit` (ruff, black, cspell) run against the changed file, passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)