### PR TITLE
Auto-restart unhealthy ML Load Forecaster

### DIFF
--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -487,6 +487,7 @@ COMPONENT_LIST = {
         "class": LoadMLComponent,
         "name": "ML Load Forecaster",
         "event_filter": "predbat_load_ml_",
+        "auto_restart": True,
         "args": {
             "load_ml_enable": {"required_true": True, "config": "load_ml_enable", "default": False},
             "load_ml_source": {"required": False, "config": "load_ml_source", "default": False},
@@ -528,6 +529,7 @@ class Components:
     def __init__(self, base):
         self.components = {}
         self.component_tasks = {}
+        self.restart_tasks = {}
         self.base = base
         self.log = base.log
 
@@ -623,6 +625,18 @@ class Components:
         self.initialize(only=only, phase=2)
         for phase in (0, 1, 2):
             self.start(only=only, phase=phase)
+
+    def auto_restart(self, only):
+        """Schedule one automatic restart for an unhealthy component."""
+        if not self.can_restart(only) or not self.is_active(only):
+            return False
+        restart_task = self.restart_tasks.get(only)
+        if restart_task and restart_task.is_alive():
+            self.log(f"Info: Automatic restart already active for {only}")
+            return False
+        self.log(f"Warn: Automatically restarting unhealthy {only} component")
+        self.restart_tasks[only] = self.base.create_task(self.restart(only), name=f"{only}_auto_restart_task")
+        return True
 
     """
     Pass through events to the appropriate component

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -766,6 +766,8 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
                     component = self.components.get_component(component_name)
                     if not component.is_calculating():
                         failed_components.append(COMPONENT_LIST.get(component_name, {}).get("name", component_name))
+                        if COMPONENT_LIST.get(component_name, {}).get("auto_restart", False):
+                            self.components.auto_restart(component_name)
                 elif is_active:
                     component_status[component_name] = "running"
                 else:

--- a/apps/predbat/tests/test_component_health_status.py
+++ b/apps/predbat/tests/test_component_health_status.py
@@ -27,6 +27,7 @@ class FakeComponents:
     def __init__(self, alive_map, calculating_map=None):
         self.alive_map = alive_map
         self.calculating_map = calculating_map or {}
+        self.auto_restart_calls = []
 
     def get_all(self):
         return list(self.alive_map.keys())
@@ -46,6 +47,10 @@ class FakeComponents:
     def get_component(self, name):
         """Return a fake component with the configured calculation state."""
         return FakeComponent(self.calculating_map.get(name, False))
+
+    def auto_restart(self, name):
+        """Record an automatic restart request."""
+        self.auto_restart_calls.append(name)
 
 
 def test_component_health_status(my_predbat):
@@ -133,6 +138,22 @@ def test_component_health_status(my_predbat):
             failed = 1
         else:
             print("OK: LoadML failure outside calculation still fails the run status")
+
+        if my_predbat.components.auto_restart_calls != ["load_ml"]:
+            print("ERROR: Non-calculating LoadML failure did not request an automatic restart: {}".format(my_predbat.components.auto_restart_calls))
+            failed = 1
+        else:
+            print("OK: Non-calculating LoadML failure requests an automatic restart")
+
+        # --- A calculating LoadML component must not be restarted ---
+        my_predbat.components = FakeComponents({"load_ml": False}, calculating_map={"load_ml": True})
+        recorded_statuses.clear()
+        my_predbat.record_final_run_status("Export", "")
+        if my_predbat.components.auto_restart_calls:
+            print("ERROR: Calculating LoadML component requested an automatic restart")
+            failed = 1
+        else:
+            print("OK: Calculating LoadML component is not automatically restarted")
 
         # --- Pre-existing error takes precedence, and is not overwritten by the component check ---
         my_predbat.had_errors = True


### PR DESCRIPTION
**Summary**
Automatically restart the ML Load Forecaster component when it becomes unhealthy outside of an active calculation. At the moment ML Load Forecaster can start before the Solis Cloud API component which leaves it in an error state until manually restarted.

**Changes**
• Added an auto_restart component setting, enabled only for load_ml.
• Added guarded asynchronous component restart handling to prevent duplicate concurrent restarts.
• Triggered automatic recovery when LoadML is active, unhealthy, and not calculating.
• Avoided restarting LoadML while it is performing training, prediction, or database work.
• Added tests covering automatic restart requests and ensuring calculating LoadML instances are not restarted.

**Behaviour**
Other components are unaffected. Genuine LoadML failures are still reported, but Predbat now attempts to recover the component automatically using the existing restart lifecycle.