### PR TITLE
docs: clarify read-only mode still performs one reset write on enable

### DIFF
--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -39,7 +39,7 @@ If the **switch.predbat_set_read_only** is set to On then this prevents Predbat 
 Predbat will continue making and updating its prediction plan every 10 minutes (by default), but no inverter changes will be made.
 This is useful if you want to override what Predbat is planning to do (e.g. your own automation), or whilst you are learning how Predbat works before turning it on 'in anger'.
 
-**Note:** _Changing the Predbat mode or the read-only switch will cause Predbat to reset the inverter settings to default, this will disable both charge and discharge, reset charge and discharge rates to full power and reset the reserve to the default setting_
+**Note:** _Changing the Predbat mode or the read-only switch will cause Predbat to reset the inverter settings to default, this will disable both charge and discharge, reset charge and discharge rates to full power and reset the reserve to the default setting. This reset write happens even when you are turning read-only **on** - it's a deliberate one-off action to hand control back to the inverter's own native scheduling, not a violation of read-only mode. Depending on your inverter, actually reverting to native behaviour after this write can take some time, not necessarily immediately. If you've set inverter values manually (e.g. directly via your inverter's own app) that you want left alone, be aware this reset will overwrite them the moment you enable read-only._
 
 ![image](https://github.com/springfall2008/batpred/assets/48591903/43faa962-6b8a-495a-88f8-f762aa1d55b8)
 


### PR DESCRIPTION
## Summary
- `switch.predbat_set_read_only` is flagged as a `reset_inverter_force` trigger, so turning it **on** deliberately fires one release write (max charge rate, cleared charge/export windows, reserve reset) to hand the inverter back to native scheduling.
- That's intentional (present since #519) and not a violation of read-only mode, but it wasn't documented - so it silently overwrote a manually-set inverter value for one reporter (closes #4298).
- No behaviour change, docs only.

## Test plan
- [x] `./run_pre_commit` (via `coverage/run_pre_commit`) - all hooks pass
- [x] Docs-only change, no code touched

Closes #4298