### PR TITLE
test(predict-pv-power): delete fixture attrs on restore instead of setting None

### DIFF
--- a/apps/predbat/tests/test_predict_pv_power.py
+++ b/apps/predbat/tests/test_predict_pv_power.py
@@ -55,15 +55,15 @@ def test_predict_pv_power_matches_input_regardless_of_plan_interval(my_predbat):
 
     # my_predbat is a shared fixture reused by every test module in the suite - save everything
     # this test mutates and restore it afterwards so later tests (e.g. model_kernel, which assumes
-    # the 30-minute default) aren't left running against a stale plan_interval_minutes.
-    original_plan_interval_minutes = my_predbat.plan_interval_minutes
-    original_forecast_minutes = my_predbat.forecast_minutes
-    original_end_record = my_predbat.end_record
-    original_pv_forecast_minute = getattr(my_predbat, "pv_forecast_minute", None)
-    original_pv_forecast_minute10 = getattr(my_predbat, "pv_forecast_minute10", None)
-    original_load_minutes_step = getattr(my_predbat, "load_minutes_step", None)
-    original_load_minutes_step10 = getattr(my_predbat, "load_minutes_step10", None)
-    original_prediction = getattr(my_predbat, "prediction", None)
+    # the 30-minute default) aren't left running against a stale plan_interval_minutes. Some of
+    # these (load_minutes_step*, prediction) aren't set until a real update_pred() cycle or
+    # calculate_plan() runs, so on a fresh fixture they may not exist as attributes at all -
+    # restoring them to None in that case would still leave the fixture in a worse state than
+    # before (an attribute that exists but is None, instead of not existing), so track presence
+    # and delete rather than assign None when the attribute was absent to begin with.
+    attrs_to_restore = ["plan_interval_minutes", "forecast_minutes", "end_record", "pv_forecast_minute", "pv_forecast_minute10", "load_minutes_step", "load_minutes_step10", "prediction"]
+    had_attr = {name: hasattr(my_predbat, name) for name in attrs_to_restore}
+    original_value = {name: getattr(my_predbat, name, None) for name in attrs_to_restore if had_attr[name]}
 
     try:
         flat_pv_kw = 4.0
@@ -78,14 +78,14 @@ def test_predict_pv_power_matches_input_regardless_of_plan_interval(my_predbat):
             else:
                 print("  plan_interval_minutes={}: predict_pv_power={}kW (expected {}kW) - OK".format(plan_interval_minutes, sample, flat_pv_kw))
     finally:
-        my_predbat.plan_interval_minutes = original_plan_interval_minutes
-        my_predbat.forecast_minutes = original_forecast_minutes
-        my_predbat.end_record = original_end_record
-        my_predbat.pv_forecast_minute = original_pv_forecast_minute
-        my_predbat.pv_forecast_minute10 = original_pv_forecast_minute10
-        my_predbat.load_minutes_step = original_load_minutes_step
-        my_predbat.load_minutes_step10 = original_load_minutes_step10
-        my_predbat.prediction = original_prediction
+        for name in attrs_to_restore:
+            if had_attr[name]:
+                setattr(my_predbat, name, original_value[name])
+            else:
+                try:
+                    delattr(my_predbat, name)
+                except AttributeError:
+                    pass
 
     if failed:
         print("Test: predict_pv_power_matches_input_regardless_of_plan_interval FAILED")


### PR DESCRIPTION
## Summary

Follow-up to #4374 (merged) - a Copilot review comment landed after the merge, flagging a real fixture-hygiene bug in the new regression test:

> The fixture-restore logic can leave `my_predbat.load_minutes_step`, `load_minutes_step10`, or `prediction` set to `None` when those attributes didn't exist before this test (e.g. `load_minutes_step*` aren't initialised in `PredBat.reset()`). That mutates the shared `my_predbat` fixture into an invalid state for later tests that expect dict/Prediction objects, and can cause order-dependent failures.

Verified directly: `load_minutes_step`/`load_minutes_step10` are only ever set at the end of a real `update_pred()` cycle ([predbat.py:1114-1115](https://github.com/springfall2008/batpred/blob/main/apps/predbat/predbat.py#L1114-L1115)), and `self.prediction` is only ever assigned when a real `Prediction` object gets constructed ([plan.py:1080](https://github.com/springfall2008/batpred/blob/main/apps/predbat/plan.py#L1080)) - neither exists on a freshly-created test fixture before this test runs. The `finally` block's `getattr(..., None)` + unconditional restore left them present-but-`None` afterwards, worse than the original missing-attribute state.

## Change

Track attribute presence up front (`hasattr`), and on restore, `delattr` rather than assign `None` for any attribute that didn't exist beforehand - matching what a genuinely fresh fixture would look like.

## Test plan
- [x] `unit_test.py --test predict_pv_power` - passes
- [x] `unit_test.py --quick` - full suite passes, no order-dependent failures
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)