### PR TITLE
fix(solax): control idle and freeze modes without the VPP self consume modes

### DIFF
--- a/apps/predbat/solax.py
+++ b/apps/predbat/solax.py
@@ -27,6 +27,23 @@ from component_base import ComponentBase
 SOLAX_TIMEOUT = 20
 SOLAX_RETRIES = 5
 SOLAX_MIN_RESERVE_PERCENT = 10  # SolaX Cloud clamps target_soc/reserve controls to this floor; see control_info()
+SOLAX_TEST_MODE_DURATION = 60 * 60  # Default timeOfDuration (seconds) for the standalone CLI raw commands
+SOLAX_MIN_MODE_DURATION = 60  # Shortest timeOfDuration (seconds) that can be requested
+SOLAX_CONTROL_RETRY_BACKOFF = 5 * 60  # First wait (seconds) before retrying a control mode the inverter rejected
+SOLAX_CONTROL_RETRY_MAX = 60 * 60  # Longest wait (seconds) between retries of a rejected control mode
+# nextMotion values, the action the inverter takes once a VPP mode ends
+SOLAX_NEXT_MOTION_EXIT = 160  # Exit remote control
+SOLAX_NEXT_MOTION_SELF_CONSUME = 161  # Back to self-consume charge/discharge mode
+# Raw commands that can be issued one at a time from the standalone CLI, see run_test_command()
+SOLAX_TEST_COMMANDS = [
+    "self_consume",
+    "self_consume_charge_only",
+    "exit_vpp",
+    "soc_target",
+    "positive_negative",
+    "work_mode_selfuse",
+    "work_mode_feedin",
+]
 SOLAX_COMMAND_RETRY_DELAY = 2.0
 SOLAX_COMMAND_MAX_RETRIES = 8
 SOLAX_REGIONS = {
@@ -339,6 +356,10 @@ class SolaxAPI(ComponentBase):
         self.current_mode_hash = None
         self.current_mode_hash_timestamp = None
         self.enable_controls = enable_controls
+        self.freeze_charge_min_soc = None
+        self.failed_mode_hash = None
+        self.failed_mode_retry_time = None
+        self.failed_mode_count = 0
 
         # Build base URL from region
         self.base_url = f"https://{SOLAX_REGIONS.get(region, SOLAX_REGIONS['eu'])}"
@@ -706,7 +727,6 @@ class SolaxAPI(ComponentBase):
         # Export takes priority over charge (although overlapping windows should not be possible)
         if export_window:
             new_target_soc = max(export_target_soc, reserve_soc)
-            duration = (export_end - now).total_seconds()
             new_end = export_end_minutes
             if new_target_soc >= current_soc:
                 # Freeze export
@@ -717,7 +737,6 @@ class SolaxAPI(ComponentBase):
                 new_mode = "export"
                 new_power = -export_power
         elif charge_window:
-            duration = (charge_end - now).total_seconds()
             new_end = charge_end_minutes
             new_target_soc = max(charge_target_soc, reserve_soc)
             if (new_target_soc == reserve_soc) or (new_target_soc == current_soc):
@@ -736,11 +755,25 @@ class SolaxAPI(ComponentBase):
             new_mode = "eco"
             new_target_soc = reserve_soc
             new_power = 0
-            duration = 12 * 60 * 60  # Default to 12 hours
             new_end = 0
 
-        duration = min(duration, 12 * 60 * 60)  # Max duration 12 hours
-        new_mode_hash = hash((new_mode, new_power, new_target_soc, new_end))
+        # Freeze charge holds the battery where it was when the window opened, the floor is not chased
+        # upwards as PV charges the battery so that a long freeze does not rewrite the inverter repeatedly
+        if new_mode == "freeze_charge":
+            if self.freeze_charge_min_soc is None:
+                self.freeze_charge_min_soc = max(reserve_soc, min(100, current_soc))
+            new_min_soc = self.freeze_charge_min_soc
+        else:
+            self.freeze_charge_min_soc = None
+            new_min_soc = reserve_soc
+
+        # Only hash what is actually sent for this mode.  The freeze modes hold the battery with min_soc
+        # and send no SOC target, so tracking new_target_soc there would rewrite the inverter every time
+        # the battery SOC moved by 1%
+        if new_mode in ("eco", "freeze_charge", "freeze_export"):
+            new_mode_hash = hash((new_mode, new_end, new_min_soc))
+        else:
+            new_mode_hash = hash((new_mode, new_power, new_target_soc, new_end, new_min_soc))
         old_mode_hash = self.current_mode_hash
         old_mode_hash_timestamp = self.current_mode_hash_timestamp
         # Check age of current mode hash
@@ -750,30 +783,39 @@ class SolaxAPI(ComponentBase):
                 old_mode_hash = None  # Force update if older than 15 minutes
         if old_mode_hash is not None and new_mode_hash == old_mode_hash:
             self.log(f"SolaX API: No control changes for plant {plant_id}, skipping")
+        elif new_mode_hash == self.failed_mode_hash and self.failed_mode_retry_time and now < self.failed_mode_retry_time:
+            # This exact mode was rejected by the inverter, back off rather than retrying every cycle.
+            # A different mode is always tried immediately as it may well be one the inverter accepts.
+            wait = int((self.failed_mode_retry_time - now).total_seconds())
+            self.log(f"Warn: SolaX API: Mode {new_mode} failed {self.failed_mode_count} time(s) for plant {plant_id}, waiting {wait} seconds before retrying")
         else:
             success = True
             if new_mode == "eco":
-                self.log(f"SolaX API: Plant {plant_id} : {sn_list} Applying self consume mode")
-                success1 = await self.set_default_work_mode(sn_list, mode="selfuse")
-                success2 = await self.self_consume_mode(sn_list, time_of_duration=duration)
+                # Hand control back to the inverter, its own self use logic is what idle means.  The VPP
+                # self consume mode is not used as some inverters reject it (device execution failed)
+                self.log(f"SolaX API: Plant {plant_id} : {sn_list} Applying self use work mode with min_soc {new_min_soc}")
+                success1 = await self.set_default_work_mode(sn_list, mode="selfuse", min_soc=new_min_soc)
+                success2 = await self.exit_vpp_mode(sn_list)
                 success = success1 and success2
             elif new_mode == "freeze_charge":
-                self.log(f"SolaX API: Plant {plant_id} : {sn_list} Applying self consume charge only mode")
-                success2 = await self.set_default_work_mode(sn_list, mode="selfuse")
-                success1 = await self.self_consume_charge_only_mode(sn_list, time_of_duration=duration)
+                # Freeze charge is self use held at the current SOC, the battery can charge from PV but
+                # will not discharge below min_soc
+                self.log(f"SolaX API: Plant {plant_id} : {sn_list} Applying self use work mode frozen at min_soc {new_min_soc}")
+                success1 = await self.set_default_work_mode(sn_list, mode="selfuse", min_soc=new_min_soc)
+                success2 = await self.exit_vpp_mode(sn_list)
                 success = success1 and success2
             elif new_mode == "freeze_export":
-                success1 = await self.set_default_work_mode(sn_list, mode="feedin")
+                success1 = await self.set_default_work_mode(sn_list, mode="feedin", min_soc=new_min_soc)
                 success2 = await self.exit_vpp_mode(sn_list)
                 success = success1 and success2
             elif new_mode == "charge":
                 self.log(f"SolaX API: Plant {plant_id} : {sn_list} Applying SOC target control mode")
-                success1 = await self.set_default_work_mode(sn_list, mode="selfuse")
+                success1 = await self.set_default_work_mode(sn_list, mode="selfuse", min_soc=new_min_soc)
                 success2 = await self.soc_target_control_mode(sn_list, new_target_soc, charge_discharge_power=new_power)
                 success = success1 and success2
             elif new_mode == "export":
                 self.log(f"SolaX API: Plant {plant_id} : {sn_list} Applying SOC target control mode for export")
-                success1 = await self.set_default_work_mode(sn_list, mode="feedin")
+                success1 = await self.set_default_work_mode(sn_list, mode="feedin", min_soc=new_min_soc)
                 success2 = await self.soc_target_control_mode(sn_list, new_target_soc, charge_discharge_power=new_power)
                 success = success1 and success2
             else:
@@ -783,7 +825,17 @@ class SolaxAPI(ComponentBase):
             if success:
                 self.current_mode_hash = new_mode_hash
                 self.current_mode_hash_timestamp = now
-                self.log(f"SolaX API: Applied new mode {new_mode} target_soc {new_target_soc} new_power {new_power} for plant {plant_id}")
+                self.failed_mode_hash = None
+                self.failed_mode_retry_time = None
+                self.failed_mode_count = 0
+                self.log(f"SolaX API: Applied new mode {new_mode} target_soc {new_target_soc} new_power {new_power} min_soc {new_min_soc} for plant {plant_id}")
+            else:
+                # Back off exponentially so a mode the inverter always rejects cannot hammer the cloud API
+                self.failed_mode_count = self.failed_mode_count + 1 if new_mode_hash == self.failed_mode_hash else 1
+                backoff = min(SOLAX_CONTROL_RETRY_BACKOFF * (2 ** (self.failed_mode_count - 1)), SOLAX_CONTROL_RETRY_MAX)
+                self.failed_mode_hash = new_mode_hash
+                self.failed_mode_retry_time = now + timedelta(seconds=backoff)
+                self.log(f"Warn: SolaX API: Failed to apply mode {new_mode} for plant {plant_id}, retry in {backoff} seconds")
 
         self.log(f"SolaX API: Applied controls for plant {plant_id}")
         return True
@@ -1666,7 +1718,7 @@ class SolaxAPI(ComponentBase):
             sn = device_result.get("sn")
             this_status = device_result.get("status")
             if this_status != status:
-                self.log(f"  {sn}: {status}")
+                self.log(f"  {sn}: {this_status} : {SOLAX_COMMAND_STATUS.get(this_status, 'Unknown status')}")
                 status = this_status
                 break
 
@@ -1720,7 +1772,8 @@ class SolaxAPI(ComponentBase):
                         self.log(f"SolaX API: Command execution succeeded for requestId {request_id}")
                         return True
                     else:
-                        self.log(f"SolaX API: Command execution failed with status {status} : {status_desc} for requestId {request_id}")
+                        result_desc = SOLAX_COMMAND_STATUS.get(status, f"Unknown status {status}")
+                        self.log(f"Warn: SolaX API: Command {command_name} execution failed with status {status} : {result_desc} for requestId {request_id} payload {payload}")
                         return False
 
                 if attempt < SOLAX_COMMAND_MAX_RETRIES - 1:
@@ -1737,7 +1790,7 @@ class SolaxAPI(ComponentBase):
         self.log(f"Warn: SolaX API: Command issuance failed or device offline {sn} status {status} : {status_desc}")
         return False
 
-    async def positive_or_negative_mode(self, sn, battery_power, time_of_duration, next_motion=161,
+    async def positive_or_negative_mode(self, sn, battery_power, time_of_duration, next_motion=SOLAX_NEXT_MOTION_SELF_CONSUME,
                                         business_type=None):
         """
         Set inverter working mode to Positive or Negative mode
@@ -1775,7 +1828,7 @@ class SolaxAPI(ComponentBase):
         # Send command and wait for result
         return await self.send_command_and_wait(endpoint, payload, "positive/negative", sn)
 
-    async def self_consume_mode(self, sn_list, time_of_duration, next_motion=161,
+    async def self_consume_mode(self, sn_list, time_of_duration, next_motion=SOLAX_NEXT_MOTION_SELF_CONSUME,
                                 business_type=None):
         """
         Set inverter working mode to Self-Consume Charge/Discharge Mode
@@ -1812,7 +1865,7 @@ class SolaxAPI(ComponentBase):
         # Send command and wait for result
         return await self.send_command_and_wait(endpoint, payload, "self-consume", sn_list)
 
-    async def self_consume_charge_only_mode(self, sn_list, time_of_duration, next_motion=161,
+    async def self_consume_charge_only_mode(self, sn_list, time_of_duration, next_motion=SOLAX_NEXT_MOTION_SELF_CONSUME,
                                             business_type=None):
         """
         Set inverter working mode to Self-Consume Charge Only Mode
@@ -1879,12 +1932,25 @@ class SolaxAPI(ComponentBase):
         # Send command and wait for result
         return await self.send_command_and_wait(endpoint, payload, "exit-vpp-mode", sn_list)
 
-    async def set_default_work_mode(self, sn_list, business_type=None, mode="selfuse"):
-        success = await self.set_work_mode(mode, sn_list, 10, 100, 0, "00:00", "00:00", "00:00", "23:59", business_type=business_type)
+    async def set_default_work_mode(self, sn_list, business_type=None, mode="selfuse", min_soc=SOLAX_MIN_RESERVE_PERCENT):
+        """
+        Set the inverter default work mode, the battery holds at min_soc and charges from PV only
+
+        Args:
+            sn_list: List of device serial numbers
+            business_type: Business type (1=Residential, 4=Commercial), defaults to residential
+            mode: Work mode, 'selfuse', 'backup' or 'feedin'
+            min_soc: Minimum SOC percentage the battery will discharge to
+
+        Returns:
+            True if command executed successfully, False otherwise
+        """
+        min_soc = max(SOLAX_MIN_RESERVE_PERCENT, min(100, as_int(min_soc, SOLAX_MIN_RESERVE_PERCENT)))
+        success = await self.set_work_mode(mode, sn_list, min_soc, 100, 0, "00:00", "00:00", "00:00", "23:59", business_type=business_type)
         if success:
-            self.log(f"SolaX API: Set default work mode to {mode} for device {sn_list}")
+            self.log(f"SolaX API: Set default work mode to {mode} min_soc {min_soc} for device {sn_list}")
         else:
-            self.log(f"Warn: SolaX API: Failed to set default work mode to {mode} for device {sn_list}")
+            self.log(f"Warn: SolaX API: Failed to set default work mode to {mode} min_soc {min_soc} for device {sn_list}")
         return success
 
     async def set_work_mode(self, mode, sn_list, min_soc, charge_upper_soc, charge_from_grid_enable,
@@ -2326,8 +2392,10 @@ class SolaxAPI(ComponentBase):
 
             inverter_max_power = self.get_max_power_inverter(plant_id)
             battery_max_power = self.get_max_power_battery(plant_id)
-            battery_soc_max = self.get_max_soc_battery(plant_id)
             battery_soc, battery_size_max_approx = self.get_current_soc_battery_kwh(plant_id)
+            # The plant capacity is a nominal figure from the portal and can read below the measured energy
+            # remaining when the battery is near full, so never publish a capacity below the current SOC
+            battery_soc_max = max(self.get_max_soc_battery(plant_id), battery_soc)
             battery_temp = self.get_battery_temperature(plant_id)
             charge_discharge_power = self.get_charge_discharge_power_battery(plant_id)
 
@@ -2647,7 +2715,50 @@ class MockBase:  # pragma: no cover
         print(f"Set arg {key} = {value} (state={state})")
 
 
-async def test_solax_api(client_id, client_secret, region, plant_id, test_mode=None):  # pragma: no cover
+async def run_test_command(solax, plant_id, command, duration, next_motion, target_soc, power):  # pragma: no cover
+    """
+    Issue a single raw control command against a plant, used to bisect which command an inverter rejects
+
+    Args:
+        solax: SolaxAPI instance
+        plant_id: Plant to control
+        command: Command name from SOLAX_TEST_COMMANDS
+        duration: Mode duration in seconds for the modes that take one
+        next_motion: Action after the mode ends (160=Exit Remote Control, 161=Back to Self-Consume Mode)
+        target_soc: Target SOC for soc_target
+        power: Charge/discharge power in Watts for soc_target and positive_negative
+
+    Returns:
+        True if the command executed successfully, False otherwise
+    """
+    sn_list = solax.plant_inverters.get(plant_id, [])
+    if not sn_list:
+        print(f"✗ No inverters found for plant {plant_id}")
+        return False
+
+    if command == "self_consume":
+        return await solax.self_consume_mode(sn_list, time_of_duration=duration, next_motion=next_motion)
+    elif command == "self_consume_charge_only":
+        return await solax.self_consume_charge_only_mode(sn_list, time_of_duration=duration, next_motion=next_motion)
+    elif command == "exit_vpp":
+        return await solax.exit_vpp_mode(sn_list)
+    elif command == "soc_target":
+        return await solax.soc_target_control_mode(sn_list, target_soc, charge_discharge_power=power)
+    elif command == "positive_negative":
+        success = True
+        for sn in sn_list:
+            success = await solax.positive_or_negative_mode(sn, battery_power=power, time_of_duration=duration, next_motion=next_motion) and success
+        return success
+    elif command == "work_mode_selfuse":
+        return await solax.set_default_work_mode(sn_list, mode="selfuse")
+    elif command == "work_mode_feedin":
+        return await solax.set_default_work_mode(sn_list, mode="feedin")
+
+    print(f"✗ Unknown test command: {command}")
+    return False
+
+
+async def test_solax_api(client_id, client_secret, region, plant_id, test_mode=None, duration=None, test_commands=None, next_motion=SOLAX_NEXT_MOTION_SELF_CONSUME, target_soc=50, power=0, command_delay=0):  # pragma: no cover
     """
     Test function for standalone execution
 
@@ -2657,6 +2768,12 @@ async def test_solax_api(client_id, client_secret, region, plant_id, test_mode=N
         region: API region
         plant_id: Optional plant ID filter
         test_mode: Optional control mode to test ('eco', 'charge', 'freeze_charge', 'export', 'freeze_export')
+        duration: Optional timeOfDuration in seconds for the raw commands that take one
+        test_commands: Optional list of raw commands to issue in order, see SOLAX_TEST_COMMANDS
+        next_motion: Action after a VPP mode ends, for the raw commands that take one
+        target_soc: Target SOC for the soc_target raw command
+        power: Charge/discharge power in Watts for the soc_target and positive_negative raw commands
+        command_delay: Seconds to hold between raw commands, use to let a mode take effect before backing out of it
     """
     print(f"\n{'=' * 60}")
     print(f"Testing SolaX API")
@@ -2666,6 +2783,10 @@ async def test_solax_api(client_id, client_secret, region, plant_id, test_mode=N
         print(f"Plant ID filter: {plant_id}")
     if test_mode:
         print(f"Test mode: {test_mode}")
+    if test_commands:
+        print(f"Test commands: {', '.join(test_commands)}")
+    if duration:
+        print(f"Mode duration: {duration} seconds")
     print(f"{'=' * 60}\n")
 
     # Create mock base
@@ -2688,6 +2809,31 @@ async def test_solax_api(client_id, client_secret, region, plant_id, test_mode=N
         return
     else:
         print("✓ Initialisation successful")
+
+    # If raw test commands are specified, issue them in order against the first plant
+    if test_commands and solax.plant_list:
+        command_plant_id = solax.plant_list[0]
+        command_duration = max(SOLAX_MIN_MODE_DURATION, duration) if duration else SOLAX_TEST_MODE_DURATION
+        current_soc_kwh, max_soc_kwh = solax.get_current_soc_battery_kwh(command_plant_id)
+        current_soc = int((current_soc_kwh / max_soc_kwh) * 100) if max_soc_kwh > 0 else 0
+        failed = False
+        for index, command in enumerate(test_commands):
+            if index and command_delay:
+                print(f"\nHolding for {command_delay} seconds before the next command...")
+                await asyncio.sleep(command_delay)
+            print(f"\n{'=' * 60}")
+            print(f"Issuing command: {command}")
+            print(f"Plant ID: {command_plant_id}")
+            print(f"Battery SOC: {current_soc}% ({current_soc_kwh:.2f} of {max_soc_kwh:.2f} kWh)")
+            print(f"{'=' * 60}\n")
+            success = await run_test_command(solax, command_plant_id, command, command_duration, next_motion, target_soc, power)
+            if success:
+                print(f"✓ Command {command} succeeded")
+            else:
+                print(f"✗ Command {command} failed")
+                failed = True
+        if failed:
+            return 1
 
     # If test_mode is specified, apply controls
     if test_mode and solax.plant_list:
@@ -2802,7 +2948,8 @@ def main():  # pragma: no cover
     """Main entry point for standalone testing"""
     parser = argparse.ArgumentParser(
         description="Test SolaX Cloud API and control modes",
-        epilog="Example: python solax.py --client-id YOUR_ID --client-secret YOUR_SECRET --test-mode charge",
+        epilog="Example: python solax.py --client-id YOUR_ID --client-secret YOUR_SECRET --test-mode charge\n"
+               "Example: python solax.py --client-id YOUR_ID --client-secret YOUR_SECRET --test-command self_consume --duration 3600",
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("--client-id", required=True, help="SolaX Cloud client ID")
@@ -2810,11 +2957,22 @@ def main():  # pragma: no cover
     parser.add_argument("--region", default="eu", choices=["eu", "us", "cn"], help="API region (default: eu)")
     parser.add_argument("--plant-id", help="Optional plant ID to filter")
     parser.add_argument("--test-mode", choices=["eco", "charge", "freeze_charge", "export", "freeze_export"],
-                        help="Test control mode: eco (no windows), charge (active charge), freeze_charge (at target), export (active export), freeze_export (at/above target)")
+                        help="Test control mode: eco (self consume, no windows), charge (active charge), freeze_charge (at target), export (active export), freeze_export (at/above target)")
+    parser.add_argument("--duration", type=int, default=None,
+                        help=f"timeOfDuration in seconds for the --test-command modes that take one (default {SOLAX_TEST_MODE_DURATION}, minimum {SOLAX_MIN_MODE_DURATION})")
+    parser.add_argument("--test-command", action="append", choices=SOLAX_TEST_COMMANDS, dest="test_commands",
+                        help="Issue a single raw control command, repeat to run several in order (e.g. --test-command exit_vpp --test-command self_consume). Use to find which command an inverter rejects")
+    parser.add_argument("--next-motion", type=int, default=SOLAX_NEXT_MOTION_SELF_CONSUME, choices=[SOLAX_NEXT_MOTION_EXIT, SOLAX_NEXT_MOTION_SELF_CONSUME],
+                        help=f"Action after a VPP mode ends for --test-command ({SOLAX_NEXT_MOTION_EXIT}=Exit Remote Control, {SOLAX_NEXT_MOTION_SELF_CONSUME}=Back to Self-Consume Mode, default {SOLAX_NEXT_MOTION_SELF_CONSUME})")
+    parser.add_argument("--target-soc", type=int, default=50, help="Target SOC for --test-command soc_target (default 50)")
+    parser.add_argument("--power", type=int, default=0, help="Charge/discharge power in Watts for --test-command soc_target and positive_negative (default 0)")
+    parser.add_argument("--command-delay", type=int, default=0,
+                        help="Seconds to hold between chained --test-command commands, e.g. soc_target, wait, exit_vpp (default 0)")
 
     args = parser.parse_args()
 
-    asyncio.run(test_solax_api(args.client_id, args.client_secret, args.region, args.plant_id, args.test_mode))
+    asyncio.run(test_solax_api(args.client_id, args.client_secret, args.region, args.plant_id, args.test_mode, args.duration,
+                               args.test_commands, args.next_motion, args.target_soc, args.power, args.command_delay))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/apps/predbat/solax.py
+++ b/apps/predbat/solax.py
@@ -767,6 +767,10 @@ class SolaxAPI(ComponentBase):
             self.freeze_charge_min_soc = None
             new_min_soc = reserve_soc
 
+        # Clamp here rather than only inside set_default_work_mode, so that the mode hash, the backoff
+        # state and the log all describe the payload that is actually sent
+        new_min_soc = max(SOLAX_MIN_RESERVE_PERCENT, min(100, new_min_soc))
+
         # Only hash what is actually sent for this mode.  The freeze modes hold the battery with min_soc
         # and send no SOC target, so tracking new_target_soc there would rewrite the inverter every time
         # the battery SOC moved by 1%

--- a/apps/predbat/solax.py
+++ b/apps/predbat/solax.py
@@ -581,6 +581,10 @@ class SolaxAPI(ComponentBase):
             except ValueError:
                 self.log(f"SolaX API: Invalid number value {value} for {entity_id}")
                 return
+            # Clamp to the range the entity advertises, a service call can set a value outside it and
+            # the entity would then disagree with what is sent to the inverter
+            if min_value is not None and max_value is not None:
+                value = max(min_value, min(max_value, value))
         self.controls[plant_id][field] = value
         self.log(f"SolaX API: Updated control for plant {plant_id}, field {field} to {value}")
         await self.publish_controls()

--- a/apps/predbat/tests/test_solax.py
+++ b/apps/predbat/tests/test_solax.py
@@ -688,6 +688,23 @@ async def test_apply_controls_min_soc_main(my_predbat):
         else:
             print(f"✓ minSoc clamped up to the SolaX floor of {SOLAX_MIN_RESERVE_PERCENT}")
 
+    # Another reserve below the floor sends the same payload, so the mode hash must not change and
+    # nothing should be re-sent.  write_setting_from_event does not clamp, so out of range values do reach here
+    print("\n--- Test 2b: A different out of range reserve does not re-send ---")
+    solax_api.controls[test_plant_id]["reserve"] = 5
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = True
+
+        await solax_api.apply_controls(test_plant_id)
+
+        if mock_send.call_count:
+            print(f"**** ERROR: The clamped payload is unchanged so nothing should be re-sent, got {mock_send.call_count} calls ****")
+            failed = True
+        else:
+            print("✓ The mode hash tracks the clamped minSoc, so no needless rewrite")
+
     # Test 3: Freeze charge holds minSoc at the SOC the window opened at, even as the battery charges
     print("\n--- Test 3: Freeze charge holds the minSoc floor ---")
     # A charge target at the reserve is a freeze charge whatever the SOC does, so the window stays in

--- a/apps/predbat/tests/test_solax.py
+++ b/apps/predbat/tests/test_solax.py
@@ -912,6 +912,21 @@ async def test_write_setting_from_event(my_predbat):
     else:
         print(f"✓ Reserve setting updated to {new_value}")
 
+    # Test 1b: A value outside the range the entity advertises is clamped rather than stored as given,
+    # a service call can bypass the min and max that the number entity publishes
+    await solax_api.number_event(entity_id, 1)
+    if solax_api.controls[test_plant_id]["reserve"] != SOLAX_MIN_RESERVE_PERCENT:
+        print(f"**** ERROR: Reserve below the floor should clamp to {SOLAX_MIN_RESERVE_PERCENT}, got {solax_api.controls[test_plant_id]['reserve']} ****")
+        failed = True
+    else:
+        await solax_api.number_event(entity_id, 150)
+        if solax_api.controls[test_plant_id]["reserve"] != 100:
+            print(f"**** ERROR: Reserve above the maximum should clamp to 100, got {solax_api.controls[test_plant_id]['reserve']} ****")
+            failed = True
+        else:
+            print(f"✓ Out of range reserve clamped to {SOLAX_MIN_RESERVE_PERCENT}-100")
+    await solax_api.number_event(entity_id, new_value)  # Restore for the tests below
+
     # Test 2: Invalid entity ID format
     invalid_entity_id = "number.invalid_format"
     await solax_api.number_event(invalid_entity_id, 30)

--- a/apps/predbat/tests/test_solax.py
+++ b/apps/predbat/tests/test_solax.py
@@ -12,7 +12,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, AsyncMock
 import json
-from solax import SolaxAPI, SOLAX_MIN_RESERVE_PERCENT
+from solax import SolaxAPI, SOLAX_MIN_RESERVE_PERCENT, SOLAX_CONTROL_RETRY_BACKOFF, SOLAX_CONTROL_RETRY_MAX
 from tests.test_infra import create_aiohttp_mock_response, create_aiohttp_mock_session
 
 
@@ -33,6 +33,10 @@ class MockSolaxAPI(SolaxAPI):
         self.dashboard_items = {}
         self.current_mode_hash = None
         self.current_mode_hash_timestamp = None
+        self.freeze_charge_min_soc = None  # Held minSoc floor while freeze charge is active
+        self.failed_mode_hash = None  # Backoff state for a mode the inverter rejected
+        self.failed_mode_retry_time = None
+        self.failed_mode_count = 0
         self.args = {}  # Configuration arguments
         self.plant_list = []  # List of plant IDs
         self.automatic = False  # Automatic config flag
@@ -87,12 +91,14 @@ class MockSolaxAPI(SolaxAPI):
         """Mock update_success_timestamp method"""
         pass
 
-    async def set_default_work_mode(self, sn_list, business_type=None, mode="selfuse"):
+    async def set_default_work_mode(self, sn_list, business_type=None, mode="selfuse", min_soc=SOLAX_MIN_RESERVE_PERCENT):
         """Mock set_default_work_mode - calls set_work_mode (which can be mocked in tests)"""
         self.set_default_work_mode_called = True
         self.last_work_mode = mode
+        self.last_min_soc = min_soc
+        min_soc = max(SOLAX_MIN_RESERVE_PERCENT, min(100, min_soc))
         # Call set_work_mode (tests can mock this)
-        success = await self.set_work_mode(mode, sn_list, 10, 100, 0, "00:00", "00:00", "00:00", "23:59", business_type=business_type)
+        success = await self.set_work_mode(mode, sn_list, min_soc, 100, 0, "00:00", "00:00", "00:00", "23:59", business_type=business_type)
         if success:
             self.log(f"SolaX API: Set default work mode to {mode} for device {sn_list}")
         else:
@@ -155,7 +161,10 @@ def run_solax_tests(my_predbat):
         failed |= asyncio.run(test_write_setting_from_event(my_predbat))
         failed |= asyncio.run(test_fetch_controls_main(my_predbat))
         failed |= asyncio.run(test_apply_controls_main(my_predbat))
+        failed |= asyncio.run(test_apply_controls_min_soc_main(my_predbat))
+        failed |= asyncio.run(test_apply_controls_backoff_main(my_predbat))
         failed |= asyncio.run(test_publish_plant_info_main(my_predbat))
+        failed |= asyncio.run(test_publish_plant_info_capacity_floor_main(my_predbat))
 
         if not failed:
             print("**** SolaX API tests: All tests passed ****")
@@ -250,13 +259,16 @@ async def test_apply_controls(solax_api, test_plant_id):
         else:
             # Verify first call is set_default_work_mode (batch_set_spontaneity_self_use endpoint)
             first_call_endpoint = mock_send.call_args_list[0][0][0]
-            # Verify second call is self_consume_mode (self_consume/charge_or_discharge_mode endpoint)
+            # Verify second call hands control back to the inverter (exit_vpp_mode endpoint)
             second_call_endpoint = mock_send.call_args_list[1][0][0]
             if "batch_set_spontaneity_self_use" not in first_call_endpoint:
                 print(f"**** ERROR: First call not set_default_work_mode (selfuse), got {first_call_endpoint} ****")
                 failed = True
-            elif "self_consume/charge_or_discharge_mode" not in second_call_endpoint:
-                print(f"**** ERROR: Second call not self_consume_mode, got {second_call_endpoint} ****")
+            elif "exit_vpp_mode" not in second_call_endpoint:
+                print(f"**** ERROR: Second call not exit_vpp_mode, got {second_call_endpoint} ****")
+                failed = True
+            elif mock_send.call_args_list[0][0][1].get("minSoc") != 10:
+                print(f"**** ERROR: Eco mode should write the reserve as minSoc 10, got {mock_send.call_args_list[0][0][1].get('minSoc')} ****")
                 failed = True
             else:
                 print(f"✓ ECO mode applied correctly at 12:00")
@@ -357,7 +369,7 @@ async def test_apply_controls(solax_api, test_plant_id):
         mock_send.return_value = True
 
         # Set hash from previous charge call
-        solax_api.current_mode_hash = hash(("charge", 5000, 95, 360))  # 06:00 = 360 minutes
+        solax_api.current_mode_hash = hash(("charge", 5000, 95, 360, 10))  # 06:00 = 360 minutes, minSoc 10
         solax_api.current_mode_hash_timestamp = test_time
 
         result = await solax_api.apply_controls(test_plant_id)
@@ -382,7 +394,7 @@ async def test_apply_controls(solax_api, test_plant_id):
 
         # Hash timestamp is 16 minutes old (> 15 minute threshold)
         old_timestamp = test_time - timedelta(minutes=16)
-        solax_api.current_mode_hash = hash(("charge", 5000, 95, 360))
+        solax_api.current_mode_hash = hash(("charge", 5000, 95, 360, 10))
         solax_api.current_mode_hash_timestamp = old_timestamp
 
         result = await solax_api.apply_controls(test_plant_id)
@@ -419,13 +431,13 @@ async def test_apply_controls(solax_api, test_plant_id):
         else:
             # Verify first call is set_default_work_mode (selfuse)
             first_call_endpoint = mock_send.call_args_list[0][0][0]
-            # Verify second call is self_consume_mode
+            # Verify second call hands control back to the inverter
             second_call_endpoint = mock_send.call_args_list[1][0][0]
             if "batch_set_spontaneity_self_use" not in first_call_endpoint:
                 print(f"**** ERROR: First call not set_default_work_mode (selfuse), got {first_call_endpoint} ****")
                 failed = True
-            elif "self_consume/charge_or_discharge_mode" not in second_call_endpoint:
-                print(f"**** ERROR: Second call not self_consume_mode, got {second_call_endpoint} ****")
+            elif "exit_vpp_mode" not in second_call_endpoint:
+                print(f"**** ERROR: Second call not exit_vpp_mode, got {second_call_endpoint} ****")
                 failed = True
             else:
                 print(f"✓ ECO mode correctly applied when charge disabled at 03:00")
@@ -455,13 +467,16 @@ async def test_apply_controls(solax_api, test_plant_id):
         else:
             # Verify first call is set_default_work_mode (batch_set_spontaneity_self_use endpoint)
             first_call_endpoint = mock_send.call_args_list[0][0][0]
-            # Verify second call is self_consume_charge_only_mode
+            # Verify second call hands control back to the inverter, the freeze is held by minSoc
             second_call_endpoint = mock_send.call_args_list[1][0][0]
             if "batch_set_spontaneity_self_use" not in first_call_endpoint:
                 print(f"**** ERROR: First call not set_default_work_mode (selfuse), got {first_call_endpoint} ****")
                 failed = True
-            elif "self_consume/charge_only_mode" not in second_call_endpoint:
-                print(f"**** ERROR: Second call not self_consume_charge_only_mode, got {second_call_endpoint} ****")
+            elif "exit_vpp_mode" not in second_call_endpoint:
+                print(f"**** ERROR: Second call not exit_vpp_mode, got {second_call_endpoint} ****")
+                failed = True
+            elif mock_send.call_args_list[0][0][1].get("minSoc") != 50:
+                print(f"**** ERROR: Freeze charge should hold minSoc at the current SOC 50, got {mock_send.call_args_list[0][0][1].get('minSoc')} ****")
                 failed = True
             else:
                 print(f"✓ Freeze charge mode applied correctly at 03:00 (target_soc == current_soc)")
@@ -527,7 +542,7 @@ async def test_apply_controls(solax_api, test_plant_id):
             print("**** ERROR: No API calls made - charge window not detected after midnight ****")
             failed = True
         else:
-            # Charge mode sends soc_target_control_mode; eco mode sends self_consume/charge_or_discharge_mode
+            # Charge mode sends soc_target_control_mode; eco mode sends exit_vpp_mode
             calls_str = " ".join(str(c) for c in mock_send.call_args_list)
             if "soc_target_control_mode" not in calls_str:
                 print(f"**** ERROR: Expected soc_target_control_mode (charge mode) after midnight, got: {calls_str} ****")
@@ -584,11 +599,262 @@ async def test_apply_controls(solax_api, test_plant_id):
             if "soc_target_control_mode" in calls_str:
                 print(f"**** ERROR: Expected eco mode at 06:00 (after window end), got charge mode: {calls_str} ****")
                 failed = True
-            elif "charge_or_discharge_mode" not in calls_str:
-                print(f"**** ERROR: Expected eco mode (charge_or_discharge_mode) at 06:00, got: {calls_str} ****")
+            elif "exit_vpp_mode" not in calls_str:
+                print(f"**** ERROR: Expected eco mode (exit_vpp_mode) at 06:00, got: {calls_str} ****")
                 failed = True
             else:
                 print(f"✓ After midnight-spanning window end (06:00) correctly uses eco mode")
+
+    return failed
+
+
+async def make_apply_controls_api():
+    """
+    Build a mock SolaX API instance with one inverter and a 15 kWh battery at 50% SOC
+
+    Returns:
+        tuple: (solax_api, test_plant_id)
+    """
+    solax_api = MockSolaxAPI(prefix="predbat")
+    test_plant_id = "1618699116555534337"
+
+    solax_api.plant_inverters[test_plant_id] = ["H1231231932123"]
+    solax_api.plant_batteries[test_plant_id] = ["TP123456123123"]
+    solax_api.device_info["H1231231932123"] = {"deviceSn": "H1231231932123", "deviceType": 1, "plantId": test_plant_id, "ratedPower": 10.0}
+    solax_api.device_info["TP123456123123"] = {"deviceSn": "TP123456123123", "deviceType": 2, "plantId": test_plant_id, "ratedPower": 5.0}
+    solax_api.plant_info = [{"plantId": test_plant_id, "batteryCapacity": 15.0}]
+    solax_api.realtime_device_data["TP123456123123"] = {"deviceSn": "TP123456123123", "batterySOC": 50, "batteryRemainings": 7.5}
+
+    return solax_api, test_plant_id
+
+
+async def test_apply_controls_min_soc_main(my_predbat):
+    """
+    Test the minSoc written by each control mode
+
+    Idle and the freeze modes are held by the work mode minSoc rather than a VPP mode, so minSoc must
+    follow the configured reserve, and must hold at the current SOC while freeze charge is active
+    """
+    from datetime import datetime as dt_class
+
+    failed = False
+    solax_api, test_plant_id = await make_apply_controls_api()
+
+    # Reserve of 25%, no active windows so that eco mode is selected
+    solax_api.controls[test_plant_id] = {
+        "reserve": 25,
+        "charge": {"start_time": "02:00:00", "end_time": "06:00:00", "enable": False, "target_soc": 95, "rate": 5000},
+        "export": {"start_time": "16:00:00", "end_time": "20:00:00", "enable": False, "target_soc": 15, "rate": 4500},
+    }
+    test_time = datetime.now(solax_api.local_tz).replace(hour=12, minute=0, second=0, microsecond=0)
+
+    # Test 1: Eco mode writes the configured reserve as minSoc, it must not be hard coded
+    print("\n--- Test 1: Eco mode minSoc follows the reserve ---")
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = True
+
+        await solax_api.apply_controls(test_plant_id)
+
+        work_mode_payload = mock_send.call_args_list[0][0][1]
+        if work_mode_payload.get("minSoc") != 25:
+            print(f"**** ERROR: Expected minSoc 25 from the reserve, got {work_mode_payload.get('minSoc')} ****")
+            failed = True
+        elif work_mode_payload.get("chargeFromGridEnable") != 0:
+            print(f"**** ERROR: Eco mode must not enable grid charging, got {work_mode_payload.get('chargeFromGridEnable')} ****")
+            failed = True
+        elif "exit_vpp_mode" not in mock_send.call_args_list[1][0][0]:
+            print(f"**** ERROR: Second call not exit_vpp_mode, got {mock_send.call_args_list[1][0][0]} ****")
+            failed = True
+        else:
+            print("✓ Eco mode writes the reserve as minSoc and exits VPP mode")
+
+    # Test 2: A reserve below the SolaX floor is clamped up
+    print("\n--- Test 2: minSoc clamped to the SolaX floor ---")
+    solax_api.controls[test_plant_id]["reserve"] = 1
+    solax_api.current_mode_hash = None
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = True
+
+        await solax_api.apply_controls(test_plant_id)
+
+        min_soc = mock_send.call_args_list[0][0][1].get("minSoc")
+        if min_soc != SOLAX_MIN_RESERVE_PERCENT:
+            print(f"**** ERROR: Expected minSoc clamped to {SOLAX_MIN_RESERVE_PERCENT}, got {min_soc} ****")
+            failed = True
+        else:
+            print(f"✓ minSoc clamped up to the SolaX floor of {SOLAX_MIN_RESERVE_PERCENT}")
+
+    # Test 3: Freeze charge holds minSoc at the SOC the window opened at, even as the battery charges
+    print("\n--- Test 3: Freeze charge holds the minSoc floor ---")
+    # A charge target at the reserve is a freeze charge whatever the SOC does, so the window stays in
+    # freeze charge as PV charges the battery
+    solax_api.controls[test_plant_id]["reserve"] = 10
+    solax_api.controls[test_plant_id]["charge"] = {"start_time": "11:00:00", "end_time": "14:00:00", "enable": True, "target_soc": 10, "rate": 5000}
+    solax_api.current_mode_hash = None
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = True
+
+        await solax_api.apply_controls(test_plant_id)
+
+        if mock_send.call_args_list[0][0][1].get("minSoc") != 50:
+            print(f"**** ERROR: Expected freeze charge minSoc 50, got {mock_send.call_args_list[0][0][1].get('minSoc')} ****")
+            failed = True
+        elif "exit_vpp_mode" not in mock_send.call_args_list[1][0][0]:
+            print(f"**** ERROR: Freeze charge second call not exit_vpp_mode, got {mock_send.call_args_list[1][0][0]} ****")
+            failed = True
+        else:
+            print("✓ Freeze charge writes the current SOC as minSoc and exits VPP mode")
+
+    # PV charges the battery to 60%, the floor must not be chased upwards and so nothing is re-sent
+    solax_api.realtime_device_data["TP123456123123"] = {"deviceSn": "TP123456123123", "batterySOC": 60, "batteryRemainings": 9.0}
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = True
+
+        await solax_api.apply_controls(test_plant_id)
+
+        if mock_send.call_count:
+            print(f"**** ERROR: Freeze charge floor should not be rewritten as the battery charges, got {mock_send.call_count} calls ****")
+            failed = True
+        else:
+            print("✓ Freeze charge floor is not chased upwards while the battery charges")
+
+    # Test 4: Leaving freeze charge releases the floor back to the reserve
+    print("\n--- Test 4: Leaving freeze charge releases the floor ---")
+    solax_api.controls[test_plant_id]["charge"]["enable"] = False
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = True
+
+        await solax_api.apply_controls(test_plant_id)
+
+        min_soc = mock_send.call_args_list[0][0][1].get("minSoc")
+        if min_soc != 10:
+            print(f"**** ERROR: Expected minSoc released back to the reserve 10, got {min_soc} ****")
+            failed = True
+        elif solax_api.freeze_charge_min_soc is not None:
+            print(f"**** ERROR: Freeze charge floor should be cleared, got {solax_api.freeze_charge_min_soc} ****")
+            failed = True
+        else:
+            print("✓ Leaving freeze charge releases minSoc back to the reserve")
+
+    return failed
+
+
+async def test_apply_controls_backoff_main(my_predbat):
+    """
+    Test that a control mode the inverter rejects backs off instead of retrying every cycle
+    """
+    from datetime import datetime as dt_class
+
+    failed = False
+    solax_api, test_plant_id = await make_apply_controls_api()
+
+    solax_api.controls[test_plant_id] = {
+        "reserve": 10,
+        "charge": {"start_time": "02:00:00", "end_time": "06:00:00", "enable": False, "target_soc": 95, "rate": 5000},
+        "export": {"start_time": "16:00:00", "end_time": "20:00:00", "enable": False, "target_soc": 15, "rate": 4500},
+    }
+    test_time = datetime.now(solax_api.local_tz).replace(hour=12, minute=0, second=0, microsecond=0)
+
+    # Test 1: A failing mode records a retry time rather than caching the mode hash
+    print("\n--- Test 1: Failure records a backoff ---")
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = False
+
+        await solax_api.apply_controls(test_plant_id)
+
+        if solax_api.current_mode_hash is not None:
+            print("**** ERROR: A failed mode must not be cached as applied ****")
+            failed = True
+        elif solax_api.failed_mode_count != 1:
+            print(f"**** ERROR: Expected failure count 1, got {solax_api.failed_mode_count} ****")
+            failed = True
+        elif solax_api.failed_mode_retry_time != test_time + timedelta(seconds=SOLAX_CONTROL_RETRY_BACKOFF):
+            print(f"**** ERROR: Expected retry time {SOLAX_CONTROL_RETRY_BACKOFF}s ahead, got {solax_api.failed_mode_retry_time} ****")
+            failed = True
+        else:
+            print(f"✓ Failed mode backs off for {SOLAX_CONTROL_RETRY_BACKOFF} seconds")
+
+    # Test 2: The next cycle inside the backoff window issues nothing
+    print("\n--- Test 2: No retry inside the backoff window ---")
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time + timedelta(seconds=65)
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = False
+
+        await solax_api.apply_controls(test_plant_id)
+
+        if mock_send.call_count:
+            print(f"**** ERROR: Expected no API calls inside the backoff window, got {mock_send.call_count} ****")
+            failed = True
+        else:
+            print("✓ No API calls while backed off")
+
+    # Test 3: A different mode is tried immediately, the inverter may well accept it
+    print("\n--- Test 3: A different mode is not held back ---")
+    solax_api.controls[test_plant_id]["charge"] = {"start_time": "11:00:00", "end_time": "14:00:00", "enable": True, "target_soc": 95, "rate": 5000}
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time + timedelta(seconds=70)
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = False
+
+        await solax_api.apply_controls(test_plant_id)
+
+        if not mock_send.call_count:
+            print("**** ERROR: A different mode should be attempted immediately ****")
+            failed = True
+        elif solax_api.failed_mode_count != 1:
+            print(f"**** ERROR: A different mode should restart the backoff at 1, got {solax_api.failed_mode_count} ****")
+            failed = True
+        else:
+            print("✓ A different mode is attempted immediately and restarts the backoff")
+
+    # Test 4: Repeated failures of the same mode back off exponentially up to the cap
+    print("\n--- Test 4: Backoff grows and is capped ---")
+    solax_api.failed_mode_count = 20  # Far beyond the cap
+    solax_api.failed_mode_retry_time = test_time
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time + timedelta(seconds=75)
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = False
+
+        await solax_api.apply_controls(test_plant_id)
+
+        expected = test_time + timedelta(seconds=75 + SOLAX_CONTROL_RETRY_MAX)
+        if solax_api.failed_mode_retry_time != expected:
+            print(f"**** ERROR: Expected backoff capped at {SOLAX_CONTROL_RETRY_MAX}s, got {solax_api.failed_mode_retry_time} ****")
+            failed = True
+        else:
+            print(f"✓ Backoff is capped at {SOLAX_CONTROL_RETRY_MAX} seconds")
+
+    # Test 5: Success clears the backoff state
+    print("\n--- Test 5: Success clears the backoff ---")
+    with patch("solax.datetime") as mock_datetime, patch.object(solax_api, "send_command_and_wait", new_callable=AsyncMock) as mock_send:
+        mock_datetime.now.return_value = test_time + timedelta(seconds=SOLAX_CONTROL_RETRY_MAX + 120)
+        mock_datetime.side_effect = lambda *args, **kw: dt_class(*args, **kw)
+        mock_send.return_value = True
+
+        await solax_api.apply_controls(test_plant_id)
+
+        if solax_api.failed_mode_hash is not None or solax_api.failed_mode_count:
+            print(f"**** ERROR: Success should clear the backoff, got hash {solax_api.failed_mode_hash} count {solax_api.failed_mode_count} ****")
+            failed = True
+        elif solax_api.current_mode_hash is None:
+            print("**** ERROR: Success should cache the applied mode ****")
+            failed = True
+        else:
+            print("✓ Success clears the backoff and caches the applied mode")
 
     return failed
 
@@ -970,6 +1236,63 @@ async def test_publish_plant_info_main(my_predbat):
     }
 
     return await test_publish_plant_info(solax_api, test_plant_id, test_plant_name)
+
+
+async def test_publish_plant_info_capacity_floor_main(my_predbat):
+    """
+    Test the published battery capacity is never below the measured energy remaining
+
+    The plant capacity is a nominal figure from the SolaX portal and is often rounded down, so a nearly
+    full battery can report more energy remaining than the nominal capacity (soc_kw > soc_max in Predbat)
+    """
+    failed = False
+
+    # Create mock SolaX API instance
+    solax_api = MockSolaxAPI(prefix="predbat")
+    test_plant_id = "1618699116555534337"
+
+    # Nominal capacity of 6.0 kWh, but the pack is really 6.16 kWh and is 99% full
+    solax_api.plant_info = [{"plantId": test_plant_id, "plantName": "Test Plant", "pvCapacity": 4.0, "batteryCapacity": 6.0}]
+    solax_api.plant_inverters[test_plant_id] = ["H4502AI4634062"]
+    solax_api.plant_batteries[test_plant_id] = ["TP123456123123"]
+    solax_api.device_info["H4502AI4634062"] = {"deviceSn": "H4502AI4634062", "deviceType": 1, "plantId": test_plant_id, "ratedPower": 5.0}
+    solax_api.device_info["TP123456123123"] = {"deviceSn": "TP123456123123", "deviceType": 2, "plantId": test_plant_id, "ratedPower": 5.0}
+    solax_api.realtime_data[test_plant_id] = {}
+    solax_api.realtime_device_data["TP123456123123"] = {"batterySOC": 99, "batteryTemperature": 30.0, "batteryRemainings": 6.1}
+
+    await solax_api.publish_plant_info()
+
+    soc_entity = f"sensor.{solax_api.prefix}_solax_{test_plant_id}_battery_soc"
+    capacity_entity = f"sensor.{solax_api.prefix}_solax_{test_plant_id}_battery_capacity"
+    battery_soc = solax_api.dashboard_items.get(soc_entity, {}).get("state")
+    battery_capacity = solax_api.dashboard_items.get(capacity_entity, {}).get("state")
+
+    if battery_soc != 6.1:
+        print(f"**** ERROR: Battery SOC incorrect. Expected 6.1, got {battery_soc} ****")
+        failed = True
+    elif battery_capacity != 6.1:
+        print(f"**** ERROR: Battery capacity should be floored at the current SOC 6.1, got {battery_capacity} ****")
+        failed = True
+    elif solax_api.dashboard_items[soc_entity]["attributes"]["soc_max"] != 6.1:
+        print(f"**** ERROR: soc_max attribute should match the published capacity, got {solax_api.dashboard_items[soc_entity]['attributes']['soc_max']} ****")
+        failed = True
+    else:
+        print("✓ Battery capacity floored at the current SOC when the nominal capacity is lower")
+
+    # A nominal capacity above the current SOC must be left alone
+    solax_api.realtime_device_data["TP123456123123"]["batteryRemainings"] = 3.0
+    solax_api.realtime_device_data["TP123456123123"]["batterySOC"] = 50
+    solax_api.dashboard_items = {}
+    await solax_api.publish_plant_info()
+
+    battery_capacity = solax_api.dashboard_items.get(capacity_entity, {}).get("state")
+    if battery_capacity != 6.0:
+        print(f"**** ERROR: Battery capacity should be the nominal 6.0, got {battery_capacity} ****")
+        failed = True
+    else:
+        print("✓ Nominal battery capacity is used when it is above the current SOC")
+
+    return failed
 
 
 async def test_publish_plant_info(solax_api, test_plant_id, test_plant_name):


### PR DESCRIPTION
## Problem

Some SolaX inverters reject both `/openapi/v2/device/inverter_vpp_mode/self_consume/*` modes with `status: 5` (device execution failed), while accepting `soc_target_control_mode` and `exit_vpp_mode` on the same account and inverter.

On an affected system this meant:

- Every idle (Demand) window left the battery in a non-discharging state — on one plan that was 05:30 to 23:30, the whole day.
- Because the pair `set_default_work_mode` + `self_consume_mode` never both succeeded, the mode hash was never cached, so the pair was retried roughly every 65 seconds indefinitely — around 1,100 cloud API calls a day.
- Overnight charging still worked, because that path uses `soc_target_control_mode`.

Live probing against an affected inverter ruled out the request being malformed — the cloud returns `code: 10000` and `status: 3` (issuance succeeded), and only the device-side execution fails. Neither `timeOfDuration` (43200 → 3600) nor `nextMotion` (161 → 160) changed the outcome, and `self_consume_charge_only_mode` fails the same way, while `soc_target_control_mode` and `exit_vpp_mode` both return `status: 4`.

## Change

Idle is not a command, it is the absence of one, so hand control back to the inverter rather than holding a VPP mode open all day. This mirrors what the freeze export branch already did.

| Mode | Work mode | minSoc | Then |
|---|---|---|---|
| eco | selfuse | reserve | `exit_vpp_mode` |
| freeze_charge | selfuse | SOC at window open | `exit_vpp_mode` |
| charge | selfuse | reserve | `soc_target_control_mode` |
| export | feedin | reserve | `soc_target_control_mode` |
| freeze_export | feedin | reserve | `exit_vpp_mode` |

No new endpoint is introduced — two are removed from the control path. `self_consume_mode` and `self_consume_charge_only_mode` remain available for the standalone CLI.

**`minSoc` now follows the configured reserve.** `set_default_work_mode` has always written a hard-coded `minSoc: 10`, which was masked while a VPP mode governed behaviour. Now that the work mode is what protects the battery when idle, anyone with a reserve above 10% would have silently lost it.

**Failure backoff.** A rejected mode now backs off from 5 minutes up to an hour instead of retrying every cycle. A *different* mode is still attempted immediately, since the inverter may well accept it.

**Mode hash excludes `target_soc` for the three modes that do not send one**, so battery SOC drifting by 1% no longer re-triggers a write. This also fixes pre-existing churn in freeze export.

## Behaviour notes

- The freeze charge floor is captured when the window opens and not chased upwards as PV charges the battery, which would otherwise rewrite the inverter every couple of minutes on a small battery.
- Freeze charge no longer auto-expires the way a VPP mode did. If Predbat stops mid-freeze the inverter keeps the raised `minSoc` until it is restarted; normal operation self-heals because the eco path rewrites `minSoc` back to the reserve.
- Backoff state is per-instance rather than per-plant, matching the existing `current_mode_hash`.

## Also included

- `--test-command` on the standalone CLI to issue raw control commands (`self_consume`, `self_consume_charge_only`, `exit_vpp`, `soc_target`, `positive_negative`, `work_mode_selfuse`, `work_mode_feedin`), repeatable to chain them, with `--duration`, `--next-motion`, `--target-soc`, `--power` and `--command-delay`. This is how the failing endpoints were isolated. Note it writes to the inverter directly and bypasses read-only mode.
- Request result logging now reports the actual device status and the rejected payload, instead of reprinting the stale issuance description ("Command execution failed with status 5 : Command issuance succeeded").
- Published battery capacity is floored at the measured energy remaining. The portal's nominal `batteryCapacity` is often rounded down, so a nearly full battery could report `soc_kw` above `soc_max` — 6.1 kWh in a 6.0 kWh battery — leaving Predbat modelling a 101% battery.

## Testing

`./run_all --test solax` and `./run_pre_commit` both pass.

Existing eco and freeze assertions updated to the new endpoints, plus new tests:

- `test_apply_controls_min_soc` — reserve passthrough, SolaX floor clamping, freeze floor held while charging and released on exit.
- `test_apply_controls_backoff` — failure records a backoff, no calls inside the window, a different mode is exempt, growth capped at an hour, success clears it.
- `test_publish_plant_info_capacity_floor` — capacity floored at SOC when nominal is lower, nominal retained otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)