### PR TITLE
fix(gateway): don't declare the API started before auto-config completes

### DIFF
--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -504,7 +504,7 @@ COMPONENT_LIST = {
             "load_ml_max_days_history": {"required": False, "config": "load_ml_max_days_history", "default": 28},
             "load_ml_database_days": {"required": False, "config": "load_ml_database_days", "default": 90},
         },
-        "phase": 1,
+        "phase": 2,  # Load ML in phase 2 so that any Predbat cloud components (such as GEcloud) have been started and initialised pv_today, etc
         "can_restart": True,
     },
 }

--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -553,7 +553,7 @@ class GatewayMQTT(ComponentBase):
             # PredBat's startup race ahead of auto-config.
             await self._startup_wait(ticks, lambda: self._auto_configured)
             if not self._auto_configured and not self.api_stop:
-                self.log(f"Warn: GatewayMQTT: Auto-config not complete after {_STARTUP_WAIT_SECONDS:.0f}s — gateway device may be offline, continuing startup")
+                self.log(f"Warn: GatewayMQTT: Auto-config not complete after {_STARTUP_WAIT_SECONDS:.0f}s — gateway device may be offline or MQTT broker unreachable, continuing startup")
             return True
 
         # Housekeeping on subsequent runs

--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -54,6 +54,10 @@ _PLAN_REPUBLISH_INTERVAL = 5 * 60
 # Telemetry staleness threshold (seconds)
 _TELEMETRY_STALE_THRESHOLD = 120
 
+# Total startup wait budget, in 0.5 s ticks, shared by the connection and auto-config waits
+_STARTUP_WAIT_TICKS = 120 * 2
+_STARTUP_WAIT_SECONDS = _STARTUP_WAIT_TICKS * 0.5
+
 # Time options for schedule select entities (HH:MM:SS, one per minute across 24 h)
 _GATEWAY_BASE_TIME = datetime.datetime.strptime("00:00", "%H:%M")
 _GATEWAY_OPTIONS_TIME = [(_GATEWAY_BASE_TIME + datetime.timedelta(seconds=m * 60)).strftime("%H:%M:%S") for m in range(0, 24 * 60, 5)]
@@ -494,6 +498,21 @@ class GatewayMQTT(ComponentBase):
         """
         await self._publish_raw(self.topic_ev_command, json.dumps(command).encode())
 
+    async def _startup_wait(self, ticks, ready):
+        """Poll ``ready`` at 0.5 s intervals until it is true or the startup budget is spent.
+
+        Args:
+            ticks: Ticks already consumed by earlier waits in this startup.
+            ready: Zero-argument callable returning True once the wait can end.
+
+        Returns:
+            int: The total ticks consumed, to pass to the next wait in the chain.
+        """
+        while ticks < _STARTUP_WAIT_TICKS and not self.api_stop and not ready():
+            await asyncio.sleep(0.5)
+            ticks += 1
+        return ticks
+
     async def run(self, seconds, first):
         """Component run loop — called every 60 seconds by ComponentBase.start().
 
@@ -520,23 +539,21 @@ class GatewayMQTT(ComponentBase):
             # Start MQTT listener as a background task
             self._mqtt_task = asyncio.ensure_future(self._mqtt_loop())
             self.log("Info: GatewayMQTT: MQTT listener task started")
-            # Wait up to a minute for first connection attempt before declaring started
-            for _ in range(60 * 2):
-                if self._first_connection_attempted or self.api_stop:
-                    break
-                await asyncio.sleep(0.5)
-            else:
+            # Wait for the first connection attempt and then for the first telemetry →
+            # auto-config, so the inverter args are wired up before startup continues.
+            # Both waits share the single _STARTUP_WAIT_TICKS budget so an offline gateway
+            # device can never stall startup for longer than that.
+            ticks = await self._startup_wait(0, lambda: self._first_connection_attempted)
+            if not self._first_connection_attempted and not self.api_stop:
                 self.log("Warn: GatewayMQTT: First connection attempt not yet complete, continuing startup")
-            # After a successful connection, wait briefly for the first telemetry → auto-config so
-            # that inverter args are wired up before other components start.  Cap at 60 s so an
-            # offline gateway device does not stall startup indefinitely.
-            if self._mqtt_connected and not self.api_stop:
-                for _ in range(60 * 2):
-                    if self._auto_configured or self.api_stop:
-                        break
-                    await asyncio.sleep(0.5)
-                else:
-                    self.log("Warn: GatewayMQTT: Auto-config not complete after 60s — gateway device may be offline, continuing startup")
+            # The auto-config wait runs even when the first attempt failed: the MQTT loop
+            # retries with backoff in the background, so a transient broker failure at
+            # startup usually still yields telemetry inside the window. Returning early
+            # here declares the component started with no inverter args set, which lets
+            # PredBat's startup race ahead of auto-config.
+            await self._startup_wait(ticks, lambda: self._auto_configured)
+            if not self._auto_configured and not self.api_stop:
+                self.log(f"Warn: GatewayMQTT: Auto-config not complete after {_STARTUP_WAIT_SECONDS:.0f}s — gateway device may be offline, continuing startup")
             return True
 
         # Housekeeping on subsequent runs
@@ -725,14 +742,20 @@ class GatewayMQTT(ComponentBase):
         self._last_telemetry_time = time.time()
         self.update_success_timestamp()
 
-        if not self.api_started:
-            self.api_started = True
-            self.log("Info: GatewayMQTT: First telemetry received, API started")
-
         self._inject_entities(status)
 
         if self._needs_reconfigure(status):
             self.automatic_config()
+
+        # Declare the API started only once auto-config has wired up the inverter args.
+        # ComponentManager.start() polls api_started from the main thread while this
+        # handler runs in the component's own thread, so setting it any earlier releases
+        # PredBat startup with num_inverters / soc_percent unset. When auto-config cannot
+        # complete (e.g. a serial filter matching nothing) the run() startup path still
+        # releases the component after its timeout.
+        if self._auto_configured and not self.api_started:
+            self.api_started = True
+            self.log("Info: GatewayMQTT: First telemetry received and auto-config complete, API started")
 
     def _is_bound_target(self, inv):
         """Whether automatic_config bound PredBat's args to this inverter's suffix.

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytz
 import gateway_status_pb2 as pb
+from gateway import _STARTUP_WAIT_TICKS
 
 import importlib.util
 
@@ -2995,6 +2996,9 @@ class TestGatewayUnitControlBinding:
         gw.args = {}
         gw._args = {}
         gw.gateway_inverter_serial = []
+        gw.gateway_evc_automatic = False
+        gw.gateway_evc_control = False
+        gw._configured_ev_chargers = frozenset()
 
         def capture_set_arg(key, value):
             gw._args[key] = value
@@ -3198,6 +3202,56 @@ class TestGatewayUnitControlBinding:
         gw._process_telemetry(self._gateway_plus_aios_status(["CH2414G318", "CH9999G999"]).SerializeToString())
         assert gw._args["num_inverters"] == 1
         assert gw._args["charge_start_time"][0] == "select.predbat_gateway_47g077_charge_slot1_start"
+
+    def test_api_started_only_set_once_auto_config_has_completed(self):
+        """api_started must not become visible before automatic_config has wired up the args.
+
+        ComponentManager.start() polls api_started from the *main* thread while the MQTT
+        listener runs in the component's own thread, so setting the flag on receipt of the
+        first telemetry frame — before automatic_config() — lets PredBat startup continue
+        with num_inverters / soc_percent unset.
+        """
+        gw = self._make_handler_gateway()
+        seen = {}
+        real_config = gw.automatic_config
+
+        def watched_config():
+            seen["api_started_during_config"] = gw.api_started
+            return real_config()
+
+        gw.automatic_config = watched_config
+        gw._process_telemetry(self._gateway_plus_aios_status(["CH2414G318"]).SerializeToString())
+
+        assert seen["api_started_during_config"] is False, "api_started was set before auto-config ran"
+        assert gw._auto_configured
+        assert gw.api_started is True
+
+    def test_api_started_stays_false_when_auto_config_aborts(self):
+        """A serial filter that matches nothing aborts auto-config, so the API is not started.
+
+        The run() startup path still releases the component after its timeout, but the
+        telemetry path must not declare the component started with no inverter args set.
+        """
+        gw = self._make_handler_gateway()
+        gw.gateway_inverter_serial = ["CH0000X000"]
+
+        gw._process_telemetry(self._gateway_plus_aios_status(["CH2414G318"]).SerializeToString())
+
+        assert gw._auto_configured is False
+        assert gw.api_started is False
+
+    def test_api_started_set_on_later_frame_that_needs_no_reconfigure(self):
+        """Once configured, a steady-state frame that triggers no re-config still starts the API."""
+        gw = self._make_handler_gateway()
+        gw.gateway_inverter_serial = ["CH0000X000"]
+        gw._process_telemetry(self._gateway_plus_aios_status(["CH2414G318"]).SerializeToString())
+        assert gw.api_started is False
+
+        # Filter corrected (as a restart would do) — the next frame configures and starts.
+        gw.gateway_inverter_serial = []
+        gw._process_telemetry(self._gateway_plus_aios_status(["CH2414G318"]).SerializeToString())
+        assert gw._auto_configured
+        assert gw.api_started is True
 
     # ------------------------------------------------------------------
     # EMS and AC3 topologies
@@ -3589,13 +3643,14 @@ class TestRunStartupWait:
         return asyncio.run(coro)
 
     def test_returns_true_without_sleeping_when_flag_already_set(self):
-        """When _first_connection_attempted is pre-set, run() returns True without sleeping."""
+        """When both startup conditions are pre-set, run() returns True without sleeping."""
         if not HAS_AIOMQTT:
             return
         from unittest.mock import patch, AsyncMock
 
         gw = self._make_gateway()
         gw._first_connection_attempted = True
+        gw._auto_configured = True
 
         async def run_test():
             async def fake_mqtt_loop():
@@ -3611,7 +3666,7 @@ class TestRunStartupWait:
         assert sleep_count == 0
 
     def test_returns_true_after_flag_set_on_first_sleep(self):
-        """run() exits the wait loop as soon as the flag is set, after a single sleep."""
+        """run() exits the wait loop as soon as the flags are set, after a single sleep."""
         if not HAS_AIOMQTT:
             return
         from unittest.mock import patch
@@ -3622,7 +3677,9 @@ class TestRunStartupWait:
         async def run_test():
             async def fake_sleep(t):
                 sleep_count[0] += 1
-                gw._first_connection_attempted = True  # Simulates MQTT loop completing first attempt
+                # Simulates the MQTT loop connecting and the first telemetry arriving
+                gw._first_connection_attempted = True
+                gw._auto_configured = True
 
             async def fake_mqtt_loop():
                 pass
@@ -3659,7 +3716,9 @@ class TestRunStartupWait:
 
         result = self._run(run_test())
         assert result is True
-        assert sleep_count[0] == 120  # 60 * 2 iterations of 0.5s each = 60s total
+        # The connection and auto-config waits share one budget, so a dead broker stalls
+        # startup for the budget once, not once per wait.
+        assert sleep_count[0] == _STARTUP_WAIT_TICKS
         warn_logged = any("Warn" in str(c) and "not yet complete" in str(c) for c in gw.log.call_args_list)
         assert warn_logged, "Expected a Warn log when the first connection attempt times out"
 
@@ -3716,32 +3775,73 @@ class TestRunStartupWait:
 
         result = self._run(run_test())
         assert result is True
-        assert sleep_count[0] == 60 * 2  # 60 * 2 iterations of 0.5s each = 60s total
+        assert sleep_count[0] == _STARTUP_WAIT_TICKS  # Whole startup budget consumed
         warn_logged = any("Warn" in str(c) and "Auto-config not complete" in str(c) for c in gw.log.call_args_list)
         assert warn_logged, "Expected a Warn log when auto-config times out"
 
-    def test_auto_config_wait_skipped_when_not_connected(self):
-        """When connection failed, auto-config wait is skipped entirely."""
+    def test_auto_config_wait_still_runs_when_first_attempt_failed(self):
+        """A failed *first* connection attempt must not skip the auto-config wait.
+
+        The MQTT loop retries with backoff in the background, so a transient broker
+        failure at startup is usually followed by a connection and telemetry within the
+        60s window. Returning immediately declares the component started with no
+        inverter args set.
+        """
         if not HAS_AIOMQTT:
             return
-        from unittest.mock import patch, AsyncMock
+        from unittest.mock import patch
 
         gw = self._make_gateway()
         gw._first_connection_attempted = True
-        # _mqtt_connected stays False (connection failed)
+        # _mqtt_connected stays False (first attempt failed)
+        sleep_count = [0]
 
         async def run_test():
+            async def fake_sleep(t):
+                sleep_count[0] += 1
+                # Reconnect succeeds and the first telemetry arrives.
+                gw._mqtt_connected = True
+                gw._auto_configured = True
+
             async def fake_mqtt_loop():
                 pass
 
             gw._mqtt_loop = fake_mqtt_loop
-            with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with patch("asyncio.sleep", side_effect=fake_sleep):
                 result = await gw.run(0, True)
-            return result, mock_sleep.call_count
+            return result
 
-        result, sleep_count = self._run(run_test())
+        result = self._run(run_test())
         assert result is True
-        assert sleep_count == 0  # No sleeps: connection-wait breaks immediately, auto-config skipped
+        assert sleep_count[0] == 1  # One sleep in the auto-config wait loop
+
+    def test_auto_config_wait_times_out_when_broker_never_reachable(self):
+        """A broker that never comes up still releases startup after the 60s cap."""
+        if not HAS_AIOMQTT:
+            return
+        from unittest.mock import patch
+
+        gw = self._make_gateway()
+        gw._first_connection_attempted = True
+        sleep_count = [0]
+
+        async def run_test():
+            async def fast_sleep(t):
+                sleep_count[0] += 1  # Never connects, never auto-configures
+
+            async def fake_mqtt_loop():
+                pass
+
+            gw._mqtt_loop = fake_mqtt_loop
+            with patch("asyncio.sleep", side_effect=fast_sleep):
+                result = await gw.run(0, True)
+            return result
+
+        result = self._run(run_test())
+        assert result is True
+        assert sleep_count[0] == _STARTUP_WAIT_TICKS  # Whole startup budget consumed
+        warn_logged = any("Warn" in str(c) and "Auto-config not complete" in str(c) for c in gw.log.call_args_list)
+        assert warn_logged, "Expected a Warn log when auto-config times out"
 
 
 class TestSetChargeSlotPayload:
@@ -4353,6 +4453,7 @@ def run_gateway_tests(my_predbat=None):
         TestDebugLogging,
         TestAutomaticConfig,
         TestBoundEntitiesAreWritten,
+        TestGatewayUnitControlBinding,
         TestEvTelemetry,
         TestEvAutoConfig,
         TestEvInitialize,


### PR DESCRIPTION
## Problem

The gateway component reported itself started before `automatic_config()` had wired up the inverter args, so PredBat's startup raced ahead with `num_inverters` / `soc_percent` unset.

`ComponentManager.start()` gates startup on `component.wait_api_started()`, which is polled from the **main thread** while the gateway's MQTT listener runs in its own thread (each component gets its own thread + event loop via `hass.create_task`). `api_started` — not `run()` returning — is what actually releases startup, and two paths set it too early:

**1. The telemetry handler set the flag before configuring anything.** `_process_telemetry` flipped `api_started = True` on the first frame, *before* `_inject_entities()` and `automatic_config()` on that same frame. That line dates from the original component commit (9f7fc558); the auto-config wait in `run(first=True)` was added later (7eac693d, 0dc56fbd) without removing it, so the wait never gated anything.

**2. A failed first connection attempt skipped the auto-config wait.** The `if self._mqtt_connected` guard meant a transient broker failure at startup (`_first_connection_attempted` is also set from the exception handler) made `run()` return True immediately, and `ComponentBase.start()` then set `api_started` itself. The MQTT loop reconnects after 5s, so the config was usually only seconds away.

## Fix

- `_process_telemetry` injects entities and runs auto-config first, then sets `api_started`, gated on `_auto_configured`. If auto-config aborts (e.g. a `gateway_inverter_serial` filter matching nothing) the flag stays down and the `run()` timeout is the sole release path — which is what the existing "leave `_auto_configured` False so we retry on the next telemetry" comment already intended.
- `run(first=True)` waits for auto-config regardless of whether the first connect attempt succeeded. The connection and auto-config waits now share one `_STARTUP_WAIT_TICKS` budget (2 minutes) via a small `_startup_wait()` helper, so they can't stack.

Trade-off: an unreachable broker now costs a startup stall where it previously returned immediately. That's the same stall the code already accepted for a connected-but-offline gateway device, and both warnings are still logged.

## Also: Load ML moved to phase 2

Load ML started in phase 1, alongside the cloud components it depends on. It now starts in phase 2 so GECloud and friends have started and initialised `pv_today` etc. before Load ML reads them — the same reason the solar component was moved to phase 2.

## Tests

Four new gateway tests, all failing before the fix:

- `test_api_started_only_set_once_auto_config_has_completed` — wraps `automatic_config` to capture `api_started` at entry; fails on old code with "api_started was set before auto-config ran".
- `test_api_started_stays_false_when_auto_config_aborts` / `test_api_started_set_on_later_frame_that_needs_no_reconfigure` — the abort and recovery paths.
- `test_auto_config_wait_still_runs_when_first_attempt_failed` — replaces `test_auto_config_wait_skipped_when_not_connected`, which encoded issue 2 as intended behaviour.

Timeout expectations now derive from `_STARTUP_WAIT_TICKS` rather than being hard-coded, so they can't drift from the constant.

### Unrelated gap found while doing this

`TestGatewayUnitControlBinding` — the 17 regression tests for the 2026-06-04 "Gateway bound as inverter 0" incident — was **not registered in `run_gateway_tests()`, so it had never run**, and had bit-rotted (its fixture was missing `gateway_evc_automatic`, failing since EV auto-config landed). Registered and fixture repaired; all 17 pass.

`TestSerialFromEntityId` is also unregistered — left alone here, worth a follow-up.

## Verification

- `./run_all --test gateway` → 269 OK, exit 0
- `./run_all --quick` → all passed, exit 0
- `pre-commit run` on all three changed files → all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)