### PR TITLE
fix(hass): don't misdetect an existing install as new on a transient predbat.status read failure

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -285,6 +285,10 @@ minsoc
 minsocongrid
 minuteb
 misclick
+misdetect
+misdetected
+misdetecting
+misdetection
 Mixergy
 mkdocs
 mlugg

--- a/apps/predbat/tests/test_new_install_detection.py
+++ b/apps/predbat/tests/test_new_install_detection.py
@@ -1,0 +1,79 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+
+"""
+Tests for userinterface.py's is_new_install() (Bug B from #4397/#4396, also seen
+independently as #3259 and #3306).
+
+A restart can catch HA's state store before it has fully warmed back up, so a single
+failed predbat.status read is not reliable evidence of a genuinely new install on its
+own. Misdetecting an existing install as new resets live config items (e.g. mode) back
+to their defaults. predbat_config.json only exists once Predbat has actually saved a
+config before, so its presence is used as a second, persistent signal.
+"""
+
+import json
+import os
+import tempfile
+
+
+def test_new_install_detection(my_predbat):
+    """Tests is_new_install() isn't fooled by a transient predbat.status read failure when predbat_config.json proves this is a real install."""
+    failed = False
+    print("**** test_new_install_detection ****")
+
+    original_load_previous_value_from_ha = my_predbat.load_previous_value_from_ha
+    original_config_root = my_predbat.config_root
+    original_db_primary = my_predbat.ha_interface.db_primary
+
+    def status_unavailable(entity, attribute=None):
+        if entity == my_predbat.prefix + ".status":
+            return None
+        return original_load_previous_value_from_ha(entity, attribute=attribute)
+
+    try:
+        my_predbat.load_previous_value_from_ha = status_unavailable
+        my_predbat.ha_interface.db_primary = False
+
+        with tempfile.TemporaryDirectory() as tmp_root:
+            my_predbat.config_root = tmp_root
+
+            print("  [no predbat_config.json] genuinely fresh install - predbat.status unavailable and nothing persisted")
+            if not my_predbat.is_new_install():
+                print("ERROR: expected a new install to be detected when predbat.status is unavailable and no predbat_config.json exists")
+                failed = True
+
+            config_path = os.path.join(tmp_root, "predbat_config.json")
+            with open(config_path, "w", encoding="utf-8") as f:
+                json.dump({"battery_capacity": 10.0}, f)
+
+            print("  [predbat_config.json exists] existing install is not misdetected as new even though predbat.status is unavailable")
+            if my_predbat.is_new_install():
+                print("ERROR: expected an existing install (predbat_config.json present) to NOT be treated as new, even with predbat.status unavailable")
+                failed = True
+
+            print("  [db_primary mode] the JSON-file signal is skipped - DB-primary installs don't use predbat_config.json")
+            my_predbat.ha_interface.db_primary = True
+            if not my_predbat.is_new_install():
+                print("ERROR: expected db_primary mode to fall back to new-install detection, ignoring predbat_config.json")
+                failed = True
+            my_predbat.ha_interface.db_primary = False
+
+        print("  [predbat.status available] a real status read is still authoritative regardless of predbat_config.json")
+        my_predbat.load_previous_value_from_ha = original_load_previous_value_from_ha
+        if my_predbat.is_new_install():
+            print("ERROR: expected an install with a readable predbat.status to not be treated as new")
+            failed = True
+    finally:
+        my_predbat.load_previous_value_from_ha = original_load_previous_value_from_ha
+        my_predbat.config_root = original_config_root
+        my_predbat.ha_interface.db_primary = original_db_primary
+
+    print("**** test_new_install_detection PASSED ****" if not failed else "**** test_new_install_detection FAILED ****")
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -28,6 +28,7 @@ from tests.test_fetch_config_options import test_fetch_config_options
 from tests.test_multi_inverter import run_inverter_multi_tests
 from tests.test_window2minutes import test_window2minutes
 from tests.test_hass_watcher import test_hass_watcher
+from tests.test_new_install_detection import test_new_install_detection
 from tests.test_history_attribute import test_history_attribute
 from tests.test_inverter import run_inverter_tests
 from tests.test_basic_rates import test_basic_rates
@@ -269,6 +270,7 @@ def main():
         ("window_sort", run_window_sort_tests, "Window sort tests", False),
         ("window2minutes", test_window2minutes, "Window to minutes tests", False),
         ("hass_watcher", test_hass_watcher, "Standalone-mode file watcher tests (#4397/#4396)", False),
+        ("new_install_detection", test_new_install_detection, "New-install misdetection tests (Bug B, #4397/#4396, #3259, #3306)", False),
         ("compute_metric", run_compute_metric_tests, "Compute metric tests", False),
         ("minute_array", test_minute_array, "MinuteArray class tests", False),
         ("minute_data", test_minute_data, "Minute data tests", False),

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -904,6 +904,29 @@ class UserInterface:
             {"domain": "update", "service": "skip", "callback": self.update_event},
         ]
 
+    def is_new_install(self):
+        """
+        Determine whether this is a genuinely new install, used to set sensible defaults
+        (e.g. mode defaults to Monitor rather than Control charge & discharge).
+        """
+        current_status = self.load_previous_value_from_ha(self.prefix + ".status")
+        if current_status:
+            return False
+
+        # HA's live state and history can both come back empty for a moment right after an
+        # abrupt restart, before HA's own state store has fully warmed back up. A single
+        # failed predbat.status read isn't enough evidence of a fresh install on its own -
+        # predbat_config.json only exists once Predbat has actually saved a config before,
+        # so its presence is a persistent, restart-proof signal that this is a real install,
+        # not a new one (see #4397/#4396 root cause, and #3259/#3306 for the resulting
+        # spurious config resets this was letting through).
+        if not self.ha_interface.db_primary and os.path.exists(self.config_root + "/predbat_config.json"):
+            self.log("predbat.status unavailable but predbat_config.json exists - not treating this as a new install")
+            return False
+
+        self.log("New install detected")
+        return True
+
     def load_user_config(self, quiet=True, register=False, load_config=False):
         """
         Load config from HA
@@ -913,12 +936,7 @@ class UserInterface:
         self.log("Refreshing Predbat configuration")
 
         # New install, used to set default of expert mode
-        new_install = True
-        current_status = self.load_previous_value_from_ha(self.prefix + ".status")
-        if current_status:
-            new_install = False
-        else:
-            self.log("New install detected")
+        new_install = self.is_new_install()
 
         # Build config index
         for item in self.CONFIG_ITEMS:

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -920,7 +920,8 @@ class UserInterface:
         # so its presence is a persistent, restart-proof signal that this is a real install,
         # not a new one (see #4397/#4396 root cause, and #3259/#3306 for the resulting
         # spurious config resets this was letting through).
-        if not self.ha_interface.db_primary and os.path.exists(self.config_root + "/predbat_config.json"):
+        config_path = os.path.join(self.config_root or "", "predbat_config.json")
+        if not self.ha_interface.db_primary and os.path.isfile(config_path):
             self.log("predbat.status unavailable but predbat_config.json exists - not treating this as a new install")
             return False
 


### PR DESCRIPTION
## Summary
- Fixes Bug B from #4397 / #4396: a single failed `predbat.status` read (e.g. right after an abrupt restart, before HA's own state store has fully warmed back up) was enough for `load_user_config()` to treat an existing install as brand new, silently resetting live config (`mode`, and anything else `reset_inverter`/`reset_inverter_force`-flagged) back to defaults.
- Bug A (the restart trigger itself) was already fixed by #4401. This is the pre-existing, independent bug it was inadvertently making much easier to hit.
- Extracted the check into `is_new_install()` and added a second, persistent signal: if `predbat_config.json` exists on disk (skipped in DB-primary mode, which doesn't use that file), don't treat the install as new even if the live/history `predbat.status` read comes back empty.
- Also matches two earlier, independent sightings of the same symptom that predate the Annual tool entirely: #3259 ("reverts to monitor mode... config settings default to default") and #3306 (a single config item silently resetting to its default).

## Test plan
- [x] New `apps/predbat/tests/test_new_install_detection.py`: covers a genuinely fresh install (no file, still detected as new), an existing install with `predbat_config.json` present (not misdetected even with `predbat.status` unavailable), DB-primary mode correctly skipping the file-based signal, and a real `predbat.status` read still being authoritative.
- [x] Full quick test suite passes.
- [x] Pre-commit clean.