### PR TITLE
fix(inverter): stop the export target sitting below the min reserve SoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ it
 
 # Runtime-generated manifest
 apps/predbat/manifest.yaml
+
+# Claude Code local worktrees
+.claude/worktrees/

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -616,10 +616,20 @@ class GECloudDirect(ComponentBase):
         device_ha_names = {regname_to_ha(registers[key].get("name", "")) for key in registers}
         has_charge_power = "battery_charge_power" in device_ha_names
         has_discharge_power = "battery_discharge_power" in device_ha_names
+        # Predbat drives the export target register itself (discharge_target_soc, the DC discharge
+        # lower SoC limit) and tracks the minimum reserve SoC there, so leave that one alone rather
+        # than resetting it and fighting adjust_force_export.
+        discharge_target = self.get_arg("discharge_target_soc", default=None, indirect=False)
+        if not isinstance(discharge_target, list):
+            discharge_target = [discharge_target] if discharge_target else []
+        discharge_target = {str(entity).lower() for entity in discharge_target if entity}
         for key in registers:
             reg_name = registers[key].get("name", "")
             value = registers[key].get("value", None)
             ha_name = regname_to_ha(reg_name)
+
+            if "number.{}_gecloud_{}_{}".format(self.prefix, device, ha_name).lower() in discharge_target:
+                continue
 
             if ("export_soc_percent_limit" in ha_name) or ("discharge_soc_percent_limit" in ha_name) or ("lower_soc_percent_limit" in ha_name):
                 if not value or value > 4:

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2491,8 +2491,11 @@ class Inverter:
             else:
                 self.log("Warn: Inverter {} unable write export end time as neither REST or discharge_end_time are set".format(self.id))
 
-        # REST export target, always set to minimum
+        # Export target, always set to the minimum reserve. This must track the reserve in *both*
+        # directions - a target left below the minimum reserve SoC (e.g. GE Cloud resets it to 4%)
+        # lets the inverter drain the battery past the reserve between Predbat cycles.
         if force_export:
+            target_soc = int(self.reserve_percent)
             if self.rest_data and self.rest_v3:
                 if "raw" in self.rest_data and "invertor" in self.rest_data["raw"] and "discharge_target_soc_1" in self.rest_data["raw"]["invertor"]:
                     current = self.rest_data["raw"]["invertor"]["discharge_target_soc_1"]
@@ -2501,8 +2504,8 @@ class Inverter:
                     except (ValueError, TypeError) as e:
                         current = 0
 
-                    if current > self.reserve_percent:
-                        self.rest_setDischargeTarget(int(self.reserve_percent))
+                    if current != target_soc:
+                        self.rest_setDischargeTarget(target_soc)
                     else:
                         self.log("Inverter {} Current discharge target is already set to {}".format(self.id, current))
             elif "discharge_target_soc" in self.base.args:
@@ -2511,8 +2514,8 @@ class Inverter:
                     current = float(current)
                 except (ValueError, TypeError) as e:
                     current = 0
-                if current > self.reserve_percent:
-                    self.write_and_poll_value("discharge_target_soc", self.base.get_arg("discharge_target_soc", indirect=False, index=self.id, required_unit="%"), int(self.reserve_percent))
+                if current != target_soc:
+                    self.write_and_poll_value("discharge_target_soc", self.base.get_arg("discharge_target_soc", indirect=False, index=self.id, required_unit="%"), target_soc)
                 else:
                     self.log("Inverter {} Current discharge target is already set to {}".format(self.id, current))
 

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -87,7 +87,7 @@ class MockGECloudDirect(GECloudDirect):
         """Mock dashboard_item - tracks calls"""
         self.dashboard_items[entity_id] = {"state": state, "attributes": attributes}
 
-    def get_arg(self, name, default=None):
+    def get_arg(self, name, default=None, **kwargs):
         """Mock get_arg"""
         return self.config_args.get(name, default)
 
@@ -238,6 +238,7 @@ def test_ge_cloud(my_predbat=None):
         ("automatic_config", _test_async_automatic_config, "Automatic config"),
         ("hybrid_detection", _test_hybrid_detection, "Hybrid inverter detection"),
         ("enable_defaults", _test_enable_default_options, "Enable default options"),
+        ("enable_defaults_skip_target", _test_enable_default_options_skips_discharge_target, "Enable defaults skips the discharge target register"),
         ("enable_defaults_read_only", _test_run_read_only_skips_reset, "Enable defaults skipped in read-only mode"),
         ("enable_defaults_after_read_only", _test_run_enables_reset_after_read_only, "Enable defaults on first non-read-only run"),
         ("enable_defaults_24h", _test_run_enables_reset_after_24h, "Enable defaults re-runs after 24 hours"),
@@ -3375,6 +3376,71 @@ def _test_hybrid_detection(my_predbat):
         return 0
 
     return run_async(test())
+
+
+def _test_enable_default_options_skips_discharge_target(my_predbat):
+    """enable_default_options must not reset the register Predbat drives as discharge_target_soc"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.settings = {"test123": {}, "other456": {}}
+
+        write_calls = []
+
+        async def mock_write(device, key, value):
+            write_calls.append({"device": device, "key": key, "value": value})
+            return {"value": value}
+
+        async def mock_publish(*args, **kwargs):
+            pass
+
+        ge_cloud.async_write_inverter_setting = mock_write
+        ge_cloud.publish_registers = mock_publish
+
+        # Predbat drives the DC discharge 1 lower SoC limit on test123 as the export target
+        ge_cloud.config_args["discharge_target_soc"] = ["number.predbat_gecloud_test123_dc_discharge_1_lower_soc_percent_limit"]
+
+        # The configured export target register must be left alone
+        registers = {100: {"name": "DC_Discharge_1_Lower_SOC_Percent_Limit", "value": 50, "validation_rules": []}}
+        result = await ge_cloud.enable_default_options("test123", registers)
+        if write_calls:
+            print("ERROR: Expected no write to the configured discharge target register, got {}".format(write_calls))
+            return 1
+        if result:
+            print("ERROR: enable_default_options should report no change when only the discharge target matched")
+            return 1
+        if registers[100]["value"] != 50:
+            print("ERROR: Discharge target register value should be untouched, got {}".format(registers[100]["value"]))
+            return 1
+
+        # Other lower SoC registers on the same device are still reset to 4%
+        write_calls.clear()
+        registers = {101: {"name": "Export_SOC_Percent_Limit", "value": 50, "validation_rules": []}}
+        result = await ge_cloud.enable_default_options("test123", registers)
+        if len(write_calls) != 1 or write_calls[0]["value"] != 4:
+            print("ERROR: Expected Export_SOC_Percent_Limit to still be reset to 4, got {}".format(write_calls))
+            return 1
+
+        # The same register on a device Predbat is not driving is still reset to 4%
+        write_calls.clear()
+        registers = {100: {"name": "DC_Discharge_1_Lower_SOC_Percent_Limit", "value": 50, "validation_rules": []}}
+        result = await ge_cloud.enable_default_options("other456", registers)
+        if len(write_calls) != 1 or write_calls[0]["value"] != 4:
+            print("ERROR: Expected the register on other456 to still be reset to 4, got {}".format(write_calls))
+            return 1
+
+        # With no discharge target configured (inverter lacks the feature) the reset still applies
+        ge_cloud.config_args["discharge_target_soc"] = None
+        write_calls.clear()
+        registers = {100: {"name": "DC_Discharge_1_Lower_SOC_Percent_Limit", "value": 50, "validation_rules": []}}
+        result = await ge_cloud.enable_default_options("test123", registers)
+        if len(write_calls) != 1 or write_calls[0]["value"] != 4:
+            print("ERROR: Expected the reset to apply when no discharge target is configured, got {}".format(write_calls))
+            return 1
+
+        return 0
+
+    return asyncio.run(test())
 
 
 def _test_enable_default_options(my_predbat):

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1553,6 +1553,85 @@ def test_discharge_window_none_value(test_name, my_predbat, dummy_items):
     return failed
 
 
+def test_discharge_target_tracks_reserve(test_name, ha, inv, dummy_rest):
+    """
+    Regression test: the export target SoC must track the minimum reserve SoC in both directions.
+
+    The export target register (GE 'DC Discharge 1 Lower SoC Limit', discharge_target_soc) is the
+    inverter side backstop that stops a timed export draining the battery below the reserve. Predbat
+    used to only pull it *down* to reserve_percent and left any lower value alone, so a target parked
+    below the minimum reserve SoC (GE Cloud writes 4% in enable_default_options) was never corrected
+    and the battery could discharge past the user's minimum reserve between Predbat cycles.
+    """
+    failed = False
+    print("Test: {}".format(test_name))
+
+    saved_reserve_percent = inv.reserve_percent
+    saved_rest_data = inv.rest_data
+    saved_rest_api = inv.rest_api
+    saved_rest_v3 = inv.rest_v3
+
+    start_time = "03:33:00"
+    end_time = "04:44:00"
+    ts = datetime.strptime(start_time, "%H:%M:%S")
+    te = datetime.strptime(end_time, "%H:%M:%S")
+
+    def setup_entity_case(current_target, reserve_percent):
+        """Prepare the entity (non REST) path with a given starting target and reserve."""
+        inv.rest_data = None
+        inv.rest_api = None
+        inv.reserve_percent = reserve_percent
+        ha.dummy_items["select.discharge_start_time"] = start_time
+        ha.dummy_items["select.discharge_end_time"] = end_time
+        ha.dummy_items["switch.scheduled_discharge_enable"] = "on"
+        ha.dummy_items["sensor.predbat_GE_0_scheduled_discharge_enable"] = "on"
+        ha.dummy_items["number.discharge_target_soc"] = current_target
+        ha.dummy_items["select.inverter_mode"] = "Timed Export"
+        ha.dummy_items["switch.inverter_button"] = "off"
+
+    try:
+        # Case 1: target parked below the reserve must be raised up to the reserve
+        setup_entity_case(current_target=4, reserve_percent=20)
+        inv.adjust_force_export(True, ts, te)
+        if float(ha.get_state("number.discharge_target_soc")) != 20:
+            print("ERROR: {}: export target below reserve should be raised to 20, got {}".format(test_name, ha.get_state("number.discharge_target_soc")))
+            failed = True
+
+        # Case 2: target above the reserve must still be pulled down to the reserve
+        setup_entity_case(current_target=50, reserve_percent=20)
+        inv.adjust_force_export(True, ts, te)
+        if float(ha.get_state("number.discharge_target_soc")) != 20:
+            print("ERROR: {}: export target above reserve should be lowered to 20, got {}".format(test_name, ha.get_state("number.discharge_target_soc")))
+            failed = True
+
+        # Case 3: same correction on the REST v3 path
+        inv.rest_api = "dummy"
+        inv.rest_v3 = True
+        inv.reserve_percent = 20
+        inv.rest_data = {
+            "Control": {"Enable_Discharge_Schedule": "on", "Mode": "Timed Export"},
+            "Timeslots": {"Discharge_start_time_slot_1": start_time, "Discharge_end_time_slot_1": end_time},
+            "raw": {"invertor": {"discharge_target_soc_1": 4}},
+        }
+        dummy_rest.clear_queue()
+        dummy_rest.rest_data = copy.deepcopy(inv.rest_data)
+        polled = copy.deepcopy(inv.rest_data)
+        polled["raw"]["invertor"]["discharge_target_soc_1"] = 20
+        dummy_rest.queue_rest_data(polled)
+
+        inv.adjust_force_export(True, ts, te)
+        if inv.rest_data["raw"]["invertor"]["discharge_target_soc_1"] != 20:
+            print("ERROR: {}: REST export target below reserve should be raised to 20, got {}".format(test_name, inv.rest_data["raw"]["invertor"]["discharge_target_soc_1"]))
+            failed = True
+    finally:
+        inv.reserve_percent = saved_reserve_percent
+        inv.rest_data = saved_rest_data
+        inv.rest_api = saved_rest_api
+        inv.rest_v3 = saved_rest_v3
+
+    return failed
+
+
 def test_force_export_unchanged_times_HM_format(test_name, ha, inv):
     """
     Regression test for GS_fb00 (Solis) 'count register writes 0' bug.
@@ -2670,6 +2749,11 @@ charge_start_service:
 
     # Regression test: GS_fb00 H M format must write time entities and press button even when times are unchanged
     failed |= test_force_export_unchanged_times_HM_format("force_export_unchanged_HM_format", ha, inv)
+    if failed:
+        return failed
+
+    # Regression test: export target SoC must track the minimum reserve SoC in both directions
+    failed |= test_discharge_target_tracks_reserve("discharge_target_tracks_reserve", ha, inv, dummy_rest)
     if failed:
         return failed
 


### PR DESCRIPTION
## Problem

Reported against GE Cloud: the export target ends up set below the minimum reserve SoC.

`adjust_force_export` only ever pulled the export target register *down* to `reserve_percent`:

```python
if current > self.reserve_percent:
    self.write_and_poll_value("discharge_target_soc", ..., int(self.reserve_percent))
else:
    self.log("Inverter {} Current discharge target is already set to {}".format(self.id, current))
```

A target already *below* the minimum reserve was treated as acceptable and left alone.

GE Cloud's `enable_default_options` resets every "lower SoC percent limit" register to 4%, at startup and again every 24 hours. That set overlaps `dc_discharge_1_lower_soc_percent_limit` — the exact register Predbat configures as `discharge_target_soc`. So a user with a higher minimum reserve was left with an inverter-side backstop of 4% that Predbat never corrected.

That register is what stops a timed export draining the battery below the reserve between Predbat's 5-minute cycles, so the battery could discharge past the configured minimum reserve.

Reproduced with `battery_min_soc: 20` and the register at 4:

```
reserve_percent = 20
discharge_target_soc before = 4
discharge_target_soc after  = 4     <- never corrected
```

## Fixes

**`inverter.py` — track the reserve in both directions.** Compare against the target rather than only testing for a higher value, so the register follows `reserve_percent` up as well as down. Applied to both the REST v3 and the entity write paths; `target_soc` is hoisted out of the two branches.

This part is not GE Cloud specific — it applies to every inverter exposing `discharge_target_soc` (fox, solax, solis, deye, enphase, sigenergy, teslemetry).

**`gecloud.py` — stop resetting the register Predbat owns.** `enable_default_options` now resolves the configured `discharge_target_soc` entities and skips the matching register before any reset rule runs, rather than fighting `adjust_force_export` every 24 hours. The match is per device and rebuilds the entity ID the same way `publish_registers` and `async_automatic_config` do, so it is exact rather than a substring guess. Registers on an inverter Predbat is not driving, and inverters with no discharge target register at all, keep the existing 4% reset.

## Tests

`test_discharge_target_tracks_reserve` in `apps/predbat/tests/test_inverter.py`:

- a target below the reserve is raised to the reserve (the bug)
- a target above the reserve is still lowered to the reserve (no regression)
- the same correction on the REST v3 path

`_test_enable_default_options_skips_discharge_target` in `apps/predbat/tests/test_ge_cloud.py`:

- the configured export target register is left untouched, with the `changed` flag unset
- other lower SoC registers on the same device are still reset to 4%
- the same register on a device Predbat is not driving is still reset
- the reset still applies when no discharge target is configured

Both were written first and confirmed failing before the fix. `MockGECloudDirect.get_arg` gained `**kwargs` so it accepts the `indirect` keyword the real `ComponentBase.get_arg` takes; the real `get_arg` was checked separately to confirm `indirect=False` returns the raw entity list rather than resolving entity states.

`./run_all --quick` and `./run_pre_commit` both exit 0.

## Also included

A `.gitignore` entry for `.claude/worktrees/`, which was showing up as untracked in every `git status`. Unrelated to the fix — happy to split it out if you would rather keep this PR single-purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)