### PR TITLE
refactor(mock): consolidate eleven per-module MockBase classes into a shared base

### DIFF
--- a/apps/predbat/axle.py
+++ b/apps/predbat/axle.py
@@ -25,6 +25,7 @@ import asyncio
 import json
 import aiohttp
 from component_base import ComponentBase
+from mock_base import MockBase as SharedMockBase
 from predbat_metrics import record_api_call
 from utils import str2time, minutes_to_time, TIME_FORMAT
 
@@ -706,60 +707,12 @@ def fetch_axle_active(base):
     return str(state).lower() == "on"
 
 
-class MockBase:  # pragma: no cover
-    """Mock base class for testing the Axle API from the command line."""
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the Axle command-line harness, with its own cache directory."""
 
     def __init__(self):
-        """Initialise a minimal mock of the PredBat base object."""
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.now_utc_exact = self.now_utc
-        self.prefix = "predbat"
-        self.args = {}
-        self.midnight_utc = datetime.now(self.local_tz).replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.entities = {}
-        self.config_root = "./temp_axle"
-        self.plan_interval_minutes = 30
-        self.fatal_error = False
-        self.had_errors = False
-        self.components = None
-
-    def get_state_wrapper(self, entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False):
-        """Return stored state or attribute for an entity."""
-        entity = self.entities.get(entity_id, {})
-        if raw:
-            return entity
-        if attribute is not None:
-            return entity.get("attributes", {}).get(attribute, default)
-        return entity.get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, required_unit=None):
-        """Store state and attributes for an entity."""
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        """Print a timestamped log message."""
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        """Print and store a dashboard item."""
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            print(f"  Attributes: {json.dumps(attributes, indent=2, default=str)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, key, default=None, indirect=True, attribute=None, combine=False, index=None, domain=None, can_override=False, required_unit=None):
-        """Return the default value for any requested argument."""
-        return default
-
-    def set_arg(self, key, value):
-        """Print a set argument request."""
-        print(f"Set arg {key} = {value}")
-
-    def call_notify(self, message):
-        """Print a notification message."""
-        print(f"NOTIFY: {message}")
+        """Initialise the shared mock with the Axle cache root."""
+        super().__init__(config_root="./temp_axle")
 
 
 async def test_axle_api(api_key, pence_per_kwh):  # pragma: no cover

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -23,8 +23,8 @@ import aiohttp
 import argparse
 import json
 import os
-from datetime import datetime
 from component_base import ComponentBase
+from mock_base import MockBase
 from oauth_mixin import OAuthMixin
 from deye_const import (
     DEYE_BASE_URLS,
@@ -1361,57 +1361,6 @@ class DeyeAPI(ComponentBase, OAuthMixin):
     async def final(self):
         """Cleanup on shutdown."""
         self.log("Info: DeyeAPI shutdown")
-
-
-class MockBase:  # pragma: no cover
-    """Mock base object so DeyeAPI can be exercised from the command line."""
-
-    def __init__(self):
-        """Set up the minimal base surface DeyeAPI reads (tz, prefix, args, time, entities)."""
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.prefix = "predbat"
-        self.args = {}
-        self.midnight_utc = datetime.now(self.local_tz).replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.entities = {}
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        """Return a previously published entity state (or default)."""
-        if raw:
-            return self.entities.get(entity_id, {})
-        return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        """Record an entity state locally."""
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        """Print a timestamped log line."""
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        """Print and record a published dashboard entity."""
-        print(f"ENTITY: {entity_id} = {state}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
-        """Return the caller's default (no configured args in CLI mode)."""
-        return default
-
-    def set_arg(self, key, value):
-        state = None
-        if isinstance(value, str) and "." in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and "." in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
 
 
 def _build_deye(mock_base, args):  # pragma: no cover

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -26,6 +26,7 @@ import uuid
 import aiohttp
 
 from component_base import ComponentBase
+from mock_base import MockBase
 from predbat_metrics import record_api_call
 
 # Defined locally (not imported from utils) - every cloud component defines its own
@@ -1465,71 +1466,6 @@ class EnphaseAPI(ComponentBase):
 
         self.failures_total += 1
         return None
-
-
-class MockBase:  # pragma: no cover
-    """Minimal stand-in for the Predbat base object so EnphaseAPI can run standalone.
-
-    Provides just the attributes and methods ComponentBase and EnphaseAPI read
-    from ``self.base`` (prefix, args, timezone/clock, state/arg accessors and a
-    logger). It deliberately has no ``components`` attribute, so ``self.storage``
-    resolves to None and the disk cache is skipped for a standalone run.
-    """
-
-    def __init__(self):
-        """Initialise the mock base with the current clock and empty state stores."""
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.prefix = "predbat"
-        self.args = {}
-        self.midnight_utc = self.now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.fatal_error = False
-        self.had_errors = False
-        self.entities = {}
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        """Return the stored state (or full record when raw) for an entity id."""
-        if raw:
-            return self.entities.get(entity_id, {})
-        else:
-            return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        """Store an entity's state and attributes in memory."""
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        """Print a timestamped log line to stdout."""
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        """Print and store a published entity, so a standalone run shows what it publishes."""
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            if "options" in attributes:
-                attributes["options"] = "..."
-            print(f"  Attributes: {json.dumps(attributes, indent=2)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
-        """Return the default for any requested arg (no real config in standalone mode)."""
-        return default
-
-    def set_arg(self, key, value):
-        """Print an arg that automatic_config would set, resolving any referenced entity state."""
-        state = None
-        if isinstance(value, str) and "." in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and "." in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
 
 
 async def test_enphase_api(username, password, site_id):  # pragma: no cover

--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -25,6 +25,7 @@ import json
 import argparse
 import random
 from component_base import ComponentBase
+from mock_base import MockBase
 from oauth_mixin import OAuthMixin
 
 # Define TIME_FORMAT_HA locally to avoid dependency issues
@@ -2244,56 +2245,6 @@ class FoxAPI(ComponentBase, OAuthMixin):
 
         if len(batteries):
             self.set_arg("battery_temperature_history", f"sensor.{self.prefix}_fox_{batteries[0]}_battemperature")
-
-
-class MockBase:  # pragma: no cover
-    """Mock base class for testing"""
-
-    def __init__(self):
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.prefix = "predbat"
-        self.args = {}
-        self.midnight_utc = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.entities = {}
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        if raw:
-            return self.entities.get(entity_id, {})
-        else:
-            return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            if "options" in attributes:
-                attributes["options"] = "..."
-            print(f"  Attributes: {json.dumps(attributes, indent=2)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, key, default=None):
-        return default
-
-    def set_arg(self, key, value):
-        state = None
-        if isinstance(value, str) and "." in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and "." in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
 
 
 async def test_write_schedule(sn, api_key, token_hash, token_expires, supabase_url, supabase_key, user_id):  # pragma: no cover

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import random
 from component_base import ComponentBase
+from mock_base import MockBase as SharedMockBase
 
 """
 GE Cloud data download
@@ -1959,57 +1960,13 @@ class MockHAInterface:  # pragma: no cover
         print(f"Set state external {entity_id} = {state}")
 
 
-class MockBase:  # pragma: no cover
-    """Mock base class for testing"""
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the GE Cloud command-line harness, with its own cache root and HA interface."""
 
     def __init__(self):
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.prefix = "predbat"
-        self.args = {}
-        self.midnight_utc = datetime.now(self.local_tz).replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.entities = {}
-        self.config_root = "./temp_gecloud"
-        self.plan_interval_minutes = 30
+        """Initialise the shared mock with the GE Cloud cache root and a mock HA interface."""
+        super().__init__(config_root="./temp_gecloud")
         self.ha_interface = MockHAInterface()
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        if raw:
-            return self.entities.get(entity_id, {})
-        else:
-            return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            if "options" in attributes:
-                attributes["options"] = "..."
-            print(f"  Attributes: {json.dumps(attributes, indent=2)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
-        return default
-
-    def set_arg(self, key, value):
-        state = None
-        if isinstance(value, str) and "." in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and "." in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
 
 
 async def test_gecloud_direct(api_key, write_entity=None, write_value=None):  # pragma: no cover

--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -16,10 +16,10 @@ GraphQL schema notes (validated against live EDF/E.ON APIs):
 import aiohttp
 import asyncio
 import types as _types
-import json
 from datetime import datetime, timedelta, timezone
 
 from component_base import ComponentBase
+from mock_base import MockBase as KrakenMockBase
 
 # Auth strategy selection — OAuthMixin for SaaS OAuth, KrakenAuthMixin for local auth.
 # Both may ship in the same release package.  _KrakenAuthMixin is stored at module level
@@ -1399,64 +1399,6 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
             return False
 
         return True
-
-
-class KrakenMockBase:  # pragma: no cover
-    """Minimal mock base object so KrakenAPI can be driven from the command line.
-
-    Mirrors the MockBase used by fox.py — provides just enough of the Predbat base
-    interface (logging, args, dashboard publishing) for a standalone KrakenAPI run.
-    """
-
-    def __init__(self, user_id=None):
-        """Initialise the mock base, optionally seeding a Supabase user_id for OAuth."""
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.prefix = "predbat"
-        self.args = {}
-        if user_id:
-            self.args["user_id"] = user_id
-        self.midnight_utc = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.entities = {}
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        if raw:
-            return self.entities.get(entity_id, {})
-        else:
-            return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            print_attrs = dict(attributes)
-            if "options" in print_attrs:
-                print_attrs["options"] = "..."
-            print(f"  Attributes: {json.dumps(print_attrs, indent=2)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
-        return default
-
-    def set_arg(self, key, value):
-        state = None
-        if isinstance(value, str) and "." in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and "." in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
 
 
 async def test_kraken_api(

--- a/apps/predbat/mock_base.py
+++ b/apps/predbat/mock_base.py
@@ -1,0 +1,125 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""Shared mock base object for standalone command-line runs of components.
+
+Most component modules (fox, solis, octopus, teslemetry, ...) can be executed directly
+from the command line to exercise their API against a live vendor endpoint. Those
+harnesses need an object to pass as the ``base`` argument of ComponentBase. MockBase
+provides the minimal PredBat base surface that ComponentBase and the components read:
+a clock, an in-memory entity store, argument accessors and a logger.
+
+It is deliberately concrete rather than abstract - modules instantiate it directly, and
+the few needing extra state subclass it. ``components`` is always None, so
+``ComponentBase.storage`` resolves to None and the disk cache is skipped for a
+standalone run.
+"""
+
+from datetime import datetime
+import json
+
+
+class MockBase:
+    """Minimal stand-in for the PredBat base object, used by the standalone CLI harnesses."""
+
+    def __init__(self, config_root="./temp_predbat", local_tz=None, **kwargs):
+        """Initialise the mock with a clock, empty entity/arg stores and the full base attribute superset.
+
+        Surplus keyword arguments are stored into self.args, with None values skipped so an
+        unset optional argument stays absent rather than shadowing a caller's default.
+        """
+        self.local_tz = local_tz if local_tz is not None else datetime.now().astimezone().tzinfo
+        self.now_utc = datetime.now(self.local_tz)
+        self.now_utc_exact = self.now_utc
+        self.midnight_utc = self.now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
+        self.prefix = "predbat"
+        self.entities = {}
+        self.config_root = config_root
+        self.plan_interval_minutes = 30
+        self.fatal_error = False
+        self.had_errors = False
+        self.components = None
+        self.num_cars = 0
+        self.currency_symbols = "£p"
+        self.arg_errors = {}
+        self.args = {key: value for key, value in kwargs.items() if value is not None}
+
+    def log(self, message):
+        """Print a timestamped log line."""
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
+
+    def get_state_wrapper(self, entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False):
+        """Return a stored entity state, one of its attributes, or the whole record when raw is set."""
+        entity = self.entities.get(entity_id, {})
+        if raw:
+            return entity
+        if attribute is not None:
+            return entity.get("attributes", {}).get(attribute, default)
+        return entity.get("state", default)
+
+    def set_state_wrapper(self, entity_id, state, attributes=None, app=None, required_unit=None):
+        """Store an entity's state and attributes in memory.
+
+        Accepts both app and required_unit because the component modules disagree on which
+        one they pass, and ComponentBase.set_state_wrapper forwards required_unit.
+        """
+        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
+
+    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
+        """Print a published entity and store it.
+
+        The options list is elided in a copy of the attributes, so the caller's dict - which
+        is then stored verbatim - is never mutated.
+        """
+        print(f"ENTITY: {entity_id} = {state}")
+        if attributes:
+            print_attrs = dict(attributes)
+            if "options" in print_attrs:
+                print_attrs["options"] = "..."
+            print(f"  Attributes: {json.dumps(print_attrs, indent=2, default=str)}")
+        self.set_state_wrapper(entity_id, state, attributes)
+
+    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
+        """Return a configured argument, falling back to the caller's default."""
+        return self.args.get(arg, default)
+
+    def set_arg(self, key, value):
+        """Record an argument set by automatic_config, printing it with any referenced entity's state."""
+        self.args[key] = value
+        if isinstance(value, str) and "." in value:
+            state = self.get_state_wrapper(value, default=None)
+        elif isinstance(value, list):
+            state = "n/a []"
+            for item in value:
+                if isinstance(item, str) and "." in item:
+                    state = self.get_state_wrapper(item, default=None)
+                    break
+        else:
+            state = "n/a"
+        print(f"Set arg {key} = {value} (state={state})")
+
+    def get_ha_config(self, name, default):
+        """Return the caller's default - a standalone run has no Home Assistant config."""
+        return default
+
+    def get_history_wrapper(self, entity_id, days=30, required=True, tracked=True):
+        """Return None - a standalone run has no Home Assistant recorder, matching PredBat's no-interface path."""
+        return None
+
+    def call_notify(self, message):
+        """Print a notification message."""
+        print(f"NOTIFY: {message}")
+
+    def record_status(self, message, debug="", had_errors=False, notify=False, extra=""):
+        """Print a status record and track the error flag."""
+        print(f"STATUS: {message}" + (f" ({debug})" if debug else ""))
+        if had_errors:
+            self.had_errors = True

--- a/apps/predbat/mock_base.py
+++ b/apps/predbat/mock_base.py
@@ -52,8 +52,12 @@ class MockBase:
         self.arg_errors = {}
         self.args = {key: value for key, value in kwargs.items() if value is not None}
 
-    def log(self, message):
-        """Print a timestamped log line."""
+    def log(self, message, quiet=True):
+        """Print a timestamped log line.
+
+        Accepts the real Hass.log's quiet keyword for signature compatibility with callers
+        that pass it; the mock always prints regardless of its value.
+        """
         print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
 
     def get_state_wrapper(self, entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False):
@@ -92,8 +96,16 @@ class MockBase:
         return self.args.get(arg, default)
 
     def set_arg(self, key, value):
-        """Record an argument set by automatic_config, printing it with any referenced entity's state."""
-        self.args[key] = value
+        """Record an argument set by automatic_config, printing it with any referenced entity's state.
+
+        Matches userinterface.py's Fetch.set_arg: a None value deletes the key rather than
+        storing it, so a later get_arg(key, default) falls back to the caller's default
+        instead of returning None.
+        """
+        if value is None:
+            self.args.pop(key, None)
+        else:
+            self.args[key] = value
         if isinstance(value, str) and "." in value:
             state = self.get_state_wrapper(value, default=None)
         elif isinstance(value, list):

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -21,6 +21,7 @@ from predbat_metrics import record_api_call
 from const import TIME_FORMAT, TIME_FORMAT_OCTOPUS
 from utils import str2time, minutes_to_time, dp1, dp2, dp4, minute_data
 from component_base import ComponentBase
+from mock_base import MockBase as SharedMockBase
 import aiohttp
 import hashlib
 import json
@@ -3001,57 +3002,12 @@ class Octopus:
         return octopus_free_slots, octopus_saving_slots
 
 
-class MockBase:  # pragma: no cover
-    """Mock base class for testing"""
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the Octopus command-line harness, with its own cache directory."""
 
     def __init__(self):
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.now_utc_exact = self.now_utc
-        self.prefix = "predbat"
-        self.args = {}
-        self.midnight_utc = datetime.now(self.local_tz).replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.entities = {}
-        self.config_root = "./temp_octopus"
-        self.plan_interval_minutes = 30
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        if raw:
-            return self.entities.get(entity_id, {})
-        else:
-            return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            if "options" in attributes:
-                attributes["options"] = "..."
-            print(f"  Attributes: {json.dumps(attributes, indent=2)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, key, default=None, indirect=True, attribute=None, combine=False, index=None, domain=None, can_override=False, required_unit=None):
-        return default
-
-    def set_arg(self, key, value):
-        state = None
-        if isinstance(value, str) and "." in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and "." in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
+        """Initialise the shared mock with the Octopus cache root."""
+        super().__init__(config_root="./temp_octopus")
 
 
 async def test_fetch_tariffs(product_code, tariff_code):  # pragma: no cover

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -83,6 +83,7 @@ except ImportError:
 
 from datetime import datetime, timedelta
 from component_base import ComponentBase
+from mock_base import MockBase as SharedMockBase
 from predbat_metrics import record_api_call
 
 
@@ -2497,52 +2498,13 @@ class SigenergyAPI(ComponentBase):
         self.log("SigenergyAPI: final() complete")
 
 
-class MockBase:  # pragma: no cover
-    """Mock base class for standalone testing."""
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the Sigenergy command-line harness, which can pre-seed read-only mode."""
 
     def __init__(self, readonly=False):
-        """Initialise mock base."""
-        self.prefix = "predbat"
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.args = {}
-        self.entities = {}
-        # Pre-populate the read-only switch so get_state_wrapper returns the right value
-        self.entities["switch.predbat_set_read_only"] = {"state": "on" if readonly else "off"}
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        """Return entity state or default."""
-        if raw:
-            return self.entities.get(entity_id, {})
-        return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        """Store entity state."""
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        """Print log message with timestamp."""
-        print("[{}] {}".format(datetime.now().strftime("%H:%M:%S"), message))
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        """Print and store a dashboard entity."""
-        import json
-        print("ENTITY: {} = {}".format(entity_id, state))
-        if attributes:
-            display = {k: ("..." if k == "options" else v) for k, v in attributes.items()}
-            print("  Attributes: {}".format(json.dumps(display, indent=2, default=str)))
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, arg, default=None, indirect=False, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
-        """Return arg default (mock always returns default)."""
-        return default
-
-    def set_arg(self, key, value):
-        """Print auto-config arg assignment."""
-        state = str(value)
-        print("Set arg {} = {}".format(key, state))
-
-    def update_success_timestamp(self):
-        """No-op success timestamp update."""
+        """Initialise the shared mock, seeding the read-only switch so control writes are gated."""
+        super().__init__()
+        self.entities["switch.predbat_set_read_only"] = {"state": "on" if readonly else "off", "attributes": {}}
 
 
 async def test_sigenergy_api(app_key, app_secret, base_url, system_id, test_mode, action=None, mqtt_host=None, ca_cert=None, client_cert=None, client_key=None, readonly=False):  # pragma: no cover

--- a/apps/predbat/solax.py
+++ b/apps/predbat/solax.py
@@ -23,6 +23,7 @@ import argparse
 import traceback
 from datetime import datetime, timezone, timedelta
 from component_base import ComponentBase
+from mock_base import MockBase as SharedMockBase
 
 SOLAX_TIMEOUT = 20
 SOLAX_RETRIES = 5
@@ -2842,54 +2843,12 @@ class SolaxAPI(ComponentBase):
         return True
 
 
-class MockBase:  # pragma: no cover
-    """Mock base class for standalone testing"""
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the Solax command-line harness, which works in UTC rather than local time."""
 
     def __init__(self):
-        self.prefix = "predbat"
-        self.local_tz = timezone.utc
-        self.args = {}
-        self.entities = {}
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        if raw:
-            return self.entities.get(entity_id, {})
-        else:
-            return self.entities.get(entity_id, {}).get('state', default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        self.entities[entity_id] = {
-            'state': state,
-            'attributes': attributes or {}
-        }
-
-    def log(self, message):
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            if 'options' in attributes:
-                attributes['options'] = '...'
-            print(f"  Attributes: {json.dumps(attributes, indent=2)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, key, default=None):
-        return default
-
-    def set_arg(self, key, value):
-        state = None
-        if isinstance(value, str) and '.' in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and '.' in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
+        """Initialise the shared mock pinned to UTC."""
+        super().__init__(local_tz=timezone.utc)
 
 
 async def run_test_command(solax, plant_id, command, duration, next_motion, target_soc, power):  # pragma: no cover

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -17,6 +17,7 @@ import copy
 from datetime import datetime, timedelta, UTC
 from predbat_metrics import record_api_call
 from component_base import ComponentBase
+from mock_base import MockBase
 from oauth_mixin import OAuthMixin
 
 
@@ -3026,57 +3027,6 @@ class SolisAPI(ComponentBase, OAuthMixin):
             await self.session.close()
             self.session = None
         self.log("Solis API: Component stopped")
-
-
-class MockBase:  # pragma: no cover
-    """Mock base class for testing"""
-
-    def __init__(self):
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.prefix = "predbat"
-        self.args = {}
-        self.midnight_utc = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.entities = {}
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        if raw:
-            return self.entities.get(entity_id, {})
-        else:
-            return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            if "options" in attributes:
-                attributes["options"] = "..."
-            print(f"  Attributes: {json.dumps(attributes, indent=2)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
-        return self.args.get(arg, default)
-
-    def set_arg(self, key, value):
-        self.args[key] = value
-        state = None
-        if isinstance(value, str) and "." in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and "." in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
 
 
 async def test_solis_api(key_id, secret):  # pragma: no cover

--- a/apps/predbat/teslemetry.py
+++ b/apps/predbat/teslemetry.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 import aiohttp
 
 from component_base import ComponentBase
+from mock_base import MockBase
 from oauth_mixin import OAuthMixin
 
 TESLEMETRY_DEFAULT_URL = "https://api.teslemetry.com"
@@ -1234,59 +1235,6 @@ class TeslemetryAPI(ComponentBase, OAuthMixin):
     async def final(self):
         """Cleanup on shutdown."""
         self.log("Info: TeslemetryAPI shutdown")
-
-
-class MockBase:  # pragma: no cover
-    """Mock base object for standalone Teslemetry testing (stands in for the PredBat instance)."""
-
-    def __init__(self):
-        """Initialise the mock base with a local-time clock and empty entity/arg stores."""
-        self.local_tz = datetime.now().astimezone().tzinfo
-        self.now_utc = datetime.now(self.local_tz)
-        self.prefix = "predbat"
-        self.args = {}
-        self.midnight_utc = datetime.now(self.local_tz).replace(hour=0, minute=0, second=0, microsecond=0)
-        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
-        self.entities = {}
-
-    def get_state_wrapper(self, entity_id, default=None, attribute=None, refresh=False, required_unit=None, raw=None):
-        if raw:
-            return self.entities.get(entity_id, {})
-        else:
-            return self.entities.get(entity_id, {}).get("state", default)
-
-    def set_state_wrapper(self, entity_id, state, attributes=None, app=None):
-        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
-
-    def log(self, message):
-        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
-
-    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
-        print(f"ENTITY: {entity_id} = {state}")
-        if attributes:
-            if "options" in attributes:
-                attributes["options"] = "..."
-            print(f"  Attributes: {json.dumps(attributes, indent=2)}")
-        self.set_state_wrapper(entity_id, state, attributes)
-
-    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
-        """Return a configured arg value, consulting self.args so set_read_only actually gates the emulator's control writes (the CLI harness relies on this to run read-only)."""
-        return self.args.get(arg, default)
-
-    def set_arg(self, key, value):
-        """Print an arg assignment made by automatic_config, showing the referenced entity's current state."""
-        state = None
-        if isinstance(value, str) and "." in value:
-            state = self.get_state_wrapper(value, default=None)
-        elif isinstance(value, list):
-            state = "n/a []"
-            for v in value:
-                if isinstance(v, str) and "." in v:
-                    state = self.get_state_wrapper(v, default=None)
-                    break
-        else:
-            state = "n/a"
-        print(f"Set arg {key} = {value} (state={state})")
 
 
 async def test_teslemetry_api(key, site_id=None, base_url=None, control=False):

--- a/apps/predbat/tests/test_mock_base.py
+++ b/apps/predbat/tests/test_mock_base.py
@@ -131,7 +131,7 @@ def test_mock_base_state_wrapper_paths(my_predbat):
     assert base.get_state_wrapper("sensor.predbat_test", attribute="unit_of_measurement") == "kWh", "attribute lookup failed"
     assert base.get_state_wrapper("sensor.predbat_test", raw=True)["state"] == "42", "raw lookup failed"
     assert base.get_state_wrapper("sensor.predbat_missing", default="none") == "none", "missing entity should return the default"
-    assert base.get_state_wrapper("sensor.predbat_test", attribute="absent", default="dflt") == "dflt", "missing attribute should return the default"
+    assert base.get_state_wrapper("sensor.predbat_test", attribute="absent", default="fallback") == "fallback", "missing attribute should return the default"
     print("PASS: MockBase get_state_wrapper handles raw/attribute/default paths")
     return False
 
@@ -161,7 +161,7 @@ def test_mock_base_record_status_tracks_errors(my_predbat):
 def test_mock_base_no_ha_helpers(my_predbat):
     """get_ha_config returns the caller's default and get_history_wrapper returns None, matching a no-HA run."""
     base = MockBase()
-    assert base.get_ha_config("anything", "dflt") == "dflt", "get_ha_config should return the default"
+    assert base.get_ha_config("anything", "fallback") == "fallback", "get_ha_config should return the default"
     assert base.get_history_wrapper("sensor.predbat_test") is None, "get_history_wrapper should return None with no HA interface"
     print("PASS: MockBase HA helpers degrade cleanly")
     return False

--- a/apps/predbat/tests/test_mock_base.py
+++ b/apps/predbat/tests/test_mock_base.py
@@ -1,0 +1,204 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Tests for the shared MockBase used by the standalone command-line harnesses.
+"""
+
+from datetime import datetime, timezone
+
+from mock_base import MockBase
+
+
+def test_mock_base_attribute_superset(my_predbat):
+    """Every attribute ComponentBase dereferences off self.base is present after construction."""
+    base = MockBase()
+    for name in (
+        "local_tz",
+        "now_utc",
+        "now_utc_exact",
+        "midnight_utc",
+        "minutes_now",
+        "prefix",
+        "args",
+        "entities",
+        "config_root",
+        "plan_interval_minutes",
+        "fatal_error",
+        "had_errors",
+        "components",
+        "num_cars",
+        "currency_symbols",
+        "arg_errors",
+    ):
+        assert hasattr(base, name), f"MockBase is missing attribute {name}"
+    assert base.prefix == "predbat", "prefix should default to predbat"
+    assert base.components is None, "components must be None so ComponentBase.storage resolves to None"
+    assert base.fatal_error is False, "fatal_error should start False"
+    assert base.had_errors is False, "had_errors should start False"
+    assert base.config_root == "./temp_predbat", "config_root should use the documented default"
+    print("PASS: MockBase exposes the full base attribute superset")
+    return False
+
+
+def test_mock_base_config_root_and_local_tz_overrides(my_predbat):
+    """config_root and local_tz are constructor-overridable, as the axle/gecloud/octopus/solax subclasses need."""
+    base = MockBase(config_root="./temp_example")
+    assert base.config_root == "./temp_example", "config_root override was ignored"
+    utc_base = MockBase(local_tz=timezone.utc)
+    assert utc_base.local_tz == timezone.utc, "local_tz override was ignored"
+    assert utc_base.now_utc.tzinfo == timezone.utc, "now_utc should use the supplied timezone"
+    print("PASS: MockBase honours config_root and local_tz overrides")
+    return False
+
+
+def test_mock_base_midnight_utc_is_aware(my_predbat):
+    """midnight_utc is timezone-aware so now_utc - midnight_utc does not raise (fox/kraken/solis had naive values)."""
+    base = MockBase()
+    assert base.midnight_utc.tzinfo is not None, "midnight_utc must be timezone-aware"
+    delta = base.now_utc - base.midnight_utc
+    assert delta.total_seconds() >= 0, "now_utc should not precede midnight"
+    assert base.midnight_utc.hour == 0, "midnight_utc should be at hour zero"
+    assert base.midnight_utc.minute == 0, "midnight_utc should be at minute zero"
+    print("PASS: MockBase midnight_utc is timezone-aware")
+    return False
+
+
+def test_mock_base_kwargs_populate_args(my_predbat):
+    """Surplus kwargs land in self.args, covering the KrakenMockBase(user_id=...) call site."""
+    base = MockBase(user_id="user-123")
+    assert base.args.get("user_id") == "user-123", "kwargs should be stored into args"
+    print("PASS: MockBase stores surplus kwargs into args")
+    return False
+
+
+def test_mock_base_none_kwargs_are_skipped(my_predbat):
+    """A None-valued kwarg is not stored, matching kraken's 'if user_id:' guard and oauth_mixin's args.get(key, '')."""
+    base = MockBase(user_id=None)
+    assert "user_id" not in base.args, "None-valued kwargs must not be stored"
+    assert base.args.get("user_id", "") == "", "absent user_id must fall back to the empty-string default"
+    falsy = MockBase(control_enable=False)
+    assert falsy.args.get("control_enable") is False, "a legitimate False value must still be stored"
+    print("PASS: MockBase skips None kwargs but keeps False")
+    return False
+
+
+def test_mock_base_arg_round_trip(my_predbat):
+    """set_arg persists into args and get_arg reads it back; unset keys return the caller's default."""
+    base = MockBase()
+    assert base.get_arg("missing_key", "fallback") == "fallback", "unset keys should return the default"
+    assert base.get_arg("set_read_only", False) is False, "unset boolean should return the supplied default"
+    base.set_arg("set_read_only", True)
+    assert base.get_arg("set_read_only", False) is True, "set_arg value should be readable via get_arg"
+    print("PASS: MockBase get_arg/set_arg round-trip")
+    return False
+
+
+def test_mock_base_dashboard_item_does_not_mutate_attributes(my_predbat):
+    """dashboard_item must not corrupt the caller's attributes dict when eliding the options list."""
+    base = MockBase()
+    attributes = {"options": ["a", "b", "c"], "friendly_name": "Test"}
+    base.dashboard_item("select.predbat_test", state="a", attributes=attributes)
+    assert attributes["options"] == ["a", "b", "c"], "dashboard_item mutated the caller's options list"
+    stored = base.get_state_wrapper("select.predbat_test", raw=True)
+    assert stored["attributes"]["options"] == ["a", "b", "c"], "the stored attributes were corrupted"
+    assert stored["state"] == "a", "the stored state is wrong"
+    print("PASS: MockBase dashboard_item leaves caller attributes intact")
+    return False
+
+
+def test_mock_base_dashboard_item_serialises_datetime(my_predbat):
+    """dashboard_item serialises non-JSON-native attribute values instead of raising TypeError."""
+    base = MockBase()
+    base.dashboard_item("sensor.predbat_test", state="ok", attributes={"last_updated": datetime.now()})
+    assert base.get_state_wrapper("sensor.predbat_test") == "ok", "state should still be stored"
+    print("PASS: MockBase dashboard_item serialises datetime attributes")
+    return False
+
+
+def test_mock_base_state_wrapper_paths(my_predbat):
+    """get_state_wrapper covers the raw, attribute and default-fallback paths."""
+    base = MockBase()
+    base.set_state_wrapper("sensor.predbat_test", "42", attributes={"unit_of_measurement": "kWh"})
+    assert base.get_state_wrapper("sensor.predbat_test") == "42", "plain state lookup failed"
+    assert base.get_state_wrapper("sensor.predbat_test", attribute="unit_of_measurement") == "kWh", "attribute lookup failed"
+    assert base.get_state_wrapper("sensor.predbat_test", raw=True)["state"] == "42", "raw lookup failed"
+    assert base.get_state_wrapper("sensor.predbat_missing", default="none") == "none", "missing entity should return the default"
+    assert base.get_state_wrapper("sensor.predbat_test", attribute="absent", default="dflt") == "dflt", "missing attribute should return the default"
+    print("PASS: MockBase get_state_wrapper handles raw/attribute/default paths")
+    return False
+
+
+def test_mock_base_set_state_wrapper_accepts_both_kwargs(my_predbat):
+    """set_state_wrapper accepts both app= and required_unit=, since the modules disagree on which they pass."""
+    base = MockBase()
+    base.set_state_wrapper("sensor.predbat_one", "1", attributes={}, app="predbat")
+    base.set_state_wrapper("sensor.predbat_two", "2", attributes={}, required_unit="kWh")
+    assert base.get_state_wrapper("sensor.predbat_one") == "1", "app= form failed"
+    assert base.get_state_wrapper("sensor.predbat_two") == "2", "required_unit= form failed"
+    print("PASS: MockBase set_state_wrapper accepts app and required_unit")
+    return False
+
+
+def test_mock_base_record_status_tracks_errors(my_predbat):
+    """record_status sets had_errors when told to, so gecloud's guarded call reflects failures."""
+    base = MockBase()
+    base.record_status("All good")
+    assert base.had_errors is False, "a clean status must not set had_errors"
+    base.record_status("Something broke", debug="url", had_errors=True)
+    assert base.had_errors is True, "had_errors should be set when reported"
+    print("PASS: MockBase record_status tracks the error flag")
+    return False
+
+
+def test_mock_base_no_ha_helpers(my_predbat):
+    """get_ha_config returns the caller's default and get_history_wrapper returns None, matching a no-HA run."""
+    base = MockBase()
+    assert base.get_ha_config("anything", "dflt") == "dflt", "get_ha_config should return the default"
+    assert base.get_history_wrapper("sensor.predbat_test") is None, "get_history_wrapper should return None with no HA interface"
+    print("PASS: MockBase HA helpers degrade cleanly")
+    return False
+
+
+def test_mock_base_all(my_predbat):
+    """Run all mock_base tests."""
+    tests = [
+        ("attribute_superset", test_mock_base_attribute_superset, "Full base attribute superset is present"),
+        ("constructor_overrides", test_mock_base_config_root_and_local_tz_overrides, "config_root and local_tz are overridable"),
+        ("midnight_aware", test_mock_base_midnight_utc_is_aware, "midnight_utc is timezone-aware"),
+        ("kwargs_args", test_mock_base_kwargs_populate_args, "Surplus kwargs populate args"),
+        ("none_kwargs", test_mock_base_none_kwargs_are_skipped, "None kwargs are skipped, False is kept"),
+        ("arg_round_trip", test_mock_base_arg_round_trip, "get_arg/set_arg round-trip"),
+        ("dashboard_no_mutate", test_mock_base_dashboard_item_does_not_mutate_attributes, "dashboard_item does not mutate caller attributes"),
+        ("dashboard_datetime", test_mock_base_dashboard_item_serialises_datetime, "dashboard_item serialises datetime attributes"),
+        ("state_wrapper", test_mock_base_state_wrapper_paths, "get_state_wrapper raw/attribute/default paths"),
+        ("state_wrapper_kwargs", test_mock_base_set_state_wrapper_accepts_both_kwargs, "set_state_wrapper accepts app and required_unit"),
+        ("record_status", test_mock_base_record_status_tracks_errors, "record_status tracks had_errors"),
+        ("ha_helpers", test_mock_base_no_ha_helpers, "HA helpers degrade cleanly"),
+    ]
+
+    failed = []
+    for name, test_func, description in tests:
+        print(f"\n*** Running: {name} - {description} ***")
+        try:
+            result = test_func(my_predbat)
+            if result:
+                failed.append(name)
+                print(f"FAILED: {name}")
+        except Exception as e:
+            failed.append(name)
+            print(f"ERROR in {name}: {e}")
+
+    if failed:
+        print(f"\n*** {len(failed)} test(s) failed: {', '.join(failed)} ***")
+        return True
+    else:
+        print(f"\n*** All {len(tests)} mock_base tests passed ***")
+        return False

--- a/apps/predbat/tests/test_mock_base.py
+++ b/apps/predbat/tests/test_mock_base.py
@@ -167,6 +167,43 @@ def test_mock_base_no_ha_helpers(my_predbat):
     return False
 
 
+def test_mock_base_module_subclasses(my_predbat):
+    """The five subclassing modules keep their distinguishing state on top of the shared base."""
+    from axle import MockBase as AxleMockBase
+    from gecloud import MockBase as GECloudMockBase
+    from octopus import MockBase as OctopusMockBase
+    from sigenergy import MockBase as SigenergyMockBase
+    from solax import MockBase as SolaxMockBase
+
+    assert AxleMockBase().config_root == "./temp_axle", "axle config_root is wrong"
+    assert OctopusMockBase().config_root == "./temp_octopus", "octopus config_root is wrong"
+
+    gecloud_base = GECloudMockBase()
+    assert gecloud_base.config_root == "./temp_gecloud", "gecloud config_root is wrong"
+    assert gecloud_base.ha_interface is not None, "gecloud must supply a mock ha_interface"
+    assert hasattr(gecloud_base.ha_interface, "set_state_external"), "gecloud ha_interface needs set_state_external"
+
+    assert SolaxMockBase().local_tz == timezone.utc, "solax must keep using UTC"
+
+    read_only = SigenergyMockBase(readonly=True)
+    assert read_only.get_state_wrapper("switch.predbat_set_read_only") == "on", "sigenergy readonly=True should seed the switch on"
+    writable = SigenergyMockBase(readonly=False)
+    assert writable.get_state_wrapper("switch.predbat_set_read_only") == "off", "sigenergy readonly=False should seed the switch off"
+
+    print("PASS: module MockBase subclasses keep their distinguishing state")
+    return False
+
+
+def test_mock_base_kraken_alias(my_predbat):
+    """KrakenMockBase is the shared base and still accepts user_id, skipping it when None."""
+    from kraken import KrakenMockBase
+
+    assert KrakenMockBase(user_id="user-123").args.get("user_id") == "user-123", "user_id should be stored"
+    assert "user_id" not in KrakenMockBase(user_id=None).args, "a None user_id must not be stored"
+    print("PASS: KrakenMockBase preserves its user_id contract")
+    return False
+
+
 def test_mock_base_all(my_predbat):
     """Run all mock_base tests."""
     tests = [
@@ -182,6 +219,8 @@ def test_mock_base_all(my_predbat):
         ("state_wrapper_kwargs", test_mock_base_set_state_wrapper_accepts_both_kwargs, "set_state_wrapper accepts app and required_unit"),
         ("record_status", test_mock_base_record_status_tracks_errors, "record_status tracks had_errors"),
         ("ha_helpers", test_mock_base_no_ha_helpers, "HA helpers degrade cleanly"),
+        ("module_subclasses", test_mock_base_module_subclasses, "Module subclasses keep their distinguishing state"),
+        ("kraken_alias", test_mock_base_kraken_alias, "KrakenMockBase alias preserves the user_id contract"),
     ]
 
     failed = []

--- a/apps/predbat/tests/test_mock_base.py
+++ b/apps/predbat/tests/test_mock_base.py
@@ -14,7 +14,16 @@ Tests for the shared MockBase used by the standalone command-line harnesses.
 
 from datetime import datetime, timezone
 
+from component_base import ComponentBase
 from mock_base import MockBase
+
+
+class _ContractProbeComponent(ComponentBase):
+    """Minimal concrete ComponentBase subclass used only to exercise the base contract."""
+
+    def initialize(self, **kwargs):
+        """Do nothing; this probe only needs the base ComponentBase wiring, not extra state."""
+        pass
 
 
 def test_mock_base_attribute_superset(my_predbat):
@@ -45,6 +54,48 @@ def test_mock_base_attribute_superset(my_predbat):
     assert base.had_errors is False, "had_errors should start False"
     assert base.config_root == "./temp_predbat", "config_root should use the documented default"
     print("PASS: MockBase exposes the full base attribute superset")
+    return False
+
+
+def test_mock_base_covers_component_base_contract(my_predbat):
+    """MockBase must satisfy every property and delegated method ComponentBase exposes.
+
+    test_mock_base_attribute_superset only checks that MockBase's attribute list mirrors this
+    file's own hardcoded copy of the ComponentBase surface - it is a change-detector, not a
+    regression test, because both lists drift together. This test instead binds a real
+    ComponentBase subclass to a MockBase and exercises the actual properties and delegate
+    methods ComponentBase defines, so it fails with an AttributeError if someone adds a new
+    self.base.<something> dereference to component_base.py that the mock does not cover.
+    """
+    component = _ContractProbeComponent(MockBase())
+
+    # Properties defined on ComponentBase that read through to self.base.
+    assert component.currency_symbols == "£p", "currency_symbols property failed"
+    assert component.arg_errors == {}, "arg_errors property failed"
+    assert component.now_utc is not None, "now_utc property failed"
+    assert component.midnight_utc is not None, "midnight_utc property failed"
+    assert component.now_utc_exact is not None, "now_utc_exact property failed"
+    assert isinstance(component.minutes_now, int), "minutes_now property failed"
+    assert component.plan_interval_minutes == 30, "plan_interval_minutes property failed"
+    assert component.num_cars == 0, "num_cars property failed"
+    assert component.config_root == "./temp_predbat", "config_root property failed"
+    assert component.storage is None, "storage property failed (components is None on MockBase)"
+    assert component.fatal_error is False, "fatal_error property failed"
+
+    # Methods ComponentBase delegates straight through to self.base.
+    assert component.get_arg("missing_key", "fallback") == "fallback", "get_arg delegate failed"
+    component.set_arg("probe_key", "probe_value")
+    assert component.get_arg("probe_key") == "probe_value", "set_arg delegate failed"
+    component.dashboard_item("sensor.predbat_probe", "on", {"friendly_name": "Probe"})
+    assert component.get_ha_config("anything", "fallback") == "fallback", "get_ha_config delegate failed"
+    assert component.get_state_wrapper("sensor.predbat_probe") == "on", "get_state_wrapper delegate failed"
+    component.set_state_wrapper("sensor.predbat_probe2", "off")
+    assert component.get_state_wrapper("sensor.predbat_probe2") == "off", "set_state_wrapper delegate failed"
+    assert component.get_history_wrapper("sensor.predbat_probe") is None, "get_history_wrapper delegate failed"
+    component.call_notify("probe notification")
+    component.log("probe log message")
+
+    print("PASS: MockBase covers the full ComponentBase property/delegate contract")
     return False
 
 
@@ -98,6 +149,65 @@ def test_mock_base_arg_round_trip(my_predbat):
     base.set_arg("set_read_only", True)
     assert base.get_arg("set_read_only", False) is True, "set_arg value should be readable via get_arg"
     print("PASS: MockBase get_arg/set_arg round-trip")
+    return False
+
+
+def test_mock_base_set_arg_none_deletes_key(my_predbat):
+    """set_arg(key, None) must delete the key, matching userinterface.py's Fetch.set_arg.
+
+    gecloud.py makes several set_arg(key, None) calls expecting the key to disappear so a
+    later get_arg(key, default) falls back to the caller's default rather than returning None.
+    """
+    base = MockBase()
+    base.set_arg("probe_key", "probe_value")
+    assert base.get_arg("probe_key", "fallback") == "probe_value", "set_arg should have stored the value"
+    base.set_arg("probe_key", None)
+    assert base.get_arg("probe_key", "fallback") == "fallback", "set_arg(key, None) should delete the key, not store None"
+    assert "probe_key" not in base.args, "the deleted key must not remain in args"
+    print("PASS: MockBase set_arg(key, None) deletes the key")
+    return False
+
+
+def test_mock_base_reexport_identity(my_predbat):
+    """The five plain re-export modules must expose the identical shared MockBase object.
+
+    deye, enphase, fox and solis are not otherwise exercised anywhere (teslemetry is covered
+    incidentally by test_teslemetry.py), so nothing else would catch a botched edit to one of
+    those `from mock_base import MockBase` lines - e.g. accidentally defining a local class
+    that shadows the shared one.
+    """
+    from deye import MockBase as DeyeMockBase
+    from enphase import MockBase as EnphaseMockBase
+    from fox import MockBase as FoxMockBase
+    from solis import MockBase as SolisMockBase
+    from teslemetry import MockBase as TeslemetryMockBase
+
+    for name, reexported in (
+        ("deye", DeyeMockBase),
+        ("enphase", EnphaseMockBase),
+        ("fox", FoxMockBase),
+        ("solis", SolisMockBase),
+        ("teslemetry", TeslemetryMockBase),
+    ):
+        assert reexported is MockBase, f"{name}.MockBase should be the identical shared mock_base.MockBase object"
+
+    from axle import MockBase as AxleMockBase
+    from gecloud import MockBase as GECloudMockBase
+    from octopus import MockBase as OctopusMockBase
+    from sigenergy import MockBase as SigenergyMockBase
+    from solax import MockBase as SolaxMockBase
+
+    for name, subclass in (
+        ("axle", AxleMockBase),
+        ("gecloud", GECloudMockBase),
+        ("octopus", OctopusMockBase),
+        ("sigenergy", SigenergyMockBase),
+        ("solax", SolaxMockBase),
+    ):
+        assert issubclass(subclass, MockBase), f"{name}.MockBase should be a subclass of the shared mock_base.MockBase"
+        assert subclass is not MockBase, f"{name}.MockBase should be its own subclass, not a bare re-export"
+
+    print("PASS: the eleven module MockBase names resolve to the shared class or a true subclass of it")
     return False
 
 
@@ -208,11 +318,14 @@ def test_mock_base_all(my_predbat):
     """Run all mock_base tests."""
     tests = [
         ("attribute_superset", test_mock_base_attribute_superset, "Full base attribute superset is present"),
+        ("component_base_contract", test_mock_base_covers_component_base_contract, "MockBase satisfies the real ComponentBase property/delegate contract"),
         ("constructor_overrides", test_mock_base_config_root_and_local_tz_overrides, "config_root and local_tz are overridable"),
         ("midnight_aware", test_mock_base_midnight_utc_is_aware, "midnight_utc is timezone-aware"),
         ("kwargs_args", test_mock_base_kwargs_populate_args, "Surplus kwargs populate args"),
         ("none_kwargs", test_mock_base_none_kwargs_are_skipped, "None kwargs are skipped, False is kept"),
         ("arg_round_trip", test_mock_base_arg_round_trip, "get_arg/set_arg round-trip"),
+        ("set_arg_none_deletes", test_mock_base_set_arg_none_deletes_key, "set_arg(key, None) deletes the key"),
+        ("reexport_identity", test_mock_base_reexport_identity, "Re-export and subclass modules resolve to the shared MockBase"),
         ("dashboard_no_mutate", test_mock_base_dashboard_item_does_not_mutate_attributes, "dashboard_item does not mutate caller attributes"),
         ("dashboard_datetime", test_mock_base_dashboard_item_serialises_datetime, "dashboard_item serialises datetime attributes"),
         ("state_wrapper", test_mock_base_state_wrapper_paths, "get_state_wrapper raw/attribute/default paths"),

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -147,6 +147,7 @@ from tests.test_github import test_github
 from tests.test_download import test_download
 from tests.test_ohme import test_ohme
 from tests.test_component_base import test_component_base_all
+from tests.test_mock_base import test_mock_base_all
 from tests.test_solis import run_solis_tests
 from tests.test_load_ml import test_load_ml
 from tests.test_temperature import test_temperature
@@ -372,6 +373,8 @@ def main():
         ("ohme", test_ohme, "Ohme EV charger comprehensive tests (helper functions, client methods, API operations, event handlers)", False),
         # ComponentBase lifecycle tests
         ("component_base", test_component_base_all, "ComponentBase tests (all)", False),
+        # Shared MockBase tests
+        ("mock_base", test_mock_base_all, "Shared CLI-harness MockBase tests", False),
         # Solis Cloud API unit tests
         ("solis", run_solis_tests, "Solis Cloud API tests (V1/V2 time window writes, change detection)", False),
         # External Temperature API tests

--- a/docs/superpowers/plans/2026-07-29-shared-mock-base.md
+++ b/docs/superpowers/plans/2026-07-29-shared-mock-base.md
@@ -1,0 +1,776 @@
+# Shared MockBase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace eleven near-identical `MockBase` classes in production modules with a single shared `apps/predbat/mock_base.py`, keeping every existing call site working.
+
+**Architecture:** One concrete (not abstract) `MockBase` class provides the full superset of the PredBat base surface that `ComponentBase` dereferences. Five modules import it directly, five subclass it to add module-specific state, and `kraken` aliases it. The spec is `docs/superpowers/specs/2026-07-29-shared-mock-base-design.md`.
+
+**Tech Stack:** Python 3, Predbat's own `unit_test.py` harness (not pytest), Black/Flake8/interrogate/CSpell via pre-commit.
+
+## Global Constraints
+
+- Line length: 256 chars (Black), 250 chars (Flake8).
+- **100% docstring coverage** (`interrogate`) — every class and every function needs a docstring, including test functions.
+- Variable naming: `lower_case_with_underscores`.
+- British English spelling (CSpell, `en-gb`).
+- Tests live in `apps/predbat/tests/`, are registered in `TEST_REGISTRY` in `apps/predbat/unit_test.py`, and are run from the `coverage/` directory.
+- **Test convention:** a test function takes a single `my_predbat` argument and returns `False` on success, `True` on failure. An aggregator `test_<feature>_all(my_predbat)` runs them and returns `True` if any failed.
+- **Always save test output to a file, then grep the file.** Never pipe test output straight into grep.
+- Every file starts with the standard 9-line Predbat copyright/pylint header (copy it verbatim from `apps/predbat/component_base.py`).
+
+## Working Context
+
+Work happens on branch `refactor/shared-mock-base`, which already exists and holds the committed spec.
+
+First-time environment setup, if the venv is not already present:
+
+```bash
+cd coverage
+source setup.csh
+```
+
+---
+
+### Task 1: Create the shared `mock_base.py` and its tests
+
+**Files:**
+- Create: `apps/predbat/mock_base.py`
+- Create: `apps/predbat/tests/test_mock_base.py`
+- Modify: `apps/predbat/unit_test.py` (add import near line 149, add `TEST_REGISTRY` entry near line 374)
+
+**Interfaces:**
+- Consumes: nothing (this is the foundation task).
+- Produces: `MockBase` in `apps/predbat/mock_base.py` with constructor
+  `MockBase(config_root="./temp_predbat", local_tz=None, **kwargs)` and methods
+  `log(message)`,
+  `get_state_wrapper(entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False)`,
+  `set_state_wrapper(entity_id, state, attributes=None, app=None, required_unit=None)`,
+  `dashboard_item(entity_id, state=None, attributes=None, app=None)`,
+  `get_arg(arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None)`,
+  `set_arg(key, value)`,
+  `get_ha_config(name, default)`,
+  `get_history_wrapper(entity_id, days=30, required=True, tracked=True)`,
+  `call_notify(message)`,
+  `record_status(message, debug="", had_errors=False, notify=False, extra="")`.
+  Instance attributes set by the constructor: `local_tz`, `now_utc`, `now_utc_exact`,
+  `midnight_utc`, `minutes_now`, `prefix`, `entities`, `config_root`,
+  `plan_interval_minutes`, `fatal_error`, `had_errors`, `components`, `num_cars`,
+  `currency_symbols`, `arg_errors`, `args`.
+
+Note: `mock_base.py` does **not** carry a `# pragma: no cover` marker. The old classes did, but this one is directly unit-tested, so the coverage should be real. The CLI harness functions that *call* it keep their own pragmas.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `apps/predbat/tests/test_mock_base.py`:
+
+```python
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Tests for the shared MockBase used by the standalone command-line harnesses.
+"""
+
+from datetime import datetime, timezone
+
+from mock_base import MockBase
+
+
+def test_mock_base_attribute_superset(my_predbat):
+    """Every attribute ComponentBase dereferences off self.base is present after construction."""
+    base = MockBase()
+    for name in (
+        "local_tz",
+        "now_utc",
+        "now_utc_exact",
+        "midnight_utc",
+        "minutes_now",
+        "prefix",
+        "args",
+        "entities",
+        "config_root",
+        "plan_interval_minutes",
+        "fatal_error",
+        "had_errors",
+        "components",
+        "num_cars",
+        "currency_symbols",
+        "arg_errors",
+    ):
+        assert hasattr(base, name), f"MockBase is missing attribute {name}"
+    assert base.prefix == "predbat", "prefix should default to predbat"
+    assert base.components is None, "components must be None so ComponentBase.storage resolves to None"
+    assert base.fatal_error is False, "fatal_error should start False"
+    assert base.had_errors is False, "had_errors should start False"
+    assert base.config_root == "./temp_predbat", "config_root should use the documented default"
+    print("PASS: MockBase exposes the full base attribute superset")
+    return False
+
+
+def test_mock_base_config_root_and_local_tz_overrides(my_predbat):
+    """config_root and local_tz are constructor-overridable, as the axle/gecloud/octopus/solax subclasses need."""
+    base = MockBase(config_root="./temp_example")
+    assert base.config_root == "./temp_example", "config_root override was ignored"
+    utc_base = MockBase(local_tz=timezone.utc)
+    assert utc_base.local_tz == timezone.utc, "local_tz override was ignored"
+    assert utc_base.now_utc.tzinfo == timezone.utc, "now_utc should use the supplied timezone"
+    print("PASS: MockBase honours config_root and local_tz overrides")
+    return False
+
+
+def test_mock_base_midnight_utc_is_aware(my_predbat):
+    """midnight_utc is timezone-aware so now_utc - midnight_utc does not raise (fox/kraken/solis had naive values)."""
+    base = MockBase()
+    assert base.midnight_utc.tzinfo is not None, "midnight_utc must be timezone-aware"
+    delta = base.now_utc - base.midnight_utc
+    assert delta.total_seconds() >= 0, "now_utc should not precede midnight"
+    assert base.midnight_utc.hour == 0, "midnight_utc should be at hour zero"
+    assert base.midnight_utc.minute == 0, "midnight_utc should be at minute zero"
+    print("PASS: MockBase midnight_utc is timezone-aware")
+    return False
+
+
+def test_mock_base_kwargs_populate_args(my_predbat):
+    """Surplus kwargs land in self.args, covering the KrakenMockBase(user_id=...) call site."""
+    base = MockBase(user_id="user-123")
+    assert base.args.get("user_id") == "user-123", "kwargs should be stored into args"
+    print("PASS: MockBase stores surplus kwargs into args")
+    return False
+
+
+def test_mock_base_none_kwargs_are_skipped(my_predbat):
+    """A None-valued kwarg is not stored, matching kraken's 'if user_id:' guard and oauth_mixin's args.get(key, '')."""
+    base = MockBase(user_id=None)
+    assert "user_id" not in base.args, "None-valued kwargs must not be stored"
+    assert base.args.get("user_id", "") == "", "absent user_id must fall back to the empty-string default"
+    falsy = MockBase(control_enable=False)
+    assert falsy.args.get("control_enable") is False, "a legitimate False value must still be stored"
+    print("PASS: MockBase skips None kwargs but keeps False")
+    return False
+
+
+def test_mock_base_arg_round_trip(my_predbat):
+    """set_arg persists into args and get_arg reads it back; unset keys return the caller's default."""
+    base = MockBase()
+    assert base.get_arg("missing_key", "fallback") == "fallback", "unset keys should return the default"
+    assert base.get_arg("set_read_only", False) is False, "unset boolean should return the supplied default"
+    base.set_arg("set_read_only", True)
+    assert base.get_arg("set_read_only", False) is True, "set_arg value should be readable via get_arg"
+    print("PASS: MockBase get_arg/set_arg round-trip")
+    return False
+
+
+def test_mock_base_dashboard_item_does_not_mutate_attributes(my_predbat):
+    """dashboard_item must not corrupt the caller's attributes dict when eliding the options list."""
+    base = MockBase()
+    attributes = {"options": ["a", "b", "c"], "friendly_name": "Test"}
+    base.dashboard_item("select.predbat_test", state="a", attributes=attributes)
+    assert attributes["options"] == ["a", "b", "c"], "dashboard_item mutated the caller's options list"
+    stored = base.get_state_wrapper("select.predbat_test", raw=True)
+    assert stored["attributes"]["options"] == ["a", "b", "c"], "the stored attributes were corrupted"
+    assert stored["state"] == "a", "the stored state is wrong"
+    print("PASS: MockBase dashboard_item leaves caller attributes intact")
+    return False
+
+
+def test_mock_base_dashboard_item_serialises_datetime(my_predbat):
+    """dashboard_item serialises non-JSON-native attribute values instead of raising TypeError."""
+    base = MockBase()
+    base.dashboard_item("sensor.predbat_test", state="ok", attributes={"last_updated": datetime.now()})
+    assert base.get_state_wrapper("sensor.predbat_test") == "ok", "state should still be stored"
+    print("PASS: MockBase dashboard_item serialises datetime attributes")
+    return False
+
+
+def test_mock_base_state_wrapper_paths(my_predbat):
+    """get_state_wrapper covers the raw, attribute and default-fallback paths."""
+    base = MockBase()
+    base.set_state_wrapper("sensor.predbat_test", "42", attributes={"unit_of_measurement": "kWh"})
+    assert base.get_state_wrapper("sensor.predbat_test") == "42", "plain state lookup failed"
+    assert base.get_state_wrapper("sensor.predbat_test", attribute="unit_of_measurement") == "kWh", "attribute lookup failed"
+    assert base.get_state_wrapper("sensor.predbat_test", raw=True)["state"] == "42", "raw lookup failed"
+    assert base.get_state_wrapper("sensor.predbat_missing", default="none") == "none", "missing entity should return the default"
+    assert base.get_state_wrapper("sensor.predbat_test", attribute="absent", default="dflt") == "dflt", "missing attribute should return the default"
+    print("PASS: MockBase get_state_wrapper handles raw/attribute/default paths")
+    return False
+
+
+def test_mock_base_set_state_wrapper_accepts_both_kwargs(my_predbat):
+    """set_state_wrapper accepts both app= and required_unit=, since the modules disagree on which they pass."""
+    base = MockBase()
+    base.set_state_wrapper("sensor.predbat_one", "1", attributes={}, app="predbat")
+    base.set_state_wrapper("sensor.predbat_two", "2", attributes={}, required_unit="kWh")
+    assert base.get_state_wrapper("sensor.predbat_one") == "1", "app= form failed"
+    assert base.get_state_wrapper("sensor.predbat_two") == "2", "required_unit= form failed"
+    print("PASS: MockBase set_state_wrapper accepts app and required_unit")
+    return False
+
+
+def test_mock_base_record_status_tracks_errors(my_predbat):
+    """record_status sets had_errors when told to, so gecloud's guarded call reflects failures."""
+    base = MockBase()
+    base.record_status("All good")
+    assert base.had_errors is False, "a clean status must not set had_errors"
+    base.record_status("Something broke", debug="url", had_errors=True)
+    assert base.had_errors is True, "had_errors should be set when reported"
+    print("PASS: MockBase record_status tracks the error flag")
+    return False
+
+
+def test_mock_base_no_ha_helpers(my_predbat):
+    """get_ha_config returns the caller's default and get_history_wrapper returns None, matching a no-HA run."""
+    base = MockBase()
+    assert base.get_ha_config("anything", "dflt") == "dflt", "get_ha_config should return the default"
+    assert base.get_history_wrapper("sensor.predbat_test") is None, "get_history_wrapper should return None with no HA interface"
+    print("PASS: MockBase HA helpers degrade cleanly")
+    return False
+
+
+def test_mock_base_all(my_predbat):
+    """Run all mock_base tests."""
+    tests = [
+        ("attribute_superset", test_mock_base_attribute_superset, "Full base attribute superset is present"),
+        ("constructor_overrides", test_mock_base_config_root_and_local_tz_overrides, "config_root and local_tz are overridable"),
+        ("midnight_aware", test_mock_base_midnight_utc_is_aware, "midnight_utc is timezone-aware"),
+        ("kwargs_args", test_mock_base_kwargs_populate_args, "Surplus kwargs populate args"),
+        ("none_kwargs", test_mock_base_none_kwargs_are_skipped, "None kwargs are skipped, False is kept"),
+        ("arg_round_trip", test_mock_base_arg_round_trip, "get_arg/set_arg round-trip"),
+        ("dashboard_no_mutate", test_mock_base_dashboard_item_does_not_mutate_attributes, "dashboard_item does not mutate caller attributes"),
+        ("dashboard_datetime", test_mock_base_dashboard_item_serialises_datetime, "dashboard_item serialises datetime attributes"),
+        ("state_wrapper", test_mock_base_state_wrapper_paths, "get_state_wrapper raw/attribute/default paths"),
+        ("state_wrapper_kwargs", test_mock_base_set_state_wrapper_accepts_both_kwargs, "set_state_wrapper accepts app and required_unit"),
+        ("record_status", test_mock_base_record_status_tracks_errors, "record_status tracks had_errors"),
+        ("ha_helpers", test_mock_base_no_ha_helpers, "HA helpers degrade cleanly"),
+    ]
+
+    failed = []
+    for name, test_func, description in tests:
+        print(f"\n*** Running: {name} - {description} ***")
+        try:
+            result = test_func(my_predbat)
+            if result:
+                failed.append(name)
+                print(f"FAILED: {name}")
+        except Exception as e:
+            failed.append(name)
+            print(f"ERROR in {name}: {e}")
+
+    if failed:
+        print(f"\n*** {len(failed)} test(s) failed: {', '.join(failed)} ***")
+        return True
+    else:
+        print(f"\n*** All {len(tests)} mock_base tests passed ***")
+        return False
+```
+
+- [ ] **Step 2: Register the test in `unit_test.py`**
+
+Add the import alongside the other test-module imports (near line 149, next to `from tests.test_component_base import test_component_base_all`):
+
+```python
+from tests.test_mock_base import test_mock_base_all
+```
+
+Add the registry entry in `TEST_REGISTRY` (near line 374, next to the `component_base` entry):
+
+```python
+        ("mock_base", test_mock_base_all, "Shared CLI-harness MockBase tests", False),
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd coverage && ./run_all --test mock_base > /tmp/mock_base_test.txt 2>&1; echo "exit=$?"
+grep -iE "ModuleNotFoundError|No module named|Traceback" /tmp/mock_base_test.txt
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'mock_base'`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `apps/predbat/mock_base.py`:
+
+```python
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""Shared mock base object for standalone command-line runs of components.
+
+Most component modules (fox, solis, octopus, teslemetry, ...) can be executed directly
+from the command line to exercise their API against a live vendor endpoint. Those
+harnesses need an object to pass as the ``base`` argument of ComponentBase. MockBase
+provides the minimal PredBat base surface that ComponentBase and the components read:
+a clock, an in-memory entity store, argument accessors and a logger.
+
+It is deliberately concrete rather than abstract - modules instantiate it directly, and
+the few needing extra state subclass it. ``components`` is always None, so
+``ComponentBase.storage`` resolves to None and the disk cache is skipped for a
+standalone run.
+"""
+
+from datetime import datetime
+import json
+
+
+class MockBase:
+    """Minimal stand-in for the PredBat base object, used by the standalone CLI harnesses."""
+
+    def __init__(self, config_root="./temp_predbat", local_tz=None, **kwargs):
+        """Initialise the mock with a clock, empty entity/arg stores and the full base attribute superset.
+
+        Surplus keyword arguments are stored into self.args, with None values skipped so an
+        unset optional argument stays absent rather than shadowing a caller's default.
+        """
+        self.local_tz = local_tz if local_tz is not None else datetime.now().astimezone().tzinfo
+        self.now_utc = datetime.now(self.local_tz)
+        self.now_utc_exact = self.now_utc
+        self.midnight_utc = self.now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+        self.minutes_now = self.now_utc.hour * 60 + self.now_utc.minute
+        self.prefix = "predbat"
+        self.entities = {}
+        self.config_root = config_root
+        self.plan_interval_minutes = 30
+        self.fatal_error = False
+        self.had_errors = False
+        self.components = None
+        self.num_cars = 0
+        self.currency_symbols = "£p"
+        self.arg_errors = {}
+        self.args = {key: value for key, value in kwargs.items() if value is not None}
+
+    def log(self, message):
+        """Print a timestamped log line."""
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] {message}")
+
+    def get_state_wrapper(self, entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False):
+        """Return a stored entity state, one of its attributes, or the whole record when raw is set."""
+        entity = self.entities.get(entity_id, {})
+        if raw:
+            return entity
+        if attribute is not None:
+            return entity.get("attributes", {}).get(attribute, default)
+        return entity.get("state", default)
+
+    def set_state_wrapper(self, entity_id, state, attributes=None, app=None, required_unit=None):
+        """Store an entity's state and attributes in memory.
+
+        Accepts both app and required_unit because the component modules disagree on which
+        one they pass, and ComponentBase.set_state_wrapper forwards required_unit.
+        """
+        self.entities[entity_id] = {"state": state, "attributes": attributes or {}}
+
+    def dashboard_item(self, entity_id, state=None, attributes=None, app=None):
+        """Print a published entity and store it.
+
+        The options list is elided in a copy of the attributes, so the caller's dict - which
+        is then stored verbatim - is never mutated.
+        """
+        print(f"ENTITY: {entity_id} = {state}")
+        if attributes:
+            print_attrs = dict(attributes)
+            if "options" in print_attrs:
+                print_attrs["options"] = "..."
+            print(f"  Attributes: {json.dumps(print_attrs, indent=2, default=str)}")
+        self.set_state_wrapper(entity_id, state, attributes)
+
+    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
+        """Return a configured argument, falling back to the caller's default."""
+        return self.args.get(arg, default)
+
+    def set_arg(self, key, value):
+        """Record an argument set by automatic_config, printing it with any referenced entity's state."""
+        self.args[key] = value
+        if isinstance(value, str) and "." in value:
+            state = self.get_state_wrapper(value, default=None)
+        elif isinstance(value, list):
+            state = "n/a []"
+            for item in value:
+                if isinstance(item, str) and "." in item:
+                    state = self.get_state_wrapper(item, default=None)
+                    break
+        else:
+            state = "n/a"
+        print(f"Set arg {key} = {value} (state={state})")
+
+    def get_ha_config(self, name, default):
+        """Return the caller's default - a standalone run has no Home Assistant config."""
+        return default
+
+    def get_history_wrapper(self, entity_id, days=30, required=True, tracked=True):
+        """Return None - a standalone run has no Home Assistant recorder, matching PredBat's no-interface path."""
+        return None
+
+    def call_notify(self, message):
+        """Print a notification message."""
+        print(f"NOTIFY: {message}")
+
+    def record_status(self, message, debug="", had_errors=False, notify=False, extra=""):
+        """Print a status record and track the error flag."""
+        print(f"STATUS: {message}" + (f" ({debug})" if debug else ""))
+        if had_errors:
+            self.had_errors = True
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd coverage && ./run_all --test mock_base > /tmp/mock_base_test.txt 2>&1; echo "exit=$?"
+grep -iE "All 12 mock_base tests passed|FAILED|ERROR in" /tmp/mock_base_test.txt
+```
+
+Expected: `*** All 12 mock_base tests passed ***`, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/predbat/mock_base.py apps/predbat/tests/test_mock_base.py apps/predbat/unit_test.py
+git commit -m "refactor(mock): add shared MockBase for standalone CLI harnesses
+
+Adds apps/predbat/mock_base.py providing the superset of the PredBat base
+surface that ComponentBase dereferences, with unit tests. No module uses it
+yet; migrations follow."
+```
+
+---
+
+### Task 2: Migrate the five plain re-export modules
+
+**Files:**
+- Modify: `apps/predbat/deye.py` (delete lines 1366-1416)
+- Modify: `apps/predbat/enphase.py` (delete lines 1470-1534)
+- Modify: `apps/predbat/fox.py` (delete lines 2249-2298)
+- Modify: `apps/predbat/solis.py` (delete lines 3031-3081)
+- Modify: `apps/predbat/teslemetry.py` (delete lines 1239-1291)
+
+**Interfaces:**
+- Consumes: `MockBase` from `mock_base` (Task 1).
+- Produces: a module-level `MockBase` name in each of these five modules, so existing call sites (`mock_base = MockBase()`) and `from teslemetry import MockBase` in `tests/test_teslemetry.py:1458` keep resolving.
+
+These five need no extra state, so each is a straight import.
+
+**Line numbers drift as you edit.** Locate each class by searching rather than trusting the numbers above:
+
+```bash
+grep -n "^class MockBase" apps/predbat/deye.py
+```
+
+- [ ] **Step 1: Replace the class in each of the five modules**
+
+In each file, delete the entire `class MockBase:` block (from the `class MockBase:  # pragma: no cover` line through to the line before the next top-level `def`/`async def`/`class`/`if __name__`), and add this import next to the existing `from component_base import ComponentBase` line at the top of the file:
+
+```python
+from mock_base import MockBase
+```
+
+Apply to: `deye.py`, `enphase.py`, `fox.py`, `solis.py`, `teslemetry.py`.
+
+Do **not** remove any `import json` or `import datetime` from these five — all five use both outside the deleted class. (Only `kraken.py` needs an import removed, handled in Task 3.)
+
+- [ ] **Step 2: Verify each module still imports cleanly**
+
+```bash
+cd apps/predbat && for m in deye enphase fox solis teslemetry; do
+  python3 -c "import $m; print('$m OK', $m.MockBase)" || echo "$m FAILED"
+done
+```
+
+Expected: five `OK` lines, each showing `<class 'mock_base.MockBase'>`.
+
+- [ ] **Step 3: Run the affected test suites**
+
+```bash
+cd coverage && ./run_all --test mock_base --test teslemetry --test fox_api --test fox_oauth --test solis --test deye_api --test enphase_api > /tmp/task2_test.txt 2>&1; echo "exit=$?"
+grep -iE "passed|FAILED|ERROR in|Traceback" /tmp/task2_test.txt | head -40
+```
+
+Expected: exit 0, all pass. In particular `test_teslemetry_mock_base_get_arg_consults_args` must still pass — it is the regression check that the `get_arg` persistence unification preserved teslemetry's behaviour.
+
+(These suite names were confirmed against `./run_all --list`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/predbat/deye.py apps/predbat/enphase.py apps/predbat/fox.py apps/predbat/solis.py apps/predbat/teslemetry.py
+git commit -m "refactor(mock): use shared MockBase in deye, enphase, fox, solis, teslemetry
+
+These five need no module-specific state, so each drops its local copy in
+favour of a plain import."
+```
+
+---
+
+### Task 3: Migrate the five subclass modules and the kraken alias
+
+**Files:**
+- Modify: `apps/predbat/axle.py` (replace class at 709-764)
+- Modify: `apps/predbat/gecloud.py` (replace class at 1962-2014; keep `MockHAInterface` at 1952-1960)
+- Modify: `apps/predbat/octopus.py` (replace class at 3004-3056; leave `QuietMockBase` untouched)
+- Modify: `apps/predbat/sigenergy.py` (replace class at 2500-2547)
+- Modify: `apps/predbat/solax.py` (replace class at 2845-2894)
+- Modify: `apps/predbat/kraken.py` (replace class at 1404-1461; **delete `import json` at line 19**)
+- Modify: `apps/predbat/tests/test_mock_base.py` (add the subclass tests below)
+
+**Interfaces:**
+- Consumes: `MockBase` from `mock_base` (Task 1).
+- Produces: `MockBase` in `axle`, `gecloud`, `octopus`, `sigenergy`, `solax`; `KrakenMockBase` in `kraken`. `sigenergy.MockBase` keeps its `readonly=False` first positional parameter.
+
+- [ ] **Step 1: Write the failing subclass tests**
+
+Append to `apps/predbat/tests/test_mock_base.py`, immediately **before** `def test_mock_base_all`:
+
+```python
+def test_mock_base_module_subclasses(my_predbat):
+    """The five subclassing modules keep their distinguishing state on top of the shared base."""
+    from axle import MockBase as AxleMockBase
+    from gecloud import MockBase as GECloudMockBase
+    from octopus import MockBase as OctopusMockBase
+    from sigenergy import MockBase as SigenergyMockBase
+    from solax import MockBase as SolaxMockBase
+
+    assert AxleMockBase().config_root == "./temp_axle", "axle config_root is wrong"
+    assert OctopusMockBase().config_root == "./temp_octopus", "octopus config_root is wrong"
+
+    gecloud_base = GECloudMockBase()
+    assert gecloud_base.config_root == "./temp_gecloud", "gecloud config_root is wrong"
+    assert gecloud_base.ha_interface is not None, "gecloud must supply a mock ha_interface"
+    assert hasattr(gecloud_base.ha_interface, "set_state_external"), "gecloud ha_interface needs set_state_external"
+
+    assert SolaxMockBase().local_tz == timezone.utc, "solax must keep using UTC"
+
+    read_only = SigenergyMockBase(readonly=True)
+    assert read_only.get_state_wrapper("switch.predbat_set_read_only") == "on", "sigenergy readonly=True should seed the switch on"
+    writable = SigenergyMockBase(readonly=False)
+    assert writable.get_state_wrapper("switch.predbat_set_read_only") == "off", "sigenergy readonly=False should seed the switch off"
+
+    print("PASS: module MockBase subclasses keep their distinguishing state")
+    return False
+
+
+def test_mock_base_kraken_alias(my_predbat):
+    """KrakenMockBase is the shared base and still accepts user_id, skipping it when None."""
+    from kraken import KrakenMockBase
+
+    assert KrakenMockBase(user_id="user-123").args.get("user_id") == "user-123", "user_id should be stored"
+    assert "user_id" not in KrakenMockBase(user_id=None).args, "a None user_id must not be stored"
+    print("PASS: KrakenMockBase preserves its user_id contract")
+    return False
+```
+
+Register both in the `tests` list inside `test_mock_base_all`, after the `ha_helpers` entry:
+
+```python
+        ("module_subclasses", test_mock_base_module_subclasses, "Module subclasses keep their distinguishing state"),
+        ("kraken_alias", test_mock_base_kraken_alias, "KrakenMockBase alias preserves the user_id contract"),
+```
+
+- [ ] **Step 2: Run to establish the baseline — these tests must PASS now**
+
+```bash
+cd coverage && ./run_all --test mock_base > /tmp/task3_baseline.txt 2>&1; echo "exit=$?"
+grep -iE "All 14 mock_base tests passed|FAILED|ERROR in" /tmp/task3_baseline.txt
+```
+
+Expected: **PASS**, exit 0.
+
+This is deliberate and is **not** a broken red step. These two are *characterization* tests: they pin down behaviour the five modules already have, so the refactor cannot silently change it. Unlike Task 1 — where the module genuinely did not exist yet — there is no new behaviour to drive out here. A test that passes before *and* after is exactly the safety net a pure refactor needs.
+
+If either test **fails** at this point, stop: the assertions do not match today's behaviour, so they would lock in the wrong contract. Correct the test against the real current behaviour before touching any module.
+
+- [ ] **Step 3: Replace each class with a subclass**
+
+**All five modules need this import** added next to their existing `from component_base import ComponentBase` line. The alias avoids a name clash with the subclass, which must keep the plain name `MockBase` for the existing call sites:
+
+```python
+from mock_base import MockBase as SharedMockBase
+```
+
+Then replace each deleted class block with the subclass below, at the position the old class occupied.
+
+In `axle.py`:
+
+```python
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the Axle command-line harness, with its own cache directory."""
+
+    def __init__(self):
+        """Initialise the shared mock with the Axle cache root."""
+        super().__init__(config_root="./temp_axle")
+```
+
+In `octopus.py` (leave the `QuietMockBase(MockBase)` subclass further down the file untouched — it now inherits through the new subclass and keeps working):
+
+```python
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the Octopus command-line harness, with its own cache directory."""
+
+    def __init__(self):
+        """Initialise the shared mock with the Octopus cache root."""
+        super().__init__(config_root="./temp_octopus")
+```
+
+In `gecloud.py` (keep the existing `MockHAInterface` class exactly as it is, directly above):
+
+```python
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the GE Cloud command-line harness, with its own cache root and HA interface."""
+
+    def __init__(self):
+        """Initialise the shared mock with the GE Cloud cache root and a mock HA interface."""
+        super().__init__(config_root="./temp_gecloud")
+        self.ha_interface = MockHAInterface()
+```
+
+In `solax.py`:
+
+```python
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the Solax command-line harness, which works in UTC rather than local time."""
+
+    def __init__(self):
+        """Initialise the shared mock pinned to UTC."""
+        super().__init__(local_tz=timezone.utc)
+```
+
+In `sigenergy.py`:
+
+```python
+class MockBase(SharedMockBase):  # pragma: no cover
+    """Mock base for the Sigenergy command-line harness, which can pre-seed read-only mode."""
+
+    def __init__(self, readonly=False):
+        """Initialise the shared mock, seeding the read-only switch so control writes are gated."""
+        super().__init__()
+        self.entities["switch.predbat_set_read_only"] = {"state": "on" if readonly else "off", "attributes": {}}
+```
+
+In `kraken.py`, delete the `class KrakenMockBase:` block, **delete `import json` on line 19**, and add:
+
+```python
+from mock_base import MockBase as KrakenMockBase
+```
+
+Note on `sigenergy`: the original seeded `{"state": ...}` with no `attributes` key. The version above adds `"attributes": {}` so the record matches what `set_state_wrapper` produces and an `attribute=` lookup cannot raise `KeyError`. `get_state_wrapper` reads `.get("state")`, so the seeded value is found either way.
+
+Note on `solax`: it already imports `timezone` from `datetime` (line 24), so no import change is needed.
+
+- [ ] **Step 4: Verify `kraken.py` has no other `json` usage before committing the import removal**
+
+```bash
+grep -n "json" apps/predbat/kraken.py
+```
+
+Expected: only `response.json()` calls, the `json={"query": ...}` kwarg, and the `"application/json"` string — no bare `json.` attribute access, and no `import json`.
+
+- [ ] **Step 5: Verify every module imports cleanly**
+
+```bash
+cd apps/predbat && for m in axle gecloud octopus sigenergy solax; do
+  python3 -c "import $m; b = $m.MockBase(); print('$m OK', b.config_root, b.local_tz)" || echo "$m FAILED"
+done
+python3 -c "import kraken; print('kraken OK', kraken.KrakenMockBase)"
+```
+
+Expected: six `OK` lines. `sigenergy` prints `./temp_predbat` (it does not override `config_root`); the others print their own roots.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd coverage && ./run_all --test mock_base --test axle --test ge_cloud --test sigenergy --test solax --test kraken --test kraken_auth -k octopus_ > /tmp/task3_test.txt 2>&1; echo "exit=$?"
+grep -iE "All 14 mock_base tests passed|FAILED|ERROR in|Traceback" /tmp/task3_test.txt
+```
+
+Expected: `*** All 14 mock_base tests passed ***` and exit 0 with no other failures — the same result as the Step 2 baseline, which is the point: the refactor changed the implementation, not the behaviour.
+
+If `-k octopus_` cannot be combined with `--test` in one invocation, run the octopus suites as a second command:
+
+```bash
+cd coverage && ./run_all -k octopus_ > /tmp/task3_octopus.txt 2>&1; echo "exit=$?"
+grep -iE "FAILED|ERROR in|Traceback" /tmp/task3_octopus.txt
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/predbat/axle.py apps/predbat/gecloud.py apps/predbat/octopus.py apps/predbat/sigenergy.py apps/predbat/solax.py apps/predbat/kraken.py apps/predbat/tests/test_mock_base.py
+git commit -m "refactor(mock): use shared MockBase in the five subclassing modules
+
+axle, gecloud and octopus keep their own cache roots, gecloud its mock HA
+interface, solax its UTC clock and sigenergy its readonly seeding. kraken
+aliases the shared class and drops the now-unused json import."
+```
+
+---
+
+### Task 4: Full-suite and pre-commit verification
+
+**Files:** none modified unless a check fails.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3.
+- Produces: a green full test suite and a clean pre-commit run.
+
+- [ ] **Step 1: Confirm no stray `MockBase` definitions remain**
+
+```bash
+grep -rn "^class MockBase\|^class KrakenMockBase" apps/predbat/*.py
+```
+
+Expected: exactly six lines — `mock_base.py` plus the five subclasses in `axle`, `gecloud`, `octopus`, `sigenergy`, `solax`. `kraken.py` must **not** appear (it is now an import alias).
+
+Note that `web_mcp.py:1293` has a function-local `class MockBase:` — it is indented, so this `^`-anchored grep will not match it. That is correct: it is a different, unrelated mock and is deliberately out of scope.
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+cd coverage && ./run_all > /tmp/full_test.txt 2>&1; echo "exit=$?"
+grep -icE "^FAILED|ERROR in|Traceback" /tmp/full_test.txt
+tail -30 /tmp/full_test.txt
+```
+
+Expected: exit 0 and no failures. If anything fails, read the surrounding context in `/tmp/full_test.txt` before changing code — do not guess at a fix.
+
+- [ ] **Step 3: Run pre-commit**
+
+```bash
+./run_pre_commit > /tmp/precommit.txt 2>&1; echo "exit=$?"
+grep -iE "Failed|error|F401|would reformat" /tmp/precommit.txt | head -30
+```
+
+Expected: exit 0. Watch specifically for:
+- **F401 unused import** — most likely `json` in `kraken.py` if Step 4 of Task 3 was missed.
+- **interrogate** docstring coverage — every new class and function needs one.
+- **CSpell** — if it flags a word, add it to `.cspell/custom-dictionary-workspace.txt`. That file is auto-sorted on commit, so re-stage it afterwards.
+- **Black** reformatting — if it rewrites a file, re-stage and re-run.
+
+- [ ] **Step 4: Commit any pre-commit fixups**
+
+Only if Step 3 changed files:
+
+```bash
+git status --short
+git add -u
+git commit -m "chore: pre-commit fixups for shared MockBase"
+```
+
+- [ ] **Step 5: Confirm the diff is the expected shape**
+
+```bash
+git diff --stat main...HEAD
+```
+
+Expected: roughly 588 lines deleted across the eleven modules, offset by ~120 added in `mock_base.py` plus ~40 in subclasses and the new test file. A substantially different shape means something was missed — investigate before finishing.

--- a/docs/superpowers/specs/2026-07-29-shared-mock-base-design.md
+++ b/docs/superpowers/specs/2026-07-29-shared-mock-base-design.md
@@ -47,10 +47,11 @@ The eleven CLI test-double classes listed above.
 - **`web_mcp.py:1293`** — an inline mock with an unrelated surface (`raw_plan`, `soc_kw`,
   `is_running`); it has no `get_state_wrapper`, `get_arg`, `log` or `dashboard_item`. There
   is nothing to share.
-- **`self.record_status(...)` calls in `octopus.py`.** `OctopusAPI` inherits `ComponentBase`,
-  which defines no `record_status` (it lives on `Output`), so those error paths would raise
-  `AttributeError` regardless of the mock. That is a pre-existing defect on `self`, not
-  `self.base`, and this work does not address it.
+- **`self.record_status(...)` calls in `octopus.py`.** These calls (around
+  `octopus.py:2067-2334`) are inside `class Octopus`, a PredBat mixin composed alongside
+  `Output` in the main `PredBat` class, where `Output.record_status` genuinely exists at
+  runtime. They are unrelated to `OctopusAPI`/`ComponentBase` or to `self.base`, and out of
+  scope for this work.
 
 ## Design
 
@@ -121,8 +122,9 @@ Three deliberate changes, all confined to CLI-harness behaviour and output:
    version adopts that approach. `default=str` (currently only in `axle`) prevents a
    `TypeError` when a component publishes a datetime.
 
-   Cosmetic consequence: `axle` and `deye` CLI output will now elide `options` as the other
-   nine already do.
+   Cosmetic consequence: `axle` CLI output will now elide `options` as the other modules
+   already do. `deye`'s old `dashboard_item` printed no attributes at all, so it gains
+   attribute printing outright rather than merely eliding `options`.
 
 3. **`set_arg` logging.** `axle` and `sigenergy` print a terser line; they adopt the common
    form that resolves the referenced entity's state. More informative, CLI-only.

--- a/docs/superpowers/specs/2026-07-29-shared-mock-base-design.md
+++ b/docs/superpowers/specs/2026-07-29-shared-mock-base-design.md
@@ -1,0 +1,185 @@
+# Shared `MockBase` for standalone CLI harnesses
+
+**Date:** 2026-07-29
+**Status:** Approved
+
+## Problem
+
+Eleven production modules each define a near-identical `MockBase` class whose only purpose is
+to stand in for the PredBat base object when the module is run standalone from the command
+line (`python fox.py --key=...`). All are marked `# pragma: no cover`.
+
+| Module | Class | Notes |
+|--------|-------|-------|
+| `axle.py` | `MockBase` | adds `config_root`, `fatal_error`, `had_errors`, `components`, `now_utc_exact`, `call_notify` |
+| `deye.py` | `MockBase` | |
+| `enphase.py` | `MockBase` | adds `fatal_error`, `had_errors` |
+| `fox.py` | `MockBase` | narrow `get_arg(key, default)` |
+| `gecloud.py` | `MockBase` | |
+| `kraken.py` | `KrakenMockBase` | takes `user_id=` |
+| `octopus.py` | `MockBase` | adds `config_root`, `plan_interval_minutes`, `now_utc_exact`; has a `QuietMockBase` subclass |
+| `sigenergy.py` | `MockBase` | takes `readonly=`; non-mutating `dashboard_item` |
+| `solax.py` | `MockBase` | narrow `get_arg(key, default)` |
+| `solis.py` | `MockBase` | persisting `get_arg`/`set_arg` |
+| `teslemetry.py` | `MockBase` | persisting `get_arg`/`set_arg` |
+
+Roughly 90% of each class is identical: `get_state_wrapper`, `set_state_wrapper`, `log`,
+`dashboard_item`, `get_arg`, `set_arg`, and the bulk of `__init__`. The divergence is
+incidental rather than intentional — each was copied from a sibling and then drifted.
+
+The drift has costs beyond duplication. Modules whose `MockBase` omits `fatal_error`,
+`had_errors` or `components` will raise `AttributeError` if a `ComponentBase` property that
+reads them is ever exercised from the CLI path. And the most widely-copied `dashboard_item`
+mutates its caller's `attributes` dict before storing it (see Behaviour Unifications below).
+
+## Scope
+
+### In scope
+
+The eleven CLI test-double classes listed above.
+
+### Explicitly out of scope
+
+- **`tests/test_hainterface_common.py:MockBase`** and the other test-local mocks in
+  `test_solcast.py`, `test_load_ml.py`, `test_solis.py`. These share a name but mock a
+  different surface with test-specific behaviour, and are already shared within the test
+  suite where it matters.
+- **`web_mcp.py:1293`** — an inline mock with an unrelated surface (`raw_plan`, `soc_kw`,
+  `is_running`); it has no `get_state_wrapper`, `get_arg`, `log` or `dashboard_item`. There
+  is nothing to share.
+- **`self.record_status(...)` calls in `octopus.py`.** `OctopusAPI` inherits `ComponentBase`,
+  which defines no `record_status` (it lives on `Output`), so those error paths would raise
+  `AttributeError` regardless of the mock. That is a pre-existing defect on `self`, not
+  `self.base`, and this work does not address it.
+
+## Design
+
+### New module: `apps/predbat/mock_base.py`
+
+A single shared class, mirroring the `component_base.py` file convention. It is a **concrete
+class, not an ABC** — being directly instantiable is the point; subclasses only add extras.
+
+### Constructor
+
+```python
+def __init__(self, config_root="./temp_predbat", **kwargs):
+```
+
+Sets the full superset of attributes, derived from every `self.base.*` dereference across
+`component_base.py` and the eleven modules:
+
+`local_tz`, `now_utc`, `now_utc_exact`, `midnight_utc`, `minutes_now`, `prefix`, `args`,
+`entities`, `config_root`, `plan_interval_minutes`, `fatal_error`, `had_errors`,
+`components` (`None`), `num_cars`, `currency_symbols`, `arg_errors`.
+
+Applying the superset to every module is purely additive: it closes the latent
+`AttributeError` gaps without changing any behaviour that works today. `components = None`
+keeps `ComponentBase.storage` resolving to `None`, so the disk cache stays skipped for
+standalone runs — matching current behaviour.
+
+Surplus `**kwargs` are stored into `self.args`, which absorbs `kraken`'s `user_id=` case
+without a bespoke subclass. **Only kwargs whose value is not `None` are stored.** This
+matters: `kraken` guards with `if user_id:` before setting `self.args["user_id"]`, and
+`oauth_mixin.py:118` reads it back as `args.get("user_id", "")`. Storing a `None` would put
+`None` where `""` is expected. Filtering `None` is exactly behaviour-preserving for the
+`KrakenMockBase(user_id=None)` call site, while still allowing a legitimate `False` or `0`
+argument to be stored.
+
+### Methods
+
+`get_state_wrapper`, `set_state_wrapper`, `log`, `dashboard_item`, `get_arg`, `set_arg`,
+`call_notify`, `record_status`, `get_ha_config`, `get_history_wrapper`.
+
+Each signature takes the **widest form observed**, so no existing caller breaks:
+
+- `get_state_wrapper(entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False)`
+  — including axle's `attribute=` lookup support.
+- `set_state_wrapper(entity_id, state, attributes=None, app=None, required_unit=None)` —
+  accepts **both** `app` and `required_unit`, because the modules disagree on which they
+  declare and `ComponentBase.set_state_wrapper` passes `required_unit`.
+- `get_arg(arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None)`
+  — the full `ComponentBase` signature, superseding the narrow `(key, default)` forms in
+  `fox` and `solax`.
+
+### Behaviour unifications
+
+Three deliberate changes, all confined to CLI-harness behaviour and output:
+
+1. **`get_arg`/`set_arg` persistence.** Unify on the `solis`/`teslemetry` form: `set_arg`
+   writes to `self.args`, `get_arg` reads it back. For the nine modules whose `get_arg`
+   returned the bare default, `self.args` stayed empty in practice, so results are unchanged.
+
+2. **`dashboard_item` attribute printing.** Unify on: elide `options` to `"..."` in a
+   **copy**, and serialise with `json.dumps(..., default=str)`.
+
+   The prevailing implementation does `attributes["options"] = "..."` — mutating the
+   caller's dict, which is then passed to `set_state_wrapper` and **stored corrupted**. This
+   is a genuine latent bug; `sigenergy` already avoids it with a display copy and the shared
+   version adopts that approach. `default=str` (currently only in `axle`) prevents a
+   `TypeError` when a component publishes a datetime.
+
+   Cosmetic consequence: `axle` and `deye` CLI output will now elide `options` as the other
+   nine already do.
+
+3. **`set_arg` logging.** `axle` and `sigenergy` print a terser line; they adopt the common
+   form that resolves the referenced entity's state. More informative, CLI-only.
+
+### Per-module changes
+
+Each module keeps a module-level `MockBase` name so its call sites and the
+`from teslemetry import MockBase` import in `tests/test_teslemetry.py:1458` keep working.
+
+Seven modules collapse to a plain re-export:
+
+```python
+from mock_base import MockBase   # deye, enphase, fox, gecloud, solax, solis, teslemetry
+```
+
+Three need a small subclass:
+
+- `axle.py` — `config_root="./temp_axle"`
+- `octopus.py` — `config_root="./temp_octopus"`; its existing `QuietMockBase(MockBase)`
+  subclass is unaffected and continues to work.
+- `sigenergy.py` — keeps its `readonly=` parameter, which pre-seeds
+  `switch.predbat_set_read_only` in `self.entities`.
+
+`kraken.py` binds `KrakenMockBase = MockBase` so its `user_id=` call site is untouched (the
+`**kwargs`-into-`args` behaviour covers it).
+
+Expected net: roughly 550 duplicated lines replaced by a ~110-line shared module plus ~25
+lines of subclasses.
+
+## Testing
+
+Per CLAUDE.md all new code needs unit tests. A new `tests/test_mock_base.py`, registered in
+`TEST_REGISTRY` in `unit_test.py`, covers `MockBase` itself:
+
+- the attribute superset is present after construction, and `config_root` is overridable
+- `**kwargs` land in `self.args` (the `kraken` `user_id=` path)
+- a `None`-valued kwarg is **not** stored (the `KrakenMockBase(user_id=None)` path)
+- `get_arg`/`set_arg` round-trip; `get_arg` returns the supplied default for unset keys
+- **`dashboard_item` does not mutate the caller's `attributes` dict** — the latent bug above;
+  this is the test that earns its keep
+- `dashboard_item` serialises a datetime attribute without raising (the `default=str` path)
+- `get_state_wrapper` raw / `attribute=` / default-fallback paths
+- `set_state_wrapper` accepts both `app=` and `required_unit=`
+- the three subclasses set their distinguishing state (`axle`/`octopus` `config_root`,
+  `sigenergy` `readonly=` seeding the read-only switch)
+
+**Not tested:** the CLI harness functions that construct a `MockBase`
+(`test_fox_api`, `test_solis_api`, `test_axle_api`, etc.). Those are `# pragma: no cover`
+test hooks that hit live vendor APIs; they are excluded from coverage by design and gain
+nothing from unit tests.
+
+The existing `test_teslemetry.py:1456` `get_arg` test must continue to pass unchanged — it
+is the regression check that the persistence unification preserved `teslemetry`'s behaviour.
+
+## Verification
+
+- `./run_all` passes (output saved to a file, then grepped, per CLAUDE.md).
+- `./run_pre_commit` passes. Several modules import `json` and/or `datetime` **only** for
+  their `MockBase`; removing it will leave unused imports that Flake8 flags. Each module's
+  remaining usage must be checked before deleting an import.
+- Each refactored module still imports cleanly and its `if __name__ == "__main__"` path is
+  intact.
+- 100% docstring coverage (`interrogate`) on the new module and its subclasses.

--- a/docs/superpowers/specs/2026-07-29-shared-mock-base-design.md
+++ b/docs/superpowers/specs/2026-07-29-shared-mock-base-design.md
@@ -14,13 +14,13 @@ line (`python fox.py --key=...`). All are marked `# pragma: no cover`.
 | `axle.py` | `MockBase` | adds `config_root`, `fatal_error`, `had_errors`, `components`, `now_utc_exact`, `call_notify` |
 | `deye.py` | `MockBase` | |
 | `enphase.py` | `MockBase` | adds `fatal_error`, `had_errors` |
-| `fox.py` | `MockBase` | narrow `get_arg(key, default)` |
-| `gecloud.py` | `MockBase` | |
-| `kraken.py` | `KrakenMockBase` | takes `user_id=` |
+| `fox.py` | `MockBase` | narrow `get_arg(key, default)`; naive `midnight_utc` |
+| `gecloud.py` | `MockBase` | adds `config_root`, `plan_interval_minutes`, `ha_interface` |
+| `kraken.py` | `KrakenMockBase` | takes `user_id=`; naive `midnight_utc`; sole user of `import json` |
 | `octopus.py` | `MockBase` | adds `config_root`, `plan_interval_minutes`, `now_utc_exact`; has a `QuietMockBase` subclass |
 | `sigenergy.py` | `MockBase` | takes `readonly=`; non-mutating `dashboard_item` |
-| `solax.py` | `MockBase` | narrow `get_arg(key, default)` |
-| `solis.py` | `MockBase` | persisting `get_arg`/`set_arg` |
+| `solax.py` | `MockBase` | narrow `get_arg(key, default)`; `local_tz = timezone.utc` |
+| `solis.py` | `MockBase` | persisting `get_arg`/`set_arg`; naive `midnight_utc` |
 | `teslemetry.py` | `MockBase` | persisting `get_arg`/`set_arg` |
 
 Roughly 90% of each class is identical: `get_state_wrapper`, `set_state_wrapper`, `log`,
@@ -62,8 +62,11 @@ class, not an ABC** — being directly instantiable is the point; subclasses onl
 ### Constructor
 
 ```python
-def __init__(self, config_root="./temp_predbat", **kwargs):
+def __init__(self, config_root="./temp_predbat", local_tz=None, **kwargs):
 ```
+
+`local_tz` defaults to the machine's local timezone; `solax` passes `timezone.utc` to preserve
+its current behaviour.
 
 Sets the full superset of attributes, derived from every `self.base.*` dereference across
 `component_base.py` and the eleven modules:
@@ -124,30 +127,43 @@ Three deliberate changes, all confined to CLI-harness behaviour and output:
 3. **`set_arg` logging.** `axle` and `sigenergy` print a terser line; they adopt the common
    form that resolves the referenced entity's state. More informative, CLI-only.
 
+4. **Timezone-aware `midnight_utc`.** `fox`, `kraken` and `solis` build `midnight_utc` from a
+   naive `datetime.now()` while their `now_utc` is timezone-aware — so any
+   `now_utc - midnight_utc` arithmetic raises `TypeError: can't subtract offset-naive and
+   offset-aware datetimes`. The shared base derives `midnight_utc` from the aware `now_utc`,
+   fixing this. `sigenergy` and `solax` set neither attribute today and gain both.
+
 ### Per-module changes
 
 Each module keeps a module-level `MockBase` name so its call sites and the
 `from teslemetry import MockBase` import in `tests/test_teslemetry.py:1458` keep working.
 
-Seven modules collapse to a plain re-export:
+**Five** modules collapse to a plain re-export:
 
 ```python
-from mock_base import MockBase   # deye, enphase, fox, gecloud, solax, solis, teslemetry
+from mock_base import MockBase   # deye, enphase, fox, solis, teslemetry
 ```
 
-Three need a small subclass:
+**Five** need a small subclass:
 
 - `axle.py` — `config_root="./temp_axle"`
+- `gecloud.py` — `config_root="./temp_gecloud"` **and** `ha_interface = MockHAInterface()`,
+  which `GECloudDirect` dereferences at `gecloud.py:1037`. `MockHAInterface` is
+  gecloud-specific and stays in `gecloud.py`.
 - `octopus.py` — `config_root="./temp_octopus"`; its existing `QuietMockBase(MockBase)`
   subclass is unaffected and continues to work.
 - `sigenergy.py` — keeps its `readonly=` parameter, which pre-seeds
   `switch.predbat_set_read_only` in `self.entities`.
+- `solax.py` — `local_tz=timezone.utc`, preserving its deliberate use of UTC rather than the
+  machine's local timezone.
 
-`kraken.py` binds `KrakenMockBase = MockBase` so its `user_id=` call site is untouched (the
-`**kwargs`-into-`args` behaviour covers it).
+**One** alias: `kraken.py` binds `KrakenMockBase = MockBase` so its `user_id=` call site is
+untouched (the `**kwargs`-into-`args` behaviour covers it).
 
-Expected net: roughly 550 duplicated lines replaced by a ~110-line shared module plus ~25
-lines of subclasses.
+Total: 5 + 5 + 1 = 11 modules.
+
+Expected net: 588 duplicated lines replaced by a ~120-line shared module plus ~40 lines of
+subclasses.
 
 ## Testing
 
@@ -163,8 +179,10 @@ Per CLAUDE.md all new code needs unit tests. A new `tests/test_mock_base.py`, re
 - `dashboard_item` serialises a datetime attribute without raising (the `default=str` path)
 - `get_state_wrapper` raw / `attribute=` / default-fallback paths
 - `set_state_wrapper` accepts both `app=` and `required_unit=`
-- the three subclasses set their distinguishing state (`axle`/`octopus` `config_root`,
-  `sigenergy` `readonly=` seeding the read-only switch)
+- `midnight_utc` is timezone-aware and `now_utc - midnight_utc` does not raise
+- the five subclasses set their distinguishing state (`axle`/`gecloud`/`octopus`
+  `config_root`, `gecloud` `ha_interface`, `sigenergy` `readonly=` seeding the read-only
+  switch, `solax` `local_tz` being UTC)
 
 **Not tested:** the CLI harness functions that construct a `MockBase`
 (`test_fox_api`, `test_solis_api`, `test_axle_api`, etc.). Those are `# pragma: no cover`
@@ -177,9 +195,12 @@ is the regression check that the persistence unification preserved `teslemetry`'
 ## Verification
 
 - `./run_all` passes (output saved to a file, then grepped, per CLAUDE.md).
-- `./run_pre_commit` passes. Several modules import `json` and/or `datetime` **only** for
-  their `MockBase`; removing it will leave unused imports that Flake8 flags. Each module's
-  remaining usage must be checked before deleting an import.
+- `./run_pre_commit` passes. Audited: **`kraken.py` is the only module whose top-level
+  `import json` exists solely for its mock** — every other `json` reference in that file is
+  `response.json()` or a string literal, so the import must be deleted or Flake8 F401 fires.
+  All other modules use `json` and `datetime` outside their mock and keep their imports.
+  `sigenergy.py:2528` also has a redundant function-local `import json` that disappears with
+  the class.
 - Each refactored module still imports cleanly and its `if __name__ == "__main__"` path is
   intact.
 - 100% docstring coverage (`interrogate`) on the new module and its subclasses.


### PR DESCRIPTION
## Summary

Eleven production modules each defined a near-identical `MockBase` class — a stand-in for the PredBat base object, used only to drive each module's standalone command-line harness (`python fox.py --key=...`). Roughly 90% of each copy was identical; the divergence was incidental drift from copy-paste, not intent.

This replaces all eleven with a single `apps/predbat/mock_base.py`:

- **5 plain imports** — `deye`, `enphase`, `fox`, `solis`, `teslemetry`
- **5 subclasses** — `axle`, `gecloud`, `octopus` (cache roots), `gecloud` (mock HA interface), `sigenergy` (`readonly=` seeding), `solax` (UTC clock)
- **1 alias** — `kraken` (`KrakenMockBase = MockBase`)

Net: 588 duplicated lines removed, replaced by a ~125-line shared module plus ~40 lines of subclasses.

## Latent bugs fixed

The drift had hidden four real defects on the CLI-harness path, none of which had automated coverage:

1. **`fox` and `solax` had a narrow `get_arg(key, default)`** — any call routed through `ComponentBase.get_arg`, which passes `indirect`/`combine`/`attribute`/`index`/`domain`/`can_override`/`required_unit` as keywords, would raise `TypeError`.
2. **`gecloud`'s `getattr(self.base, "record_status", None)` guard was always falsy** — the mock had no `record_status`, so cloud auth-denied was silently never reported from the CLI.
3. **`fox`, `kraken` and `solis` built a naive `midnight_utc`** from `datetime.now()` alongside a timezone-aware `now_utc`, so `now_utc - midnight_utc` raised `TypeError: can't subtract offset-naive and offset-aware datetimes`.
4. **The most-copied `dashboard_item` mutated its caller's dict** — `attributes["options"] = "..."` was applied to the caller's own dict, which was then handed to `set_state_wrapper` and stored corrupted. `kraken` and `sigenergy` already avoided this with a display copy; the shared version adopts that.

Two further behaviours were unified deliberately: `get_arg`/`set_arg` now persist to and read from `self.args` everywhere (previously nine modules returned the bare default, with `self.args` empty in practice, so results are unchanged), and `set_arg(key, None)` now deletes the key to match `userinterface.py`.

## Tests

New `apps/predbat/tests/test_mock_base.py` — 17 tests registered in `TEST_REGISTRY`. Beyond the per-method coverage, two are worth calling out:

- `test_mock_base_covers_component_base_contract` binds a real `ComponentBase` subclass to a `MockBase` and exercises every property and delegate, so it fails with `AttributeError` if someone adds a `self.base.<x>` dereference the mock doesn't cover. Verified non-vacuous: deleting an attribute makes it raise.
- `test_mock_base_reexport_identity` asserts the five re-export modules expose the shared class by identity and the five subclassing modules are subclasses of it — catching a botched future edit to any of those import lines.

`kraken.py`'s `import json` and `deye.py`'s `from datetime import datetime` became unused and were removed (verified with `ruff F401`).

## Verification

- Full suite: `./run_all` → exit 0, "All tests passed (total time: 102.38s)"
- `./run_pre_commit` → all 10 hooks green

## Notes

Out of scope by design: the test-local `MockBase` classes in `tests/` (different surface, already shared where it matters) and `web_mcp.py`'s inline mock (unrelated surface — no `get_state_wrapper`/`get_arg` at all).

Separately worth knowing: `interrogate` is configured with `fail-under = 100` in `pyproject.toml` but is **not** wired into `.pre-commit-config.yaml`, so the 100% docstring rule in CLAUDE.md has never actually been gate-enforced. This branch satisfies it regardless — flagging as a pre-existing repo issue, not something to fix here.

Design and plan: `docs/superpowers/specs/2026-07-29-shared-mock-base-design.md`, `docs/superpowers/plans/2026-07-29-shared-mock-base.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)