### PR TITLE
fix(web): show a clear message on Compare when no tariffs are configured

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -300,8 +300,10 @@ njpwerner
 nobat
 nocharge
 nodischarge
+noopener
 nord
 nordpool
+noreferrer
 nosc
 nrgheat
 numpy

--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -8,6 +8,8 @@
 # pylint: disable=line-too-long
 # pylint: disable=attribute-defined-outside-init
 
+import asyncio
+
 from web import WebInterface
 
 
@@ -177,7 +179,52 @@ def run_web_functions_tests(my_predbat):
     # The web UI must show the user's configured currency symbol, not the raw "p".
     failed += run_currency_unit_tests(my_predbat, web)
 
+    # -------------------------------------------------------------------------
+    # Compare page empty state (issue #4334) - an empty compare_list must not show the
+    # "Loading chart (please wait)..." messages forever, since nothing will ever load.
+    failed += run_compare_empty_state_tests(my_predbat, web)
+
     print("**** Web functions tests completed ****")
+    return failed
+
+
+def run_compare_empty_state_tests(my_predbat, web):
+    """Unit tests for the Compare page's empty-state messaging (issue #4334)."""
+    failed = 0
+    print("**** Running compare empty state tests ****")
+
+    original_args = my_predbat.args.copy()
+
+    # -------------------------------------------------------------------------
+    print("Test: no compare_list configured shows a clear 'not configured' message, not a stuck loading message")
+    my_predbat.args.pop("compare_list", None)
+    response = asyncio.run(web.html_compare(None))
+    text = response.text
+    if "No tariffs configured yet" not in text:
+        print(f"  ERROR: expected a 'no tariffs configured' message when compare_list is empty")
+        failed += 1
+    if "Loading chart (please wait)" in text:
+        print(f"  ERROR: should not show the stuck 'Loading chart' message when nothing is configured")
+        failed += 1
+    if "7 day rolling average chart loading (please wait)" in text:
+        print(f"  ERROR: should not show the stuck '7 day rolling average' message when nothing is configured")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: a configured but not-yet-computed compare_list keeps the genuine loading message")
+    my_predbat.args["compare_list"] = [{"id": "test1", "name": "Test tariff"}]
+    response = asyncio.run(web.html_compare(None))
+    text = response.text
+    if "No tariffs configured yet" in text:
+        print(f"  ERROR: should not show the 'no tariffs configured' message when compare_list is set")
+        failed += 1
+    if "Loading chart (please wait)" not in text:
+        print(f"  ERROR: expected the genuine loading message when compare_list is set but not yet computed")
+        failed += 1
+
+    my_predbat.args = original_args
+
+    print("**** Compare empty state tests completed ****")
     return failed
 
 

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -3889,7 +3889,7 @@ chart.render();
         if compare_hist:
             text += self.render_chart(series_data, self.currency_symbols[0], "Tariff Comparison - True cost", now_str, daily_chart=False)
         elif not compare_list:
-            text += '<br><h2>No tariffs configured yet - see <a href="https://springfall2008.github.io/batpred/compare/" target="_blank">Compare Energy Tariff</a> for how to add some to apps.yaml</h2><br>'
+            text += '<br><h2>No tariffs configured yet - see <a href="https://springfall2008.github.io/batpred/compare/" target="_blank" rel="noopener noreferrer">Comparing Energy Tariffs</a> for how to add some to apps.yaml</h2><br>'
         else:
             text += "<br><h2>Loading chart (please wait)...</h2><br>"
 

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -3888,6 +3888,8 @@ chart.render();
 
         if compare_hist:
             text += self.render_chart(series_data, self.currency_symbols[0], "Tariff Comparison - True cost", now_str, daily_chart=False)
+        elif not compare_list:
+            text += '<br><h2>No tariffs configured yet - see <a href="https://springfall2008.github.io/batpred/compare/" target="_blank">Compare Energy Tariff</a> for how to add some to apps.yaml</h2><br>'
         else:
             text += "<br><h2>Loading chart (please wait)...</h2><br>"
 
@@ -3904,6 +3906,8 @@ chart.render();
                 series_7d.append({"name": name, "data": rolling, "chart_type": "line", "stroke_width": "2"})
         if series_7d:
             text += self.render_chart(series_7d, self.currency_symbols[0], "Tariff Comparison - 7 day rolling average", now_str, tagname="chart7d", daily_chart=False)
+        elif not compare_list:
+            pass  # Already explained by the "No tariffs configured" message above
         else:
             text += "<br><h2>7 day rolling average chart loading (please wait)...</h2><br>"
 


### PR DESCRIPTION
## Summary
- Follows on from #4334 - a user reported the Compare page as "broken/empty," which turned out to be an empty `compare_list` in `apps.yaml` (no tariffs configured), not a routing bug. But the page's actual behaviour in that state was genuinely misleading: it showed "Loading chart (please wait)..." and "7 day rolling average chart loading (please wait)..." forever, since nothing was ever going to load without a `compare_list` entry - indistinguishable from an actually broken page.
- Now checks `compare_list` directly: if it's empty, shows a message pointing at the [Compare Energy Tariff docs](https://springfall2008.github.io/batpred/compare/) instead. If `compare_list` is set but the comparison hasn't run/computed yet, keeps the original "please wait" message, since that's a genuine loading state.
- Entities page wasn't touched - its existing "No entities selected" empty state is already clear and correctly worded, this was Compare-specific.

## Test plan
- [x] New tests in `test_web_functions.py` covering both branches (empty `compare_list` shows the new message and not the stuck loading text; a configured-but-not-yet-computed `compare_list` keeps the genuine loading message)
- [x] `./run_all --test web_functions --test compare --test web_charts` - all pass
- [x] `pre-commit` (ruff, black, cspell) run against the changed files, passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)