### PR TITLE
feat(deye): persist state and refresh on TTL tiers instead of every tick

### DIFF
--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -54,12 +54,10 @@ from deye_const import (
     DEYE_TTL_STATIC,
     DEYE_TTL_CONFIG,
     DEYE_TTL_LIVE,
-    DEYE_RESTORE_MAX_LIVE,
     DEYE_RESTORE_MAX_CONTROL,
     DEYE_CACHE_STATIC,
     DEYE_CACHE_CONFIG,
     DEYE_CACHE_RATINGS,
-    DEYE_CACHE_LIVE,
     DEYE_CACHE_CONTROL,
 )
 
@@ -128,6 +126,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         # at startup so the refresh cadence survives a restart instead of restarting with it.
         self._tier_refreshed = {}
         self._cache_restored = False
+        self._saved_ratings = None  # signature of the ratings last written, to skip no-op saves
         self.battery_nominal_voltage = self._as_float(battery_nominal_voltage, 0.0)
         # auth_method defaults to app_credentials, but an injected access token with no
         # developer app credentials can only be oauth — and in app_credentials mode
@@ -967,13 +966,25 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         """Cache the per-device config/battery responses."""
         return await self.save_cache(DEYE_CACHE_CONFIG, self.device_battery_config)
 
-    async def save_ratings(self):
-        """Cache the static per-device ratings derived from device/latest."""
-        return await self.save_cache(DEYE_CACHE_RATINGS, {"capacity": self.device_capacity, "pack_voltage": self.device_pack_voltage, "rated_power": self.device_rated_power})
+    def _ratings_payload(self):
+        """Return the static per-device ratings in their cached shape."""
+        return {"capacity": self.device_capacity, "pack_voltage": self.device_pack_voltage, "rated_power": self.device_rated_power}
 
-    async def save_live(self):
-        """Cache the latest telemetry and energy counters."""
-        return await self.save_cache(DEYE_CACHE_LIVE, {"values": self.device_values, "energy": self.device_energy})
+    async def save_ratings(self):
+        """Cache the ratings, but only when they have actually changed.
+
+        These are written by the once-a-minute live poll yet are static per install, so an
+        unconditional save would rewrite an identical file 1440 times a day. Compared by
+        serialised value rather than identity because the dicts are mutated in place.
+        """
+        payload = self._ratings_payload()
+        signature = json.dumps(payload, sort_keys=True, default=str)
+        if signature == getattr(self, "_saved_ratings", None):
+            return False
+        if await self.save_cache(DEYE_CACHE_RATINGS, payload):
+            self._saved_ratings = signature
+            return True
+        return False
 
     async def save_control(self):
         """Cache control state: what was last written, and any order still in flight."""
@@ -1013,15 +1024,14 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             self.device_capacity = ratings.get("capacity") or {}
             self.device_pack_voltage = ratings.get("pack_voltage") or {}
             self.device_rated_power = ratings.get("rated_power") or {}
+            # Record what is already on disk so the first poll does not rewrite an
+            # identical file.
+            self._saved_ratings = json.dumps(self._ratings_payload(), sort_keys=True, default=str)
 
-        live, age = await self.load_cache(DEYE_CACHE_LIVE)
-        if isinstance(live, dict) and live:
-            if age is not None and age < DEYE_RESTORE_MAX_LIVE:
-                self.device_values = live.get("values") or {}
-                self.device_energy = live.get("energy") or {}
-                self.mark_refreshed("live", age)
-            else:
-                self.log(f"Info: DEYE telemetry cache is stale (age {self._age_text(age)}), waiting for a fresh poll rather than republishing it")
+        # Telemetry is deliberately not restored: the live tier polls every minute anyway,
+        # and HA keeps the last published value of each entity, so there is nothing to gain
+        # from caching it 1440 times a day. The live clock therefore starts unset and the
+        # first tick polls immediately.
 
         control, age = await self.load_cache(DEYE_CACHE_CONTROL)
         if isinstance(control, dict):
@@ -1104,7 +1114,8 @@ class DeyeAPI(ComponentBase, OAuthMixin):
                 self.log(f"Warn: DEYE device/latest failed for {sn}: {e}")
         if got_any:
             self.mark_refreshed("live")
-            await self.save_live()
+            # Only the ratings are cached, and only when they change — the telemetry itself
+            # is not persisted (see DEYE_CACHE_* in deye_const.py).
             await self.save_ratings()
         return got_any
 

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -1105,6 +1105,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
 
     async def refresh_live(self):
         """Poll device/latest for every device, then cache ratings (telemetry is not persisted)."""
+        got_any = False
         for sn in self.device_list:
             try:
                 if await self.fetch_device_data(sn):

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -1146,8 +1146,9 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         if self.tier_expired("config", DEYE_TTL_CONFIG):
             await self.refresh_config()
 
+        live_ok = True
         if self.tier_expired("live", DEYE_TTL_LIVE):
-            await self.refresh_live()
+            live_ok = await self.refresh_live()
 
         # Free: reads the HA control entities rather than the API, so it runs every tick
         # regardless of tier.
@@ -1186,6 +1187,15 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             await self.save_control()
 
         await self._reconcile_control()
+
+        if first and not live_ok:
+            # Startup has not really succeeded without telemetry: automatic_config() would
+            # map only the args backed by cached ratings and permanently skip the rest,
+            # because it runs on the first cycle alone. Returning False leaves first set,
+            # so ComponentBase retries the whole startup path on its backoff (60s doubling
+            # to 128 minutes) until a poll comes back.
+            self.log("Warn: DEYE first poll returned no telemetry, deferring startup; it will be retried after a backoff")
+            return False
 
         if first and self.automatic:
             await self.automatic_config()

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -1104,8 +1104,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         return got_any
 
     async def refresh_live(self):
-        """Poll device/latest for every device, then cache telemetry and ratings."""
-        got_any = False
+        """Poll device/latest for every device, then cache ratings (telemetry is not persisted)."""
         for sn in self.device_list:
             try:
                 if await self.fetch_device_data(sn):

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -18,6 +18,7 @@ token) auth.
 
 import hashlib
 import asyncio
+import time
 import aiohttp
 import argparse
 import json
@@ -49,6 +50,17 @@ from deye_const import (
     DEYE_RATED_POWER_KEY,
     LIFEPO4_CHARGE_VOLTS_PER_CELL,
     LIFEPO4_NOMINAL_VOLTS_PER_CELL,
+    DEYE_STORAGE_MODULE,
+    DEYE_TTL_STATIC,
+    DEYE_TTL_CONFIG,
+    DEYE_TTL_LIVE,
+    DEYE_RESTORE_MAX_LIVE,
+    DEYE_RESTORE_MAX_CONTROL,
+    DEYE_CACHE_STATIC,
+    DEYE_CACHE_CONFIG,
+    DEYE_CACHE_RATINGS,
+    DEYE_CACHE_LIVE,
+    DEYE_CACHE_CONTROL,
 )
 
 
@@ -112,6 +124,10 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         self.applied_payload = {}
         self.control_active = set()
         self.cached_values = {}
+        # tier name -> wall-clock time of last successful refresh; seeded from storage.age()
+        # at startup so the refresh cadence survives a restart instead of restarting with it.
+        self._tier_refreshed = {}
+        self._cache_restored = False
         self.battery_nominal_voltage = self._as_float(battery_nominal_voltage, 0.0)
         # auth_method defaults to app_credentials, but an injected access token with no
         # developer app credentials can only be oauth — and in app_credentials mode
@@ -663,6 +679,10 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         if order_id:
             self.pending_orders[sn] = order_id
             self.log(f"Info: DEYE {sn} control submitted, orderId={order_id}")
+        # Persist immediately rather than at the end of the cycle: a restart between the
+        # write and the next tick would otherwise lose track of the in-flight order and
+        # re-write a payload the inverter already holds.
+        await self.save_control()
         return True
 
     async def poll_order(self, sn):
@@ -889,8 +909,207 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         self.set_arg("scheduled_discharge_enable", [self._control_name("switch", sn, "battery_schedule_export_enable") for sn in devices])
         self.set_arg("schedule_write_button", [self._control_name("switch", sn, "battery_schedule_charge_write") for sn in devices])
 
+    @staticmethod
+    def _age_text(age):
+        """Render a cache age in minutes for logging, tolerating an unknown age."""
+        return f"{age:.1f} minutes" if age is not None else "unknown"
+
+    def tier_expired(self, tier, ttl_minutes):
+        """Return True when a tier has never refreshed or its TTL has elapsed."""
+        last = self._tier_refreshed.get(tier)
+        if last is None:
+            return True
+        return (time.time() - last) / 60.0 >= ttl_minutes
+
+    def mark_refreshed(self, tier, age_minutes=0.0):
+        """Start (or seed) a tier's TTL clock.
+
+        age_minutes lets a restored cache backdate the clock, so a tier cached 2 minutes
+        before a restart still has 13 of its 15 minutes left rather than a fresh 15.
+        """
+        self._tier_refreshed[tier] = time.time() - (age_minutes or 0.0) * 60.0
+
+    async def load_cache(self, name):
+        """Return (data, age_minutes) for one cache file, or (None, None).
+
+        A cache must never break a run, so storage being absent, unreadable or corrupt is
+        reported and treated as a miss — the tier then simply refreshes.
+        """
+        storage = self.storage
+        if not storage:
+            return None, None
+        try:
+            data = await storage.load(DEYE_STORAGE_MODULE, name)
+            if data is None:
+                return None, None
+            age = await storage.age(DEYE_STORAGE_MODULE, name)
+        except Exception as e:
+            self.log(f"Warn: DEYE could not read the {name} cache: {e}")
+            return None, None
+        return data, age
+
+    async def save_cache(self, name, data):
+        """Persist one cache file. No-ops when storage is unavailable."""
+        storage = self.storage
+        if not storage:
+            return False
+        try:
+            return await storage.save(DEYE_STORAGE_MODULE, name, data, format="json", expiry=None)
+        except Exception as e:
+            self.log(f"Warn: DEYE could not write the {name} cache: {e}")
+            return False
+
+    async def save_static(self):
+        """Cache discovery results."""
+        return await self.save_cache(DEYE_CACHE_STATIC, {"station_ids": self.station_ids, "device_list": self.device_list})
+
+    async def save_config(self):
+        """Cache the per-device config/battery responses."""
+        return await self.save_cache(DEYE_CACHE_CONFIG, self.device_battery_config)
+
+    async def save_ratings(self):
+        """Cache the static per-device ratings derived from device/latest."""
+        return await self.save_cache(DEYE_CACHE_RATINGS, {"capacity": self.device_capacity, "pack_voltage": self.device_pack_voltage, "rated_power": self.device_rated_power})
+
+    async def save_live(self):
+        """Cache the latest telemetry and energy counters."""
+        return await self.save_cache(DEYE_CACHE_LIVE, {"values": self.device_values, "energy": self.device_energy})
+
+    async def save_control(self):
+        """Cache control state: what was last written, and any order still in flight."""
+        return await self.save_cache(DEYE_CACHE_CONTROL, {"applied_payload": self.applied_payload, "pending_orders": self.pending_orders, "order_poll_count": self.order_poll_count})
+
+    async def restore_state(self):
+        """Restore cached state at startup and seed each tier's refresh clock.
+
+        Seeding the clocks from storage.age() rather than from process start is what makes
+        the cadence survive a restart: a tier cached two minutes ago keeps the rest of its
+        TTL, one cached nine hours ago re-polls immediately.
+        """
+        static, age = await self.load_cache(DEYE_CACHE_STATIC)
+        if isinstance(static, dict):
+            station_ids = static.get("station_ids")
+            device_list = static.get("device_list")
+            # An empty device_list is never restored as valid: caching an empty discovery
+            # (an outage during the previous run) would otherwise pin the component dead
+            # for the whole 8 hour TTL.
+            if isinstance(device_list, list) and device_list:
+                self.device_list = device_list
+                self.station_ids = station_ids if isinstance(station_ids, list) else []
+                self.mark_refreshed("static", age)
+                self.log(f"Info: DEYE restored {len(device_list)} inverter(s) from cache (age {self._age_text(age)})")
+
+        config, age = await self.load_cache(DEYE_CACHE_CONFIG)
+        if isinstance(config, dict) and config:
+            self.device_battery_config = config
+            self.mark_refreshed("config", age)
+
+        # Ratings are static per install and carry no TTL of their own — device/latest
+        # rewrites them on every live refresh. Restoring them unconditionally is the main
+        # win: automatic_config() can map soc_max/battery_rate_max/inverter_limit at
+        # startup without waiting for a poll to complete.
+        ratings, _ = await self.load_cache(DEYE_CACHE_RATINGS)
+        if isinstance(ratings, dict):
+            self.device_capacity = ratings.get("capacity") or {}
+            self.device_pack_voltage = ratings.get("pack_voltage") or {}
+            self.device_rated_power = ratings.get("rated_power") or {}
+
+        live, age = await self.load_cache(DEYE_CACHE_LIVE)
+        if isinstance(live, dict) and live:
+            if age is not None and age < DEYE_RESTORE_MAX_LIVE:
+                self.device_values = live.get("values") or {}
+                self.device_energy = live.get("energy") or {}
+                self.mark_refreshed("live", age)
+            else:
+                self.log(f"Info: DEYE telemetry cache is stale (age {self._age_text(age)}), waiting for a fresh poll rather than republishing it")
+
+        control, age = await self.load_cache(DEYE_CACHE_CONTROL)
+        if isinstance(control, dict):
+            orders = control.get("pending_orders")
+            counts = control.get("order_poll_count")
+            # Orders restore unconditionally: an unpolled order is orphaned, and
+            # DEYE_ORDER_MAX_POLLS still bounds how long it can stay unconfirmed.
+            if isinstance(orders, dict):
+                self.pending_orders = orders
+                if orders:
+                    self.log(f"Info: DEYE resuming {len(orders)} pending control order(s) from cache")
+            if isinstance(counts, dict):
+                self.order_poll_count = counts
+            applied = control.get("applied_payload")
+            if isinstance(applied, dict) and applied:
+                if age is not None and age < DEYE_RESTORE_MAX_CONTROL:
+                    self.applied_payload = applied
+                else:
+                    # Deliberately discarded. This cache asserts the inverter still holds
+                    # what Predbat last wrote; after a long gap that may be false, and a
+                    # wrongly SKIPPED write leaves the battery diverging from the plan. A
+                    # redundant write is the cheaper mistake.
+                    self.log(f"Info: DEYE applied-payload cache is stale (age {self._age_text(age)}), the next apply will re-write to the inverter")
+
+    async def refresh_static(self):
+        """Re-run discovery and the per-model capability reads, then cache them."""
+        # get_device_list() clears device_list when discovery comes back empty. That was
+        # harmless when discovery only ran at startup, but this tier re-runs every 8 hours
+        # in a long-lived process, and one transient failure must not take a working
+        # component down until the next success. Absence of a result is not a result.
+        previous_devices, previous_stations = self.device_list, self.station_ids
+        await self.get_device_list()
+        if not self.device_list:
+            if previous_devices:
+                self.device_list, self.station_ids = previous_devices, previous_stations
+                self.log(f"Warn: DEYE discovery returned no inverters, keeping the {len(previous_devices)} already known")
+                return False
+            # Neither marked nor saved: an empty discovery must be retried on the next
+            # tick, not cached and left for 8 hours.
+            return False
+        for station_id in self.station_ids:
+            try:
+                await self.fetch_station_latest(station_id)
+            except Exception as e:
+                self.log(f"Warn: DEYE station/latest failed for {station_id}: {e}")
+        for sn in self.device_list:
+            try:
+                await self.fetch_measure_points(sn)
+            except Exception as e:
+                self.log(f"Warn: DEYE device/measurePoints failed for {sn}: {e}")
+        self.mark_refreshed("static")
+        await self.save_static()
+        return True
+
+    async def refresh_config(self):
+        """Re-read config/battery for every device and cache it when anything came back."""
+        got_any = False
+        for sn in self.device_list:
+            try:
+                if await self.fetch_battery_config(sn):
+                    got_any = True
+            except Exception as e:
+                self.log(f"Warn: DEYE config/battery failed for {sn}: {e}")
+        # The clock is started either way so a model that rejects this config point
+        # entirely retries on the tier cadence rather than on every single tick, but the
+        # cache is only written when there is something worth keeping.
+        self.mark_refreshed("config")
+        if got_any:
+            await self.save_config()
+        return got_any
+
+    async def refresh_live(self):
+        """Poll device/latest for every device, then cache telemetry and ratings."""
+        got_any = False
+        for sn in self.device_list:
+            try:
+                if await self.fetch_device_data(sn):
+                    got_any = True
+            except Exception as e:
+                self.log(f"Warn: DEYE device/latest failed for {sn}: {e}")
+        if got_any:
+            self.mark_refreshed("live")
+            await self.save_live()
+            await self.save_ratings()
+        return got_any
+
     async def run(self, seconds, first):
-        """Main component loop: auth, discover, poll, publish, configure."""
+        """Main component loop: auth, restore, tiered refresh, publish, configure."""
         if self.auth_method == "app_credentials" and not getattr(self, "access_token", None):
             if not await self.fetch_token():
                 self.log("Warn: DEYE token unavailable, skipping run")
@@ -899,33 +1118,33 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             self.log("Warn: DEYE OAuth token invalid, skipping run")
             return False
 
-        if first or not self.device_list:
-            await self.get_device_list()
+        if first and not self._cache_restored:
+            # Once per process. Restoring before any polling is what lets the TTL checks
+            # below skip work a previous run already did.
+            self._cache_restored = True
+            await self.restore_state()
+
+        # Discovery also refreshes whenever there are no devices to work with: without
+        # that guard a failed discovery would be retried only once the 8 hour TTL expired.
+        if self.tier_expired("static", DEYE_TTL_STATIC) or not self.device_list:
+            await self.refresh_static()
         if not self.device_list:
             self.log("Error: DEYE no inverters found")
             return False
 
-        if first:
-            # Read-only discovery, once per start: these responses are the reference for
-            # what this model actually exposes, and are traced by the API debug logging.
-            for station_id in self.station_ids:
-                try:
-                    await self.fetch_station_latest(station_id)
-                except Exception as e:
-                    self.log(f"Warn: DEYE station/latest failed for {station_id}: {e}")
-            for sn in self.device_list:
-                try:
-                    await self.fetch_measure_points(sn)
-                except Exception as e:
-                    self.log(f"Warn: DEYE device/measurePoints failed for {sn}: {e}")
+        if self.tier_expired("config", DEYE_TTL_CONFIG):
+            await self.refresh_config()
 
+        if self.tier_expired("live", DEYE_TTL_LIVE):
+            await self.refresh_live()
+
+        # Free: reads the HA control entities rather than the API, so it runs every tick
+        # regardless of tier.
         for sn in self.device_list:
             try:
-                await self.fetch_battery_config(sn)
-                await self.fetch_device_data(sn)
                 await self.get_schedule_settings_ha(sn)
             except Exception as e:
-                self.log(f"Warn: DEYE poll failed for {sn}: {e}")
+                self.log(f"Warn: DEYE schedule read failed for {sn}: {e}")
 
         await self.publish_data()
         for sn in self.device_list:
@@ -934,6 +1153,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         # Drain any control orders left pending by apply_dynamic_control() every cycle (not
         # just on first run) so a write that is HTTP-accepted but then fails to apply on the
         # device doesn't stay masked forever behind the applied-payload change-detection cache.
+        orders_changed = bool(self.pending_orders)
         for sn in list(self.pending_orders.keys()):
             try:
                 status = await self.poll_order(sn)
@@ -949,6 +1169,10 @@ class DeyeAPI(ComponentBase, OAuthMixin):
                     self.pending_orders.pop(sn, None)
                     self.order_poll_count.pop(sn, None)
                     self.applied_payload.pop(sn, None)  # invalidate cache -> next apply re-writes
+        if orders_changed:
+            # Only when orders were actually drained, so an idle cycle does not rewrite the
+            # cache and needlessly reset the applied-payload age used on restore.
+            await self.save_control()
 
         await self._reconcile_control()
 

--- a/apps/predbat/deye_const.py
+++ b/apps/predbat/deye_const.py
@@ -37,6 +37,38 @@ TOU_FILLER_TIMES = ["00:00", "04:00", "08:00", "12:00", "16:00", "20:00", "23:00
 # cache is invalidated and the next apply is forced to re-write.
 DEYE_ORDER_MAX_POLLS = 3
 
+# Storage module name for every persisted DEYE cache file.
+DEYE_STORAGE_MODULE = "deye"
+
+# Refresh cadence per class of state, in minutes. ComponentBase ticks run() every 60
+# seconds, so DEYE_TTL_LIVE of 1 means "every tick". These are the maximum ages a cached
+# tier may reach before it is re-polled; the clocks are seeded from storage.age() at
+# startup so the cadence survives a process restart rather than restarting with it.
+DEYE_TTL_STATIC = 8 * 60  # station/device discovery, measure points — changes when hardware does
+DEYE_TTL_CONFIG = 15  # config/battery — installer settings, effectively static
+DEYE_TTL_LIVE = 1  # device/latest — telemetry and energy counters
+
+# Restore bounds, in minutes. Data older than this is discarded at startup rather than
+# reused, because republishing it would be actively misleading rather than merely stale.
+# Telemetry: an hours-old SOC published as current is worse than a brief gap, and the
+# energy counters feed Predbat's load/rate history.
+DEYE_RESTORE_MAX_LIVE = 15
+# applied_payload: this is a change-detection cache with no API read-back, so restoring it
+# asserts the inverter still holds what Predbat last wrote. If it was changed externally
+# while Predbat was down that assertion is false, the next write is wrongly SKIPPED and the
+# battery silently diverges from the plan. A redundant write is cheap; a skipped one is
+# not. Bounded so quick restarts keep the benefit and any longer outage forces a rewrite.
+DEYE_RESTORE_MAX_CONTROL = 15
+
+# Cache file names under DEYE_STORAGE_MODULE. One file per tier so storage.age() gives each
+# an independent clock; a single blob would need hand-rolled per-section timestamps, and
+# rewriting it every minute for live data would reset the static tier's age to zero.
+DEYE_CACHE_STATIC = "static"  # station_ids, device_list
+DEYE_CACHE_CONFIG = "config"  # device_battery_config
+DEYE_CACHE_RATINGS = "ratings"  # device_capacity, device_pack_voltage, device_rated_power
+DEYE_CACHE_LIVE = "live"  # device_values, device_energy
+DEYE_CACHE_CONTROL = "control"  # applied_payload, pending_orders, order_poll_count
+
 # DEYE does NOT answer an expired/invalid bearer token with HTTP 401 — it returns
 # HTTP 200 carrying a body-level failure, e.g. {"success": false, "msg": "auth invalid
 # token"}. Status-code-only handling therefore never triggers a refresh and the

--- a/apps/predbat/deye_const.py
+++ b/apps/predbat/deye_const.py
@@ -48,12 +48,8 @@ DEYE_TTL_STATIC = 8 * 60  # station/device discovery, measure points — changes
 DEYE_TTL_CONFIG = 15  # config/battery — installer settings, effectively static
 DEYE_TTL_LIVE = 1  # device/latest — telemetry and energy counters
 
-# Restore bounds, in minutes. Data older than this is discarded at startup rather than
-# reused, because republishing it would be actively misleading rather than merely stale.
-# Telemetry: an hours-old SOC published as current is worse than a brief gap, and the
-# energy counters feed Predbat's load/rate history.
-DEYE_RESTORE_MAX_LIVE = 15
-# applied_payload: this is a change-detection cache with no API read-back, so restoring it
+# Restore bound in minutes for applied_payload: this is a change-detection cache with no
+# API read-back, so restoring it
 # asserts the inverter still holds what Predbat last wrote. If it was changed externally
 # while Predbat was down that assertion is false, the next write is wrongly SKIPPED and the
 # battery silently diverges from the plan. A redundant write is cheap; a skipped one is
@@ -66,8 +62,16 @@ DEYE_RESTORE_MAX_CONTROL = 15
 DEYE_CACHE_STATIC = "static"  # station_ids, device_list
 DEYE_CACHE_CONFIG = "config"  # device_battery_config
 DEYE_CACHE_RATINGS = "ratings"  # device_capacity, device_pack_voltage, device_rated_power
-DEYE_CACHE_LIVE = "live"  # device_values, device_energy
 DEYE_CACHE_CONTROL = "control"  # applied_payload, pending_orders, order_poll_count
+
+# Telemetry and the energy counters are deliberately NOT cached. The live tier polls every
+# minute, so a cache would be written 1440 times a day to save at most one tick's gap at
+# startup — a poor trade against that much file or network IO. Home Assistant already
+# retains the last published value of every entity, and publish_data() only writes a
+# sensor when it has a value, so a failed poll leaves the previous reading in place rather
+# than overwriting it. Ratings are written by the same poll but ARE cached, because they
+# are static and are what lets automatic_config() map soc_max/battery_rate_max/
+# inverter_limit at startup; they are saved only when they actually change.
 
 # DEYE does NOT answer an expired/invalid bearer token with HTTP 401 — it returns
 # HTTP 200 carrying a body-level failure, e.g. {"success": false, "msg": "auth invalid

--- a/apps/predbat/tests/test_deye_api.py
+++ b/apps/predbat/tests/test_deye_api.py
@@ -48,6 +48,8 @@ class MockDeye(DeyeAPI):
         self.applied_payload = {}
         self.control_active = set()
         self.cached_values = {}
+        self._tier_refreshed = {}
+        self._cache_restored = False
         self.log_messages = []
         self.local_tz = pytz.timezone("Europe/London")
         self.base = MagicMock()

--- a/apps/predbat/tests/test_deye_control.py
+++ b/apps/predbat/tests/test_deye_control.py
@@ -273,6 +273,10 @@ async def _fake_run_step():
 
 def _patched_run(d, poll_status):
     """Run one DEYE run() cycle with per-inverter I/O stubbed and poll_order fixed to poll_status."""
+    # These tests are about draining control orders on a component that has already
+    # discovered its inverters, so the static tier starts fresh; without this run() would
+    # re-run discovery over the network before ever reaching the drain loop.
+    d.mark_refreshed("static")
 
     async def fake_poll_order(sn):
         """Return the fixed status for every call, mirroring the real poll_order's pop-on-success side effect."""

--- a/apps/predbat/tests/test_deye_storage.py
+++ b/apps/predbat/tests/test_deye_storage.py
@@ -414,6 +414,88 @@ def test_fresh_applied_payload_suppresses_a_redundant_write():
     assert not failed, "test_fresh_applied_payload_suppresses_a_redundant_write"
 
 
+def test_first_run_fails_when_telemetry_is_unavailable():
+    """A first cycle with no telemetry returns False so ComponentBase retries startup.
+
+    automatic_config() runs on the first cycle alone, so completing startup without
+    telemetry would permanently skip the energy args (import_today and friends) until the
+    next process restart. Failing the run leaves first set and the driver backs off and
+    retries instead.
+    """
+    failed = False
+    d = StorageDeye(auth_method="oauth")
+    d._mock_storage = _warm_cache()
+    configured = []
+
+    async def fake_post(endpoint_key, body):
+        """Fake DEYE POST: device/latest reports a failure body."""
+        if endpoint_key == "device_latest":
+            return {"success": False, "msg": "device offline"}
+        return {"success": True}
+
+    async def record_config():
+        """Record that automatic_config was reached."""
+        configured.append(True)
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        with patch.object(d, "check_and_refresh_oauth_token", side_effect=_true):
+            with patch.object(d, "publish_data", side_effect=_noop):
+                with patch.object(d, "publish_schedule_settings_ha", side_effect=_noop_arg):
+                    with patch.object(d, "_reconcile_control", side_effect=_noop):
+                        with patch.object(d, "automatic_config", side_effect=record_config):
+                            d.automatic = True
+                            result = run_async(d.run(seconds=0, first=True))
+
+    if result is not False:
+        print(f"ERROR: a first run without telemetry must return False, got {result!r}")
+        failed = True
+    if configured:
+        print("ERROR: automatic_config must not run on an incomplete first cycle")
+        failed = True
+    if not any("deferring startup" in m for m in d.log_messages):
+        print(f"ERROR: expected a deferred-startup warning: {d.log_messages}")
+        failed = True
+    assert not failed, "test_first_run_fails_when_telemetry_is_unavailable"
+
+
+def test_first_run_succeeds_once_telemetry_arrives():
+    """The retry completes startup: telemetry polls, automatic_config runs, run returns True."""
+    failed = False
+    d = StorageDeye(auth_method="oauth")
+    d._mock_storage = _warm_cache()
+    configured = []
+
+    async def fake_post(endpoint_key, body):
+        """Fake DEYE POST: device/latest now succeeds."""
+        if endpoint_key == "device_latest":
+            return {"success": True, "deviceDataList": [{"deviceSn": "INV1", "dataList": LIVE_DATA_LIST}]}
+        return {"success": True}
+
+    async def record_config():
+        """Record that automatic_config was reached."""
+        configured.append(True)
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        with patch.object(d, "check_and_refresh_oauth_token", side_effect=_true):
+            with patch.object(d, "publish_data", side_effect=_noop):
+                with patch.object(d, "publish_schedule_settings_ha", side_effect=_noop_arg):
+                    with patch.object(d, "_reconcile_control", side_effect=_noop):
+                        with patch.object(d, "automatic_config", side_effect=record_config):
+                            d.automatic = True
+                            result = run_async(d.run(seconds=0, first=True))
+
+    if result is not True:
+        print(f"ERROR: a first run with telemetry must return True, got {result!r}")
+        failed = True
+    if not configured:
+        print("ERROR: automatic_config should run once telemetry is available")
+        failed = True
+    if not d.device_energy.get("INV1"):
+        print(f"ERROR: energy counters should be populated for automatic_config: {d.device_energy}")
+        failed = True
+    assert not failed, "test_first_run_succeeds_once_telemetry_arrives"
+
+
 def test_storage_absent_behaves_as_before():
     """With no storage component every load/save no-ops and each tier simply refreshes."""
     failed = False
@@ -576,6 +658,8 @@ def run_deye_storage_tests(my_predbat):
         ("restore_primes_ratings", test_restore_primes_the_ratings_signature),
         ("stale_applied_payload", test_stale_applied_payload_is_discarded_but_orders_are_not),
         ("fresh_applied_payload_suppresses", test_fresh_applied_payload_suppresses_a_redundant_write),
+        ("first_fails_without_telemetry", test_first_run_fails_when_telemetry_is_unavailable),
+        ("first_succeeds_with_telemetry", test_first_run_succeeds_once_telemetry_arrives),
         ("storage_absent", test_storage_absent_behaves_as_before),
         ("corrupt_cache_isolated", test_corrupt_cache_only_affects_its_own_tier),
         ("shape_validation", test_shape_validation_rejects_garbage),

--- a/apps/predbat/tests/test_deye_storage.py
+++ b/apps/predbat/tests/test_deye_storage.py
@@ -12,7 +12,7 @@ import time
 from unittest.mock import patch
 from tests.test_infra import run_async
 from tests.test_deye_api import MockDeye, LIVE_DATA_LIST
-from deye_const import DEYE_TTL_STATIC, DEYE_TTL_CONFIG, DEYE_TTL_LIVE, DEYE_RESTORE_MAX_LIVE, DEYE_RESTORE_MAX_CONTROL, DEYE_CACHE_STATIC, DEYE_CACHE_CONFIG, DEYE_CACHE_RATINGS, DEYE_CACHE_LIVE, DEYE_CACHE_CONTROL
+from deye_const import DEYE_TTL_STATIC, DEYE_TTL_CONFIG, DEYE_TTL_LIVE, DEYE_RESTORE_MAX_CONTROL, DEYE_CACHE_STATIC, DEYE_CACHE_CONFIG, DEYE_CACHE_RATINGS, DEYE_CACHE_CONTROL
 
 
 class FakeStorage:
@@ -62,7 +62,6 @@ def _warm_cache(**ages):
         DEYE_CACHE_STATIC: {"station_ids": [61016286], "device_list": ["INV1"]},
         DEYE_CACHE_CONFIG: {"INV1": {"battCapacity": 1200, "battLowCapacity": 14, "maxChargeCurrent": 185}},
         DEYE_CACHE_RATINGS: {"capacity": {"INV1": 61.44}, "pack_voltage": {"INV1": 51.2}, "rated_power": {"INV1": 8000.0}},
-        DEYE_CACHE_LIVE: {"values": {"INV1": {"soc": 94.0}}, "energy": {"INV1": {"load_today": 14326.4}}},
         DEYE_CACHE_CONTROL: {"applied_payload": {"INV1": {"deviceSn": "INV1", "touAction": "on"}}, "pending_orders": {}, "order_poll_count": {}},
     }
     default_ages = {name: ages.get(name, 0.5) for name in data}
@@ -115,16 +114,17 @@ def test_restore_seeds_clocks_and_state():
     if d.device_capacity.get("INV1") != 61.44 or d.device_rated_power.get("INV1") != 8000.0:
         print(f"ERROR: ratings not restored: {d.device_capacity} {d.device_rated_power}")
         failed = True
-    if d.device_values.get("INV1", {}).get("soc") != 94.0:
-        print(f"ERROR: telemetry not restored: {d.device_values}")
-        failed = True
     if d.applied_payload.get("INV1", {}).get("touAction") != "on":
         print(f"ERROR: applied_payload not restored: {d.applied_payload}")
         failed = True
-    for tier, ttl in (("static", DEYE_TTL_STATIC), ("config", DEYE_TTL_CONFIG), ("live", DEYE_TTL_LIVE)):
+    for tier, ttl in (("static", DEYE_TTL_STATIC), ("config", DEYE_TTL_CONFIG)):
         if d.tier_expired(tier, ttl):
             print(f"ERROR: {tier} clock should have been seeded fresh")
             failed = True
+    # Live is deliberately not cached, so its clock stays unset and the first tick polls
+    if not d.tier_expired("live", DEYE_TTL_LIVE):
+        print("ERROR: the live tier must start expired so telemetry is polled fresh")
+        failed = True
     assert not failed, "test_restore_seeds_clocks_and_state"
 
 
@@ -134,7 +134,6 @@ def test_warm_restart_makes_no_api_calls_beyond_live():
     d = StorageDeye(auth_method="oauth")
     d._mock_storage = _warm_cache()
     # Live is 1 minute, so age it past that while leaving the other tiers fresh
-    d._mock_storage.ages[DEYE_CACHE_LIVE] = 5.0
     calls = []
 
     async def fake_post(endpoint_key, body):
@@ -277,26 +276,83 @@ def test_failed_discovery_is_not_cached():
     assert not failed, "test_failed_discovery_is_not_cached"
 
 
-def test_stale_telemetry_is_discarded():
-    """Telemetry older than the restore bound is dropped rather than republished as current."""
+def test_telemetry_is_not_cached_at_all():
+    """Telemetry is never persisted: the live tier re-polls, and HA holds the last value.
+
+    Caching it would mean 1440 writes a day to save at most one tick's gap at startup.
+    Ratings come from the same poll but ARE cached, because they are static and are what
+    lets automatic_config() map soc_max/inverter_limit before the first poll returns.
+    """
     failed = False
     d = StorageDeye()
     d._mock_storage = _warm_cache()
-    d._mock_storage.ages[DEYE_CACHE_LIVE] = DEYE_RESTORE_MAX_LIVE + 1
 
     run_async(d.restore_state())
 
-    if d.device_values:
-        print(f"ERROR: stale telemetry should not be restored: {d.device_values}")
+    if d.device_values or d.device_energy:
+        print(f"ERROR: telemetry must not be restored: {d.device_values} {d.device_energy}")
         failed = True
-    if not any("telemetry cache is stale" in m for m in d.log_messages):
-        print(f"ERROR: expected a stale-telemetry log line: {d.log_messages}")
+    if not d.tier_expired("live", DEYE_TTL_LIVE):
+        print("ERROR: with no telemetry cache the live tier must start expired so it polls")
         failed = True
-    # Ratings are static and must survive regardless of the telemetry bound
     if d.device_rated_power.get("INV1") != 8000.0:
-        print(f"ERROR: ratings must restore unconditionally: {d.device_rated_power}")
+        print(f"ERROR: ratings must still restore: {d.device_rated_power}")
         failed = True
-    assert not failed, "test_stale_telemetry_is_discarded"
+    assert not failed, "test_telemetry_is_not_cached_at_all"
+
+
+def test_ratings_are_saved_only_when_they_change():
+    """The once-a-minute poll must not rewrite an identical ratings file every time."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = FakeStorage()
+    d.device_list = ["INV1"]
+
+    async def fake_post(endpoint_key, body):
+        """Fake DEYE POST returning the same device/latest payload each call."""
+        return {"success": True, "deviceDataList": [{"deviceSn": "INV1", "dataList": LIVE_DATA_LIST}]}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        run_async(d.refresh_live())
+        first_saves = list(d._mock_storage.saves)
+        for _ in range(5):
+            run_async(d.refresh_live())
+
+    if first_saves.count(DEYE_CACHE_RATINGS) != 1:
+        print(f"ERROR: the first poll should write ratings once: {first_saves}")
+        failed = True
+    if d._mock_storage.saves.count(DEYE_CACHE_RATINGS) != 1:
+        print(f"ERROR: unchanged ratings must not be rewritten: {d._mock_storage.saves}")
+        failed = True
+
+    # A genuine change is written
+    d.device_rated_power["INV1"] = 5000.0
+    run_async(d.save_ratings())
+    if d._mock_storage.saves.count(DEYE_CACHE_RATINGS) != 2:
+        print(f"ERROR: changed ratings should be saved: {d._mock_storage.saves}")
+        failed = True
+    assert not failed, "test_ratings_are_saved_only_when_they_change"
+
+
+def test_restore_primes_the_ratings_signature():
+    """Restored ratings are recorded as already-on-disk so the first poll writes nothing."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = _warm_cache()
+    run_async(d.restore_state())
+    d.device_list = ["INV1"]
+
+    async def fake_post(endpoint_key, body):
+        """Fake DEYE POST returning the same ratings the cache already holds."""
+        return {"success": True, "deviceDataList": [{"deviceSn": "INV1", "dataList": LIVE_DATA_LIST}]}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        run_async(d.refresh_live())
+
+    if DEYE_CACHE_RATINGS in d._mock_storage.saves:
+        print(f"ERROR: identical restored ratings must not be rewritten: {d._mock_storage.saves}")
+        failed = True
+    assert not failed, "test_restore_primes_the_ratings_signature"
 
 
 def test_stale_applied_payload_is_discarded_but_orders_are_not():
@@ -411,10 +467,9 @@ def test_shape_validation_rejects_garbage():
             DEYE_CACHE_STATIC: ["not", "a", "dict"],
             DEYE_CACHE_CONFIG: "garbage",
             DEYE_CACHE_RATINGS: 42,
-            DEYE_CACHE_LIVE: {"values": "not-a-dict"},
             DEYE_CACHE_CONTROL: {"applied_payload": "nope", "pending_orders": []},
         },
-        ages={name: 0.1 for name in (DEYE_CACHE_STATIC, DEYE_CACHE_CONFIG, DEYE_CACHE_RATINGS, DEYE_CACHE_LIVE, DEYE_CACHE_CONTROL)},
+        ages={name: 0.1 for name in (DEYE_CACHE_STATIC, DEYE_CACHE_CONFIG, DEYE_CACHE_RATINGS, DEYE_CACHE_CONTROL)},
     )
 
     run_async(d.restore_state())
@@ -432,7 +487,7 @@ def test_shape_validation_rejects_garbage():
 
 
 def test_refresh_saves_each_tier():
-    """A successful refresh writes its own cache file, and live also writes ratings."""
+    """A successful refresh writes its own cache file; the live poll writes ratings."""
     failed = False
     d = StorageDeye()
     d._mock_storage = FakeStorage()
@@ -448,7 +503,7 @@ def test_refresh_saves_each_tier():
         run_async(d.refresh_config())
         run_async(d.refresh_live())
 
-    for name in (DEYE_CACHE_CONFIG, DEYE_CACHE_LIVE, DEYE_CACHE_RATINGS):
+    for name in (DEYE_CACHE_CONFIG, DEYE_CACHE_RATINGS):
         if name not in d._mock_storage.saves:
             print(f"ERROR: {name} was not saved after a successful refresh: {d._mock_storage.saves}")
             failed = True
@@ -516,7 +571,9 @@ def run_deye_storage_tests(my_predbat):
         ("tiers_expire_independently", test_expired_config_refreshes_without_touching_discovery),
         ("empty_devices_force_discovery", test_empty_device_list_forces_discovery_despite_fresh_clock),
         ("failed_discovery_not_cached", test_failed_discovery_is_not_cached),
-        ("stale_telemetry_discarded", test_stale_telemetry_is_discarded),
+        ("telemetry_not_cached", test_telemetry_is_not_cached_at_all),
+        ("ratings_saved_on_change", test_ratings_are_saved_only_when_they_change),
+        ("restore_primes_ratings", test_restore_primes_the_ratings_signature),
         ("stale_applied_payload", test_stale_applied_payload_is_discarded_but_orders_are_not),
         ("fresh_applied_payload_suppresses", test_fresh_applied_payload_suppresses_a_redundant_write),
         ("storage_absent", test_storage_absent_behaves_as_before),

--- a/apps/predbat/tests/test_deye_storage.py
+++ b/apps/predbat/tests/test_deye_storage.py
@@ -1,0 +1,539 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# Test DEYE storage persistence and tiered refresh
+# -----------------------------------------------------------------------------
+
+"""Tests for DEYE cache persistence and the TTL-driven refresh tiers (``deye.py``)."""
+
+import time
+from unittest.mock import patch
+from tests.test_infra import run_async
+from tests.test_deye_api import MockDeye, LIVE_DATA_LIST
+from deye_const import DEYE_TTL_STATIC, DEYE_TTL_CONFIG, DEYE_TTL_LIVE, DEYE_RESTORE_MAX_LIVE, DEYE_RESTORE_MAX_CONTROL, DEYE_CACHE_STATIC, DEYE_CACHE_CONFIG, DEYE_CACHE_RATINGS, DEYE_CACHE_LIVE, DEYE_CACHE_CONTROL
+
+
+class FakeStorage:
+    """In-memory stand-in for the Storage component, with controllable ages."""
+
+    def __init__(self, data=None, ages=None):
+        """Seed the fake with pre-existing cache entries and their ages in minutes."""
+        self.data = dict(data or {})
+        self.ages = dict(ages or {})
+        self.saves = []
+        self.fail_on = set()
+
+    async def save(self, module, filename, data, format="yaml", expiry=None):
+        """Record a save and store the value, resetting that entry's age to zero."""
+        if filename in self.fail_on:
+            raise IOError(f"simulated write failure for {filename}")
+        self.saves.append(filename)
+        self.data[filename] = data
+        self.ages[filename] = 0.0
+        return True
+
+    async def load(self, module, filename):
+        """Return a stored value, or None when absent."""
+        if filename in self.fail_on:
+            raise IOError(f"simulated read failure for {filename}")
+        return self.data.get(filename)
+
+    async def age(self, module, filename):
+        """Return the stored age in minutes, or None when absent."""
+        if filename not in self.data:
+            return None
+        return self.ages.get(filename, 0.0)
+
+
+class StorageDeye(MockDeye):
+    """MockDeye with an injectable storage component, mirroring tests/test_ge_cloud.py."""
+
+    @property
+    def storage(self):
+        """Return the injected storage double, or None when not set."""
+        return getattr(self, "_mock_storage", None)
+
+
+def _warm_cache(**ages):
+    """Build a FakeStorage holding a complete set of caches at the given ages."""
+    data = {
+        DEYE_CACHE_STATIC: {"station_ids": [61016286], "device_list": ["INV1"]},
+        DEYE_CACHE_CONFIG: {"INV1": {"battCapacity": 1200, "battLowCapacity": 14, "maxChargeCurrent": 185}},
+        DEYE_CACHE_RATINGS: {"capacity": {"INV1": 61.44}, "pack_voltage": {"INV1": 51.2}, "rated_power": {"INV1": 8000.0}},
+        DEYE_CACHE_LIVE: {"values": {"INV1": {"soc": 94.0}}, "energy": {"INV1": {"load_today": 14326.4}}},
+        DEYE_CACHE_CONTROL: {"applied_payload": {"INV1": {"deviceSn": "INV1", "touAction": "on"}}, "pending_orders": {}, "order_poll_count": {}},
+    }
+    default_ages = {name: ages.get(name, 0.5) for name in data}
+    return FakeStorage(data=data, ages=default_ages)
+
+
+def test_tier_expiry_clock():
+    """A tier is expired when never refreshed or older than its TTL, and fresh in between."""
+    failed = False
+    d = StorageDeye()
+    if not d.tier_expired("static", DEYE_TTL_STATIC):
+        print("ERROR: an unrefreshed tier must be expired")
+        failed = True
+    d.mark_refreshed("static")
+    if d.tier_expired("static", DEYE_TTL_STATIC):
+        print("ERROR: a just-refreshed tier must not be expired")
+        failed = True
+    # Backdate past the TTL
+    d.mark_refreshed("static", age_minutes=DEYE_TTL_STATIC + 1)
+    if not d.tier_expired("static", DEYE_TTL_STATIC):
+        print("ERROR: a tier older than its TTL must be expired")
+        failed = True
+    # Backdating preserves the remaining life rather than granting a full TTL
+    d.mark_refreshed("config", age_minutes=DEYE_TTL_CONFIG - 1)
+    if d.tier_expired("config", DEYE_TTL_CONFIG):
+        print("ERROR: a tier with life left must not be expired")
+        failed = True
+    d.mark_refreshed("config", age_minutes=DEYE_TTL_CONFIG - 1)
+    with patch("deye.time.time", return_value=time.time() + 120):
+        if not d.tier_expired("config", DEYE_TTL_CONFIG):
+            print("ERROR: the remaining life must expire, not reset to a full TTL")
+            failed = True
+    assert not failed, "test_tier_expiry_clock"
+
+
+def test_restore_seeds_clocks_and_state():
+    """A warm cache restores every tier and seeds its clock, so nothing needs re-polling."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = _warm_cache()
+
+    run_async(d.restore_state())
+
+    if d.device_list != ["INV1"] or d.station_ids != [61016286]:
+        print(f"ERROR: discovery not restored: {d.device_list} {d.station_ids}")
+        failed = True
+    if d.device_battery_config.get("INV1", {}).get("battCapacity") != 1200:
+        print(f"ERROR: config not restored: {d.device_battery_config}")
+        failed = True
+    if d.device_capacity.get("INV1") != 61.44 or d.device_rated_power.get("INV1") != 8000.0:
+        print(f"ERROR: ratings not restored: {d.device_capacity} {d.device_rated_power}")
+        failed = True
+    if d.device_values.get("INV1", {}).get("soc") != 94.0:
+        print(f"ERROR: telemetry not restored: {d.device_values}")
+        failed = True
+    if d.applied_payload.get("INV1", {}).get("touAction") != "on":
+        print(f"ERROR: applied_payload not restored: {d.applied_payload}")
+        failed = True
+    for tier, ttl in (("static", DEYE_TTL_STATIC), ("config", DEYE_TTL_CONFIG), ("live", DEYE_TTL_LIVE)):
+        if d.tier_expired(tier, ttl):
+            print(f"ERROR: {tier} clock should have been seeded fresh")
+            failed = True
+    assert not failed, "test_restore_seeds_clocks_and_state"
+
+
+def test_warm_restart_makes_no_api_calls_beyond_live():
+    """The point of the whole feature: a restart inside every TTL only polls device/latest."""
+    failed = False
+    d = StorageDeye(auth_method="oauth")
+    d._mock_storage = _warm_cache()
+    # Live is 1 minute, so age it past that while leaving the other tiers fresh
+    d._mock_storage.ages[DEYE_CACHE_LIVE] = 5.0
+    calls = []
+
+    async def fake_post(endpoint_key, body):
+        """Record every endpoint the run touches."""
+        calls.append(endpoint_key)
+        if endpoint_key == "device_latest":
+            return {"success": True, "deviceDataList": [{"deviceSn": "INV1", "dataList": LIVE_DATA_LIST}]}
+        return {"success": True}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        with patch.object(d, "check_and_refresh_oauth_token", side_effect=_true):
+            with patch.object(d, "publish_data", side_effect=_noop):
+                with patch.object(d, "publish_schedule_settings_ha", side_effect=_noop_arg):
+                    with patch.object(d, "_reconcile_control", side_effect=_noop):
+                        with patch.object(d, "automatic_config", side_effect=_noop):
+                            run_async(d.run(seconds=0, first=True))
+
+    if "station_list" in calls or "station_device" in calls:
+        print(f"ERROR: discovery re-polled on a warm restart: {calls}")
+        failed = True
+    if "config_battery" in calls:
+        print(f"ERROR: config/battery re-polled while still inside its TTL: {calls}")
+        failed = True
+    if "device_latest" not in calls:
+        print(f"ERROR: the live tier should still poll: {calls}")
+        failed = True
+    assert not failed, "test_warm_restart_makes_no_api_calls_beyond_live"
+
+
+async def _true(*args, **kwargs):
+    """Async stand-in returning True."""
+    return True
+
+
+async def _noop(*args, **kwargs):
+    """Async no-op."""
+    return None
+
+
+async def _noop_arg(*args, **kwargs):
+    """Async no-op accepting positional arguments."""
+    return None
+
+
+def test_expired_config_refreshes_without_touching_discovery():
+    """Tiers expire independently — a stale config must not drag discovery along with it."""
+    failed = False
+    d = StorageDeye(auth_method="oauth")
+    d._mock_storage = _warm_cache()
+    d._mock_storage.ages[DEYE_CACHE_CONFIG] = DEYE_TTL_CONFIG + 5
+    calls = []
+
+    async def fake_post(endpoint_key, body):
+        """Record every endpoint the run touches."""
+        calls.append(endpoint_key)
+        if endpoint_key == "device_latest":
+            return {"success": True, "deviceDataList": [{"deviceSn": "INV1", "dataList": LIVE_DATA_LIST}]}
+        return {"success": True, "battCapacity": 1200}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        with patch.object(d, "check_and_refresh_oauth_token", side_effect=_true):
+            with patch.object(d, "publish_data", side_effect=_noop):
+                with patch.object(d, "publish_schedule_settings_ha", side_effect=_noop_arg):
+                    with patch.object(d, "_reconcile_control", side_effect=_noop):
+                        with patch.object(d, "automatic_config", side_effect=_noop):
+                            run_async(d.run(seconds=0, first=True))
+
+    if "config_battery" not in calls:
+        print(f"ERROR: an expired config tier should re-poll: {calls}")
+        failed = True
+    if "station_list" in calls:
+        print(f"ERROR: discovery must not refresh just because config expired: {calls}")
+        failed = True
+    assert not failed, "test_expired_config_refreshes_without_touching_discovery"
+
+
+def test_empty_device_list_forces_discovery_despite_fresh_clock():
+    """No devices means rediscover now — never wait out the 8h TTL with nothing to work on."""
+    failed = False
+    d = StorageDeye(auth_method="oauth")
+    # A cache written during an outage: the file exists and is fresh, but holds no devices
+    d._mock_storage = FakeStorage(data={DEYE_CACHE_STATIC: {"station_ids": [], "device_list": []}}, ages={DEYE_CACHE_STATIC: 0.1})
+
+    run_async(d.restore_state())
+    if not d.tier_expired("static", DEYE_TTL_STATIC):
+        print("ERROR: an empty device_list must not seed the static clock")
+        failed = True
+
+    # Even with a deliberately fresh clock, an empty device list must still trigger refresh
+    d.mark_refreshed("static")
+    calls = []
+
+    async def fake_post(endpoint_key, body):
+        """Record calls and return a station/device discovery result."""
+        calls.append(endpoint_key)
+        if endpoint_key == "station_list":
+            return {"success": True, "stationList": [{"id": 7}]}
+        if endpoint_key == "station_device":
+            return {"success": True, "total": 1, "deviceListItems": [{"deviceType": "INVERTER", "deviceSn": "INV9"}]}
+        if endpoint_key == "device_latest":
+            return {"success": True, "deviceDataList": [{"deviceSn": "INV9", "dataList": LIVE_DATA_LIST}]}
+        return {"success": True}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        with patch.object(d, "check_and_refresh_oauth_token", side_effect=_true):
+            with patch.object(d, "publish_data", side_effect=_noop):
+                with patch.object(d, "publish_schedule_settings_ha", side_effect=_noop_arg):
+                    with patch.object(d, "_reconcile_control", side_effect=_noop):
+                        with patch.object(d, "automatic_config", side_effect=_noop):
+                            run_async(d.run(seconds=60, first=False))
+
+    if "station_list" not in calls:
+        print(f"ERROR: an empty device_list must force rediscovery: {calls}")
+        failed = True
+    if d.device_list != ["INV9"]:
+        print(f"ERROR: rediscovery did not populate the device list: {d.device_list}")
+        failed = True
+    assert not failed, "test_empty_device_list_forces_discovery_despite_fresh_clock"
+
+
+def test_failed_discovery_is_not_cached():
+    """A discovery that finds nothing must not be saved, or it would stick for 8 hours."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = FakeStorage()
+
+    async def fake_post(endpoint_key, body):
+        """Fake DEYE POST: the account returns no stations."""
+        return {"success": True, "stationList": []}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        run_async(d.refresh_static())
+
+    if DEYE_CACHE_STATIC in d._mock_storage.saves:
+        print("ERROR: an empty discovery must not be cached")
+        failed = True
+    if not d.tier_expired("static", DEYE_TTL_STATIC):
+        print("ERROR: a failed discovery must leave the tier expired so it retries")
+        failed = True
+    assert not failed, "test_failed_discovery_is_not_cached"
+
+
+def test_stale_telemetry_is_discarded():
+    """Telemetry older than the restore bound is dropped rather than republished as current."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = _warm_cache()
+    d._mock_storage.ages[DEYE_CACHE_LIVE] = DEYE_RESTORE_MAX_LIVE + 1
+
+    run_async(d.restore_state())
+
+    if d.device_values:
+        print(f"ERROR: stale telemetry should not be restored: {d.device_values}")
+        failed = True
+    if not any("telemetry cache is stale" in m for m in d.log_messages):
+        print(f"ERROR: expected a stale-telemetry log line: {d.log_messages}")
+        failed = True
+    # Ratings are static and must survive regardless of the telemetry bound
+    if d.device_rated_power.get("INV1") != 8000.0:
+        print(f"ERROR: ratings must restore unconditionally: {d.device_rated_power}")
+        failed = True
+    assert not failed, "test_stale_telemetry_is_discarded"
+
+
+def test_stale_applied_payload_is_discarded_but_orders_are_not():
+    """A stale applied_payload is dropped so the next apply re-writes; orders always resume."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = _warm_cache()
+    d._mock_storage.data[DEYE_CACHE_CONTROL]["pending_orders"] = {"INV1": "order-1"}
+    d._mock_storage.data[DEYE_CACHE_CONTROL]["order_poll_count"] = {"INV1": 2}
+    d._mock_storage.ages[DEYE_CACHE_CONTROL] = DEYE_RESTORE_MAX_CONTROL + 1
+
+    run_async(d.restore_state())
+
+    if d.applied_payload:
+        print(f"ERROR: a stale applied_payload must be discarded: {d.applied_payload}")
+        failed = True
+    if not any("applied-payload cache is stale" in m for m in d.log_messages):
+        print(f"ERROR: expected a stale applied-payload log line: {d.log_messages}")
+        failed = True
+    if d.pending_orders != {"INV1": "order-1"}:
+        print(f"ERROR: pending orders must resume regardless of age: {d.pending_orders}")
+        failed = True
+    if d.order_poll_count != {"INV1": 2}:
+        print(f"ERROR: the poll count must carry over so DEYE_ORDER_MAX_POLLS still bounds it: {d.order_poll_count}")
+        failed = True
+    assert not failed, "test_stale_applied_payload_is_discarded_but_orders_are_not"
+
+
+def test_fresh_applied_payload_suppresses_a_redundant_write():
+    """A recent applied_payload survives a restart and stops the same payload being rewritten."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = _warm_cache()
+    d.device_list = ["INV1"]
+    run_async(d.restore_state())
+
+    desired = d.applied_payload.get("INV1")
+    if not desired:
+        print("ERROR: applied_payload should have restored")
+        return True
+
+    posted = []
+
+    async def fake_post(endpoint_key, body):
+        """Record any write attempt."""
+        posted.append(endpoint_key)
+        return {"success": True}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        with patch.object(d, "build_dynamic_payload", return_value=dict(desired)):
+            wrote = run_async(d.apply_dynamic_control("INV1", {}, 50))
+
+    if wrote:
+        print("ERROR: an unchanged payload should not be written after a restart")
+        failed = True
+    if posted:
+        print(f"ERROR: no API write should have been made: {posted}")
+        failed = True
+    assert not failed, "test_fresh_applied_payload_suppresses_a_redundant_write"
+
+
+def test_storage_absent_behaves_as_before():
+    """With no storage component every load/save no-ops and each tier simply refreshes."""
+    failed = False
+    d = StorageDeye()  # no _mock_storage set, so the property returns None
+
+    run_async(d.restore_state())
+
+    if d.device_list or d.device_values:
+        print("ERROR: nothing should be restored without storage")
+        failed = True
+    for tier, ttl in (("static", DEYE_TTL_STATIC), ("config", DEYE_TTL_CONFIG), ("live", DEYE_TTL_LIVE)):
+        if not d.tier_expired(tier, ttl):
+            print(f"ERROR: {tier} must be expired so it refreshes without storage")
+            failed = True
+    if run_async(d.save_static()) is not False:
+        print("ERROR: save must no-op and report False without storage")
+        failed = True
+    assert not failed, "test_storage_absent_behaves_as_before"
+
+
+def test_corrupt_cache_only_affects_its_own_tier():
+    """An unreadable file refreshes that tier alone and never breaks the others."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = _warm_cache()
+    d._mock_storage.fail_on.add(DEYE_CACHE_CONFIG)
+
+    run_async(d.restore_state())
+
+    if not d.tier_expired("config", DEYE_TTL_CONFIG):
+        print("ERROR: an unreadable config cache must leave that tier expired")
+        failed = True
+    if d.device_list != ["INV1"]:
+        print(f"ERROR: the other tiers must still restore: {d.device_list}")
+        failed = True
+    if d.tier_expired("static", DEYE_TTL_STATIC):
+        print("ERROR: a corrupt config file must not disturb the static clock")
+        failed = True
+    if not any("could not read the config cache" in m for m in d.log_messages):
+        print(f"ERROR: expected a cache-read warning: {d.log_messages}")
+        failed = True
+    assert not failed, "test_corrupt_cache_only_affects_its_own_tier"
+
+
+def test_shape_validation_rejects_garbage():
+    """A file holding the wrong shape is ignored rather than poisoning in-memory state."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = FakeStorage(
+        data={
+            DEYE_CACHE_STATIC: ["not", "a", "dict"],
+            DEYE_CACHE_CONFIG: "garbage",
+            DEYE_CACHE_RATINGS: 42,
+            DEYE_CACHE_LIVE: {"values": "not-a-dict"},
+            DEYE_CACHE_CONTROL: {"applied_payload": "nope", "pending_orders": []},
+        },
+        ages={name: 0.1 for name in (DEYE_CACHE_STATIC, DEYE_CACHE_CONFIG, DEYE_CACHE_RATINGS, DEYE_CACHE_LIVE, DEYE_CACHE_CONTROL)},
+    )
+
+    run_async(d.restore_state())
+
+    if d.device_list or d.device_battery_config or d.applied_payload:
+        print(f"ERROR: garbage should not be restored: {d.device_list} {d.device_battery_config} {d.applied_payload}")
+        failed = True
+    if not isinstance(d.pending_orders, dict):
+        print(f"ERROR: pending_orders must stay a dict: {d.pending_orders}")
+        failed = True
+    if not d.tier_expired("static", DEYE_TTL_STATIC):
+        print("ERROR: a rejected cache must leave the tier expired")
+        failed = True
+    assert not failed, "test_shape_validation_rejects_garbage"
+
+
+def test_refresh_saves_each_tier():
+    """A successful refresh writes its own cache file, and live also writes ratings."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = FakeStorage()
+    d.device_list = ["INV1"]
+
+    async def fake_post(endpoint_key, body):
+        """Fake DEYE POST covering config/battery and device/latest."""
+        if endpoint_key == "device_latest":
+            return {"success": True, "deviceDataList": [{"deviceSn": "INV1", "dataList": LIVE_DATA_LIST}]}
+        return {"success": True, "battCapacity": 1200}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        run_async(d.refresh_config())
+        run_async(d.refresh_live())
+
+    for name in (DEYE_CACHE_CONFIG, DEYE_CACHE_LIVE, DEYE_CACHE_RATINGS):
+        if name not in d._mock_storage.saves:
+            print(f"ERROR: {name} was not saved after a successful refresh: {d._mock_storage.saves}")
+            failed = True
+    assert not failed, "test_refresh_saves_each_tier"
+
+
+def test_failed_live_refresh_does_not_save_or_clobber():
+    """A failed poll leaves the cached values alone and writes nothing."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = FakeStorage()
+    d.device_list = ["INV1"]
+    d.device_values = {"INV1": {"soc": 80.0}}
+
+    async def fake_post(endpoint_key, body):
+        """Fake DEYE POST: device/latest returns a failure body."""
+        return {"success": False, "msg": "device offline"}
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        run_async(d.refresh_live())
+
+    if d._mock_storage.saves:
+        print(f"ERROR: a failed refresh must not save: {d._mock_storage.saves}")
+        failed = True
+    if d.device_values.get("INV1", {}).get("soc") != 80.0:
+        print(f"ERROR: a failed refresh must not clobber cached values: {d.device_values}")
+        failed = True
+    if not d.tier_expired("live", DEYE_TTL_LIVE):
+        print("ERROR: a failed refresh must leave the tier expired so it retries")
+        failed = True
+    assert not failed, "test_failed_live_refresh_does_not_save_or_clobber"
+
+
+def test_save_failure_is_survivable():
+    """A storage write error is logged, not raised — a cache must never break a run."""
+    failed = False
+    d = StorageDeye()
+    d._mock_storage = FakeStorage()
+    d._mock_storage.fail_on.add(DEYE_CACHE_STATIC)
+    d.station_ids = [1]
+    d.device_list = ["INV1"]
+
+    try:
+        result = run_async(d.save_static())
+    except Exception as e:
+        print(f"ERROR: save must not raise, got {type(e).__name__}: {e}")
+        return True
+
+    if result is not False:
+        print(f"ERROR: a failed save should report False, got {result!r}")
+        failed = True
+    if not any("could not write the static cache" in m for m in d.log_messages):
+        print(f"ERROR: expected a cache-write warning: {d.log_messages}")
+        failed = True
+    assert not failed, "test_save_failure_is_survivable"
+
+
+def run_deye_storage_tests(my_predbat):
+    """Run all DEYE storage persistence tests."""
+    failed = False
+    for name, fn in [
+        ("tier_expiry_clock", test_tier_expiry_clock),
+        ("restore_seeds_clocks", test_restore_seeds_clocks_and_state),
+        ("warm_restart_no_api", test_warm_restart_makes_no_api_calls_beyond_live),
+        ("tiers_expire_independently", test_expired_config_refreshes_without_touching_discovery),
+        ("empty_devices_force_discovery", test_empty_device_list_forces_discovery_despite_fresh_clock),
+        ("failed_discovery_not_cached", test_failed_discovery_is_not_cached),
+        ("stale_telemetry_discarded", test_stale_telemetry_is_discarded),
+        ("stale_applied_payload", test_stale_applied_payload_is_discarded_but_orders_are_not),
+        ("fresh_applied_payload_suppresses", test_fresh_applied_payload_suppresses_a_redundant_write),
+        ("storage_absent", test_storage_absent_behaves_as_before),
+        ("corrupt_cache_isolated", test_corrupt_cache_only_affects_its_own_tier),
+        ("shape_validation", test_shape_validation_rejects_garbage),
+        ("refresh_saves_tiers", test_refresh_saves_each_tier),
+        ("failed_refresh_safe", test_failed_live_refresh_does_not_save_or_clobber),
+        ("save_failure_survivable", test_save_failure_is_survivable),
+    ]:
+        try:
+            if fn():
+                print(f"  FAILED: deye_storage.{name}")
+                failed = True
+        except Exception as e:
+            print(f"  EXCEPTION in deye_storage.{name}: {e}")
+            import traceback
+
+            traceback.print_exc()
+            failed = True
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -124,6 +124,7 @@ from tests.test_deye_api import run_deye_api_tests
 from tests.test_deye_oauth import run_deye_oauth_tests
 from tests.test_deye_control import run_deye_control_tests
 from tests.test_deye_publish import run_deye_publish_tests
+from tests.test_deye_storage import run_deye_storage_tests
 from tests.test_enphase_api import run_enphase_api_tests
 from tests.test_solcast import run_solcast_tests
 from tests.test_open_meteo import run_open_meteo_tests
@@ -319,6 +320,7 @@ def main():
         ("deye_oauth", run_deye_oauth_tests, "DEYE auth tests", False),
         ("deye_control", run_deye_control_tests, "DEYE control-logic tests", False),
         ("deye_publish", run_deye_publish_tests, "DEYE publish/config tests", False),
+        ("deye_storage", run_deye_storage_tests, "DEYE storage persistence tests", False),
         ("enphase_api", run_enphase_api_tests, "Enphase API tests", False),
         ("solcast", run_solcast_tests, "Solcast API tests", False),
         ("open_meteo", run_open_meteo_tests, "Open-Meteo solar forecast provider tests", False),

--- a/docs/superpowers/specs/2026-07-28-deye-storage-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-28-deye-storage-persistence-design.md
@@ -48,8 +48,8 @@ no special handling.
 |---|---|---|---|
 | `static` | 8h | `station/list`, `station/device`, `station/latest`, `device/measurePoints` | `station_ids`, `device_list` |
 | `config` | 15 min | `config/battery` per device | `device_battery_config` |
-| `ratings` | — (written by the `live` refresh) | none of its own | `device_capacity`, `device_pack_voltage`, `device_rated_power` |
-| `live` | 1 min | `device/latest` per device | `device_values`, `device_energy` |
+| `ratings` | — (written by the `live` refresh, saved only on change) | none of its own | `device_capacity`, `device_pack_voltage`, `device_rated_power` |
+| `live` | 1 min | `device/latest` per device | `device_values`, `device_energy` — **not cached** |
 | `control` | on change | none | `applied_payload`, `pending_orders`, `order_poll_count` |
 
 `device/latest` returns telemetry, the energy counters and the ratings
@@ -62,8 +62,22 @@ Steady-state API cost falls from 2 calls/device/minute to ~1.07, and
 
 ## Storage layout
 
-One file per tier under module `deye`: `static`, `config`, `ratings`, `live`,
-`control`.
+Four files under module `deye`: `static`, `config`, `ratings`, `control`.
+
+Telemetry and the energy counters are deliberately **not** cached. The live tier
+polls every minute, so persisting it would mean 1440 writes a day to save at most
+one tick's gap at startup — a poor trade against that much file or network IO.
+Home Assistant already retains the last published value of every entity, and
+`publish_data()` only writes a sensor when it has a value, so a failed poll
+leaves the previous reading in place rather than overwriting it. The `live` tier
+therefore has a TTL (governing poll cadence) but no file: its clock starts unset
+after a restart and the first tick polls immediately.
+
+Ratings come from the same `device/latest` response but *are* cached, because
+they are static and are what lets `automatic_config()` map `soc_max`,
+`battery_rate_max` and `inverter_limit` before the first poll returns. They are
+written only when the value actually changes, compared by serialised signature,
+so the once-a-minute poll does not rewrite an identical file.
 
 Per-tier files rather than a single blob because `storage.age()` is per-file, so
 each tier gets an independent clock for free. A single blob would need
@@ -109,7 +123,6 @@ removed.
 | `static` | unconditional | Station and device IDs do not go stale. |
 | `config` | unconditional | Installer settings. Also covers a transient `config/battery` failure — this endpoint has already returned `2106001 config point not supported` on one cycle and succeeded on the next. |
 | `ratings` | unconditional | Static per install. Restoring these is the main win: `automatic_config()` can map `soc_max`, `battery_rate_max` and `inverter_limit` at startup without waiting for a poll. |
-| `live` | only if age < 15 min | Republishing hours-old SOC as current is worse than a brief gap, and the energy counters feed Predbat's load/rate history. |
 | `control` — `pending_orders`, `order_poll_count` | unconditional | An unpolled order is orphaned. `DEYE_ORDER_MAX_POLLS` still bounds it. |
 | `control` — `applied_payload` | only if age < 15 min | See below. |
 
@@ -153,6 +166,9 @@ Cases:
 
 - Cold start, no stored state: every tier refreshes.
 - Warm restart inside every TTL: **zero** API calls beyond the `live` tier.
+- Telemetry is never restored and the live clock always starts expired.
+- Unchanged ratings are not rewritten by repeated polls; a changed rating is.
+- Restored ratings prime the signature so the first poll writes nothing.
 - Each tier expiring independently: an expired `config` does not trigger a
   `static` refresh, and vice versa.
 - Empty `device_list` forces a `static` refresh despite a fresh clock.
@@ -161,6 +177,7 @@ Cases:
 - A failed refresh does not save and does not clobber cached state.
 - `applied_payload` restored inside 15 minutes suppresses a redundant write;
   outside 15 minutes it is discarded and the next apply writes.
+- A discovery that returns nothing does not clobber an already-known device list.
 - A pending order restored from storage resumes polling to completion.
 
 ## Files touched

--- a/docs/superpowers/specs/2026-07-28-deye-storage-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-28-deye-storage-persistence-design.md
@@ -1,0 +1,172 @@
+# DEYE storage persistence and tiered refresh — design
+
+Date: 2026-07-28
+Status: approved, ready for implementation planning
+
+## Problem
+
+The DEYE component holds all of its state in memory and re-polls everything on
+every 60-second tick. Two consequences:
+
+1. **Every restart is a cold start.** `run()` gates discovery on
+   `if first or not self.device_list`, so a process restart re-runs
+   `station/list` and `station/device`, and rebuilds every derived value from
+   scratch. Predbat restarts routinely, so this is the common case, not an edge
+   case.
+2. **Steady-state polling is wasteful.** `config/battery` is called once per
+   device per minute — 1440 calls/device/day — to read installer settings that
+   change perhaps once a year.
+
+Worse, some state cannot be re-derived at all. `applied_payload` is a pure
+in-memory change-detection cache with no API read-back (`config/tou` is defined
+in `DEYE_ENDPOINTS` but never called), and `pending_orders` tracks in-flight
+control orders. Both are lost on restart.
+
+## Goals
+
+- Survive a restart without a full poll.
+- Refresh each class of state on a cadence matched to how fast it actually
+  changes.
+- Never let persistence cause the inverter to be controlled incorrectly.
+
+## Non-goals
+
+- Multi-instance coordination. `StorageBase` exposes `_acquire_refresh_lock()`
+  for this; a single DEYE component per Predbat instance does not need it.
+- Persisting `local_schedule`. It is rebuilt for free from HA entity states on
+  every tick, and the existing `"unknown"`/`"unavailable"` defaulting in
+  `get_schedule_settings_ha()` already covers the startup window before HA has
+  republished.
+
+## Refresh tiers
+
+`ComponentBase` ticks `run()` every 60 seconds after startup
+(`seconds % 60 == 0`), so a one-minute live tier is the natural rate and needs
+no special handling.
+
+| Tier | TTL | API calls | State refreshed |
+|---|---|---|---|
+| `static` | 8h | `station/list`, `station/device`, `station/latest`, `device/measurePoints` | `station_ids`, `device_list` |
+| `config` | 15 min | `config/battery` per device | `device_battery_config` |
+| `ratings` | — (written by the `live` refresh) | none of its own | `device_capacity`, `device_pack_voltage`, `device_rated_power` |
+| `live` | 1 min | `device/latest` per device | `device_values`, `device_energy` |
+| `control` | on change | none | `applied_payload`, `pending_orders`, `order_poll_count` |
+
+`device/latest` returns telemetry, the energy counters and the ratings
+(`RatedPower`, `BatteryRatedCapacity`, `BMSChargeVoltage`) in a single response,
+so the `ratings` tier has no API cost of its own — it is a separate *file*
+purely because it has a different restore rule (see below), not a separate poll.
+
+Steady-state API cost falls from 2 calls/device/minute to ~1.07, and
+`config/battery` from 1440 to 96 calls/device/day.
+
+## Storage layout
+
+One file per tier under module `deye`: `static`, `config`, `ratings`, `live`,
+`control`.
+
+Per-tier files rather than a single blob because `storage.age()` is per-file, so
+each tier gets an independent clock for free. A single blob would need
+hand-rolled per-section timestamps, and rewriting it every minute for live data
+would reset the static section's age to zero, defeating the 8h TTL.
+
+`save()` stamps `created` on every write, so `age()` is time-since-last-write.
+This only holds as a TTL if a tier is saved **only when it actually refreshes**.
+
+## The refresh clock
+
+Each tier keeps an in-memory last-refresh timestamp. At startup it is seeded
+from `storage.age()`; a tier with no stored file leaves its timestamp unset.
+
+A tier refreshes when:
+
+- its timestamp is unset, **or**
+- its timestamp is older than the tier's TTL, **or**
+- its product is empty — specifically `not self.device_list` forces a `static`
+  refresh regardless of TTL.
+
+That last condition matters: without it, a discovery attempt that ran during an
+API outage and cached an empty `device_list` would pin the component dead for a
+full 8 hours.
+
+This deliberately does **not** use the `seconds % N == 0` idiom seen in
+`gecloud.py` and `ha.py`. That counter starts from process start, so every
+restart re-polls every tier — exactly the behaviour being removed. Seeding from
+`storage.age()` is what makes the cadence survive a restart.
+
+The design works unchanged when storage is absent: `self.storage` returns `None`,
+no timestamps are seeded, every tier refreshes on the first tick, and the
+in-memory clock governs from then on.
+
+`first` reduces to "process start": restore the five files, seed the clocks, then
+let the TTLs decide. The existing `if first or not self.device_list` gate is
+removed.
+
+## Restore rules
+
+| File | Restore rule | Rationale |
+|---|---|---|
+| `static` | unconditional | Station and device IDs do not go stale. |
+| `config` | unconditional | Installer settings. Also covers a transient `config/battery` failure — this endpoint has already returned `2106001 config point not supported` on one cycle and succeeded on the next. |
+| `ratings` | unconditional | Static per install. Restoring these is the main win: `automatic_config()` can map `soc_max`, `battery_rate_max` and `inverter_limit` at startup without waiting for a poll. |
+| `live` | only if age < 15 min | Republishing hours-old SOC as current is worse than a brief gap, and the energy counters feed Predbat's load/rate history. |
+| `control` — `pending_orders`, `order_poll_count` | unconditional | An unpolled order is orphaned. `DEYE_ORDER_MAX_POLLS` still bounds it. |
+| `control` — `applied_payload` | only if age < 15 min | See below. |
+
+### Why `applied_payload` is bounded
+
+This is the one place persistence can cause *incorrect control*, not merely
+staleness.
+
+`apply_dynamic_control()` skips the write when the desired payload equals the
+applied one. Restoring `applied_payload` asserts *"the inverter still holds what
+we last wrote"*. If the inverter was changed externally while Predbat was down —
+installer, the Deye app, a manual TOU edit — that assertion is false, the write
+is skipped, and the battery silently diverges from the plan.
+
+Today a restart clears the cache and forces one corrective write. That is
+accidentally safe, and the safety must not be lost.
+
+A redundant write is cheap. A skipped write means the battery does the wrong
+thing. The 15-minute bound keeps the benefit for the quick restarts Predbat
+actually performs, and forces a corrective rewrite after any longer outage.
+
+## Error handling
+
+- `self.storage` is `None` → every save and load no-ops (the `teslemetry.py`
+  idiom).
+- A corrupt or missing file → that tier's clock stays unset → it refreshes on the
+  next tick. No other tier is affected.
+- Restored data is shape-validated (`isinstance` dict/list) before use, as
+  `gecloud.py` does, so a truncated file cannot poison in-memory state.
+- A failed refresh must **not** save — saving would reset the TTL and skip the
+  retry — and must not clobber good in-memory state. This is the same principle
+  as the `RatedPower` clobber fix: absence of data is not zero.
+
+## Testing
+
+`MockDeye` gains an injected `storage` property returning `self._mock_storage`,
+following the pattern already in `tests/test_ge_cloud.py`. `StorageLocalFiles`
+is used for a round-trip test against a temporary directory.
+
+Cases:
+
+- Cold start, no stored state: every tier refreshes.
+- Warm restart inside every TTL: **zero** API calls beyond the `live` tier.
+- Each tier expiring independently: an expired `config` does not trigger a
+  `static` refresh, and vice versa.
+- Empty `device_list` forces a `static` refresh despite a fresh clock.
+- Corrupt file for one tier: that tier refreshes, the others restore.
+- `storage is None` throughout: component behaves exactly as it does today.
+- A failed refresh does not save and does not clobber cached state.
+- `applied_payload` restored inside 15 minutes suppresses a redundant write;
+  outside 15 minutes it is discarded and the next apply writes.
+- A pending order restored from storage resumes polling to completion.
+
+## Files touched
+
+- `apps/predbat/deye.py` — tier clocks, restore/save, `run()` restructuring.
+- `apps/predbat/deye_const.py` — TTL constants.
+- `apps/predbat/tests/test_deye_storage.py` — new.
+- `apps/predbat/tests/test_deye_api.py` — `MockDeye` storage property.
+- `apps/predbat/unit_test.py` — register the new test module.

--- a/docs/superpowers/specs/2026-07-28-deye-storage-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-28-deye-storage-persistence-design.md
@@ -152,6 +152,15 @@ actually performs, and forces a corrective rewrite after any longer outage.
   next tick. No other tier is affected.
 - Restored data is shape-validated (`isinstance` dict/list) before use, as
   `gecloud.py` does, so a truncated file cannot poison in-memory state.
+- A first cycle whose live poll returns nothing makes `run()` return **False**.
+  `automatic_config()` runs on the first cycle alone, so completing startup
+  without telemetry would permanently skip the energy args until the next process
+  restart. Returning False leaves `first` set and `ComponentBase` retries the
+  whole startup path on its backoff (60s doubling to 128 minutes). Deliberately
+  gated on the live poll only, not on `config/battery`: that endpoint can be
+  permanently unsupported on a model (`2106001`), and gating on it would back off
+  to 128 minutes and never complete startup, whereas `automatic_config()` already
+  degrades gracefully when battery config is missing.
 - A failed refresh must **not** save — saving would reset the TTL and skip the
   retry — and must not clobber good in-memory state. This is the same principle
   as the `RatedPower` clobber fix: absence of data is not zero.
@@ -178,6 +187,8 @@ Cases:
 - `applied_payload` restored inside 15 minutes suppresses a redundant write;
   outside 15 minutes it is discarded and the next apply writes.
 - A discovery that returns nothing does not clobber an already-known device list.
+- A first cycle without telemetry returns False and does not run
+  `automatic_config()`; the retry with telemetry returns True and does.
 - A pending order restored from storage resumes polling to completion.
 
 ## Files touched


### PR DESCRIPTION
DEYE kept all of its state in memory and re-polled everything on every 60-second tick, so a restart was always a cold start. Some state could not be re-derived at all: `applied_payload` is a change-detection cache with no API read-back (`config/tou` is defined but never called), and `pending_orders` tracks in-flight control orders — both were lost on restart.

State now goes through the Storage component, and each class of state refreshes on a cadence matched to how fast it actually changes.

Design: [`docs/superpowers/specs/2026-07-28-deye-storage-persistence-design.md`](docs/superpowers/specs/2026-07-28-deye-storage-persistence-design.md)

## Refresh tiers

| Tier | TTL | API calls | Cached? |
|---|---|---|---|
| `static` | 8h | `station/list`, `station/device`, `station/latest`, `device/measurePoints` | yes |
| `config` | 15 min | `config/battery` per device | yes |
| `ratings` | — (written by the live poll) | none of its own | yes, **only when changed** |
| `live` | 1 min | `device/latest` per device | **no** |
| `control` | on change | none | yes |

Steady state falls from **2 API calls/device/minute to ~1.07**, and `config/battery` from 1440 to 96 calls/device/day.

## The clock is what makes it survive a restart

Each tier keeps an in-memory last-refresh timestamp, **seeded from `storage.age()` at startup**. This is deliberately not the `seconds % N == 0` idiom used in `gecloud.py` and `ha.py` — that counter starts from process start, so every restart re-polls every tier, which is exactly the behaviour being removed.

Discovery additionally refreshes whenever `device_list` is empty, so a failed discovery is retried on the next tick rather than after the 8h TTL. An empty discovery result is never cached, which would otherwise pin the component dead for 8 hours.

## Telemetry is deliberately not cached

The live tier polls every minute, so persisting it would mean 1440 cache writes a day to save at most one tick's gap at startup. Home Assistant already retains the last published value of every entity, and `publish_data()` only writes a sensor when it has a value, so a failed poll leaves the previous reading in place rather than overwriting it.

Ratings come from the same `device/latest` response but *are* cached, because they are static and are what lets `automatic_config()` map `soc_max`, `battery_rate_max` and `inverter_limit` before the first poll returns. They are written only when the value actually changes (compared by serialised signature), and a restore primes that signature so the first poll after a restart writes nothing either.

## `applied_payload` is bounded to 15 minutes

This is the one place persistence could cause *incorrect control* rather than staleness. `apply_dynamic_control()` skips the write when the desired payload equals the applied one, so restoring the cache asserts *"the inverter still holds what we last wrote"*. If it was changed externally while Predbat was down — installer, the Deye app, a manual TOU edit — that assertion is false, the write is skipped, and the battery silently diverges from the plan.

Today a restart clears the cache and forces one corrective write. That accidental safety is preserved: the bound keeps the benefit for the quick restarts Predbat actually performs and forces a rewrite after any longer outage. A redundant write is cheap; a skipped one is not.

Pending orders restore unconditionally — an unpolled order is orphaned — with `order_poll_count` carried over so `DEYE_ORDER_MAX_POLLS` still bounds them.

## Two bugs surfaced while implementing this

**`get_device_list()` clobbered a good device list.** It sets `device_list = []` when discovery returns nothing. That was harmless when discovery only ran at startup, but this tier re-runs every 8 hours in a long-lived process, so one transient failure would take a working component down until the next success. Found because two existing control tests started failing — the failure was real signal, not test-fit.

**A failed startup poll silently lost the energy args.** `automatic_config()` runs on the first cycle alone, so a startup that completed without telemetry would map only the ratings-backed args and permanently skip `import_today`/`export_today`/`pv_today`/`load_today` until the next process restart — and `fetch_sensor_data()` raises `ValueError` when `load_today` is unset, aborting every Predbat run. `run()` now returns False on such a cycle; `ComponentBase` leaves `first` set and retries the whole startup path on its backoff. Gated on the live poll only, not `config/battery`, since that endpoint can be permanently unsupported on a model (`2106001`) and would back off to 128 minutes without ever completing startup.

## Testing

17 new tests in `test_deye_storage.py` covering: tier expiry arithmetic, restore seeding every clock, a warm restart making zero API calls beyond `live`, tiers expiring independently, an empty `device_list` forcing rediscovery despite a fresh clock, a failed discovery not being cached, telemetry never being cached, ratings saved only on change, restore priming the ratings signature, stale vs fresh `applied_payload`, orders resuming, `storage is None` behaving exactly as before, a corrupt file affecting only its own tier, shape validation rejecting garbage, a failed refresh neither saving nor clobbering, save errors being survivable, and the first-cycle retry in both directions.

Each behavioural claim was verified to fail without its fix — disabling `restore_state()` produces `discovery re-polled on a warm restart: ['station_list']`, and removing the first-cycle guard produces `a first run without telemetry must return False, got True`.

One existing test harness changed: `_patched_run` in `test_deye_control.py` now seeds the static clock. Those tests are about draining control orders on a component that has already discovered its inverters; without it `run()` attempted real network discovery before reaching the drain loop (they were taking 2.5s and hitting the network — now 0.01s).

Full quick suite passes; `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
