### PR TITLE
fix(fetch): publish rate_import/rate_export atomically to remove a read race

### DIFF
--- a/apps/predbat/axle.py
+++ b/apps/predbat/axle.py
@@ -647,9 +647,9 @@ def fetch_axle_sessions(base):
     return axle_events_deduplicated
 
 
-def load_axle_slot(base, axle_sessions, export, rate_replicate=None):
+def load_axle_slot(base, axle_sessions, rate_dict, export, rate_replicate=None):
     """
-    Load Axle VPP session slot
+    Load Axle VPP session slot into rate_dict (in place)
     """
     if rate_replicate is None:
         rate_replicate = {}
@@ -679,11 +679,11 @@ def load_axle_slot(base, axle_sessions, export, rate_replicate=None):
                 base.log("Setting Axle VPP session in range {} - {} export {} pence_per_kwh {}".format(base.time_abs_str(start_minutes), base.time_abs_str(end_minutes), export, pence_per_kwh))
                 for minute in range(start_minutes, end_minutes):
                     if export:
-                        base.rate_export[minute] = base.rate_export.get(minute, 0) + pence_per_kwh
+                        rate_dict[minute] = rate_dict.get(minute, 0) + pence_per_kwh
                         base.load_scaling_dynamic[minute] = base.load_scaling_saving
                         rate_replicate[minute] = "saving"
                     else:
-                        base.rate_import[minute] = base.rate_import.get(minute, 0) - pence_per_kwh
+                        rate_dict[minute] = rate_dict.get(minute, 0) - pence_per_kwh
                         base.load_scaling_dynamic[minute] = base.load_scaling_free
                         rate_replicate[minute] = "saving"
 

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -989,7 +989,7 @@ class Fetch:
             self.rate_import_no_io = {}
             self.log("Warning: No import rate data provided")
             self.record_status(message="Error: No import rate data provided", had_errors=True)
-        # Atomic publish: readers (e.g. async components) never see a half-built or empty rate_import.
+        # Atomic publish: readers (e.g. async components) never see a half-built or transiently-empty rate_import during rebuild.
         self.rate_import = import_rates
 
         # Replicate and scan export rates

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1902,8 +1902,12 @@ class Fetch:
         curr = self.currency_symbols[1]
 
         if print:
-            # Calculate minimum forward rates only once rate replicate has run (when print is True)
-            self.rate_min_forward = self.rate_min_forward_calc(self.rate_import)
+            # Calculate minimum forward rates only once rate replicate has run (when print is True).
+            # Use the `rates` argument, not self.rate_import: during fetch's atomic rebuild self.rate_import
+            # still holds the PREVIOUS cycle's data (publish is deferred to the end of the block), so
+            # reading it here would make rate_min_forward - which drives plan.py charge/discharge economics
+            # - a cycle stale. `rates` is the freshly-built current-cycle dict being scanned.
+            self.rate_min_forward = self.rate_min_forward_calc(rates)
             self.log("Import rates: min {}{}, max {}{}, average {}{}".format(self.rate_min, curr, self.rate_max, curr, self.rate_average, curr))
 
     def rate_scan_gas(self, rates, print=True):

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -708,9 +708,9 @@ class Fetch:
         prev_octopus_free_slots = self.octopus_free_slots.copy()
         prev_axle_sessions = self.axle_sessions.copy()
 
-        self.rate_import = {}
+        import_rates = {}
         self.rate_import_replicated = {}
-        self.rate_export = {}
+        export_rates = {}
         self.rate_export_replicated = {}
         self.rate_slots = []
         self.io_adjusted = {}
@@ -849,36 +849,36 @@ class Fetch:
             # Fixed URL for rate import
             self.log("Downloading import rates directly from URL {}".format(self.get_arg("rates_import_octopus_url", indirect=False)))
             # Need to take a copy, as saving sessions will repeatedly increment cached import rates
-            self.rate_import = copy.deepcopy(self.download_octopus_rates(self.get_arg("rates_import_octopus_url", indirect=False)))
+            import_rates = copy.deepcopy(self.download_octopus_rates(self.get_arg("rates_import_octopus_url", indirect=False)))
         elif "metric_octopus_import" in self.args:
             # Octopus import rates
             entity_id = self.get_arg("metric_octopus_import", None, indirect=False)
-            self.rate_import = self.fetch_octopus_rates(entity_id, adjust_key="is_intelligent_adjusted")
-            if not self.rate_import:
+            import_rates = self.fetch_octopus_rates(entity_id, adjust_key="is_intelligent_adjusted")
+            if not import_rates:
                 self.log("Error: metric_octopus_import is not set correctly in apps.yaml, or no energy rates can be read")
                 self.record_status(message="Error: metric_octopus_import not set correctly in apps.yaml, or no energy rates can be read", had_errors=True)
         elif "metric_energidataservice_import" in self.args:
             # Energi Data Service import rates
             entity_id = self.get_arg("metric_energidataservice_import", None, indirect=False)
-            self.rate_import = self.fetch_energidataservice_rates(entity_id, adjust_key="is_intelligent_adjusted")
-            if not self.rate_import:
+            import_rates = self.fetch_energidataservice_rates(entity_id, adjust_key="is_intelligent_adjusted")
+            if not import_rates:
                 self.log("Error: metric_energidataservice_import is not set correctly in apps.yaml, or no energy rates can be read")
                 self.record_status(message="Error: metric_energidataservice_import not set correctly in apps.yaml, or no energy rates can be read", had_errors=True)
         elif "metric_stromligning_import_today" in self.args or "metric_stromligning_import_tomorrow" in self.args:
             # Strømligning import rates
             entity_id_today = self.get_arg("metric_stromligning_import_today", None, indirect=False)
             entity_id_tomorrow = self.get_arg("metric_stromligning_import_tomorrow", None, indirect=False)
-            self.rate_import = self.fetch_stromligning_rates(entity_id_today, entity_id_tomorrow, adjust_key="is_intelligent_adjusted")
-            if not self.rate_import:
+            import_rates = self.fetch_stromligning_rates(entity_id_today, entity_id_tomorrow, adjust_key="is_intelligent_adjusted")
+            if not import_rates:
                 self.log("Error: metric_stromligning_import sensors are not set correctly or no energy rates can be read")
                 self.record_status(message="Error: metric_stromligning_import sensors not set correctly or no energy rates can be read", had_errors=True)
 
         # Fallback if no other rate types are set
-        if not self.rate_import:
+        if not import_rates:
             # Basic rates defined by user over time
             rate_import_dict = self.get_arg("rates_import", [], indirect=False)
             if rate_import_dict:
-                self.rate_import = self.basic_rates(rate_import_dict, "rates_import")
+                import_rates = self.basic_rates(rate_import_dict, "rates_import")
 
         # Gas rates if set
         if "metric_octopus_gas" in self.args:
@@ -925,36 +925,36 @@ class Fetch:
             # Fixed URL for rate export
             self.log("Downloading export rates directly from URL {}".format(self.get_arg("rates_export_octopus_url", indirect=False)))
             # Need to take a copy, as saving sessions will repeatedly increment cached export rates
-            self.rate_export = copy.deepcopy(self.download_octopus_rates(self.get_arg("rates_export_octopus_url", indirect=False)))
+            export_rates = copy.deepcopy(self.download_octopus_rates(self.get_arg("rates_export_octopus_url", indirect=False)))
         elif "metric_octopus_export" in self.args:
             # Octopus export rates
             entity_id = self.get_arg("metric_octopus_export", None, indirect=False)
-            self.rate_export = self.fetch_octopus_rates(entity_id)
-            if not self.rate_export:
+            export_rates = self.fetch_octopus_rates(entity_id)
+            if not export_rates:
                 self.log("Warning: metric_octopus_export is not set correctly in apps.yaml, or no energy rates can be read")
                 self.record_status(message="Error: metric_octopus_export not set correctly in apps.yaml, or no energy rates can be read", had_errors=True)
         elif "metric_energidataservice_export" in self.args:
             # Energi Data Service export rates
             entity_id = self.get_arg("metric_energidataservice_export", None, indirect=False)
-            self.rate_export = self.fetch_energidataservice_rates(entity_id)
-            if not self.rate_export:
+            export_rates = self.fetch_energidataservice_rates(entity_id)
+            if not export_rates:
                 self.log("Warning: metric_energidataservice_export is not set correctly in apps.yaml, or no energy rates can be read")
                 self.record_status(message="Error: metric_energidataservice_export not set correctly in apps.yaml, or no energy rates can be read", had_errors=True)
         elif "metric_stromligning_export_today" in self.args or "metric_stromligning_export_tomorrow" in self.args:
             # Strømligning export rates
             entity_id_today = self.get_arg("metric_stromligning_export_today", None, indirect=False)
             entity_id_tomorrow = self.get_arg("metric_stromligning_export_tomorrow", None, indirect=False)
-            self.rate_export = self.fetch_stromligning_rates(entity_id_today, entity_id_tomorrow)
-            if not self.rate_export:
+            export_rates = self.fetch_stromligning_rates(entity_id_today, entity_id_tomorrow)
+            if not export_rates:
                 self.log("Warning: metric_stromligning_export sensors are not set correctly or no energy rates can be read")
                 self.record_status(message="Error: metric_stromligning_export sensors not set correctly or no energy rates can be read", had_errors=True)
 
         # Fallback if no other rate types are set
-        if not self.rate_export:
+        if not export_rates:
             # Basic rates defined by user over time
             rate_export_dict = self.get_arg("rates_export", [], indirect=False)
             # Allow all zero export rates, as some users have a feed-in tariff that is zero
-            self.rate_export = self.basic_rates(rate_export_dict, "rates_export")
+            export_rates = self.basic_rates(rate_export_dict, "rates_export")
 
         # Fetch Axle sessions first so Octopus auto-join can skip saving sessions that overlap an Axle VPP session
         self.axle_sessions = fetch_axle_sessions(self)
@@ -967,44 +967,47 @@ class Fetch:
 
         # futurerate data
         futurerate = FutureRate(self)
-        self.future_energy_rates_import, self.future_energy_rates_export = futurerate.futurerate_analysis(self.rate_import, self.rate_export)
+        self.future_energy_rates_import, self.future_energy_rates_export = futurerate.futurerate_analysis(import_rates, export_rates)
 
         # Replicate and scan import rates
-        if self.rate_import:
-            self.rate_scan(self.rate_import, print=False)
+        if import_rates:
+            self.rate_scan(import_rates, print=False)
             self.rate_max_base = self.rate_max  # True peak rate before saving sessions / overrides inflate it
             self.rate_min_base = self.rate_min  # True off-peak rate before free sessions / overrides deflate it
-            self.rate_import_base, _ = self.rate_replicate(self.rate_import.copy(), {}, is_import=True)  # True import rates, gap-filled but without IO/saving/override distortion
-            self.rate_import, self.rate_import_replicated = self.rate_replicate(self.rate_import, self.io_adjusted, is_import=True)
-            self.rate_import_no_io = self.rate_import.copy()
+            self.rate_import_base, _ = self.rate_replicate(import_rates.copy(), {}, is_import=True)  # True import rates, gap-filled but without IO/saving/override distortion
+            import_rates, self.rate_import_replicated = self.rate_replicate(import_rates, self.io_adjusted, is_import=True)
+            self.rate_import_no_io = import_rates.copy()
             for car_n in range(self.num_cars):
-                self.rate_import = self.rate_add_io_slots(car_n, self.rate_import, self.octopus_slots[car_n])
-            self.load_saving_slot(self.octopus_saving_slots, export=False, rate_replicate=self.rate_import_replicated)
-            self.load_free_slot(self.octopus_free_slots, export=False, rate_replicate=self.rate_import_replicated)
-            load_axle_slot(self, self.axle_sessions, export=False, rate_replicate=self.rate_import_replicated)
-            self.rate_import = self.basic_rates(self.get_arg("rates_import_override", [], indirect=False), "rates_import_override", self.rate_import, self.rate_import_replicated)
-            self.rate_import = self.apply_manual_rates(self.rate_import, self.manual_import_rates, is_import=True, rate_replicate=self.rate_import_replicated)
-            self.rate_scan(self.rate_import, print=True)
+                import_rates = self.rate_add_io_slots(car_n, import_rates, self.octopus_slots[car_n])
+            self.load_saving_slot(self.octopus_saving_slots, import_rates, export=False, rate_replicate=self.rate_import_replicated)
+            self.load_free_slot(self.octopus_free_slots, import_rates, export=False, rate_replicate=self.rate_import_replicated)
+            load_axle_slot(self, self.axle_sessions, import_rates, export=False, rate_replicate=self.rate_import_replicated)
+            import_rates = self.basic_rates(self.get_arg("rates_import_override", [], indirect=False), "rates_import_override", import_rates, self.rate_import_replicated)
+            import_rates = self.apply_manual_rates(import_rates, self.manual_import_rates, is_import=True, rate_replicate=self.rate_import_replicated)
+            self.rate_scan(import_rates, print=True)
         else:
             self.rate_import_no_io = {}
             self.log("Warning: No import rate data provided")
             self.record_status(message="Error: No import rate data provided", had_errors=True)
+        # Atomic publish: readers (e.g. async components) never see a half-built or empty rate_import.
+        self.rate_import = import_rates
 
         # Replicate and scan export rates
-        if self.rate_export:
-            self.rate_scan_export(self.rate_export, print=False)
-            self.rate_export, self.rate_export_replicated = self.rate_replicate(self.rate_export, is_import=False)
-            self.rate_export_base = self.rate_export.copy()
+        if export_rates:
+            self.rate_scan_export(export_rates, print=False)
+            export_rates, self.rate_export_replicated = self.rate_replicate(export_rates, is_import=False)
+            self.rate_export_base = export_rates.copy()
             # For export tariff only load the saving session if enabled
             if self.rate_export_max > 0:
-                self.load_saving_slot(self.octopus_saving_slots, export=True, rate_replicate=self.rate_export_replicated)
-            load_axle_slot(self, self.axle_sessions, export=True, rate_replicate=self.rate_export_replicated)
-            self.rate_export = self.basic_rates(self.get_arg("rates_export_override", [], indirect=False), "rates_export_override", self.rate_export, self.rate_export_replicated)
-            self.rate_export = self.apply_manual_rates(self.rate_export, self.manual_export_rates, is_import=False, rate_replicate=self.rate_export_replicated)
-            self.rate_scan_export(self.rate_export, print=True)
+                self.load_saving_slot(self.octopus_saving_slots, export_rates, export=True, rate_replicate=self.rate_export_replicated)
+            load_axle_slot(self, self.axle_sessions, export_rates, export=True, rate_replicate=self.rate_export_replicated)
+            export_rates = self.basic_rates(self.get_arg("rates_export_override", [], indirect=False), "rates_export_override", export_rates, self.rate_export_replicated)
+            export_rates = self.apply_manual_rates(export_rates, self.manual_export_rates, is_import=False, rate_replicate=self.rate_export_replicated)
+            self.rate_scan_export(export_rates, print=True)
         else:
             self.log("Warning: No export rate data provided")
             self.record_status(message="Error: No export rate data provided", had_errors=True)
+        self.rate_export = export_rates
 
         # Set rate thresholds
         if self.rate_import or self.rate_export:

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2686,7 +2686,11 @@ class Octopus:
                         if octopus_slot_low_rate:
                             assumed_price = self.rate_min_base
                         else:
-                            assumed_price = self.rate_import.get(start_minutes, self.rate_min)
+                            # Use the `rates` working dict, not self.rate_import: fetch now publishes
+                            # rate_import atomically at the end of the rebuild, so self.rate_import holds
+                            # the previous cycle's data here. (On main these were the same object, so this
+                            # is behaviour-preserving there and simply avoids the staleness this PR adds.)
+                            assumed_price = rates.get(start_minutes, self.rate_min)
 
                         if minute in saved_slots:
                             continue  # Already applied a low rate slot to this minute, skip

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2405,9 +2405,9 @@ class Octopus:
         except (ValueError, TypeError):
             return None
 
-    def load_free_slot(self, octopus_free_slots, export=False, rate_replicate=None):
+    def load_free_slot(self, octopus_free_slots, rate_dict, export=False, rate_replicate=None):
         """
-        Load octopus free session slot
+        Load octopus free session slot into rate_dict (in place)
         """
         if rate_replicate is None:
             rate_replicate = {}
@@ -2436,15 +2436,15 @@ class Octopus:
                 self.log("Setting Octopus free session in range {} - {} export {} rate {}".format(self.time_abs_str(start_minutes), self.time_abs_str(end_minutes), export, rate))
                 for minute in range(start_minutes, end_minutes):
                     if export:
-                        self.rate_export[minute] = rate
+                        rate_dict[minute] = rate
                     else:
-                        self.rate_import[minute] = min(rate, self.rate_import[minute])
+                        rate_dict[minute] = min(rate, rate_dict[minute])
                         self.load_scaling_dynamic[minute] = self.load_scaling_free
                     rate_replicate[minute] = "saving"
 
-    def load_saving_slot(self, octopus_saving_slots, export=False, rate_replicate=None):
+    def load_saving_slot(self, octopus_saving_slots, rate_dict, export=False, rate_replicate=None):
         """
-        Load octopus saving session slot
+        Load octopus saving session slot into rate_dict (in place)
         """
         if rate_replicate is None:
             rate_replicate = {}
@@ -2476,15 +2476,11 @@ class Octopus:
             if start_minutes < (self.forecast_minutes + self.minutes_now):
                 self.log("Octopus: Setting Octopus saving session in range {} - {} export {} rate {}".format(self.time_abs_str(start_minutes), self.time_abs_str(end_minutes), export, rate))
                 for minute in range(start_minutes, end_minutes):
-                    if export:
-                        if minute in self.rate_export:
-                            self.rate_export[minute] += rate
-                            rate_replicate[minute] = "saving"
-                    else:
-                        if minute in self.rate_import:
-                            self.rate_import[minute] += rate
+                    if minute in rate_dict:
+                        rate_dict[minute] += rate
+                        rate_replicate[minute] = "saving"
+                        if not export:
                             self.load_scaling_dynamic[minute] = self.load_scaling_saving
-                            rate_replicate[minute] = "saving"
 
     def decode_octopus_slot(self, car_n, slot, raw=False):
         """

--- a/apps/predbat/tests/test_axle.py
+++ b/apps/predbat/tests/test_axle.py
@@ -1072,7 +1072,7 @@ def _test_axle_load_slot_export(my_predbat=None):
 
     # Load the Axle export slot
     rate_replicate = {}
-    load_axle_slot(base, axle_sessions, export=True, rate_replicate=rate_replicate)
+    load_axle_slot(base, axle_sessions, base.rate_export, export=True, rate_replicate=rate_replicate)
 
     # Verify rates were increased by 100p/kWh during the event period
     for minute in range(start_minutes, end_minutes):
@@ -1155,7 +1155,7 @@ def _test_axle_load_slot_import(my_predbat=None):
     original_rate = base.rate_import[start_minutes]
 
     rate_replicate = {}
-    load_axle_slot(base, axle_sessions, export=False, rate_replicate=rate_replicate)
+    load_axle_slot(base, axle_sessions, base.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Verify import rates were decreased by pence_per_kwh during the event period
     for minute in range(start_minutes, end_minutes):

--- a/apps/predbat/tests/test_load_free_slot.py
+++ b/apps/predbat/tests/test_load_free_slot.py
@@ -52,7 +52,7 @@ def test_load_free_slot(my_predbat):
     free_slots = [{"start": "2025-01-15T10:00:00+00:00", "end": "2025-01-15T11:00:00+00:00", "rate": 0.0}]
 
     rate_replicate = {}
-    my_predbat.load_free_slot(free_slots, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(free_slots, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Check rates were set to 0 for the hour (10:00-11:00 = minute 600-660)
     start_min = 10 * 60  # 600
@@ -89,7 +89,7 @@ def test_load_free_slot(my_predbat):
     print("*** Test 2: Free slot setting export rates to 0")
 
     rate_replicate = {}
-    my_predbat.load_free_slot(free_slots, export=True, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(free_slots, my_predbat.rate_export, export=True, rate_replicate=rate_replicate)
 
     for minute in range(start_min, end_min):
         if my_predbat.rate_export[minute] != 0.0:
@@ -116,7 +116,7 @@ def test_load_free_slot(my_predbat):
     multi_slots = [{"start": "2025-01-15T10:00:00+00:00", "end": "2025-01-15T11:00:00+00:00", "rate": 0.0}, {"start": "2025-01-15T14:00:00+00:00", "end": "2025-01-15T15:30:00+00:00", "rate": 0.0}]
 
     rate_replicate = {}
-    my_predbat.load_free_slot(multi_slots, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(multi_slots, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Check first slot (10:00-11:00)
     for minute in range(10 * 60, 11 * 60):
@@ -151,7 +151,7 @@ def test_load_free_slot(my_predbat):
     midnight_slot = [{"start": "2025-01-15T23:00:00+00:00", "end": "2025-01-16T01:00:00+00:00", "rate": 0.0}]
 
     rate_replicate = {}
-    my_predbat.load_free_slot(midnight_slot, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(midnight_slot, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Check 23:00-00:00 (day 1)
     for minute in range(23 * 60, 24 * 60):
@@ -181,7 +181,7 @@ def test_load_free_slot(my_predbat):
     invalid_slots = [{"start": "invalid-time", "end": "2025-01-15T11:00:00+00:00", "rate": 0.0}, {"start": "2025-01-15T12:00:00+00:00", "end": "also-invalid", "rate": 0.0}]
 
     rate_replicate = {}
-    my_predbat.load_free_slot(invalid_slots, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(invalid_slots, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Rates should remain unchanged
     if my_predbat.rate_import[10 * 60] != 20.0 or my_predbat.rate_import[12 * 60] != 20.0:
@@ -201,7 +201,7 @@ def test_load_free_slot(my_predbat):
     future_slot = [{"start": "2025-01-17T10:00:00+00:00", "end": "2025-01-17T11:00:00+00:00", "rate": 0.0}]  # Day 3, outside forecast
 
     rate_replicate = {}
-    my_predbat.load_free_slot(future_slot, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(future_slot, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # No rates should change since slot is outside forecast window
     unchanged = all(my_predbat.rate_import[n] == 20.0 for n in range(0, min(100, my_predbat.forecast_minutes)))
@@ -222,7 +222,7 @@ def test_load_free_slot(my_predbat):
     partial_slot = [{"start": "2025-01-16T23:00:00+00:00", "end": "2025-01-17T02:00:00+00:00", "rate": 0.0}]  # Near end of day 2  # Extends into day 3 (beyond forecast)
 
     rate_replicate = {}
-    my_predbat.load_free_slot(partial_slot, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(partial_slot, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Should apply to minutes within forecast window only
     # 23:00 on day 2 = minute 47*60 = 2820
@@ -247,7 +247,7 @@ def test_load_free_slot(my_predbat):
     bonus_slot = [{"start": "2025-01-15T10:00:00+00:00", "end": "2025-01-15T11:00:00+00:00", "rate": -5.0}]  # Negative rate (you get paid to use electricity)
 
     rate_replicate = {}
-    my_predbat.load_free_slot(bonus_slot, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(bonus_slot, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Check the rate is set correctly (min of existing rate and slot rate)
     for minute in range(10 * 60, 11 * 60):
@@ -273,7 +273,7 @@ def test_load_free_slot(my_predbat):
     overlap_slot = [{"start": "2025-01-15T10:00:00+00:00", "end": "2025-01-15T11:00:00+00:00", "rate": 5.0}]  # Higher than existing 1.0 for first 30 mins
 
     rate_replicate = {}
-    my_predbat.load_free_slot(overlap_slot, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(overlap_slot, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # First 30 minutes should keep lower rate of 1.0
     for minute in range(10 * 60, 10 * 60 + 30):
@@ -299,7 +299,7 @@ def test_load_free_slot(my_predbat):
     my_predbat.rate_import = {n: 20.0 for n in range(0, my_predbat.forecast_minutes)}
 
     rate_replicate = {}
-    my_predbat.load_free_slot([], export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot([], my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Nothing should change
     if my_predbat.rate_import[10 * 60] != 20.0:
@@ -317,7 +317,7 @@ def test_load_free_slot(my_predbat):
     none_slots = [{"start": None, "end": "2025-01-15T11:00:00+00:00", "rate": 0.0}, {"start": "2025-01-15T12:00:00+00:00", "end": None, "rate": 0.0}]
 
     rate_replicate = {}
-    my_predbat.load_free_slot(none_slots, export=False, rate_replicate=rate_replicate)
+    my_predbat.load_free_slot(none_slots, my_predbat.rate_import, export=False, rate_replicate=rate_replicate)
 
     # Rates should remain unchanged
     if my_predbat.rate_import[10 * 60] != 20.0 or my_predbat.rate_import[12 * 60] != 20.0:

--- a/apps/predbat/tests/test_rate_add_io_slots.py
+++ b/apps/predbat/tests/test_rate_add_io_slots.py
@@ -143,6 +143,21 @@ def run_rate_add_io_slots_tests(my_predbat):
 
     failed |= run_rate_add_io_slots_test("test6_low_rate_false", my_predbat, slots, False, 12, expected_rates)
 
+    # Test 7: octopus_slot_low_rate=False must derive the assumed price from the `rates` argument, not
+    # self.rate_import. Regression tied to fetch's atomic publish: self.rate_import now holds the
+    # previous cycle's data during the rebuild. Stage a stale self.rate_import (99p) distinct from the
+    # 10p working rates and require the slot to keep the 10p working value.
+    print("\n**** Test 7: octopus_slot_low_rate=False uses rates arg, not self.rate_import ****")
+    saved_rate_import, saved_rate_min = my_predbat.rate_import, my_predbat.rate_min
+    my_predbat.rate_import = {minute: 99.0 for minute in range(-96 * 60, max(my_predbat.forecast_minutes, 3 * 24 * 60))}
+    my_predbat.rate_min = 99.0  # so even the fallback is 99: the only way to see 10 is reading `rates`
+    slot_start = midnight_utc + timedelta(hours=2)
+    slot_end = slot_start + timedelta(minutes=30)
+    slots = [{"start": slot_start.strftime(TIME_FORMAT), "end": slot_end.strftime(TIME_FORMAT), "charge_in_kwh": 2.5, "source": "smart-charge", "location": "AT_HOME"}]
+    expected_rates = {minute: 10.0 for minute in range(120, 150)}  # from the 10p rates arg, not the 99p stale self.rate_import
+    failed |= run_rate_add_io_slots_test("test7_low_rate_false_uses_rates_arg", my_predbat, slots, False, 12, expected_rates)
+    my_predbat.rate_import, my_predbat.rate_min = saved_rate_import, saved_rate_min
+
     # Test 7: Custom octopus_slot_max value (e.g., 6 slots = 3 hours)
     print("\n**** Test 7: Custom slot max (6 slots) ****")
     slots = []

--- a/apps/predbat/tests/test_rate_min_forward_calc.py
+++ b/apps/predbat/tests/test_rate_min_forward_calc.py
@@ -111,6 +111,23 @@ def test_rate_min_forward_calc(my_predbat):
     # Every minute in the output range should see 1.0 as the forward minimum
     failed |= _check_range(result, output_start, output_end, 1.0, "min at end of array")
 
+    # --- Test 7: rate_scan derives rate_min_forward from its `rates` argument, not self.rate_import ---
+    # Regression: fetch's atomic rebuild defers publishing self.rate_import to the end of the block, so
+    # during the build it still holds the previous cycle's data. rate_scan must scan its argument, not
+    # self.rate_import, or rate_min_forward (which drives plan.py charge/discharge economics) goes stale.
+    print("*** rate_min_forward_calc test 7: rate_scan uses passed rates, not stale self.rate_import")
+    # rate_scan mutates several shared fields; snapshot and restore them all so later tests are unaffected.
+    saved = {attr: getattr(my_predbat, attr, None) for attr in ("rate_import", "rate_min", "rate_max", "rate_average", "rate_min_minute", "rate_max_minute", "rate_min_forward")}
+    total = my_predbat.forecast_minutes + my_predbat.minutes_now + 48 * 60
+    my_predbat.rate_import = {m: 99.0 for m in range(total)}  # stale previous-cycle rates (expensive)
+    my_predbat.rate_scan({m: 5.0 for m in range(total)}, print=True)  # freshly-built current-cycle rates (cheap)
+    sample = my_predbat.rate_min_forward.get(my_predbat.minutes_now)
+    if sample is None or sample > 50:
+        print("ERROR: test 7: rate_min_forward {} reflects stale self.rate_import, not the scanned rates".format(sample))
+        failed = 1
+    for attr, value in saved.items():
+        setattr(my_predbat, attr, value)
+
     # Restore
     my_predbat.forecast_minutes = old_forecast_minutes
     my_predbat.minutes_now = old_minutes_now

--- a/apps/predbat/tests/test_saving_session.py
+++ b/apps/predbat/tests/test_saving_session.py
@@ -121,7 +121,7 @@ friendly_name: Octoplus Saving Session Events (A-12345678)
 
     rate_import_replicated = {}
     my_predbat.rate_import = {n: 0 for n in range(-24 * 60, 48 * 60)}
-    my_predbat.load_saving_slot(expected_saving, export=False, rate_replicate=rate_import_replicated)
+    my_predbat.load_saving_slot(expected_saving, my_predbat.rate_import, export=False, rate_replicate=rate_import_replicated)
     price_ranges = [[(17.5 - 24) * 60, (18.5 - 24) * 60, 19.2], [(16.5) * 60, (17.5) * 60, 44.8], [-24 * 60, (10.5 - 24) * 60, 44.8]]
     for minute in range(-24 * 60, 48 * 60):
         rate = my_predbat.rate_import[minute]


### PR DESCRIPTION
## Summary

Root-cause fix for the rate-dict read race noted in #4367: `update_pred` rebuilds `rate_import`/`rate_export` on an AppDaemon **worker thread**, while async components (the Teslemetry tariff builder, and any future reader) read them from the **asyncio event loop**, with no lock. The build:

- reset them to `{}` at the start,
- reassigned them per provider step, and
- **mutated them in place** (`load_saving_slot` / `load_free_slot` / `load_axle_slot` doing `self.rate_export[minute] += rate`).

So a concurrent reader could observe an **empty** dict (during the reset window) or a **half-merged** one (mid saving-session apply) — producing a transiently wrong result.

## Change

- Build each side into a **local** (`import_rates` / `export_rates`) through the entire fetch → replicate → slot pipeline, and assign `self.rate_import` / `self.rate_export` **exactly once** at the end. A reader now always sees either the previous complete dict or the new complete dict — never an intermediate.
- The three in-place slot mutators now take the working dict as a **parameter** (`load_saving_slot(..., rate_dict, ...)`, etc.) and operate on it, instead of touching `self.rate_*`. Call sites (5 in `fetch.py`) and their unit tests updated.

Only the working-variable references were rethreaded (a `\b`-anchored transform); the derived attributes (`rate_import_base`, `_replicated`, `_no_io`, `rate_export_base`, `_replicated`) are untouched and still assigned from the locals — so behaviour is preserved.

## Why not a per-consumer snapshot

#4367 added a defensive `dict()` snapshot in the Teslemetry component to dodge this race. This fixes it at the source for **all** consumers and closes the transient-empty window a per-read snapshot can't. Once this lands, that snapshot in #4367 becomes redundant and can be reverted (it's harmless until then). Note this PR does not itself remove that snapshot — it lives on the #4367 branch, not `main`.

## Test plan
- [x] `unit_test.py --quick` — full suite passes (identical to baseline, incl. the pre-existing intentional exception-handling tracebacks); the rate paths (octopus rates, saving/free/axle slots, overrides, manual rates, IO) directly assert the resulting `rate_import`/`rate_export` values, so byte-level behaviour is covered.
- [x] `load_free_slot`, `saving_session`, `axle` mutator tests updated for the new signature and pass.
- [x] pre-commit (ruff, black, cspell) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
