### PR TITLE
feat(whatif): edf tariffs

### DIFF
--- a/apps/predbat/tariff_catalogue.py
+++ b/apps/predbat/tariff_catalogue.py
@@ -98,7 +98,16 @@ IMPORT_TARIFFS = [
     {"id": "flux", "name": "Octopus Flux", "import_octopus_url": "{}/FLUX-IMPORT-23-02-14/electricity-tariffs/E-1R-FLUX-IMPORT-23-02-14-{{dno_region}}/standard-unit-rates".format(_OCTOPUS)},
     {"id": "intelligent_flux", "name": "Octopus Intelligent Flux", "import_octopus_url": _INTELLI_FLUX},
     {"id": "edf_go", "name": "EDF Go Electric", "import_octopus_url": "{}/EDF_EV_FIX_GOELEC_12M_HH/electricity-tariffs/E-1R-EDF_EV_FIX_GOELEC_12M_HH-{{dno_region}}/standard-unit-rates/".format(_EDF)},
-    {"id": "edf_empower_fixed", "name": "EDF Empower Fixed", "import_octopus_url": "{}/EDF_EMPOWER_TRACKER_EX_SEG_12M_V2_HH/electricity-tariffs/E-1R-EDF_EMPOWER_TRACKER_EX_SEG_12M_V2_HH-{{dno_region}}/standard-unit-rates/".format(_EDF)},
+    {
+        "id": "edf_empower_fixed",
+        "name": "EDF Empower Fixed",
+        "rates_import": [
+            {"rate": 10, "start": "00:00:00", "end": "03:00:00"},
+            {"rate": 20, "start": "03:00:00", "end": "16:00:00"},
+            {"rate": 30, "start": "16:00:00", "end": "19:00:00"},
+            {"rate": 20, "start": "19:00:00", "end": "00:00:00"},
+        ],
+    },
 ]
 
 EXPORT_TARIFFS = [

--- a/apps/predbat/tariff_catalogue.py
+++ b/apps/predbat/tariff_catalogue.py
@@ -74,6 +74,10 @@ _OUTGOING_PRIME = "{}/OUTGOING-PRIME-FIX-12M-26-06-23/electricity-tariffs/E-1R-O
 # export entry below to a distinct export code; that product does not exist and 404s.
 _INTELLI_FLUX = "{}/INTELLI-FLUX-IMPORT-23-07-14/electricity-tariffs/E-1R-INTELLI-FLUX-IMPORT-23-07-14-{{dno_region}}/standard-unit-rates/".format(_OCTOPUS)
 
+# EDF Kraken API base URL for EDF tariffs
+_EDF = "https://api.edfgb-kraken.energy/v1/products"
+
+
 # Import and export are chosen independently, so they are listed independently. They used
 # to be one list of pre-paired combinations, which could not express a pairing nobody had
 # thought to enumerate - and, because the pairs were matched back to the dropdown on their
@@ -93,6 +97,8 @@ IMPORT_TARIFFS = [
     {"id": "snug", "name": "Octopus Snug", "import_octopus_url": "{}/SNUG-24-11-07/electricity-tariffs/E-1R-SNUG-24-11-07-{{dno_region}}/standard-unit-rates/".format(_OCTOPUS)},
     {"id": "flux", "name": "Octopus Flux", "import_octopus_url": "{}/FLUX-IMPORT-23-02-14/electricity-tariffs/E-1R-FLUX-IMPORT-23-02-14-{{dno_region}}/standard-unit-rates".format(_OCTOPUS)},
     {"id": "intelligent_flux", "name": "Octopus Intelligent Flux", "import_octopus_url": _INTELLI_FLUX},
+    {"id": "edf_go", "name": "EDF Go Electric", "import_octopus_url": "{}/EDF_EV_FIX_GOELEC_12M_HH/electricity-tariffs/E-1R-EDF_EV_FIX_GOELEC_12M_HH-{{dno_region}}/standard-unit-rates/".format(_EDF)},
+    {"id": "edf_empower_fixed", "name": "EDF Empower Fixed", "import_octopus_url": "{}/EDF_EMPOWER_TRACKER_EX_SEG_12M_V2_HH/electricity-tariffs/E-1R-EDF_EMPOWER_TRACKER_EX_SEG_12M_V2_HH-{{dno_region}}/standard-unit-rates/".format(_EDF)},
 ]
 
 EXPORT_TARIFFS = [
@@ -104,6 +110,8 @@ EXPORT_TARIFFS = [
     {"id": "flux_export", "name": "Octopus Flux export", "export_octopus_url": "{}/FLUX-EXPORT-23-02-14/electricity-tariffs/E-1R-FLUX-EXPORT-23-02-14-{{dno_region}}/standard-unit-rates".format(_OCTOPUS)},
     {"id": "intelligent_flux_export", "name": "Octopus Intelligent Flux export", "export_octopus_url": _INTELLI_FLUX},
     {"id": "eon_next_export", "name": "Eon Next export (16.5p)", "rates_export": [{"rate": 16.5}]},
+    {"id": "edf_export", "name": "EDF Export (15p)", "rates_export": [{"rate": 15.0}]},
+    {"id": "edf_export_exclusive", "name": "EDF Export Exclusive (18p)", "rates_export": [{"rate": 18.0}]},
 ]
 
 

--- a/apps/predbat/tests/test_tariff_catalogue.py
+++ b/apps/predbat/tests/test_tariff_catalogue.py
@@ -65,12 +65,12 @@ def test_tariff_catalogue(my_predbat):
                 failed = True
 
     print("Test: the built-in catalogues contain exactly the expected ids")
-    expected_import = ["price_cap", "eon_next_drive", "agile", "intelligent_go", "go", "cosy", "snug", "flux", "intelligent_flux"]
+    expected_import = ["price_cap", "eon_next_drive", "agile", "intelligent_go", "go", "cosy", "snug", "flux", "intelligent_flux", "edf_go", "edf_empower_fixed"]
     actual_import = [entry["id"] for entry in IMPORT_TARIFFS]
     if actual_import != expected_import:
         print("  ERROR: import ids changed, expected {} got {}".format(expected_import, actual_import))
         failed = True
-    expected_export = [NO_EXPORT_ID, "seg", "outgoing_fixed", "outgoing_prime", "agile_outgoing", "flux_export", "intelligent_flux_export", "eon_next_export"]
+    expected_export = [NO_EXPORT_ID, "seg", "outgoing_fixed", "outgoing_prime", "agile_outgoing", "flux_export", "intelligent_flux_export", "eon_next_export", "edf_export", "edf_export_exclusive"]
     actual_export = [entry["id"] for entry in EXPORT_TARIFFS]
     if actual_export != expected_export:
         print("  ERROR: export ids changed, expected {} got {}".format(expected_export, actual_export))

--- a/apps/predbat/tests/test_web_annual.py
+++ b/apps/predbat/tests/test_web_annual.py
@@ -2030,12 +2030,15 @@ def test_web_annual_pages(my_predbat):
     print("Test: a tariff that matches no catalogue entry falls back to something readable, not a blank")
     # A hand-entered URL, or a compare_list entry the user has since deleted. The
     # product code is the part of a 130-character URL anyone recognises.
+    # The export rate has to be one no EXPORT_TARIFFS entry uses, or it matches the
+    # catalogue and is named rather than falling back - 15.0p stopped being unmatched
+    # once EDF Export was added, which is what this rate is dodging.
     odd = [
         {
             "id": "odd",
             "label": "System Delta",
             "summary": {
-                "tariff": {"import_octopus_url": "https://api.octopus.energy/v1/products/MY-OWN-DEAL-24/electricity-tariffs/x/", "rates_export": [{"rate": 15.0}]},
+                "tariff": {"import_octopus_url": "https://api.octopus.energy/v1/products/MY-OWN-DEAL-24/electricity-tariffs/x/", "rates_export": [{"rate": 21.5}]},
                 "baseline_tariff": {},
                 "payback_years": {},
             },
@@ -2045,7 +2048,7 @@ def test_web_annual_pages(my_predbat):
     if "MY-OWN-DEAL-24" not in odd_table:
         print("  ERROR: an unmatched import URL should fall back to its product code, got {}".format(odd_table))
         failed = True
-    if "flat 15.0p" not in odd_table:
+    if "flat 21.5p" not in odd_table:
         print("  ERROR: an unmatched export rate should be described rather than blanked, got {}".format(odd_table))
         failed = True
 

--- a/apps/predbat/web_annual.py
+++ b/apps/predbat/web_annual.py
@@ -763,6 +763,8 @@ class AnnualPage:
                             baseline.update({key: copy.deepcopy(export_entry[key]) for key in ["export_octopus_url", "rates_export"] if export_entry.get(key)})
                             break
                     config["baseline_tariff"] = baseline
+                    if value("tariff_dno_region"):
+                        config["baseline_tariff"]["dno_region"] = value("tariff_dno_region")
                     break
 
         if value("year"):


### PR DESCRIPTION
- import tariffs
  - EDF Go Electric 
  - EDF Empower Fixed
- Export tariffs
  - EDF Export 15p
  - EDF Export Exclusive 18p

Sources:
- https://www.edfenergy.com/solar/solar-tariffs   
- https://www.edfenergy.com/energy-efficiency/smart-export-tariff#one

- includes a fix for the "Import tariff without PV or a battery" if it use a URL that has a dno_region