### PR TITLE
fix(deye): deliver charge/export windows to the inverter, and stop re-sending unchanged payloads

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -1986,7 +1986,7 @@ INVERTER_DEF = {
         "has_target_soc": True,
         "has_reserve_soc": True,
         "has_timed_pause": False,
-        "charge_time_format": "HH:MM",
+        "charge_time_format": "HH:MM:SS",
         "charge_time_entity_is_option": True,
         "soc_units": "%",
         "num_load_entities": 1,

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -552,9 +552,11 @@ class DeyeAPI(ComponentBase, OAuthMixin):
                 intent = {"reserve": reserve, "charge": {"enable": False}, "export": {"enable": False}}
                 intent[direction] = {"enable": True, "soc": window.get("soc", 0), "power": window.get("power", 0)}
                 state = self.derive_control_state(intent, current_soc)
-                segments[window["start"]] = state
+                # Normalised to HH:MM here: these strings become DEYE slot times, and the
+                # entities they came from carry seconds.
+                segments[self._to_slot_time(window["start"])] = state
                 # After the window, return to self-use at reserve.
-                segments.setdefault(window["end"], {"behaviour": "idle", "power": 0, "slot_soc": reserve, "grid_charge": False, "solar_sell": False, "work_mode": None})
+                segments.setdefault(self._to_slot_time(window["end"]), {"behaviour": "idle", "power": 0, "slot_soc": reserve, "grid_charge": False, "solar_sell": False, "work_mode": None})
         ordered = sorted(segments.items(), key=lambda kv: kv[0])
         slots = []
         for start_time, state in ordered:
@@ -582,6 +584,23 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             return int(self.minutes_now)
         except (TypeError, ValueError):
             return 0
+
+    @staticmethod
+    def _to_slot_time(value):
+        """Normalise a schedule time to the HH:MM DEYE's TOU slots require.
+
+        The control entities carry HH:MM:SS because that is the format Predbat writes (see
+        INVERTER_DEF charge_time_format), but DEYE's timeUseSettingItems take HH:MM, so the
+        seconds are dropped here — at the one point a schedule time becomes a slot time.
+        """
+        text = str(value or "00:00")
+        parts = text.split(":")
+        if len(parts) < 2:
+            return "00:00"
+        try:
+            return f"{int(parts[0]):02d}:{int(parts[1]):02d}"
+        except ValueError:
+            return "00:00"
 
     @staticmethod
     def _hm_to_minutes(hm):
@@ -825,8 +844,13 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         )
         for direction in ("charge", "export"):
             window = local.get(direction, {})
-            self.dashboard_item(self._control_name("select", sn, f"battery_schedule_{direction}_start_time"), state=window.get("start", "00:00"), attributes={"friendly_name": f"DEYE {sn} {direction.title()} Start", "icon": "mdi:clock-outline"}, app="deye")
-            self.dashboard_item(self._control_name("select", sn, f"battery_schedule_{direction}_end_time"), state=window.get("end", "00:00"), attributes={"friendly_name": f"DEYE {sn} {direction.title()} End", "icon": "mdi:clock-outline"}, app="deye")
+            # HH:MM:SS to match INVERTER_DEF charge_time_format. Any other value makes
+            # Predbat replace these entities with its own dummies (inverter.py, the
+            # inv_charge_time_format != "HH:MM:SS" branch) and the window never arrives.
+            self.dashboard_item(
+                self._control_name("select", sn, f"battery_schedule_{direction}_start_time"), state=window.get("start", "00:00:00"), attributes={"friendly_name": f"DEYE {sn} {direction.title()} Start", "icon": "mdi:clock-outline"}, app="deye"
+            )
+            self.dashboard_item(self._control_name("select", sn, f"battery_schedule_{direction}_end_time"), state=window.get("end", "00:00:00"), attributes={"friendly_name": f"DEYE {sn} {direction.title()} End", "icon": "mdi:clock-outline"}, app="deye")
             self.dashboard_item(
                 self._control_name("number", sn, f"battery_schedule_{direction}_soc"),
                 state=int(window.get("soc", 0)),
@@ -856,8 +880,8 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         for direction in ("charge", "export"):
             schedule[direction] = {
                 "enable": self.get_state_wrapper(self._control_name("switch", sn, f"battery_schedule_{direction}_enable"), default="off") == "on",
-                "start": self.get_state_wrapper(self._control_name("select", sn, f"battery_schedule_{direction}_start_time"), default="00:00"),
-                "end": self.get_state_wrapper(self._control_name("select", sn, f"battery_schedule_{direction}_end_time"), default="00:00"),
+                "start": self.get_state_wrapper(self._control_name("select", sn, f"battery_schedule_{direction}_start_time"), default="00:00:00"),
+                "end": self.get_state_wrapper(self._control_name("select", sn, f"battery_schedule_{direction}_end_time"), default="00:00:00"),
                 "soc": int(self._as_float(self.get_state_wrapper(self._control_name("number", sn, f"battery_schedule_{direction}_soc"), default=0), 0)),
                 "power": int(self._as_float(self.get_state_wrapper(self._control_name("number", sn, f"battery_schedule_{direction}_power"), default=0), 0)),
             }

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -890,8 +890,17 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         self.control_active.add(sn)  # Predbat is now actively controlling this inverter
         return await self.apply_dynamic_control(sn, schedule, current_soc, force=True)
 
-    async def apply_schedule(self, sn, force=True):
-        """Recompute the schedule from HA control entities and push it for one inverter."""
+    async def apply_schedule(self, sn, force=False):
+        """Recompute the schedule from HA control entities and push it for one inverter.
+
+        Not forced by default. Predbat presses the write button on every cycle as its normal
+        "apply the schedule" action, so forcing here re-sent a byte-identical payload every
+        few minutes — 36 orders in two hours on a live site with nothing actually changing.
+        The applied-payload cache is the single source of truth for whether a write is
+        needed; when it must be distrusted (an order left unconfirmed after
+        DEYE_ORDER_MAX_POLLS) that path already pops the entry, which makes the next apply
+        write naturally.
+        """
         schedule = await self.get_schedule_settings_ha(sn)
         current_soc = self.device_values.get(sn, {}).get("soc", schedule.get("reserve", 0))
         self.control_active.add(sn)  # Predbat is now actively controlling this inverter
@@ -978,7 +987,9 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             # A momentary button, not schedule state: it has nothing to store, and must not
             # fall through to update_local_schedule where "_charge_" would match a direction.
             if service in ("turn_on", "on", "toggle"):
-                await self.apply_schedule(sn, force=True)
+                # Unforced: change detection decides. Predbat presses this every cycle, so
+                # forcing would re-send an unchanged payload each time.
+                await self.apply_schedule(sn)
             return
         await self._handle_control_event(entity_id, service)
 

--- a/apps/predbat/tests/test_deye_config.py
+++ b/apps/predbat/tests/test_deye_config.py
@@ -24,6 +24,14 @@ def test_deyecloud_inverter_def():
             "support_charge_freeze": True,
             "support_discharge_freeze": True,
             "target_soc_used_for_discharge": True,
+            # Load-bearing, not cosmetic. inverter.py replaces charge/discharge
+            # start/end_time with its own dummy sensor.predbat_<type>_<id>_* entities for
+            # ANY format other than "HH:MM:SS", discarding whatever automatic_config
+            # mapped. DEYE was the only inverter declaring "HH:MM", a value handled
+            # nowhere else in inverter.py, so Predbat wrote the window times to dummies
+            # while this component read its own untouched selects — every control payload
+            # went out with no charge or export window at all.
+            "charge_time_format": "HH:MM:SS",
         }
         for k, v in expect.items():
             if d.get(k) != v:

--- a/apps/predbat/tests/test_deye_control.py
+++ b/apps/predbat/tests/test_deye_control.py
@@ -9,7 +9,7 @@
 """Tests for the DEYE behaviour to work-mode derivation (``derive_control_state``)."""
 
 from unittest.mock import patch
-from deye_const import DEYE_WORKMODE, FREEZE_EXPORT_SOC, TOU_FIELD, TOU_SLOT_COUNT, DEYE_ORDER_MAX_POLLS
+from deye_const import DEYE_WORKMODE, FREEZE_EXPORT_SOC, TOU_FIELD, TOU_SLOT_COUNT, TOU_FILLER_TIMES, DEYE_ORDER_MAX_POLLS
 from tests.test_deye_api import MockDeye
 from tests.test_infra import run_async as run_async_local
 
@@ -351,6 +351,60 @@ def test_run_clears_pending_order_and_count_on_success():
     assert not failed, "test_run_clears_pending_order_and_count_on_success"
 
 
+def test_window_times_reach_the_slots_in_deye_format():
+    """A HH:MM:SS window becomes HH:MM slot times and actually produces a window.
+
+    Live regression: every control payload for two hours carried only the filler times
+    (00:00/04:00/08:00/12:00/16:00/20:00) with grid charge off everywhere — the signature of
+    build_tou_slots seeing no window at all — because Predbat was writing the window times
+    to dummy entities this component never reads.
+    """
+    failed = False
+    d = MockDeye()
+    sched = {
+        "reserve": 14,
+        "charge": {"enable": True, "soc": 95, "power": 3000, "start": "05:00:00", "end": "05:30:00"},
+        "export": {"enable": False, "soc": 0, "power": 0},
+    }
+    slots = d.build_tou_slots(sched, current_soc=40)
+    times = [s[TOU_FIELD["time"]] for s in slots]
+
+    if any(len(t) != 5 or t.count(":") != 1 for t in times):
+        print(f"ERROR: DEYE slot times must be HH:MM, got {times}")
+        failed = True
+    if "05:00" not in times:
+        print(f"ERROR: the charge window start never reached the slots: {times}")
+        failed = True
+    if not any(s[TOU_FIELD["grid_charge"]] and s[TOU_FIELD["soc"]] == 95 for s in slots):
+        print(f"ERROR: no grid-charge slot was produced for the window: {slots}")
+        failed = True
+    # The all-filler payload is exactly what the bug produced, so assert we are not back there
+    if times == TOU_FILLER_TIMES[:TOU_SLOT_COUNT]:
+        print(f"ERROR: slots are pure filler, the window was lost: {times}")
+        failed = True
+
+    # A HH:MM window still works, so a stale entity value cannot break the payload
+    sched["charge"]["start"] = "05:00"
+    sched["charge"]["end"] = "05:30"
+    if "05:00" not in [s[TOU_FIELD["time"]] for s in d.build_tou_slots(sched, current_soc=40)]:
+        print("ERROR: a HH:MM window should still resolve")
+        failed = True
+    assert not failed, "test_window_times_reach_the_slots_in_deye_format"
+
+
+def test_to_slot_time_normalisation():
+    """Schedule times are reduced to the HH:MM DEYE requires, tolerating bad input."""
+    failed = False
+    d = MockDeye()
+    cases = [("05:00:00", "05:00"), ("05:30", "05:30"), ("5:3", "05:03"), ("23:59:59", "23:59"), ("", "00:00"), (None, "00:00"), ("garbage", "00:00"), ("12", "00:00")]
+    for value, want in cases:
+        got = d._to_slot_time(value)
+        if got != want:
+            print(f"ERROR: _to_slot_time({value!r}) expected {want!r}, got {got!r}")
+            failed = True
+    assert not failed, "test_to_slot_time_normalisation"
+
+
 def test_repeated_write_button_presses_do_not_resend_an_unchanged_payload():
     """Predbat presses the write button every cycle, so it must not force a write.
 
@@ -616,6 +670,8 @@ def run_deye_control_tests(my_predbat):
         ("poll_order_empty_pending", test_poll_order_empty_response_stays_pending),
         ("run_forces_rewrite_after_max_polls", test_run_forces_rewrite_after_max_unconfirmed_polls),
         ("run_clears_on_success", test_run_clears_pending_order_and_count_on_success),
+        ("window_times_reach_slots", test_window_times_reach_the_slots_in_deye_format),
+        ("to_slot_time", test_to_slot_time_normalisation),
         ("write_button_no_resend", test_repeated_write_button_presses_do_not_resend_an_unchanged_payload),
         ("write_button_writes_on_change", test_write_button_still_writes_when_the_schedule_changes),
         ("slot_soc_floor", test_slot_soc_never_goes_below_the_inverter_floor),

--- a/apps/predbat/tests/test_deye_control.py
+++ b/apps/predbat/tests/test_deye_control.py
@@ -351,6 +351,79 @@ def test_run_clears_pending_order_and_count_on_success():
     assert not failed, "test_run_clears_pending_order_and_count_on_success"
 
 
+def test_repeated_write_button_presses_do_not_resend_an_unchanged_payload():
+    """Predbat presses the write button every cycle, so it must not force a write.
+
+    Live regression: 40 button presses produced 36 byte-identical control orders across two
+    hours with nothing changing, because apply_schedule defaulted to force=True and bypassed
+    the applied-payload cache. Over the same period _reconcile_control, which is unforced,
+    correctly suppressed 119 writes — so the cache was working; only the button ignored it.
+    """
+    failed = False
+    d = MockDeye()
+    d.device_list = ["INV1"]
+    d.device_values = {"INV1": {"soc": 99.0}}
+    d.local_schedule["INV1"] = {"reserve": 14, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000, "start": "16:00", "end": "23:30"}}
+    posts = []
+
+    async def fake_post(endpoint_key, body):
+        """Record every control POST that reaches the API."""
+        posts.append(endpoint_key)
+        return {"success": True, "orderId": len(posts)}
+
+    async def fake_read(sn):
+        """Return the unchanging schedule, as the HA entities would."""
+        return d.local_schedule["INV1"]
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        with patch.object(d, "get_schedule_settings_ha", side_effect=fake_read):
+            for _ in range(5):
+                # Clear the order the previous press raised, as poll_order does on success,
+                # so the in-flight guard is not what suppresses the repeats.
+                d.pending_orders.pop("INV1", None)
+                run_async_local(d.switch_event("switch.predbat_deye_inv1_battery_schedule_charge_write", "turn_on"))
+
+    if len(posts) != 1:
+        print(f"ERROR: an unchanged schedule should be written once, got {len(posts)} writes")
+        failed = True
+    if not any("control unchanged" in m for m in d.log_messages):
+        print(f"ERROR: expected the repeats to be suppressed as unchanged: {d.log_messages}")
+        failed = True
+    assert not failed, "test_repeated_write_button_presses_do_not_resend_an_unchanged_payload"
+
+
+def test_write_button_still_writes_when_the_schedule_changes():
+    """Suppression must not swallow a genuine change."""
+    failed = False
+    d = MockDeye()
+    d.device_list = ["INV1"]
+    d.device_values = {"INV1": {"soc": 50.0}}
+    d.local_schedule["INV1"] = {"reserve": 14, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    posts = []
+
+    async def fake_post(endpoint_key, body):
+        """Record every control POST that reaches the API."""
+        posts.append(body)
+        return {"success": True, "orderId": len(posts)}
+
+    async def fake_read(sn):
+        """Return the current schedule, as the HA entities would."""
+        return d.local_schedule["INV1"]
+
+    with patch.object(d, "_post", side_effect=fake_post):
+        with patch.object(d, "get_schedule_settings_ha", side_effect=fake_read):
+            run_async_local(d.switch_event("switch.predbat_deye_inv1_battery_schedule_charge_write", "turn_on"))
+            d.pending_orders.pop("INV1", None)
+            # A real change: a charge window opens
+            d.local_schedule["INV1"]["charge"] = {"enable": True, "soc": 90, "power": 3000, "start": "01:00", "end": "05:00"}
+            run_async_local(d.switch_event("switch.predbat_deye_inv1_battery_schedule_charge_write", "turn_on"))
+
+    if len(posts) != 2:
+        print(f"ERROR: a changed schedule must be written, got {len(posts)} writes")
+        failed = True
+    assert not failed, "test_write_button_still_writes_when_the_schedule_changes"
+
+
 def test_slot_soc_never_goes_below_the_inverter_floor():
     """Slot SOC is clamped to config/battery battLowCapacity, whatever the schedule says.
 
@@ -543,6 +616,8 @@ def run_deye_control_tests(my_predbat):
         ("poll_order_empty_pending", test_poll_order_empty_response_stays_pending),
         ("run_forces_rewrite_after_max_polls", test_run_forces_rewrite_after_max_unconfirmed_polls),
         ("run_clears_on_success", test_run_clears_pending_order_and_count_on_success),
+        ("write_button_no_resend", test_repeated_write_button_presses_do_not_resend_an_unchanged_payload),
+        ("write_button_writes_on_change", test_write_button_still_writes_when_the_schedule_changes),
         ("slot_soc_floor", test_slot_soc_never_goes_below_the_inverter_floor),
         ("battery_reserve_min", test_battery_reserve_min_reads_the_configured_floor),
         ("control_deferred_in_flight", test_control_write_deferred_while_an_order_is_in_flight),

--- a/apps/predbat/tests/test_deye_publish.py
+++ b/apps/predbat/tests/test_deye_publish.py
@@ -489,8 +489,10 @@ def test_write_button_applies_and_is_not_stored_as_schedule():
 
     with patch.object(d, "apply_schedule", side_effect=fake_apply):
         ti.run_async(d.switch_event("switch.predbat_deye_inv1_battery_schedule_charge_write", "turn_on"))
-    if applied != [("INV1", True)]:
-        print(f"ERROR: expected a forced apply, got {applied}")
+    # Unforced: Predbat presses this every cycle, so forcing would re-send an unchanged
+    # payload each time. Change detection decides whether a write is actually needed.
+    if applied != [("INV1", False)]:
+        print(f"ERROR: expected an unforced apply, got {applied}")
         failed = True
     if d.local_schedule.get("INV1", {}).get("charge", {}):
         print(f"ERROR: the write button must not be stored as schedule state: {d.local_schedule}")


### PR DESCRIPTION
Two control bugs found from live logs. The second is the serious one: **the charge and export windows have never reached the inverter.**

## 1. Window times went to dummy entities, so no window was ever sent

`DeyeCloud` declared `charge_time_format: "HH:MM"`. `inverter.py` replaces `charge`/`discharge` `start_time` and `end_time` with its own dummy `sensor.predbat_<type>_<id>_*` entities for **any** format other than `"HH:MM:SS"`, discarding whatever `automatic_config` mapped:

```python
if self.inv_charge_time_format != "HH:MM:SS":
    for x in ["charge", "discharge"]:
        for y in ["start", "end"]:
            self.base.args[f"{x}_{y}_time"][id] = self.create_entity(...)
```

So Predbat wrote the window times to dummy entities while this component kept reading its own selects, which nothing ever wrote. This is visible in the config UI, where the time args point at `sensor.predbat_DeyeCloud_0_charge_start_time` while every other arg points at a real `predbat_deye_<serial>_*` entity.

The consequence, from a two-hour live log — **every** control payload:

```
times     = ('00:00', '04:00', '08:00', '12:00', '16:00', '20:00')
gridCharge= (False, False, False, False, False, False)
workMode  = ZERO_EXPORT_TO_LOAD   gridAction = off   sellAction = off
```

Those are exactly `TOU_FILLER_TIMES` — `build_tou_slots` padding with no charge and no export window at all — while Predbat reported "Freeze exporting" for the entire period. Reserve, charge limit and the enable switches *were* mapped correctly, which is why the component looked healthy.

DEYE was the only inverter in `INVERTER_DEF` declaring `"HH:MM"`, a value handled nowhere else in `inverter.py`: it appears in neither `is_hm_format` nor any of the `H M` / `H:M-H:M` / `S` branches. Its only effect was tripping that dummy-creation test.

**Fix:** the entities now carry `HH:MM:SS` to match the declared format, and `_to_slot_time()` drops the seconds at the single point a schedule time becomes a DEYE slot time (`timeUseSettingItems` take `HH:MM`). `HH:MM` input still resolves, so a stale entity value cannot break the payload. `_hm_to_minutes` already ignored trailing seconds, so window matching needed no change.

The `INVERTER_DEF` value is now pinned by `test_deyecloud_inverter_def` with the reason recorded, because getting it wrong is silent — everything still runs, it just never controls anything.

## 2. The write button re-sent an unchanged payload every cycle

`switch_event` called `apply_schedule(sn, force=True)`, and `force` bypasses the applied-payload change detection. Predbat presses that button on **every cycle** as its normal apply action, so the bypass fired every time: 40 presses produced 36 byte-identical orders over two hours (every consecutive pair diffed to zero changed keys), plus 4 deferred by the in-flight guard.

The cache was working — `_reconcile_control`, which is unforced, correctly suppressed 119 writes over the same period. Only the button ignored it.

`apply_schedule` now defaults to unforced. Nothing loses the ability to re-assert: when the cache must be distrusted (an order unconfirmed after `DEYE_ORDER_MAX_POLLS`) that path already pops the entry, which makes the next apply write naturally.

## Testing

Four new tests. A `HH:MM:SS` window produces `HH:MM` slot times, actually yields a grid-charge slot, and explicitly asserts the payload is **not** all-filler — the exact signature of the live bug. `_to_slot_time` normalisation including malformed input. Five presses of an unchanged schedule produce one write, with the in-flight guard cleared between presses so suppression is proven to come from change detection. A genuine change still writes.

Both fixes verified against the pre-fix code: reverting the format gives `DeyeCloud[charge_time_format] expected HH:MM:SS got HH:MM`; restoring `force=True` gives `an unchanged schedule should be written once, got 5 writes`.

Full quick suite passes; `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
