### PR TITLE
docs(plan): name "Demand mode" explicitly in its own tooltip text

### DIFF
--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -29,15 +29,15 @@ from prediction import Prediction
 # own "reasons" params - published once here rather than duplicating the rendered sentence on
 # every row (per maintainer review on PR #4311).
 REASON_TEMPLATES = {
-    "demand_rising": "Battery level is expected to rise from solar generation; no charging or exporting is scheduled this slot.",
-    "demand_falling": "Battery is expected to discharge to cover house demand; no charging or exporting is scheduled this slot.",
-    "demand_steady": "Battery level is expected to stay steady; no charging or exporting is scheduled this slot.",
+    "demand_rising": "Demand — battery level is expected to rise from solar generation; no charging or exporting is scheduled this slot.",
+    "demand_falling": "Demand — the battery is expected to discharge to cover house load; no charging or exporting is scheduled this slot.",
+    "demand_steady": "Demand — battery level is expected to stay steady; no charging or exporting is scheduled this slot.",
     # Used for the first half of a split slot where the export window only starts partway through -
     # deliberately worded without the "nothing is scheduled this slot" clause of the plain demand
     # reasons above, which would contradict the export reason sitting alongside it in the same slot.
-    "demand_before_export_rising": "Until the export window starts partway through this slot, the battery level is expected to rise from solar generation.",
-    "demand_before_export_falling": "Until the export window starts partway through this slot, the battery is expected to discharge to cover house demand.",
-    "demand_before_export_steady": "Until the export window starts partway through this slot, the battery level is expected to stay steady.",
+    "demand_before_export_rising": "Until the export window starts partway through this slot, this is Demand mode - the battery level is expected to rise from solar generation.",
+    "demand_before_export_falling": "Until the export window starts partway through this slot, this is Demand mode - the battery is expected to discharge to cover house load.",
+    "demand_before_export_steady": "Until the export window starts partway through this slot, this is Demand mode - the battery level is expected to stay steady.",
     "freeze_charge": "Freeze charging — the battery holds at the current level rather than charging further this slot (import rate {rate}p/kWh vs. your {threshold}p/kWh threshold).",
     "hold_charge_at_target": "Holding — the battery is already predicted to be at or above the {target_percent}% target for this window without charging further.",
     "charge_low_rate": "Charging up to {target_percent}% at the import rate for this slot of ({rate}p/kWh).",


### PR DESCRIPTION
## Summary

The plain-arrow plan cells (no charge/discharge/freeze scheduled) never actually said "Demand" in their tooltip, despite that being the exact mode name shown in the mode selector and Status card elsewhere in the UI. Noticed live while reading a plan next to the Status card - nothing in the tooltip connected "this arrow-only cell" to "this is Demand mode."

- `demand_rising`/`demand_falling`/`demand_steady` now lead with "Demand — ...", matching the existing style of `freeze_charge` ("Freeze charging — ...") and `freeze_export_below_threshold` ("Freezing export — ...").
- Also swapped "house demand" for "house load" in the same templates and their `demand_before_export_*` split-cell counterparts - the generic English word "demand" collided with the Predbat mode name enough to undercut the fix if left sitting right next to it.
- Text-only change - no reason codes renamed, no template logic touched, frontend reads these from the published `reason_templates` JSON so there's no separate copy to update.

## Test plan

- [x] `./run_pre_commit` (via `coverage/run_pre_commit`) - all hooks pass
- [x] `./run_all --test plan_why_reason` - passes (asserts reason *codes*, not literal text, so unaffected structurally; confirmed no test hardcodes the old strings)
- [x] Full quick suite (`./run_all --quick`) passes