### PR TITLE
feat(solax): cache plant and device info in storage and refresh it by data age

### DIFF
--- a/apps/predbat/solax.py
+++ b/apps/predbat/solax.py
@@ -44,6 +44,9 @@ SOLAX_TEST_COMMANDS = [
     "work_mode_selfuse",
     "work_mode_feedin",
 ]
+SOLAX_PLANT_INFO_MAX_AGE = 8 * 60  # Plant info is static, re-poll it once the data is this many minutes old
+SOLAX_DEVICE_INFO_MAX_AGE = 30  # Device info changes rarely, re-poll it once the data is this many minutes old
+SOLAX_CACHE_EXPIRY_HOURS = 24  # Cached plant and device info is discarded by the storage layer after this long
 SOLAX_COMMAND_RETRY_DELAY = 2.0
 SOLAX_COMMAND_MAX_RETRIES = 8
 SOLAX_REGIONS = {
@@ -377,6 +380,15 @@ class SolaxAPI(ComponentBase):
         self.realtime_data = {}
         self.realtime_device_data = {}
         self.controls = {}
+
+        # Which plants and devices failed their most recent realtime poll, stale data is not republished
+        self.realtime_plant_failed = set()
+        self.realtime_device_failed = set()
+
+        # When the plant and device info was last read, seeded from the storage cache on startup so that
+        # a restart does not re-read data that is still current
+        self.plant_info_updated = None
+        self.device_info_updated = None
 
         # Error tracking
         self.error_count = 0
@@ -1298,6 +1310,101 @@ class SolaxAPI(ComponentBase):
             self.plant_info = result
         return result
 
+    def data_is_due(self, updated, max_age_minutes):
+        """
+        Work out whether data needs re-reading based on how old it is
+
+        Args:
+            updated: When the data was last read, or None if it never has been
+            max_age_minutes: How old the data may be before it is re-read
+
+        Returns:
+            True if the data should be read now
+        """
+        if updated is None:
+            return True
+        return (datetime.now(timezone.utc) - updated).total_seconds() >= max_age_minutes * 60
+
+    async def load_cached_info(self, name, max_age_minutes):
+        """
+        Load one static info cache entry if it is still within its maximum age
+
+        Args:
+            name: Cache entry name
+            max_age_minutes: How old the cached data may be before it is treated as missing
+
+        Returns:
+            tuple: (data, updated) where data is None when there is nothing usable to restore
+        """
+        if not self.storage:
+            return None, None
+
+        cached = await self.storage.load("solax", name)
+        if not isinstance(cached, dict) or not cached:
+            self.log(f"SolaX API: No {name} in the storage cache, will poll")
+            return None, None
+
+        age = await self.storage.age("solax", name)
+        if age is None or age >= max_age_minutes:
+            self.log("SolaX API: Cached {} is stale (age {}), will poll".format(name, "{:.1f} minutes".format(age) if age is not None else "unknown"))
+            return None, None
+
+        self.log(f"SolaX API: Restored {name} from the storage cache (age {age:.1f} minutes)")
+        return cached, datetime.now(timezone.utc) - timedelta(minutes=age)
+
+    async def load_static_info(self):
+        """
+        Restore the plant and device info from the storage cache
+
+        Plant and device info describe the hardware and barely change, so a restart can reuse whatever is
+        still within its maximum age rather than re-reading it all from the cloud.  The recorded read time
+        comes from the cache age, so data that is already close to expiry is re-polled promptly.
+        """
+        plant_cached, plant_updated = await self.load_cached_info("plant_info", SOLAX_PLANT_INFO_MAX_AGE)
+        if plant_cached and plant_cached.get("plant_info"):
+            self.plant_info = plant_cached["plant_info"]
+            self.plant_info_updated = plant_updated
+
+        device_cached, device_updated = await self.load_cached_info("device_info", SOLAX_DEVICE_INFO_MAX_AGE)
+        if device_cached and device_cached.get("device_info"):
+            self.device_info = device_cached["device_info"]
+            self.plant_inverters = device_cached.get("plant_inverters", {})
+            self.plant_batteries = device_cached.get("plant_batteries", {})
+            self.device_info_updated = device_updated
+
+    async def save_plant_info(self):
+        """
+        Save the plant info to the storage cache
+
+        Returns:
+            True on success, False if there is no storage or the save failed
+        """
+        if not self.storage:
+            return False
+        expiry = datetime.now(timezone.utc) + timedelta(hours=SOLAX_CACHE_EXPIRY_HOURS)
+        return await self.storage.save("solax", "plant_info", {"plant_info": self.plant_info}, format="json", expiry=expiry)
+
+    async def save_device_info(self):
+        """
+        Save the device info and its plant mappings to the storage cache
+
+        Returns:
+            True on success, False if there is no storage or the save failed
+        """
+        if not self.storage:
+            return False
+        return await self.storage.save(
+            "solax",
+            "device_info",
+            {
+                "device_info": self.device_info,
+                "plant_inverters": self.plant_inverters,
+                "plant_batteries": self.plant_batteries,
+            },
+            format="json",
+            expiry=datetime.now(timezone.utc) + timedelta(hours=SOLAX_CACHE_EXPIRY_HOURS),
+        )
+
     async def query_device_info(self, plant_id, device_type, device_sn=None, business_type=None):
         """
         Query device information with pagination support
@@ -1665,8 +1772,10 @@ class SolaxAPI(ComponentBase):
         if result is not None and len(result) > 0:
             # One result per device SN
             self.realtime_device_data[sn] = result[0]
+            self.realtime_device_failed.discard(sn)
             self.log(f"SolaX API: Retrieved real-time data for device SN {sn} {result[0]}")
             return result
+        self.realtime_device_failed.add(sn)
         return None
 
     def is_a1_hybrid_g2(self, device_sn):
@@ -2120,8 +2229,12 @@ class SolaxAPI(ComponentBase):
         # Per-plant accumulators for the load-power calculation (second pass below)
         plant_save = {}  # plant_id -> {"grid": W, "pv": W, "battery": W, "inverter_sn": sn, "friendly_name": name}
 
-        # Publish per-device realtime data
+        # Publish per-device realtime data, skipping any device that was not read on this cycle so that
+        # its sensors keep their previous values rather than being republished from stale data
         for device_sn, realtime in self.realtime_device_data.items():
+            if device_sn in self.realtime_device_failed:
+                self.log(f"Warn: SolaX API: No realtime data read for device {device_sn}, keeping the previous sensor values")
+                continue
             device = self.device_info.get(device_sn, {})
             device_type = device.get("deviceType")
             plant_id = device.get("plantId", "unknown").lower().replace(" ", "_")
@@ -2407,31 +2520,51 @@ class SolaxAPI(ComponentBase):
             battery_temp = self.get_battery_temperature(plant_id)
             charge_discharge_power = self.get_charge_discharge_power_battery(plant_id)
 
-            # Battery SOC
-            self.dashboard_item(
-                f"sensor.{self.prefix}_solax_{plant_id}_battery_soc",
-                state=battery_soc,
-                attributes={
-                    "friendly_name": f"SolaX {plant_name} Battery SOC",
-                    "unit_of_measurement": "kWh",
-                    "device_class": "energy",
-                    "state_class": "measurement",
-                    "soc_max": battery_soc_max,
-                },
-                app="solax",
-            )
-            # Battery Charge/Discharge Power
-            self.dashboard_item(
-                f"sensor.{self.prefix}_solax_{plant_id}_battery_charge_discharge_power",
-                state=charge_discharge_power,
-                attributes={
-                    "friendly_name": f"SolaX {plant_name} Battery Charge/Discharge Power",
-                    "unit_of_measurement": "W",
-                    "device_class": "power",
-                    "state_class": "measurement",
-                },
-                app="solax",
-            )
+            # The battery sensors come from the device realtime data, so hold them back when a battery
+            # failed its last read rather than republishing stale values
+            battery_ok = not any(device_sn in self.realtime_device_failed for device_sn in self.plant_batteries.get(plant_id, []))
+
+            if battery_ok:
+                # Battery SOC
+                self.dashboard_item(
+                    f"sensor.{self.prefix}_solax_{plant_id}_battery_soc",
+                    state=battery_soc,
+                    attributes={
+                        "friendly_name": f"SolaX {plant_name} Battery SOC",
+                        "unit_of_measurement": "kWh",
+                        "device_class": "energy",
+                        "state_class": "measurement",
+                        "soc_max": battery_soc_max,
+                    },
+                    app="solax",
+                )
+                # Battery Charge/Discharge Power
+                self.dashboard_item(
+                    f"sensor.{self.prefix}_solax_{plant_id}_battery_charge_discharge_power",
+                    state=charge_discharge_power,
+                    attributes={
+                        "friendly_name": f"SolaX {plant_name} Battery Charge/Discharge Power",
+                        "unit_of_measurement": "W",
+                        "device_class": "power",
+                        "state_class": "measurement",
+                    },
+                    app="solax",
+                )
+                # Battery temperature sensor
+                self.dashboard_item(
+                    f"sensor.{self.prefix}_solax_{plant_id}_battery_temperature",
+                    state=battery_temp,
+                    attributes={
+                        "friendly_name": f"SolaX {plant_name} Battery Temperature",
+                        "unit_of_measurement": "°C",
+                        "device_class": "temperature",
+                        "state_class": "measurement",
+                    },
+                    app="solax",
+                )
+            else:
+                self.log(f"Warn: SolaX API: No battery realtime data read for plant {plant_id}, keeping the previous battery sensor values")
+
             # Battery SOC max sensor
             self.dashboard_item(
                 f"sensor.{self.prefix}_solax_{plant_id}_battery_capacity",
@@ -2440,19 +2573,6 @@ class SolaxAPI(ComponentBase):
                     "friendly_name": f"SolaX {plant_name} Battery Capacity",
                     "unit_of_measurement": "kWh",
                     "device_class": "energy",
-                    "state_class": "measurement",
-                },
-                app="solax",
-            )
-
-            # Battery temperature sensor
-            self.dashboard_item(
-                f"sensor.{self.prefix}_solax_{plant_id}_battery_temperature",
-                state=battery_temp,
-                attributes={
-                    "friendly_name": f"SolaX {plant_name} Battery Temperature",
-                    "unit_of_measurement": "°C",
-                    "device_class": "temperature",
                     "state_class": "measurement",
                 },
                 app="solax",
@@ -2497,9 +2617,12 @@ class SolaxAPI(ComponentBase):
                 app="solax",
             )
 
-            # Publish realtime data if available
+            # Publish realtime data, but only when this cycle actually read it.  Publishing on a failed
+            # read would push stale totals, or zeros before the first successful read
             realtime_plant_id = plant.get("plantId")
-            if realtime_plant_id and realtime_plant_id in self.realtime_data:
+            if realtime_plant_id and realtime_plant_id in self.realtime_plant_failed:
+                self.log(f"Warn: SolaX API: No realtime data read for plant {realtime_plant_id}, keeping the previous sensor values")
+            elif realtime_plant_id and realtime_plant_id in self.realtime_data:
                 realtime = self.realtime_data[realtime_plant_id]
 
                 # Total Yield sensor
@@ -2611,14 +2734,26 @@ class SolaxAPI(ComponentBase):
             True on success, False on failure
         """
         if first:
-            # Fetch plant information on startup
-            self.log("SolaX API: Fetching plant information...")
-            await self.query_plant_info()
+            # Reuse whatever hardware information is still current, a restart then avoids re-reading it all
+            await self.load_static_info()
 
-            if self.plant_info is None:
+        # Plant info is static, it is only re-read once the data itself has aged out
+        plant_info_refreshed = False
+        if self.data_is_due(self.plant_info_updated, SOLAX_PLANT_INFO_MAX_AGE):
+            self.log("SolaX API: Fetching plant information...")
+            result = await self.query_plant_info()
+            if result is not None and self.plant_info is not None:
+                self.plant_info_updated = datetime.now(timezone.utc)
+                plant_info_refreshed = True
+                await self.save_plant_info()
+            elif self.plant_info is None:
                 self.log("Warn: SolaX API: Failed to fetch plant information")
                 return False
+            else:
+                # A refresh that fails keeps whatever was read before rather than dropping the plants
+                self.log("Warn: SolaX API: Failed to refresh plant information, keeping the previous data")
 
+        if first or plant_info_refreshed:
             self.plant_list = [plant.get('plantId') for plant in self.plant_info]
             if self.plant_sn_filter:
                 self.plant_list = [pid for pid in self.plant_list if pid in self.plant_sn_filter]
@@ -2627,8 +2762,8 @@ class SolaxAPI(ComponentBase):
         # Check readonly mode
         is_readonly = self.get_state_wrapper(f'switch.{self.prefix}_set_read_only', default='off') == 'on'
 
-        if first or seconds % (30 * 60) == 0:
-            # Periodic plant info refresh every 30 minutes
+        # Device info is re-read once the data has aged out rather than on a fixed cycle since startup
+        if self.data_is_due(self.device_info_updated, SOLAX_DEVICE_INFO_MAX_AGE):
             for plantID in self.plant_list:
                 self.log(f"SolaX API: Fetching device information for plant ID {plantID}...")
                 await self.query_device_info(plantID, device_type=SOLAX_DEVICE_TYPE_INVERTER)  # Inverter
@@ -2637,9 +2772,17 @@ class SolaxAPI(ComponentBase):
                 # await self.query_device_info(plantID, device_type=SOLAX_DEVICE_TYPE_METER)  # Meter
                 # await self.query_plant_statistics_daily(plantID)
 
+            self.device_info_updated = datetime.now(timezone.utc)
+            # Refresh the cache so that a restart can skip this read
+            await self.save_device_info()
+
         if first or seconds % 60 == 0:
             for plantID in self.plant_list:
-                await self.query_plant_realtime_data(plantID)
+                # Note what failed to read, those sensors are not republished from stale data below
+                if await self.query_plant_realtime_data(plantID) is None:
+                    self.realtime_plant_failed.add(plantID)
+                else:
+                    self.realtime_plant_failed.discard(plantID)
                 await self.query_device_realtime_data_all(plantID)
 
         # Fetch controls first time only

--- a/apps/predbat/solax.py
+++ b/apps/predbat/solax.py
@@ -47,6 +47,7 @@ SOLAX_TEST_COMMANDS = [
 SOLAX_PLANT_INFO_MAX_AGE = 8 * 60  # Plant info is static, re-poll it once the data is this many minutes old
 SOLAX_DEVICE_INFO_MAX_AGE = 30  # Device info changes rarely, re-poll it once the data is this many minutes old
 SOLAX_CACHE_EXPIRY_HOURS = 24  # Cached plant and device info is discarded by the storage layer after this long
+SOLAX_INFO_RETRY_MINUTES = 5  # Wait this long before retrying a plant or device info read that failed
 SOLAX_COMMAND_RETRY_DELAY = 2.0
 SOLAX_COMMAND_MAX_RETRIES = 8
 SOLAX_REGIONS = {
@@ -385,10 +386,13 @@ class SolaxAPI(ComponentBase):
         self.realtime_plant_failed = set()
         self.realtime_device_failed = set()
 
-        # When the plant and device info was last read, seeded from the storage cache on startup so that
-        # a restart does not re-read data that is still current
+        # When the plant and device info was last read successfully, seeded from the storage cache on
+        # startup so that a restart does not re-read data that is still current, plus when it was last
+        # attempted so that a failing read is retried at a sensible rate rather than every cycle
         self.plant_info_updated = None
+        self.plant_info_attempted = None
         self.device_info_updated = None
+        self.device_info_attempted = None
 
         # Error tracking
         self.error_count = 0
@@ -1310,20 +1314,25 @@ class SolaxAPI(ComponentBase):
             self.plant_info = result
         return result
 
-    def data_is_due(self, updated, max_age_minutes):
+    def data_is_due(self, updated, attempted, max_age_minutes):
         """
         Work out whether data needs re-reading based on how old it is
 
         Args:
-            updated: When the data was last read, or None if it never has been
+            updated: When the data was last read successfully, or None if it never has been
+            attempted: When the data was last attempted, or None if it never has been
             max_age_minutes: How old the data may be before it is re-read
 
         Returns:
             True if the data should be read now
         """
-        if updated is None:
-            return True
-        return (datetime.now(timezone.utc) - updated).total_seconds() >= max_age_minutes * 60
+        now = datetime.now(timezone.utc)
+        if updated is not None and (now - updated).total_seconds() < max_age_minutes * 60:
+            return False
+        # Run is called every few seconds, so a read that keeps failing must not be retried every cycle
+        if attempted is not None and (now - attempted).total_seconds() < SOLAX_INFO_RETRY_MINUTES * 60:
+            return False
+        return True
 
     async def load_cached_info(self, name, max_age_minutes):
         """
@@ -2739,8 +2748,9 @@ class SolaxAPI(ComponentBase):
 
         # Plant info is static, it is only re-read once the data itself has aged out
         plant_info_refreshed = False
-        if self.data_is_due(self.plant_info_updated, SOLAX_PLANT_INFO_MAX_AGE):
+        if self.data_is_due(self.plant_info_updated, self.plant_info_attempted, SOLAX_PLANT_INFO_MAX_AGE):
             self.log("SolaX API: Fetching plant information...")
+            self.plant_info_attempted = datetime.now(timezone.utc)
             result = await self.query_plant_info()
             if result is not None and self.plant_info is not None:
                 self.plant_info_updated = datetime.now(timezone.utc)
@@ -2763,18 +2773,26 @@ class SolaxAPI(ComponentBase):
         is_readonly = self.get_state_wrapper(f'switch.{self.prefix}_set_read_only', default='off') == 'on'
 
         # Device info is re-read once the data has aged out rather than on a fixed cycle since startup
-        if self.data_is_due(self.device_info_updated, SOLAX_DEVICE_INFO_MAX_AGE):
+        if self.data_is_due(self.device_info_updated, self.device_info_attempted, SOLAX_DEVICE_INFO_MAX_AGE):
+            self.device_info_attempted = datetime.now(timezone.utc)
+            # An empty plant list means nothing was read, so it must not count as a successful refresh
+            device_info_ok = bool(self.plant_list)
             for plantID in self.plant_list:
                 self.log(f"SolaX API: Fetching device information for plant ID {plantID}...")
-                await self.query_device_info(plantID, device_type=SOLAX_DEVICE_TYPE_INVERTER)  # Inverter
-                await self.query_device_info(plantID, device_type=SOLAX_DEVICE_TYPE_BATTERY)  # Battery
+                for device_type in (SOLAX_DEVICE_TYPE_INVERTER, SOLAX_DEVICE_TYPE_BATTERY):
+                    if await self.query_device_info(plantID, device_type=device_type) is None:
+                        device_info_ok = False
 
                 # await self.query_device_info(plantID, device_type=SOLAX_DEVICE_TYPE_METER)  # Meter
                 # await self.query_plant_statistics_daily(plantID)
 
-            self.device_info_updated = datetime.now(timezone.utc)
-            # Refresh the cache so that a restart can skip this read
-            await self.save_device_info()
+            if device_info_ok:
+                self.device_info_updated = datetime.now(timezone.utc)
+                # Refresh the cache so that a restart can skip this read
+                await self.save_device_info()
+            else:
+                # Do not mark a partial read as fresh, or cache it over data that was complete
+                self.log(f"Warn: SolaX API: Failed to read device information, retrying in {SOLAX_INFO_RETRY_MINUTES} minutes")
 
         if first or seconds % 60 == 0:
             for plantID in self.plant_list:

--- a/apps/predbat/solax.py
+++ b/apps/predbat/solax.py
@@ -2777,6 +2777,7 @@ class SolaxAPI(ComponentBase):
             self.device_info_attempted = datetime.now(timezone.utc)
             # An empty plant list means nothing was read, so it must not count as a successful refresh
             device_info_ok = bool(self.plant_list)
+            previous_devices = set(self.device_info.keys())
             for plantID in self.plant_list:
                 self.log(f"SolaX API: Fetching device information for plant ID {plantID}...")
                 for device_type in (SOLAX_DEVICE_TYPE_INVERTER, SOLAX_DEVICE_TYPE_BATTERY):
@@ -2790,6 +2791,13 @@ class SolaxAPI(ComponentBase):
                 self.device_info_updated = datetime.now(timezone.utc)
                 # Refresh the cache so that a restart can skip this read
                 await self.save_device_info()
+
+                # Hardware changes show up in the plant record too, battery and PV capacity come from
+                # there, so a changed device list makes the plant info suspect however recently it was read
+                if previous_devices and set(self.device_info.keys()) != previous_devices:
+                    self.log("SolaX API: Device list changed, re-reading plant information")
+                    self.plant_info_updated = None
+                    self.plant_info_attempted = None
             else:
                 # Do not mark a partial read as fresh, or cache it over data that was complete
                 self.log(f"Warn: SolaX API: Failed to read device information, retrying in {SOLAX_INFO_RETRY_MINUTES} minutes")

--- a/apps/predbat/tests/test_solax.py
+++ b/apps/predbat/tests/test_solax.py
@@ -12,7 +12,15 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, AsyncMock
 import json
-from solax import SolaxAPI, SOLAX_MIN_RESERVE_PERCENT, SOLAX_CONTROL_RETRY_BACKOFF, SOLAX_CONTROL_RETRY_MAX
+from solax import (
+    SolaxAPI,
+    SOLAX_MIN_RESERVE_PERCENT,
+    SOLAX_CONTROL_RETRY_BACKOFF,
+    SOLAX_CONTROL_RETRY_MAX,
+    SOLAX_PLANT_INFO_MAX_AGE,
+    SOLAX_DEVICE_INFO_MAX_AGE,
+    SOLAX_CACHE_EXPIRY_HOURS,
+)
 from tests.test_infra import create_aiohttp_mock_response, create_aiohttp_mock_session
 
 
@@ -29,6 +37,9 @@ class MockSolaxAPI(SolaxAPI):
         self.device_info = {}
         self.realtime_data = {}
         self.realtime_device_data = {}
+        self.realtime_plant_failed = set()  # Plants whose last realtime read failed
+        self.realtime_device_failed = set()  # Devices whose last realtime read failed
+        self._storage = None  # No storage cache by default in tests
         self.log_messages = []
         self.dashboard_items = {}
         self.current_mode_hash = None
@@ -59,6 +70,16 @@ class MockSolaxAPI(SolaxAPI):
         self.access_token = None
         self.token_expiry = None
         self.error_count = 0
+
+    @property
+    def storage(self):
+        """Mock storage component, ComponentBase resolves this from the base object which tests do not have"""
+        return self._storage
+
+    @storage.setter
+    def storage(self, value):
+        """Allow tests to install a mock storage backend"""
+        self._storage = value
 
     def log(self, message):
         """Mock log method"""
@@ -165,6 +186,8 @@ def run_solax_tests(my_predbat):
         failed |= asyncio.run(test_apply_controls_backoff_main(my_predbat))
         failed |= asyncio.run(test_publish_plant_info_main(my_predbat))
         failed |= asyncio.run(test_publish_plant_info_capacity_floor_main(my_predbat))
+        failed |= asyncio.run(test_static_info_cache_main(my_predbat))
+        failed |= asyncio.run(test_realtime_publish_gating_main(my_predbat))
 
         if not failed:
             print("**** SolaX API tests: All tests passed ****")
@@ -872,6 +895,357 @@ async def test_apply_controls_backoff_main(my_predbat):
             failed = True
         else:
             print("✓ Success clears the backoff and caches the applied mode")
+
+    return failed
+
+
+class MockStorage:
+    """Mock storage backend recording saves and serving a configurable per key age"""
+
+    def __init__(self, data=None, ages=None):
+        """
+        Args:
+            data: Dict of cache name to contents
+            ages: Dict of cache name to age in minutes
+        """
+        self.data = data or {}
+        self.ages = ages or {}
+        self.saved = []
+
+    async def load(self, module, filename):
+        """Return the configured cache contents for this key"""
+        return self.data.get(filename)
+
+    async def age(self, module, filename):
+        """Return the configured cache age in minutes for this key"""
+        return self.ages.get(filename)
+
+    async def save(self, module, filename, data, format="yaml", expiry=None):
+        """Record the saved data and reset its age"""
+        self.saved.append({"module": module, "filename": filename, "data": data, "format": format, "expiry": expiry})
+        self.data[filename] = data
+        self.ages[filename] = 0
+        return True
+
+
+async def run_one_cycle(api, seconds=0, first=True):
+    """
+    Run a single run() cycle with everything except the static info handling mocked out
+
+    Returns:
+        tuple: (result, mock_query_plant_info, mock_query_device_info)
+    """
+    with patch.object(api, "query_plant_info", new_callable=AsyncMock) as mock_plant:
+        with patch.object(api, "query_device_info", new_callable=AsyncMock) as mock_device:
+            with patch.object(api, "query_plant_realtime_data", new_callable=AsyncMock):
+                with patch.object(api, "query_device_realtime_data_all", new_callable=AsyncMock):
+                    with patch.object(api, "fetch_controls", new_callable=AsyncMock):
+                        with patch.object(api, "publish_plant_info", new_callable=AsyncMock):
+                            with patch.object(api, "publish_device_info", new_callable=AsyncMock):
+                                with patch.object(api, "publish_device_realtime_data", new_callable=AsyncMock):
+                                    with patch.object(api, "publish_controls", new_callable=AsyncMock):
+                                        with patch.object(api, "apply_controls", new_callable=AsyncMock):
+                                            mock_plant.return_value = api.plant_info
+                                            result = await api.run(seconds=seconds, first=first)
+    return result, mock_plant, mock_device
+
+
+def build_cached_api(plant_age=None, device_age=None):
+    """
+    Build a mock API with a storage cache holding plant and device info at the given ages
+
+    Args:
+        plant_age: Age in minutes of the cached plant info, None for no cache entry
+        device_age: Age in minutes of the cached device info, None for no cache entry
+
+    Returns:
+        MockSolaxAPI instance with storage installed
+    """
+    api = MockSolaxAPI()
+    api.initialize(client_id="test", client_secret="test", region="eu")
+
+    data = {}
+    ages = {}
+    if plant_age is not None:
+        data["plant_info"] = {"plant_info": [{"plantId": "plant1", "batteryCapacity": 15.0}]}
+        ages["plant_info"] = plant_age
+    if device_age is not None:
+        data["device_info"] = {
+            "device_info": {"INV1": {"deviceSn": "INV1", "deviceType": 1, "plantId": "plant1"}},
+            "plant_inverters": {"plant1": ["INV1"]},
+            "plant_batteries": {"plant1": ["BAT1"]},
+        }
+        ages["device_info"] = device_age
+
+    api.storage = MockStorage(data=data, ages=ages)
+    api.plant_info = [{"plantId": "plant1", "batteryCapacity": 15.0}]
+    return api
+
+
+async def test_static_info_cache_main(my_predbat):
+    """
+    Test that plant and device info are cached in storage and re-read based on the age of the data
+
+    Re-reading every plant and device on each restart is slow, so the hardware information is cached and
+    only re-polled once the data itself is older than its maximum age
+    """
+    failed = False
+    print("\n=== Testing static info storage cache ===")
+
+    # Test 1: Cached data still within its maximum age is restored without polling
+    print("Test 1: Fresh cache is restored without polling")
+    api = build_cached_api(plant_age=60, device_age=5)
+
+    result, mock_plant, mock_device = await run_one_cycle(api)
+
+    if not result:
+        print("**** ERROR: Run failed with a fresh cache ****")
+        failed = True
+    elif mock_plant.called:
+        print("**** ERROR: query_plant_info should not be called when the cached plant info is fresh ****")
+        failed = True
+    elif mock_device.called:
+        print("**** ERROR: query_device_info should not be called when the cached device info is fresh ****")
+        failed = True
+    elif api.plant_list != ["plant1"]:
+        print(f"**** ERROR: Plant list not built from the cache, got {api.plant_list} ****")
+        failed = True
+    elif api.plant_inverters != {"plant1": ["INV1"]} or api.plant_batteries != {"plant1": ["BAT1"]}:
+        print(f"**** ERROR: Device mappings not restored, got {api.plant_inverters} {api.plant_batteries} ****")
+        failed = True
+    else:
+        print("✓ Fresh cache restored without any polling")
+
+    # Test 2: Device info older than its maximum age is re-read even though the plant info is fresh
+    print("Test 2: Aged device info is re-read, fresh plant info is not")
+    api = build_cached_api(plant_age=60, device_age=SOLAX_DEVICE_INFO_MAX_AGE + 1)
+
+    result, mock_plant, mock_device = await run_one_cycle(api)
+
+    if mock_plant.called:
+        print("**** ERROR: Plant info is still fresh and should not be polled ****")
+        failed = True
+    elif not mock_device.called:
+        print("**** ERROR: Device info older than the maximum age should be re-read ****")
+        failed = True
+    elif [item["filename"] for item in api.storage.saved] != ["device_info"]:
+        print(f"**** ERROR: Only device info should be saved, got {[item['filename'] for item in api.storage.saved]} ****")
+        failed = True
+    elif api.storage.saved[-1]["expiry"] is None:
+        print("**** ERROR: Cached data must be saved with an expiry so a stale cache is discarded ****")
+        failed = True
+    elif not (timedelta(hours=SOLAX_CACHE_EXPIRY_HOURS - 1) < api.storage.saved[-1]["expiry"] - datetime.now(timezone.utc) <= timedelta(hours=SOLAX_CACHE_EXPIRY_HOURS)):
+        print(f"**** ERROR: Expected roughly a {SOLAX_CACHE_EXPIRY_HOURS} hour expiry, got {api.storage.saved[-1]['expiry']} ****")
+        failed = True
+    else:
+        print(f"✓ Device info re-read once older than {SOLAX_DEVICE_INFO_MAX_AGE} minutes")
+
+    # Test 3: Plant info older than its maximum age is re-read
+    print("Test 3: Aged plant info is re-read")
+    api = build_cached_api(plant_age=SOLAX_PLANT_INFO_MAX_AGE + 1, device_age=5)
+
+    result, mock_plant, mock_device = await run_one_cycle(api)
+
+    if not mock_plant.called:
+        print("**** ERROR: Plant info older than the maximum age should be re-read ****")
+        failed = True
+    elif mock_device.called:
+        print("**** ERROR: Device info is still fresh and should not be polled ****")
+        failed = True
+    elif "plant_info" not in [item["filename"] for item in api.storage.saved]:
+        print("**** ERROR: Refreshed plant info should be saved ****")
+        failed = True
+    else:
+        print(f"✓ Plant info re-read once older than {SOLAX_PLANT_INFO_MAX_AGE} minutes")
+
+    # Test 4: The age carries over from the cache, a restart does not restart the interval
+    print("Test 4: Device info age carries over across a restart")
+    api = build_cached_api(plant_age=60, device_age=SOLAX_DEVICE_INFO_MAX_AGE - 2)
+
+    result, mock_plant, mock_device = await run_one_cycle(api)
+    if mock_device.called:
+        print("**** ERROR: Device info just under the maximum age should not be polled yet ****")
+        failed = True
+    else:
+        # Two more minutes of data age is enough to make it due, without waiting a full interval
+        api.device_info_updated = api.device_info_updated - timedelta(minutes=3)
+        result, mock_plant, mock_device = await run_one_cycle(api, seconds=5, first=False)
+        if not mock_device.called:
+            print("**** ERROR: Device info should be re-read once the data ages past the maximum ****")
+            failed = True
+        else:
+            print("✓ The refresh follows the age of the data, not the time since startup")
+
+    # Test 5: No cache at all falls back to polling everything
+    print("Test 5: Missing cache polls everything")
+    api = build_cached_api()
+
+    result, mock_plant, mock_device = await run_one_cycle(api)
+
+    if not mock_plant.called or not mock_device.called:
+        print("**** ERROR: Without a cache both plant and device info must be polled ****")
+        failed = True
+    elif sorted(item["filename"] for item in api.storage.saved) != ["device_info", "plant_info"]:
+        print(f"**** ERROR: Both caches should be written, got {[item['filename'] for item in api.storage.saved]} ****")
+        failed = True
+    else:
+        print("✓ Missing cache falls back to polling and saves both entries")
+
+    # Test 6: With no storage configured the behaviour is unchanged
+    print("Test 6: No storage configured")
+    api = MockSolaxAPI()
+    api.initialize(client_id="test", client_secret="test", region="eu")
+    api.plant_info = [{"plantId": "plant1", "batteryCapacity": 15.0}]
+
+    result, mock_plant, mock_device = await run_one_cycle(api)
+
+    if not result:
+        print("**** ERROR: Run failed without storage ****")
+        failed = True
+    elif not mock_plant.called or not mock_device.called:
+        print("**** ERROR: Without storage everything must still be polled ****")
+        failed = True
+    else:
+        print("✓ Without storage the poll behaviour is unchanged")
+
+    # Test 7: A failed refresh keeps the previous data rather than dropping it
+    print("Test 7: A failed refresh keeps the previous plant info")
+    api = build_cached_api(plant_age=SOLAX_PLANT_INFO_MAX_AGE + 1, device_age=5)
+
+    with patch.object(api, "query_plant_info", new_callable=AsyncMock) as mock_plant:
+        with patch.object(api, "query_device_info", new_callable=AsyncMock):
+            with patch.object(api, "query_plant_realtime_data", new_callable=AsyncMock):
+                with patch.object(api, "query_device_realtime_data_all", new_callable=AsyncMock):
+                    with patch.object(api, "fetch_controls", new_callable=AsyncMock):
+                        with patch.object(api, "publish_plant_info", new_callable=AsyncMock):
+                            with patch.object(api, "publish_device_info", new_callable=AsyncMock):
+                                with patch.object(api, "publish_device_realtime_data", new_callable=AsyncMock):
+                                    with patch.object(api, "publish_controls", new_callable=AsyncMock):
+                                        with patch.object(api, "apply_controls", new_callable=AsyncMock):
+                                            mock_plant.return_value = None  # Refresh fails
+                                            result = await api.run(seconds=0, first=True)
+
+    if not result:
+        print("**** ERROR: A failed refresh should not abort the run when cached data exists ****")
+        failed = True
+    elif api.plant_list != ["plant1"]:
+        print(f"**** ERROR: The cached plant info should be kept on a failed refresh, got {api.plant_list} ****")
+        failed = True
+    else:
+        print("✓ A failed refresh keeps the cached plant info")
+
+    return failed
+
+
+async def test_realtime_publish_gating_main(my_predbat):
+    """
+    Test that realtime sensors are not published when the read failed
+
+    Publishing on a failed read would push stale values, or defaults of zero before the first successful
+    read, which corrupts the energy totals Predbat consumes
+    """
+    failed = False
+    print("\n=== Testing realtime publish gating ===")
+
+    test_plant_id = "1618699116555534337"
+
+    def build_api():
+        """Build a mock API with one inverter and one battery holding realtime data"""
+        api = MockSolaxAPI(prefix="predbat")
+        api.plant_info = [{"plantId": test_plant_id, "plantName": "Test Plant", "batteryCapacity": 15.0, "pvCapacity": 8.5}]
+        api.plant_inverters[test_plant_id] = ["H1231231932123"]
+        api.plant_batteries[test_plant_id] = ["TP123456123123"]
+        api.device_info["H1231231932123"] = {"deviceSn": "H1231231932123", "deviceType": 1, "plantId": test_plant_id, "ratedPower": 10.0}
+        api.device_info["TP123456123123"] = {"deviceSn": "TP123456123123", "deviceType": 2, "plantId": test_plant_id, "ratedPower": 5.0}
+        api.realtime_data[test_plant_id] = {"totalYield": 3250.5, "totalCharged": 1850.2, "totalDischarged": 1720.8, "totalImported": 4200.3, "totalExported": 2800.7, "totalEarnings": 485.5}
+        api.realtime_device_data["TP123456123123"] = {"deviceSn": "TP123456123123", "batterySOC": 75, "batteryRemainings": 11.25, "batteryTemperature": 18.5}
+        return api
+
+    yield_entity = f"sensor.predbat_solax_{test_plant_id}_total_yield"
+    soc_entity = f"sensor.predbat_solax_{test_plant_id}_battery_soc"
+
+    # Test 1: With no failures everything is published
+    print("Test 1: Successful reads publish")
+    api = build_api()
+    await api.publish_plant_info()
+
+    if yield_entity not in api.dashboard_items:
+        print("**** ERROR: Total yield sensor not published on a good read ****")
+        failed = True
+    elif soc_entity not in api.dashboard_items:
+        print("**** ERROR: Battery SOC sensor not published on a good read ****")
+        failed = True
+    else:
+        print("✓ Sensors published when the read succeeded")
+
+    # Test 2: A failed plant read holds back the plant totals but not the static sensors
+    print("Test 2: Failed plant read holds back the totals")
+    api = build_api()
+    api.realtime_plant_failed.add(test_plant_id)
+    await api.publish_plant_info()
+
+    if yield_entity in api.dashboard_items:
+        print("**** ERROR: Total yield published despite the plant read failing ****")
+        failed = True
+    elif f"sensor.predbat_solax_{test_plant_id}_pv_capacity" not in api.dashboard_items:
+        print("**** ERROR: Static sensors should still be published on a failed realtime read ****")
+        failed = True
+    else:
+        print("✓ Plant totals held back, static sensors still published")
+
+    # Test 3: A failed battery read holds back the battery sensors
+    print("Test 3: Failed battery read holds back the battery sensors")
+    api = build_api()
+    api.realtime_device_failed.add("TP123456123123")
+    await api.publish_plant_info()
+
+    if soc_entity in api.dashboard_items:
+        print("**** ERROR: Battery SOC published despite the battery read failing ****")
+        failed = True
+    elif f"sensor.predbat_solax_{test_plant_id}_battery_capacity" not in api.dashboard_items:
+        print("**** ERROR: Battery capacity is static and should still be published ****")
+        failed = True
+    else:
+        print("✓ Battery sensors held back on a failed battery read")
+
+    # Test 4: Per-device publishing skips the failed device only
+    print("Test 4: Per-device publishing skips only the failed device")
+    api = build_api()
+    api.realtime_device_data["H1231231932123"] = {"deviceSn": "H1231231932123", "deviceStatus": 102, "gridPower": 100.0, "totalYield": 3250.5}
+    api.realtime_device_failed.add("H1231231932123")
+    await api.publish_device_realtime_data()
+
+    inverter_entity = f"sensor.predbat_solax_{test_plant_id}_H1231231932123_grid_power"
+    battery_entity = f"sensor.predbat_solax_{test_plant_id}_TP123456123123_battery_soc"
+    if inverter_entity in api.dashboard_items:
+        print("**** ERROR: Failed inverter device was published ****")
+        failed = True
+    elif battery_entity not in api.dashboard_items:
+        print("**** ERROR: The battery read succeeded and should still be published ****")
+        failed = True
+    else:
+        print("✓ Only the failed device is skipped")
+
+    # Test 5: A failing device read is recorded, and a later success clears it
+    print("Test 5: Failures are recorded and cleared")
+    api = build_api()
+    with patch.object(api, "fetch_single_result", new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = (None, None)
+        await api.query_device_realtime_data("TP123456123123", 2)
+
+    if "TP123456123123" not in api.realtime_device_failed:
+        print("**** ERROR: A failed read should be recorded ****")
+        failed = True
+    else:
+        with patch.object(api, "fetch_single_result", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = ([{"deviceSn": "TP123456123123", "batterySOC": 80, "batteryRemainings": 12.0}], "req1")
+            await api.query_device_realtime_data("TP123456123123", 2)
+
+        if "TP123456123123" in api.realtime_device_failed:
+            print("**** ERROR: A successful read should clear the failure ****")
+            failed = True
+        else:
+            print("✓ Failures are recorded on a bad read and cleared on a good one")
 
     return failed
 
@@ -6201,6 +6575,9 @@ async def test_run_main():
     api2.initialize(client_id="test", client_secret="test", region="eu")
     api2.plant_info = [{"plantId": "plant1"}]
     api2.plant_list = ["plant1"]
+    # Static info was read moments ago, so neither poll is due yet
+    api2.plant_info_updated = datetime.now(timezone.utc)
+    api2.device_info_updated = datetime.now(timezone.utc)
 
     with patch.object(api2, "query_plant_info", new_callable=AsyncMock) as mock_query_plant:
         with patch.object(api2, "query_device_info", new_callable=AsyncMock) as mock_query_device:

--- a/apps/predbat/tests/test_solax.py
+++ b/apps/predbat/tests/test_solax.py
@@ -1211,6 +1211,81 @@ async def test_static_info_cache_main(my_predbat):
         else:
             print("✓ A failing plant info read is rate limited too")
 
+    # Test 11: A changed device list makes the plant info suspect and forces a re-read
+    print("Test 11: A device change forces a plant info re-read")
+    # Start from a restored cache so there is a known device list to compare against, then age it out
+    api = build_cached_api(plant_age=60, device_age=5)
+    await run_one_cycle(api)
+    api.device_info_updated = api.device_info_updated - timedelta(minutes=SOLAX_DEVICE_INFO_MAX_AGE + 1)
+    api.storage.saved = []
+
+    async def add_a_device(plant_id, device_type, device_sn=None, business_type=None):
+        """Return a battery that was not in the cached device list"""
+        if device_type == 2:
+            api.device_info["BAT_NEW"] = {"deviceSn": "BAT_NEW", "deviceType": 2, "plantId": "plant1"}
+            return [api.device_info["BAT_NEW"]]
+        return []
+
+    with patch.object(api, "query_plant_info", new_callable=AsyncMock) as mock_plant:
+        with patch.object(api, "query_device_info", side_effect=add_a_device):
+            with patch.object(api, "query_plant_realtime_data", new_callable=AsyncMock):
+                with patch.object(api, "query_device_realtime_data_all", new_callable=AsyncMock):
+                    with patch.object(api, "fetch_controls", new_callable=AsyncMock):
+                        with patch.object(api, "publish_plant_info", new_callable=AsyncMock):
+                            with patch.object(api, "publish_device_info", new_callable=AsyncMock):
+                                with patch.object(api, "publish_device_realtime_data", new_callable=AsyncMock):
+                                    with patch.object(api, "publish_controls", new_callable=AsyncMock):
+                                        with patch.object(api, "apply_controls", new_callable=AsyncMock):
+                                            mock_plant.return_value = api.plant_info
+                                            await api.run(seconds=5, first=False)
+
+    if mock_plant.called:
+        print("**** ERROR: The cached plant info was fresh, it should not have been read on this cycle ****")
+        failed = True
+    elif api.plant_info_updated is not None or api.plant_info_attempted is not None:
+        print("**** ERROR: A device change should clear the plant info read and attempt times ****")
+        failed = True
+    else:
+        # The next cycle picks the plant info back up, without waiting for the retry interval
+        result, mock_plant, mock_device = await run_one_cycle(api, seconds=5, first=False)
+        if not mock_plant.called:
+            print("**** ERROR: Plant info should be re-read on the cycle after a device change ****")
+            failed = True
+        else:
+            print("✓ A changed device list forces the plant info to be re-read")
+
+    # Test 12: An unchanged device list leaves the fresh plant info alone
+    print("Test 12: An unchanged device list does not force a plant re-read")
+    api = build_cached_api(plant_age=60, device_age=5)
+    await run_one_cycle(api)
+    api.device_info_updated = api.device_info_updated - timedelta(minutes=SOLAX_DEVICE_INFO_MAX_AGE + 1)
+    plant_updated_before = None
+
+    with patch.object(api, "query_plant_info", new_callable=AsyncMock) as mock_plant:
+        with patch.object(api, "query_device_info", new_callable=AsyncMock) as mock_device:
+            with patch.object(api, "query_plant_realtime_data", new_callable=AsyncMock):
+                with patch.object(api, "query_device_realtime_data_all", new_callable=AsyncMock):
+                    with patch.object(api, "fetch_controls", new_callable=AsyncMock):
+                        with patch.object(api, "publish_plant_info", new_callable=AsyncMock):
+                            with patch.object(api, "publish_device_info", new_callable=AsyncMock):
+                                with patch.object(api, "publish_device_realtime_data", new_callable=AsyncMock):
+                                    with patch.object(api, "publish_controls", new_callable=AsyncMock):
+                                        with patch.object(api, "apply_controls", new_callable=AsyncMock):
+                                            mock_device.return_value = []  # Poll succeeds, nothing new
+                                            await api.run(seconds=5, first=False)
+                                            plant_updated_before = api.plant_info_updated
+
+    if plant_updated_before is None and api.plant_info_attempted is None:
+        print("**** ERROR: An unchanged device list should leave the cached plant info in place ****")
+        failed = True
+    else:
+        result, mock_plant, mock_device = await run_one_cycle(api, seconds=5, first=False)
+        if mock_plant.called:
+            print("**** ERROR: Plant info should not be re-read when the device list is unchanged ****")
+            failed = True
+        else:
+            print("✓ An unchanged device list leaves the plant info alone")
+
     return failed
 
 

--- a/apps/predbat/tests/test_solax.py
+++ b/apps/predbat/tests/test_solax.py
@@ -20,6 +20,7 @@ from solax import (
     SOLAX_PLANT_INFO_MAX_AGE,
     SOLAX_DEVICE_INFO_MAX_AGE,
     SOLAX_CACHE_EXPIRY_HOURS,
+    SOLAX_INFO_RETRY_MINUTES,
 )
 from tests.test_infra import create_aiohttp_mock_response, create_aiohttp_mock_session
 
@@ -1133,6 +1134,82 @@ async def test_static_info_cache_main(my_predbat):
         failed = True
     else:
         print("✓ A failed refresh keeps the cached plant info")
+
+    # Test 8: A failed device info read does not mark the data fresh or overwrite a good cache
+    print("Test 8: A failed device info read is not treated as a refresh")
+    api = build_cached_api(plant_age=60, device_age=SOLAX_DEVICE_INFO_MAX_AGE + 1)
+    good_cache = api.storage.data["device_info"]
+
+    with patch.object(api, "query_plant_info", new_callable=AsyncMock):
+        with patch.object(api, "query_device_info", new_callable=AsyncMock) as mock_device:
+            with patch.object(api, "query_plant_realtime_data", new_callable=AsyncMock):
+                with patch.object(api, "query_device_realtime_data_all", new_callable=AsyncMock):
+                    with patch.object(api, "fetch_controls", new_callable=AsyncMock):
+                        with patch.object(api, "publish_plant_info", new_callable=AsyncMock):
+                            with patch.object(api, "publish_device_info", new_callable=AsyncMock):
+                                with patch.object(api, "publish_device_realtime_data", new_callable=AsyncMock):
+                                    with patch.object(api, "publish_controls", new_callable=AsyncMock):
+                                        with patch.object(api, "apply_controls", new_callable=AsyncMock):
+                                            mock_device.return_value = None  # API failure
+                                            await api.run(seconds=0, first=True)
+
+    if api.device_info_updated is not None:
+        print(f"**** ERROR: A failed device read must not mark the data fresh, got {api.device_info_updated} ****")
+        failed = True
+    elif [item["filename"] for item in api.storage.saved] != []:
+        print(f"**** ERROR: A failed device read must not write the cache, got {[item['filename'] for item in api.storage.saved]} ****")
+        failed = True
+    elif api.storage.data["device_info"] is not good_cache:
+        print("**** ERROR: The previous good cache should be left alone ****")
+        failed = True
+    else:
+        print("✓ A failed device read is not marked fresh and does not overwrite the cache")
+
+    # Test 9: A failing read is retried at the retry interval, not on every cycle
+    print("Test 9: A failing read is rate limited")
+    result, mock_plant, mock_device = await run_one_cycle(api, seconds=5, first=False)
+
+    if mock_device.called:
+        print("**** ERROR: A failed read must not be retried on the very next cycle ****")
+        failed = True
+    else:
+        # Once the retry interval has passed the read is attempted again
+        api.device_info_attempted = api.device_info_attempted - timedelta(minutes=SOLAX_INFO_RETRY_MINUTES + 1)
+        result, mock_plant, mock_device = await run_one_cycle(api, seconds=10, first=False)
+        if not mock_device.called:
+            print(f"**** ERROR: The read should be retried after {SOLAX_INFO_RETRY_MINUTES} minutes ****")
+            failed = True
+        else:
+            print(f"✓ A failing read is retried every {SOLAX_INFO_RETRY_MINUTES} minutes, not every cycle")
+
+    # Test 10: A failing plant info read is rate limited in the same way
+    print("Test 10: A failing plant info read is rate limited")
+    api = build_cached_api()
+    api.plant_info = [{"plantId": "plant1"}]
+
+    with patch.object(api, "query_plant_info", new_callable=AsyncMock) as mock_plant:
+        with patch.object(api, "query_device_info", new_callable=AsyncMock):
+            with patch.object(api, "query_plant_realtime_data", new_callable=AsyncMock):
+                with patch.object(api, "query_device_realtime_data_all", new_callable=AsyncMock):
+                    with patch.object(api, "fetch_controls", new_callable=AsyncMock):
+                        with patch.object(api, "publish_plant_info", new_callable=AsyncMock):
+                            with patch.object(api, "publish_device_info", new_callable=AsyncMock):
+                                with patch.object(api, "publish_device_realtime_data", new_callable=AsyncMock):
+                                    with patch.object(api, "publish_controls", new_callable=AsyncMock):
+                                        with patch.object(api, "apply_controls", new_callable=AsyncMock):
+                                            mock_plant.return_value = None
+                                            await api.run(seconds=0, first=True)
+
+    if api.plant_info_updated is not None:
+        print("**** ERROR: A failed plant read must not mark the data fresh ****")
+        failed = True
+    else:
+        result, mock_plant, mock_device = await run_one_cycle(api, seconds=5, first=False)
+        if mock_plant.called:
+            print("**** ERROR: A failed plant read must not be retried on the very next cycle ****")
+            failed = True
+        else:
+            print("✓ A failing plant info read is rate limited too")
 
     return failed
 


### PR DESCRIPTION
## Problem

Every restart re-read the full plant list and every device from the SolaX cloud before Predbat could do anything, even though that information describes the hardware and barely changes. Other integrations already avoid this — `gecloud.py` restores its settings from storage on startup.

Separately, realtime data was published to Home Assistant whether or not the read succeeded. `realtime_device_data` is only written on a successful read, so a failed poll republished the previous values, and before any successful read the plant totals were published as `0.0` from the `.get(..., 0.0)` defaults. Those totals feed `import_today` / `export_today` / `load_today`, so publishing zeros or stale values corrupts what Predbat consumes.

## Change

**Plant and device info are cached in storage** under `solax/plant_info` and `solax/device_info`, and restored on startup. Two entries rather than one, because a single file's timestamp would be refreshed by every 30 minute device save, and the plant info age rule would then never fire.

**The refresh is driven by the age of the data, not the time since startup.** Previously `seconds % (30 * 60) == 0` meant a restart began a fresh 30 minute interval regardless of how old the data actually was. Now:

| Entry | Contents | Re-read once older than |
|---|---|---|
| `plant_info` | plant list | 8 hours |
| `device_info` | device info and the plant to inverter/battery maps | 30 minutes |

Restoring from the cache carries the age over, so a restart neither re-reads data that is still current nor waits a full interval to refresh data that was already nearly due — 25 minute old device info refreshes 5 minutes later, not 30. Entries are written with a 24 hour expiry so an abandoned cache is discarded by the storage layer.

**Realtime data is not published when the read failed.** Failures are recorded per plant and per device and cleared on the next success. Tracking failures rather than successes matters: it distinguishes "never polled" from "poll failed", and a missing update simply leaves the entity at its last value in HA, which is the desired outcome. Plant totals, battery sensors and per-device sensors are gated independently, so one failing device does not suppress the rest. Static sensors — capacity, PV capacity, max power — are always published.

Realtime data is deliberately still not cached to storage, as it is polled every 60 seconds.

## Behaviour notes

- A plant info refresh that fails now keeps the previously known plants and logs a warning rather than aborting the run. Returning `False` on an 8 hourly refresh blip would take out an otherwise healthy cycle. It remains fatal when nothing has ever been read.
- `plant_list` is now recomputed whenever plant info is successfully refreshed, not only on the first run, so a plant added to the account is picked up within 8 hours.
- With no storage component available the behaviour is unchanged and everything is polled.

## Testing

`./run_all --test solax` and `./run_pre_commit` both pass.

- `test_static_info_cache` — fresh cache restored with no polling, each entry ageing out independently, the age carrying across a restart rather than restarting the interval, missing cache, no storage configured, a failed refresh keeping the previous data, and the 24 hour expiry.
- `test_realtime_publish_gating` — successful reads publish, a failed plant read holds back the totals while static sensors still publish, a failed battery read holds back the battery sensors, per-device publishing skips only the failed device, and failures are recorded on a bad read and cleared on a good one.
- Two existing run loop tests needed seeding with `plant_info_updated` / `device_info_updated`, since "subsequent run" no longer implies "never polls plant info".

🤖 Generated with [Claude Code](https://claude.com/claude-code)