### PR TITLE
fix(teslemetry): consolidate tariff periods across identical days

### DIFF
--- a/apps/predbat/teslemetry.py
+++ b/apps/predbat/teslemetry.py
@@ -918,18 +918,45 @@ class TeslemetryAPI(ComponentBase, OAuthMixin):
         return layout
 
     @staticmethod
+    def _day_runs(layout):
+        """Group days 0-6 sharing an identical interval list into maximal contiguous day-of-week runs.
+
+        _side_layout replicates tomorrow's shape onto every day except today, so 6 of the 7 entries
+        are typically byte-identical - grouping first means callers emit one ranged period per run
+        instead of one period per individual day. Returns [(from_day, to_day, intervals), ...],
+        sorted; runs never wrap past day 6 back to day 0, since a run only ever extends forward.
+        """
+        by_signature = {}
+        for day in range(7):
+            by_signature.setdefault(tuple(layout.get(day, [])), []).append(day)
+
+        runs = []
+        for intervals, days in by_signature.items():
+            days = sorted(days)
+            run_start = run_end = days[0]
+            for day in days[1:]:
+                if day == run_end + 1:
+                    run_end = day
+                else:
+                    runs.append((run_start, run_end, intervals))
+                    run_start = run_end = day
+            runs.append((run_start, run_end, intervals))
+        runs.sort()
+        return runs
+
+    @staticmethod
     def _render_side(layout, tier_prices):
         """Render a per-day interval layout into (energy_charges_side, tou_periods), matched tier sets only."""
         periods = {}
         used = set()
-        for day, intervals in layout.items():
+        for from_day, to_day, intervals in TeslemetryAPI._day_runs(layout):
             for frm, to, tier in intervals:
                 from_hour, from_minute = frm // 60, frm % 60
                 if to >= 1440:
                     to_hour, to_minute = 0, 0
                 else:
                     to_hour, to_minute = to // 60, to % 60
-                periods.setdefault(tier, {"periods": []})["periods"].append({"fromDayOfWeek": day, "toDayOfWeek": day, "fromHour": from_hour, "fromMinute": from_minute, "toHour": to_hour, "toMinute": to_minute})
+                periods.setdefault(tier, {"periods": []})["periods"].append({"fromDayOfWeek": from_day, "toDayOfWeek": to_day, "fromHour": from_hour, "fromMinute": from_minute, "toHour": to_hour, "toMinute": to_minute})
                 used.add(tier)
         rates = {tier: price for tier, price in tier_prices.items() if tier in used}
         energy_charges_side = {"ALL": {"rates": {"ALL": 0}}, "AllYear": {"rates": rates}}

--- a/apps/predbat/tests/test_teslemetry.py
+++ b/apps/predbat/tests/test_teslemetry.py
@@ -607,8 +607,48 @@ def test_teslemetry_build_tariff_periods_partition_each_day():
     tariff = api.build_tariff((1020, 1080), now_min=600)
     for tou_periods in (tariff["seasons"]["AllYear"]["tou_periods"], tariff["sell_tariff"]["seasons"]["AllYear"]["tou_periods"]):
         for day in range(7):
-            day_periods = {tier: {"periods": [p for p in block["periods"] if p["fromDayOfWeek"] == day]} for tier, block in tou_periods.items()}
+            # fromDayOfWeek/toDayOfWeek may now span a range (days sharing an identical pattern are
+            # consolidated, see _day_runs), so membership is a range check, not exact equality.
+            day_periods = {tier: {"periods": [p for p in block["periods"] if p["fromDayOfWeek"] <= day <= p["toDayOfWeek"]]} for tier, block in tou_periods.items()}
             _assert_tou_periods_partition_day(day_periods)
+
+
+def test_teslemetry_build_tariff_consolidates_replicated_days():
+    """Days sharing tomorrow's replicated pattern (issue #4346) collapse into ranged periods, not one
+    per individual day - 6 near-identical days should render as at most 2 contiguous-day periods per
+    tier/time, not 6, and every day must still resolve to exactly one period per tier via range lookup."""
+    api = MockTeslemetryAPI()
+    api.base = _rate_base(import_p=28.0, export_p=15.0)
+    tariff = api.build_tariff(None)
+    for tou_periods in (tariff["seasons"]["AllYear"]["tou_periods"], tariff["sell_tariff"]["seasons"]["AllYear"]["tou_periods"]):
+        for tier, block in tou_periods.items():
+            for period in block["periods"]:
+                assert period["fromDayOfWeek"] <= period["toDayOfWeek"], "period {} for tier {} should not wrap".format(period, tier)
+            # Today's own day and the 6 replicated days can span at most 2 runs each (removing one day
+            # from a linear 0-6 range leaves at most 2 contiguous remainders) plus today's own entry -
+            # so no single tier should ever need more than 3 period entries for a flat rate.
+            assert len(block["periods"]) <= 3, "tier {} has {} period entries, expected consolidated ranges (<=3): {}".format(tier, len(block["periods"]), block["periods"])
+
+
+def test_teslemetry_day_runs_groups_replicated_days():
+    """_day_runs() itself: 6 identical days plus 1 different day collapse to 2 runs, not 7 singletons."""
+    api = MockTeslemetryAPI()
+    same = [(0, 1440, "SUPER_OFF_PEAK")]
+    different = [(0, 600, "SUPER_OFF_PEAK"), (600, 1440, "MID_PEAK")]
+    layout = {day: list(same) for day in range(7)}
+    layout[3] = list(different)  # Wednesday differs from every other day
+    runs = api._day_runs(layout)
+    # Day 3 isolated -> its own run; days 0-2 and 4-6 are the two remaining contiguous blocks
+    assert sorted(runs) == sorted([(0, 2, tuple(same)), (3, 3, tuple(different)), (4, 6, tuple(same))])
+
+
+def test_teslemetry_day_runs_all_identical_single_run():
+    """_day_runs() with every day identical (no boost, flat week) collapses to exactly one run."""
+    api = MockTeslemetryAPI()
+    same = [(0, 1440, "SUPER_OFF_PEAK")]
+    layout = {day: list(same) for day in range(7)}
+    runs = api._day_runs(layout)
+    assert runs == [(0, 6, tuple(same))]
 
 
 def test_teslemetry_set_tariff_posts_tou_settings():
@@ -1790,6 +1830,9 @@ def test_teslemetry(my_predbat=None):
     test_teslemetry_build_tariff_fallback_flat_when_no_rates()
     test_teslemetry_build_tariff_boost_clamps_above_high_rates()
     test_teslemetry_build_tariff_periods_partition_each_day()
+    test_teslemetry_build_tariff_consolidates_replicated_days()
+    test_teslemetry_day_runs_groups_replicated_days()
+    test_teslemetry_day_runs_all_identical_single_run()
     test_teslemetry_set_tariff_posts_tou_settings()
     test_teslemetry_sync_tariff_dedupes_unchanged()
     test_teslemetry_sync_tariff_pushes_on_window_change()


### PR DESCRIPTION
## Summary

Reported in #4346 - the tariff pushed to Tesla via Teslemetry showed a "mess": 6-7 near-identical duplicate rows for the same time period in the Tesla app's rate plan summary, and an "Invalid schedule - Time of use schedule should cover exactly 24 hours" validation error.

**Root cause of the duplication (confirmed and fixed here)**: `_side_layout` places today's actual rate pattern on `today_dow` and replicates *tomorrow's* pattern onto the other 6 days of the week (Predbat only has real rate data for today+tomorrow). `_render_side` then looped `for day in layout.items()` and emitted a separate period object per individual day - even when 6 of the 7 day-entries were byte-identical. Tesla's app renders each period object as its own row with no dedup on its side, so the redundancy showed through directly.

**The fix**: a new `_day_runs()` helper groups the 7 days by their exact interval list, splits each group into maximal contiguous day-of-week runs (removing one outlier day from a linear 0-6 range leaves at most 2 contiguous remainders), and `_render_side` now emits one ranged `fromDayOfWeek`-`toDayOfWeek` period per run instead of one per individual day. A typical week now produces at most 2-3 period entries per tier instead of 7.

**On the "should cover exactly 24 hours" error**: I couldn't find a distinct logic bug in the carving/partition code (`_carve_interval`/`_apply_boost`) - the existing `test_teslemetry_build_tariff_periods_partition_each_day` test already verifies every individual day's periods partition [0, 1440) exactly with no gaps or overlaps, and it still passes after this change. My working theory is this error is a downstream symptom of the same duplication (e.g. Tesla's app hitting an entry-count limit and silently dropping some of the 6-7 redundant entries, leaving a real gap) rather than a separate bug - but I can't confirm this without live Tesla hardware to test the actual push+validation cycle. Flagging this honestly rather than claiming it's fixed - would appreciate the reporter confirming once this is out whether that error also clears up.

## Test plan
- [x] New tests: `test_teslemetry_day_runs_groups_replicated_days` and `test_teslemetry_day_runs_all_identical_single_run` (unit tests for the grouping helper itself), `test_teslemetry_build_tariff_consolidates_replicated_days` (end-to-end: asserts <=3 period entries per tier, and no period ever wraps past day 6)
- [x] Updated `test_teslemetry_build_tariff_periods_partition_each_day` to check day-range membership instead of exact-day equality, since periods can now legitimately span a range
- [x] `./run_all --test teslemetry` - all pass
- [x] `pre-commit` (ruff, black, cspell) run against the changed files, passed

Fixes #4346 (duplication half; 24-hour validation error needs reporter confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)