### PR TITLE
fix(plan): score plan selection on the plan as optimised, not as clipped

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -354,6 +354,7 @@ powerline
 Powerwall
 ppdetails
 ppkwh
+preclip
 pred
 predai
 predbat

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -999,6 +999,25 @@ class Plan:
         self.plan_window_restore(typ, window_n, snapshot)
         return baseline
 
+    def plan_scoring_pair(self, plan_new, plan_prev, preclip_new, preclip_prev):
+        """Return the (new, previous) plans that selection should be scored on.
+
+        Plans are (charge_limit, charge_window, export_window, export_limits) tuples.
+
+        Clipping sets the charge/export percentage actually shown on the plan and sent to the inverter, so it
+        has to stay. It is a no-op in the expected case - the mid-case cost is unchanged - but it moves the
+        metric through the PV10 branch by an amount that depends on plan shape. Scoring the clipped plans
+        therefore decides between them partly on a difference clipping invented rather than one the plans
+        really have, and by then the slot is usually hours away and will be re-planned many times before it
+        executes.
+
+        Both sides fall back together when either snapshot is missing (the first recompute after a restart):
+        scoring an un-taxed new plan against a taxed incumbent would favour the new plan on the tax alone.
+        """
+        if preclip_new is not None and preclip_prev is not None:
+            return preclip_new, preclip_prev
+        return plan_new, plan_prev
+
     def calculate_plan(self, recompute=True, debug_mode=False, publish=True):
         """
         Calculate the new plan (best)
@@ -1047,12 +1066,14 @@ class Plan:
                 charge_window_best_prev = copy.deepcopy(self.charge_window_best)
                 export_window_best_prev = copy.deepcopy(self.export_window_best)
                 export_limits_best_prev = copy.deepcopy(self.export_limits_best)
+                preclip_prev = self.plan_preclip
                 self.log("Recompute is saving previous plan...")
             else:
                 charge_limit_best_prev = None
                 charge_window_best_prev = None
                 export_window_best_prev = None
                 export_limits_best_prev = None
+                preclip_prev = None
                 self.log("Recompute, previous plan is invalid...")
 
             self.plan_valid = False  # In case of crash, plan is now invalid
@@ -1179,6 +1200,9 @@ class Plan:
             # Remove charge windows that overlap with export windows
             self.charge_limit_best, self.charge_window_best = remove_intersecting_windows(self.charge_limit_best, self.charge_window_best, self.export_limits_best, self.export_window_best)
 
+            # Snapshot the plan as optimised, before clipping adjusts the percentages for execution
+            preclip_new = (copy.deepcopy(self.charge_limit_best), copy.deepcopy(self.charge_window_best), copy.deepcopy(self.export_window_best), copy.deepcopy(self.export_limits_best))
+
             # Filter out any unused export windows
             if self.calculate_best_export and self.export_window_best:
                 # Filter out the windows we disabled
@@ -1263,26 +1287,37 @@ class Plan:
 
             # Plan comparison
             if charge_window_best_prev is not None and not debug_mode:
-                metric, battery_value, cost, metric_keep, battery_cycle, final_carbon_g, import_kwh, export_kwh = self.run_prediction_metric(
-                    self.charge_limit_best, self.charge_window_best, self.export_window_best, self.export_limits_best, end_record=self.end_record
+                # Score the plans as optimised rather than as clipped - see plan_scoring_pair()
+                score_new, score_prev = self.plan_scoring_pair(
+                    (self.charge_limit_best, self.charge_window_best, self.export_window_best, self.export_limits_best),
+                    (charge_limit_best_prev, charge_window_best_prev, export_window_best_prev, export_limits_best_prev),
+                    preclip_new,
+                    preclip_prev,
                 )
+                metric, battery_value, cost, metric_keep, battery_cycle, final_carbon_g, import_kwh, export_kwh = self.run_prediction_metric(score_new[0], score_new[1], score_new[2], score_new[3], end_record=self.end_record)
                 metric_prev, battery_value_prev, cost_prev, metric_keep_prev, battery_cycle_prev, final_carbon_g_prev, import_kwh_prev, export_kwh_prev = self.run_prediction_metric(
-                    charge_limit_best_prev, charge_window_best_prev, export_window_best_prev, export_limits_best_prev, end_record=self.end_record
+                    score_prev[0], score_prev[1], score_prev[2], score_prev[3], end_record=self.end_record
                 )
 
                 self.log("Previous plan best metric is {} (cost {}) and new plan best metric is {} (cost {})".format(dp2(metric_prev), dp2(cost_prev), dp2(metric), dp2(cost)))
-                fragmentation_prev = self.plan_fragmentation(charge_window_best_prev, charge_limit_best_prev, export_window_best_prev, export_limits_best_prev)
-                fragmentation_new = self.plan_fragmentation(self.charge_window_best, self.charge_limit_best, self.export_window_best, self.export_limits_best)
+                fragmentation_prev = self.plan_fragmentation(score_prev[1], score_prev[0], score_prev[2], score_prev[3])
+                fragmentation_new = self.plan_fragmentation(score_new[1], score_new[0], score_new[2], score_new[3])
                 if not self.should_replace_plan(metric_prev, metric, fragmentation_prev, fragmentation_new):
                     self.log("New plan metric is not significantly better (metric_min_improvement_plan {}) than previous plan, using previous plan".format(self.metric_min_improvement_plan))
                     self.charge_window_best = copy.deepcopy(charge_window_best_prev)
                     self.charge_limit_best = copy.deepcopy(charge_limit_best_prev)
                     self.export_window_best = copy.deepcopy(export_window_best_prev)
                     self.export_limits_best = copy.deepcopy(export_limits_best_prev)
+                    # Keeping the incumbent keeps its pre-clip snapshot too, so the next cycle still compares
+                    # like for like
+                    preclip_new = preclip_prev
                 elif (metric_prev - metric) >= self.metric_min_improvement_plan:
                     self.log("New plan metric is significantly better from previous plan, using new plan")
                 else:
                     self.log("New plan is a cost-neutral improvement but less fragmented ({} vs {} segments), using new plan".format(fragmentation_new, fragmentation_prev))
+
+            # Carry the pre-clip snapshot of whichever plan we kept into the next cycle
+            self.plan_preclip = preclip_new
 
             # Plan is now valid
             self.log("Plan valid is now true after recompute was {}".format(self.plan_valid))

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -340,6 +340,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.previous_status = None
         self.had_errors = False
         self.plan_valid = False
+        self.plan_preclip = None
         self.plan_last_updated = None
         self.plan_last_updated_minutes = 0
         self.plugin_system = None
@@ -684,6 +685,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
             "charge_limit_best": self.charge_limit_best,
             "export_window_best": self.export_window_best,
             "export_limits_best": self.export_limits_best,
+            "plan_preclip": self.plan_preclip,
             "plan_last_updated": self.plan_last_updated.isoformat() if self.plan_last_updated else None,
             "plan_last_updated_minutes": self.plan_last_updated_minutes,
         }
@@ -735,6 +737,10 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.charge_limit_best = plan_data.get("charge_limit_best", [])
         self.export_window_best = plan_data.get("export_window_best", [])
         self.export_limits_best = plan_data.get("export_limits_best", [])
+        # The pre-clip snapshot plan selection scores against. Older saves predate it, and it is only ever a
+        # four part plan, so anything else is discarded and the comparison falls back to the clipped plans.
+        preclip = plan_data.get("plan_preclip")
+        self.plan_preclip = tuple(preclip) if isinstance(preclip, (list, tuple)) and len(preclip) == 4 else None
         self.plan_last_updated = saved_dt
         self.plan_last_updated_minutes = plan_data.get("plan_last_updated_minutes", 0)
         self.plan_valid = True

--- a/apps/predbat/tests/test_plan_persistence.py
+++ b/apps/predbat/tests/test_plan_persistence.py
@@ -62,6 +62,11 @@ def test_plan_persistence(my_predbat):
         my_predbat.plan_last_updated_minutes = saved_minutes
         my_predbat.plan_valid = True
 
+        # The pre-clip snapshot is what plan selection scores against next cycle, so it has to survive a
+        # restart too - without it the first recompute back compares a clipped incumbent and falls back
+        preclip = ([9.0], charge_windows, export_windows, [0.0])
+        my_predbat.plan_preclip = preclip
+
         # 1. save_plan() must not raise and must write something loadable
         print("  Test 1: save_plan() round-trip")
         my_predbat.save_plan()
@@ -74,6 +79,7 @@ def test_plan_persistence(my_predbat):
         my_predbat.plan_last_updated = None
         my_predbat.plan_last_updated_minutes = 0
         my_predbat.plan_valid = False
+        my_predbat.plan_preclip = None
 
         my_predbat.load_plan()
 
@@ -94,6 +100,12 @@ def test_plan_persistence(my_predbat):
             failed += 1
         if my_predbat.plan_last_updated_minutes != saved_minutes:
             print("  FAILED: plan_last_updated_minutes mismatch: {}".format(my_predbat.plan_last_updated_minutes))
+            failed += 1
+        if my_predbat.plan_preclip is None:
+            print("  FAILED: plan_preclip was not restored")
+            failed += 1
+        elif [list(x) for x in my_predbat.plan_preclip] != [list(x) for x in preclip]:
+            print("  FAILED: plan_preclip mismatch: {}".format(my_predbat.plan_preclip))
             failed += 1
 
         # 2. load_plan() with empty storage leaves plan_valid False

--- a/apps/predbat/tests/test_plan_preclip.py
+++ b/apps/predbat/tests/test_plan_preclip.py
@@ -1,0 +1,75 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+"""Tests that plan selection scores the plan as optimised rather than as clipped.
+
+clip_export_slots and clip_charge_slots set the percentage shown on the plan and sent to the inverter. They
+are a no-op in the expected case but move the metric through the PV10 branch, so calculate_plan keeps a
+snapshot of the plan taken before clipping and compares on that instead - see plan_scoring_pair().
+"""
+from tests.test_infra import reset_inverter
+from tests.test_random_scenarios import load_scenarios, run_scenario
+
+
+def run_plan_preclip_tests(my_predbat):
+    """Run the pre-clip plan selection tests. Returns True on failure."""
+    print("**** Running plan pre-clip selection tests ****")
+    failed = False
+
+    # read_debug_yaml reconfigures the instance wholesale, so work on a throwaway one rather than leaving the
+    # shared fixture holding this debug case for every test that runs after
+    from unit_test import create_predbat
+
+    my_predbat = create_predbat()
+
+    reset_inverter(my_predbat)
+    my_predbat.read_debug_yaml("cases/predbat_debug_agile1.yaml")
+    my_predbat.config_root = "./"
+    my_predbat.save_restore_dir = "./"
+    my_predbat.load_user_config()
+
+    # Reuse a benchmark scenario rather than generating one: these are known to plan in a couple of seconds
+    # Scenario 10 is one where clipping measurably taxes the metric, so the comparison below has teeth: on an
+    # untaxed scenario pre-clip and clipped score the same and the assertion would pass either way
+    scenario = [s for s in load_scenarios("cases/random_scenarios.yaml") if s["id"] == 10][0]
+
+    # First plan establishes an incumbent; the second recompute is the one that runs the comparison
+    run_scenario(my_predbat, scenario)
+    if my_predbat.plan_preclip is None:
+        print("ERROR: plan_preclip was not captured by the first recompute")
+        return True
+
+    run_scenario(my_predbat, scenario)
+
+    if my_predbat.plan_preclip is None:
+        print("ERROR: plan_preclip was not carried through the second recompute")
+        return True
+    if len(my_predbat.plan_preclip) != 4:
+        print("ERROR: plan_preclip should be a four part plan, got {}".format(len(my_predbat.plan_preclip)))
+        return True
+
+    # Clipping never improves a plan, so the snapshot selection scores must be no worse than the plan that
+    # actually executes. Taking the snapshot after clipping instead would make these equal at best and hand
+    # the taxed metric to should_replace_plan.
+    preclip = my_predbat.plan_preclip
+    metric_preclip = my_predbat.run_prediction_metric(preclip[0], preclip[1], preclip[2], preclip[3], end_record=my_predbat.end_record)[0]
+    metric_final = my_predbat.run_prediction_metric(my_predbat.charge_limit_best, my_predbat.charge_window_best, my_predbat.export_window_best, my_predbat.export_limits_best, end_record=my_predbat.end_record)[0]
+
+    if metric_final - metric_preclip < 0.01:
+        print("ERROR: clipping did not tax this scenario ({} vs {}), so the comparison proves nothing".format(metric_preclip, metric_final))
+        failed = True
+    elif metric_preclip > metric_final + 0.0001:
+        print("ERROR: pre-clip plan scored {} which is worse than the clipped plan {} - snapshot is not pre-clip".format(metric_preclip, metric_final))
+        failed = True
+    else:
+        print("pre-clip metric {} vs clipped {} (clipping tax {})".format(round(metric_preclip, 4), round(metric_final, 4), round(metric_final - metric_preclip, 4)))
+
+    if not failed:
+        print("**** Plan pre-clip selection tests passed ****")
+    return failed

--- a/apps/predbat/tests/test_plan_tiebreak.py
+++ b/apps/predbat/tests/test_plan_tiebreak.py
@@ -79,10 +79,36 @@ def _tiebreak_decision_tests(my_predbat, failures):
     _check(my_predbat.should_replace_plan(-200.0, -200.0, 4, 2) is True, "cost-neutral cleaner plan adopts new", failures)
 
 
+def _scoring_pair_tests(my_predbat, failures):
+    """plan_scoring_pair: selection scores the pre-clip plans, and never mixes a clipped side with a pre-clip one.
+
+    Clipping sets the percentage actually sent to the inverter. It is a no-op in the expected case but moves the
+    metric through the PV10 branch by an amount that depends on plan shape, so comparing post-clip decides
+    between plans on a difference clipping invented rather than one the plans really have.
+    """
+    clipped_new = ([1.0], [{"start": 0, "end": 30}], [{"start": 30, "end": 60}], [100.0])
+    clipped_prev = ([2.0], [{"start": 0, "end": 30}], [{"start": 30, "end": 60}], [100.0])
+    preclip_new = ([3.0], [{"start": 0, "end": 30}], [{"start": 30, "end": 60}], [0.0])
+    preclip_prev = ([4.0], [{"start": 0, "end": 30}], [{"start": 30, "end": 60}], [0.0])
+
+    # Both pre-clip snapshots available: score the plans as optimised
+    pair = my_predbat.plan_scoring_pair(clipped_new, clipped_prev, preclip_new, preclip_prev)
+    _check(pair == (preclip_new, preclip_prev), "with both snapshots the pre-clip plans are scored", failures)
+
+    # No incumbent snapshot (first recompute after a restart): fall back to clipped on BOTH sides, never a mix,
+    # otherwise the new plan is scored untaxed against a taxed incumbent and wins on the difference
+    pair = my_predbat.plan_scoring_pair(clipped_new, clipped_prev, preclip_new, None)
+    _check(pair == (clipped_new, clipped_prev), "without an incumbent snapshot both sides fall back to clipped", failures)
+
+    pair = my_predbat.plan_scoring_pair(clipped_new, clipped_prev, None, preclip_prev)
+    _check(pair == (clipped_new, clipped_prev), "without a new snapshot both sides fall back to clipped", failures)
+
+
 def run_plan_tiebreak_tests(my_predbat):
     """Run the plan fragmentation tie-break tests. Returns True on failure."""
     print("**** Running plan tie-break tests ****")
     failures = []
     _fragmentation_tests(my_predbat, failures)
     _tiebreak_decision_tests(my_predbat, failures)
+    _scoring_pair_tests(my_predbat, failures)
     return len(failures) > 0

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -46,6 +46,7 @@ from tests.test_component_health_status import test_component_health_status
 from tests.test_optimise_levels import run_optimise_levels_tests
 from tests.test_trim_export import run_trim_export_tests
 from tests.test_plan_tiebreak import run_plan_tiebreak_tests
+from tests.test_plan_preclip import run_plan_preclip_tests
 from tests.test_export_commitment import run_export_commitment_tests
 from tests.test_energydataservice import run_energydataservice_tests
 from tests.test_iboost import run_iboost_smart_tests
@@ -454,6 +455,7 @@ def main():
         ("optimise_levels", run_optimise_levels_tests, "Optimise levels tests", False),
         ("trim_export", run_trim_export_tests, "Export trim ordering (buffer from cheapest slot) tests", False),
         ("plan_tiebreak", run_plan_tiebreak_tests, "Plan fragmentation near-tie tie-break tests", False),
+        ("plan_preclip", run_plan_preclip_tests, "Plan selection scores the pre-clip plan", True),
         ("export_commitment", run_export_commitment_tests, "Forced-export commitment / anti-flapping tests", False),
         ("load_ml", test_load_ml, "ML Load Forecaster tests (MLP, training, persistence, validation)", True),
         # ("optimise_windows", run_optimise_all_windows_tests, "Optimise all windows tests", True),


### PR DESCRIPTION
Follow-up to #4402, from investigating why the metric got *worse* after optimisation finished.

## The finding

`clip_export_slots` sets the export percentage shown on the plan and sent to the inverter. Measured across the 20-scenario random benchmark, it is a **perfect no-op in the expected case** — mid-case cost delta was exactly `+0.00` on all 12 calls that reached it. But it still moves the metric, entirely through the PV10 branch:

```
75 windows clipped across 12 scenarios
mid-case cost : +0.00 on every call
PV10 cost     : +287.33 total, avg +23.94, max +140.08, never negative
metric        : +19.73 total, avg +1.64, max +4.25
7 worse    0 better    5 neutral
```

Never once beneficial. The clip decides using only the mid-case `predict_soc`, where the battery never reaches the export target so raising it looks free; under PV10 the battery does go that low and the raised target binds.

## Why that matters

The tax lands **after optimisation and before `should_replace_plan`**. Both sides of that comparison are post-clip, so it isn't a systematic bias — but the tax is **shape-dependent**, so a plan taxed 4.25 can lose to one taxed 0.0 on a difference clipping invented rather than one the plans really have.

And it buys nothing: by the time clipping runs, the affected slot is usually hours out and will be re-planned many times before it executes, so constraining its PV10 branch today has no bearing on what the inverter does.

## The fix

**Clipping is unchanged.** Executed and displayed percentages are exactly as before — the percentage should reflect the expected case, which is what clipping gives.

`calculate_plan` keeps a snapshot of the plan taken before clipping, and selection scores that. Both sides fall back to the clipped plans *together* when either snapshot is missing (first recompute after a restart), so a fresh plan is never scored untaxed against a taxed incumbent. The snapshot is persisted alongside the plan so a restart doesn't lose it.

## Rejected alternative

The first attempt made `clip_export_slots` take its SoC range across both traces, so the clip became a true no-op in both. That fixed the metric (6 better, 1 worse, avg −0.50) but changed the executed percentages — targets moved *down*, e.g. `89→86`, `12→11`. That's the wrong trade: it buys a cleaner metric by making the number sent to the inverter less representative of the expected case, and erodes the "Export level adjustments for safety" intent.

## Tests

- `plan_scoring_pair` unit tested, including that both sides fall back together and never mix a clipped side with a pre-clip one
- save/load round trip extended to cover the snapshot
- new `plan_preclip` test drives two real recomputes on a scenario where clipping demonstrably taxes the metric (3.4897) and asserts the snapshot scores no worse than the plan that executes. Taking the snapshot after clipping instead makes it fail — verified.

Note `debug_cases` does **not** cover this path: `plan_valid` is False on both of its runs, so the comparison block never executes there. That's why the new test drives the scenario harness instead, on its own PredBat instance since `read_debug_yaml` reconfigures the shared fixture.

Full `./run_all` green (281.66s, 0 failures), `./run_pre_commit` clean.

## Still open

`clip_charge_slots` has a similar one-directional signature — 9 of 20 scenarios worse, 0 better, +14.44 total — but by a different mechanism: mid cost moves while final SoC does not, so it appears to be clipping away slots that are doing real work rather than the mid-vs-PV10 split above. It needs its own diagnosis and is deliberately not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
