### PR TITLE
fix(plan): tooltips on History views, split-slot first half, and an invalid escape

### DIFF
--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -1305,15 +1305,18 @@ class Output:
                     start = self.export_window_best[export_window_n]["start"]
                     if start > minute:
                         soc_change_this = self.predict_soc_best.get(max(start - self.minutes_now, 0), 0.0) - self.predict_soc_best.get(minute_relative_start, 0.0)
-                        if soc_change_this >= 0:
-                            state = " &nearr;"
-                            reason_parts.append({"code": "demand_before_export_rising", "params": {}})
-                        elif soc_change_this < 0:
-                            state = " &searr;"
-                            reason_parts.append({"code": "demand_before_export_falling", "params": {}})
-                        else:
+                        # Same near-flat tolerance as the whole-slot demand arrow above - testing
+                        # soc_change_this >= 0 first would make the steady case unreachable and
+                        # render a flat pre-window period as rising
+                        if abs(soc_change_this) < 0.05:
                             state = " &rarr;"
                             reason_parts.append({"code": "demand_before_export_steady", "params": {}})
+                        elif soc_change_this >= 0:
+                            state = " &nearr;"
+                            reason_parts.append({"code": "demand_before_export_rising", "params": {}})
+                        else:
+                            state = " &searr;"
+                            reason_parts.append({"code": "demand_before_export_falling", "params": {}})
                         state_color = "#FFFFFF"
                         show_limit = ""
                         had_state = True

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -32,12 +32,18 @@ REASON_TEMPLATES = {
     "demand_rising": "Battery level is expected to rise from solar generation; no charging or exporting is scheduled this slot.",
     "demand_falling": "Battery is expected to discharge to cover house demand; no charging or exporting is scheduled this slot.",
     "demand_steady": "Battery level is expected to stay steady; no charging or exporting is scheduled this slot.",
-    "freeze_charge_reserve": "Freeze charging — the battery holds at the reserve level rather than charging further this slot (import rate {rate}p/kWh vs. your {threshold}p/kWh threshold).",
+    # Used for the first half of a split slot where the export window only starts partway through -
+    # deliberately worded without the "nothing is scheduled this slot" clause of the plain demand
+    # reasons above, which would contradict the export reason sitting alongside it in the same slot.
+    "demand_before_export_rising": "Until the export window starts partway through this slot, the battery level is expected to rise from solar generation.",
+    "demand_before_export_falling": "Until the export window starts partway through this slot, the battery is expected to discharge to cover house demand.",
+    "demand_before_export_steady": "Until the export window starts partway through this slot, the battery level is expected to stay steady.",
+    "freeze_charge": "Freeze charging — the battery holds at the current level rather than charging further this slot (import rate {rate}p/kWh vs. your {threshold}p/kWh threshold).",
     "hold_charge_at_target": "Holding — the battery is already predicted to be at or above the {target_percent}% target for this window without charging further.",
-    "charge_low_rate": "Charging up to {target_percent}% because the import rate this slot ({rate}p/kWh) is low enough to be worth it before a more expensive period.",
-    "freeze_export_below_threshold": "Freezing export — the battery holds its charge rather than selling it back this slot (export rate {rate}p/kWh vs. your {threshold}p/kWh threshold).",
+    "charge_low_rate": "Charging up to {target_percent}% at the import rate for this slot of ({rate}p/kWh).",
+    "freeze_export_below_threshold": "Freezing export — excess solar is exported to the grid (export rate {rate}p/kWh vs. your {threshold}p/kWh threshold).",
     "hold_export_unreachable": "Export window active but not triggered — the battery isn't predicted to reach the {target_percent}% level needed to export this slot.",
-    "export_high_rate": "Exporting down to {target_percent}% because the export rate this slot ({rate}p/kWh) is high enough to be worth selling stored energy back to the grid.",
+    "export_high_rate": "Exporting down to {target_percent}% at the export rate of ({rate}p/kWh) using stored energy back to the grid.",
     "manual_override_charge": "You manually set this slot to charge.",
     "manual_override_freeze_charge": "You manually set this slot to freeze charging.",
     "manual_override_export": "You manually set this slot to export.",
@@ -1269,7 +1275,7 @@ class Output:
                         state_color = "#EEEEEE"
                         raw_state = "FrzChrg"
                         limit_percent = soc_percent
-                        reason_parts.append({"code": "freeze_charge_reserve", "params": {"rate": "{:.2f}".format(rate_value_import), "threshold": "{:.2f}".format(import_cost_threshold)}})
+                        reason_parts.append({"code": "freeze_charge", "params": {"rate": "{:.2f}".format(rate_value_import), "threshold": "{:.2f}".format(import_cost_threshold)}})
                     elif limit_percent <= soc_percent_min_window:
                         state = "HoldChrg&rarr;"
                         state_color = "#34DBEB"
@@ -1301,10 +1307,13 @@ class Output:
                         soc_change_this = self.predict_soc_best.get(max(start - self.minutes_now, 0), 0.0) - self.predict_soc_best.get(minute_relative_start, 0.0)
                         if soc_change_this >= 0:
                             state = " &nearr;"
+                            reason_parts.append({"code": "demand_before_export_rising", "params": {}})
                         elif soc_change_this < 0:
                             state = " &searr;"
+                            reason_parts.append({"code": "demand_before_export_falling", "params": {}})
                         else:
                             state = " &rarr;"
+                            reason_parts.append({"code": "demand_before_export_steady", "params": {}})
                         state_color = "#FFFFFF"
                         show_limit = ""
                         had_state = True

--- a/apps/predbat/tests/test_plan_why_reason.py
+++ b/apps/predbat/tests/test_plan_why_reason.py
@@ -9,7 +9,9 @@
 # pylint: disable=attribute-defined-outside-init
 
 import re
+import warnings
 
+import web_helper
 from prediction import Prediction
 from tests.test_infra import reset_inverter, reset_rates, update_rates_import
 from utils import calc_percent_limit
@@ -156,7 +158,7 @@ def run_test_plan_why_reason(my_predbat):
     my_predbat.predict_soc_best = _flat_soc(my_predbat, 5.0)
     _, raw_plan = render()
     row = _get_row(raw_plan, minutes_now)
-    if row is None or _codes(row) != ["freeze_charge_reserve"]:
+    if row is None or _codes(row) != ["freeze_charge"]:
         print("ERROR: FrzChrg reasons unexpected: {}".format(row and _codes(row)))
         failed = True
     elif set(row["reasons"][0]["params"]) != {"rate", "threshold"}:
@@ -273,6 +275,34 @@ def run_test_plan_why_reason(my_predbat):
         failed = True
     my_predbat.manual_demand_times = []
 
+    # --- Test 10b: split slot where the export window only starts partway through ---
+    # The state cell splits into "arrow | Exp", so the tooltip must explain both halves - the
+    # pre-window arrow used to contribute no reason at all, leaving the split cell with only the
+    # export sentence.
+    print("Test split slot (demand arrow then export) explains both halves")
+    my_predbat.charge_window_best = []
+    my_predbat.charge_limit_best = []
+    my_predbat.export_window_best = [{"start": minutes_now + 15, "end": minutes_now + 60, "average": 15.0}]
+    my_predbat.export_limits_best = [50.0]
+    _, raw_plan = render()
+    row = _get_row(raw_plan, minutes_now)
+    if row is None or not row.get("split"):
+        print("ERROR: expected a split state cell for a mid-slot export window start")
+        failed = True
+    elif len(_codes(row)) != 2 or not _codes(row)[0].startswith("demand_before_export_") or _codes(row)[1] != "export_high_rate":
+        # The arrow direction depends on the predicted SoC trend; only the pairing matters here
+        print("ERROR: split slot reasons unexpected: {}".format(_codes(row)))
+        failed = True
+    else:
+        rendered = _render(row, templates)
+        if "Until the export window starts" not in rendered or "Exporting down to" not in rendered:
+            print("ERROR: split slot tooltip should explain both halves, got: {}".format(rendered))
+            failed = True
+        # The pre-window wording must not claim nothing is scheduled - the slot does export later
+        if "no charging or exporting is scheduled" in rendered:
+            print("ERROR: split slot tooltip contradicts itself: {}".format(rendered))
+            failed = True
+
     # --- Test 11: reason_templates has an entry for every code used across all scenarios ---
     print("Test reason_templates covers every code used")
     all_codes = set()
@@ -300,6 +330,43 @@ def run_test_plan_why_reason(my_predbat):
         failed = True
     if "state2_color || '#FFFFFF'}${titleAttr}" not in renderer_js:
         print("ERROR: expected the split (state2) cell to also carry the title= tooltip, not just the first half")
+        failed = True
+
+    # --- Test 13: the read-only (History / Yesterday Without Predbat) state cells also get tooltips ---
+    print("Test the non-editable state cell path also emits a title= tooltip")
+    if "function reasonTitleAttr" not in renderer_js:
+        print("ERROR: expected a shared reasonTitleAttr() helper used by both state-cell paths")
+        failed = True
+    if "state_color || '#FFFFFF'}${titleAttr}" not in renderer_js:
+        print("ERROR: expected the read-only state cell (editable=false) to carry the title= tooltip")
+        failed = True
+    # Both the editable and read-only paths render a split second half, so the tooltip appears twice
+    if renderer_js.count("state2_color || '#FFFFFF'}${titleAttr}") != 2:
+        print("ERROR: expected both the editable and read-only split cells to carry the title= tooltip")
+        failed = True
+    # Templates must come from the dataset being rendered, not the plan view's global - otherwise
+    # the History/Yesterday views would render against the wrong (or a missing) template table
+    if "window.planData && window.planData.reason_templates" in renderer_js:
+        print("ERROR: reason templates should come from the rendered jsonData, not window.planData")
+        failed = True
+    if "const reasonTemplates = jsonData.reason_templates" not in renderer_js:
+        print("ERROR: expected renderPlanTable to take reason_templates from the dataset it renders")
+        failed = True
+
+    # --- Test 14: the renderer JS source has no invalid Python escape sequences ---
+    # The JS regexes live inside plain (non-raw) triple-quoted Python strings, so a backslash
+    # intended for JS must be doubled. A single "\{" raises SyntaxWarning today and becomes a
+    # SyntaxError in a future Python.
+    print("Test web_helper.py has no invalid escape sequences")
+    with open(web_helper.__file__, "r") as han:
+        web_helper_source = han.read()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        compile(web_helper_source, web_helper.__file__, "exec")
+        syntax_warnings = [item for item in caught if issubclass(item.category, SyntaxWarning)]
+    if syntax_warnings:
+        for item in syntax_warnings:
+            print("ERROR: SyntaxWarning in web_helper.py line {}: {}".format(item.lineno, item.message))
         failed = True
 
     if not failed:

--- a/apps/predbat/tests/test_plan_why_reason.py
+++ b/apps/predbat/tests/test_plan_why_reason.py
@@ -303,6 +303,21 @@ def run_test_plan_why_reason(my_predbat):
             print("ERROR: split slot tooltip contradicts itself: {}".format(rendered))
             failed = True
 
+    # --- Test 10c: a near-flat SoC before the export window reads as steady, not rising ---
+    # Deliberately a small but non-zero rise (0.02kWh over the pre-window period): an exact-zero
+    # trend would also pass under a plain "> 0" test, so only a near-flat one actually exercises
+    # the same 0.05kWh tolerance the whole-slot demand arrow uses.
+    print("Test near-flat SoC before an export window reads as steady")
+    my_predbat.predict_soc_best = {minute: 5.0 + min(minute, 15) * (0.02 / 15.0) for minute in range(0, my_predbat.forecast_minutes + my_predbat.plan_interval_minutes + 5, 5)}
+    _, raw_plan = render()
+    row = _get_row(raw_plan, minutes_now)
+    if row is None or _codes(row) != ["demand_before_export_steady", "export_high_rate"]:
+        print("ERROR: flat pre-export slot reasons unexpected: {}".format(row and _codes(row)))
+        failed = True
+    elif "expected to stay steady" not in _render(row, templates):
+        print("ERROR: flat pre-export tooltip unexpected: {}".format(_render(row, templates)))
+        failed = True
+
     # --- Test 11: reason_templates has an entry for every code used across all scenarios ---
     print("Test reason_templates covers every code used")
     all_codes = set()

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -6378,6 +6378,10 @@ def get_plan_renderer_js():
             // not 0 which is what a plain hours*60+minutes calculation would return).
             window.planMidnightRef = jsonData.time || null;
 
+            // Reason templates come from the dataset being rendered, not from window.planData -
+            // the History/Yesterday views publish their own copy alongside their own rows.
+            const reasonTemplates = jsonData.reason_templates;
+
             let html = '<table>';
             const cellStyle = 'style="padding: 4px;"';
 
@@ -6462,15 +6466,16 @@ def get_plan_renderer_js():
                 // State cells (with rowspan and split handling)
                 if (!row.skip_state_cell) {
                     if (editable) {
-                        html += renderStateCell(row, timeDisplay, overrides);
+                        html += renderStateCell(row, timeDisplay, overrides, reasonTemplates);
                     } else {
                         const rowspanAttr = row.rowspan_state > 0 ? ` rowspan="${row.rowspan_state}"` : '';
                         const colspanAttr = row.split ? '' : ' colspan=2';
-                        html += `<td${colspanAttr}${rowspanAttr} ${cellStyle} bgcolor=${row.state_color || '#FFFFFF'}>${row.state_text || ''}</td>`;
+                        const titleAttr = reasonTitleAttr(row, reasonTemplates);
+                        html += `<td${colspanAttr}${rowspanAttr} ${cellStyle} bgcolor=${row.state_color || '#FFFFFF'}${titleAttr}>${row.state_text || ''}</td>`;
 
-                        // Second state cell if split
+                        // Second state cell if split - same combined reason text as the first half
                         if (row.split && row.state2_text) {
-                            html += `<td${rowspanAttr} ${cellStyle} bgcolor=${row.state2_color || '#FFFFFF'}>${row.state2_text}</td>`;
+                            html += `<td${rowspanAttr} ${cellStyle} bgcolor=${row.state2_color || '#FFFFFF'}${titleAttr}>${row.state2_text}</td>`;
                         }
                     }
                 }
@@ -6705,7 +6710,7 @@ def get_plan_renderer_js():
                 if (!template) {
                     return '';
                 }
-                return template.replace(/\{(\w+)\}/g, function (match, key) {
+                return template.replace(/\\{(\\w+)\\}/g, function (match, key) {
                     return entry.params && entry.params[key] !== undefined ? entry.params[key] : match;
                 });
             })
@@ -6713,8 +6718,16 @@ def get_plan_renderer_js():
             .join(' ');
     }
 
+    // Build the ` title="..."` tooltip attribute for a row's state cell, or '' when the row
+    // has no reasons. Shared by both the editable (renderStateCell) and read-only state-cell
+    // paths so the History/Yesterday views get the same tooltips as the plan view.
+    function reasonTitleAttr(row, templates) {
+        const reasonText = renderReasonText(row.reasons, templates);
+        return reasonText ? ` title="${escapeAttr(reasonText)}"` : '';
+    }
+
     // Render state cell without dropdown (dropdown moved to time column)
-    function renderStateCell(row, timeDisplay, overrides) {
+    function renderStateCell(row, timeDisplay, overrides, templates) {
         const cellStyle = 'style="padding: 4px;"';
         const timeStr = row.time;
         const minutesFromMidnight = row.slot_minute !== undefined ? row.slot_minute : getMinutesFromTimeString(timeStr);
@@ -6742,8 +6755,7 @@ def get_plan_renderer_js():
 
         const rowspanAttr = row.rowspan_state > 0 ? ` rowspan="${row.rowspan_state}"` : '';
         const colspanAttr = row.split ? '' : ' colspan=2';
-        const reasonText = renderReasonText(row.reasons, window.planData && window.planData.reason_templates);
-        const titleAttr = reasonText ? ` title="${escapeAttr(reasonText)}"` : '';
+        const titleAttr = reasonTitleAttr(row, templates);
 
         let html = `<td${colspanAttr}${rowspanAttr} ${cellStyle} bgcolor=${bgColor} class="${overrideClass}"${titleAttr}>`;
         html += row.state_text || '';


### PR DESCRIPTION
Follow-ups to the "why" tooltips in #4311. All three were found by executing the shipped renderer JS against a real `raw_plan` under Node, rather than by reading it.

## History / "Yesterday Without Predbat" had no tooltips at all

`renderPlanTable` has two state-cell paths and only the editable one (the plan view, `editable = currentView === 'plan'`) called `renderStateCell`. The read-only branch built its `<td>` inline with no `title=`, so those views rendered zero tooltips. Both paths now share a `reasonTitleAttr()` helper.

Those datasets already carry `reasons` and `reason_templates` — they come from the same `publish_html_plan` — so this is a render-only fix, no new data.

## Templates were read from the wrong dataset

`renderReasonText` looked templates up in `window.planData.reason_templates` even though `renderPlanTable` was handed a `jsonData`. Harmless while only the plan view rendered tooltips; once History does too, it would be looking up its rows against the plan view's table. It now takes them from the dataset it is rendering.

## A split slot only explained one of its two halves

When an export window starts partway through a slot, the state cell splits into `arrow | Exp`. The pre-window arrow ([output.py](../blob/main/apps/predbat/output.py) ~L1302) was the only state that appended no reason, so `reasons` held just the export entry and the tooltip explained only the second half:

```
split: True    state_text: " ↘"    state2_text: "Exp↘"
reason codes: ['export_high_rate']          <-- one reason, two-part cell
```

It now emits `demand_before_export_{rising,falling,steady}`, deliberately worded without the "no charging or exporting is scheduled this slot" clause the plain demand reasons use — that would contradict the export sentence sitting beside it in the same tooltip.

## SyntaxWarning on import

```
/config/web_helper.py:6330: SyntaxWarning: invalid escape sequence '\{'
```

`renderReasonText`'s regex `/\{(\w+)\}/g` sits inside a plain (non-raw) triple-quoted Python string, so its backslashes needed doubling — the convention already used by every other JS regex in these blobs (e.g. `(\\d{2})` a few lines below). The emitted JS is **byte-identical** (Python passes invalid escapes through verbatim), so this changes no behaviour, but it becomes a `SyntaxError` in a future Python. It was the only such warning in the package.

## Verification

Running the real `get_plan_renderer_js()` output against a generated plan:

```
PLAN view (editable)    -> title= attributes: 48
HISTORY view (readonly) -> title= attributes: 48     (was 0)
with window.planData UNSET -> title= attributes: 48
```

New tests in `test_plan_why_reason.py` (15 total, all passing): split-slot reason pairing and non-contradictory wording, the read-only tooltip path, templates sourced from `jsonData`, and a guard that `web_helper.py` compiles with no `SyntaxWarning`. `./run_all --quick` and `./run_pre_commit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)