### PR TITLE
fix(plan): add a charge step margin to the clip charge slot compares

### DIFF
--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -2325,7 +2325,13 @@ class Plan:
         """
         Clip charge slots that are useless as they don't charge at all
         set the 'target' field in the charge window for HTML reporting
+
+        Both clip-up branches raise the limit to the full battery so that adjacent windows share a limit and can
+        be merged, which is only sound when the limit had no influence on the simulated charge. The achieved SoC
+        lands just under the limit when the limit clamped it (charge loss), and can dip a hair below its own peak
+        for the same reason, so both tests need a margin of one charge step to tell a real effect from rounding.
         """
+        charge_step = self.battery_rate_max_charge * self.battery_rate_max_scaling * step
         for window_n in range(min(record_charge_windows, len(charge_window_best))):
             window = charge_window_best[window_n]
             limit = charge_limit_best[window_n]
@@ -2363,13 +2369,13 @@ class Plan:
                         window["target"] = 0
                         if self.debug_enable:
                             self.log("Clip off charge window {} from {} - {} from limit {} to new limit {} min percent {} limit percent {}".format(window_n, window_start, window_end, limit, charge_limit_best[window_n], soc_min_percent, limit_percent))
-                    elif soc_max < limit:
+                    elif soc_max < (limit - charge_step):
                         # Work out what can be achieved in the window and set the target to match that
                         window["target"] = soc_max
                         charge_limit_best[window_n] = self.soc_max
                         if self.debug_enable:
                             self.log("Clip up charge window {} from {} - {} from limit {} to new limit {} target set to {}".format(window_n, window_start, window_end, limit, charge_limit_best[window_n], window["target"]))
-                    elif (soc_max > soc_m1) and soc_max == limit:
+                    elif (soc_max > (soc_m1 + charge_step)) and soc_max == limit:
                         window["target"] = soc_max
                         charge_limit_best[window_n] = self.soc_max
                         if self.debug_enable:

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -2328,8 +2328,8 @@ class Plan:
 
         Both clip-up branches raise the limit to the full battery so that adjacent windows share a limit and can
         be merged, which is only sound when the limit had no influence on the simulated charge. The achieved SoC
-        lands just under the limit when the limit clamped it (charge loss), and can dip a hair below its own peak
-        for the same reason, so both tests need a margin of one charge step to tell a real effect from rounding.
+        can land just under the limit even when the limit never clamped it (e.g. charge loss/rounding), and can dip
+        a hair below its own peak for the same reason, so both tests need a margin of one charge step to tell a real effect from rounding.
         """
         charge_step = self.battery_rate_max_charge * self.battery_rate_max_scaling * step
         for window_n in range(min(record_charge_windows, len(charge_window_best))):

--- a/apps/predbat/tests/test_clip_charge_slots.py
+++ b/apps/predbat/tests/test_clip_charge_slots.py
@@ -20,7 +20,12 @@ def run_clip_charge_slots_tests(my_predbat):
     failed |= test_clip_off_soc_above_limit(my_predbat)
     failed |= test_clip_off_preserves_reserve(my_predbat)
     failed |= test_clip_up_soc_max_below_limit(my_predbat)
+    failed |= test_clip_up_soc_max_within_margin_of_limit(my_predbat)
+    failed |= test_clip_up_soc_max_beyond_margin_of_limit(my_predbat)
     failed |= test_clip_up_soc_max_equals_limit_and_dropping(my_predbat)
+    failed |= test_clip_up_dropping_within_margin(my_predbat)
+    failed |= test_clip_margin_scales_with_charge_rate(my_predbat)
+    failed |= test_clip_margin_scales_with_step(my_predbat)
     failed |= test_freeze_charge_to_charge_at_100_soc(my_predbat)
     failed |= test_freeze_charge_kept_below_100_soc(my_predbat)
     failed |= test_normal_window_unchanged(my_predbat)
@@ -50,6 +55,16 @@ def make_predict_soc_ramp(minutes_now, soc_start, soc_end, duration_minutes=60):
             predict_soc[minute] = soc_start + (soc_end - soc_start) * i / steps
         else:
             predict_soc[minute] = soc_start
+    return predict_soc
+
+
+def make_predict_soc_dip(soc_peak, soc_end, duration_minutes=30):
+    """Build a predict_soc dict that holds at soc_peak then dips to soc_end for the last two entries"""
+    predict_soc = {}
+    for minute in range(0, duration_minutes + 5, 5):
+        predict_soc[minute] = soc_peak
+    predict_soc[max(duration_minutes - 5, 0)] = soc_end
+    predict_soc[duration_minutes] = soc_end
     return predict_soc
 
 
@@ -183,6 +198,58 @@ def test_clip_up_soc_max_below_limit(my_predbat):
     return failed
 
 
+def test_clip_up_soc_max_within_margin_of_limit(my_predbat):
+    """When soc_max is under the limit by less than one charge step it's just charge loss, so don't clip up"""
+    print("**** test_clip_charge_up_soc_max_within_margin_of_limit ****")
+    failed = False
+    setup(my_predbat)
+
+    minutes_now = 720
+    windows = [make_window(720, 750)]
+    limits = [5.0]  # Want to charge to 5 kWh
+    # SoC lands at 4.95, only 0.05 short of the limit, less than one charge step (1kW * 5 minutes = 0.0833)
+    predict_soc = make_predict_soc(minutes_now, 4.95, 60)
+
+    result_windows, result_limits = my_predbat.clip_charge_slots(minutes_now, predict_soc, windows, limits, 1, 5)
+
+    if result_limits[0] != 5.0:
+        print("ERROR: Expected limit unchanged at 5.0 but got {}".format(result_limits[0]))
+        failed = True
+    if result_windows[0]["target"] != 5.0:
+        print("ERROR: Expected target unchanged at 5.0 but got {}".format(result_windows[0]["target"]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_clip_up_soc_max_beyond_margin_of_limit(my_predbat):
+    """When soc_max is under the limit by more than one charge step the limit had no effect, so clip up"""
+    print("**** test_clip_charge_up_soc_max_beyond_margin_of_limit ****")
+    failed = False
+    setup(my_predbat)
+
+    minutes_now = 720
+    windows = [make_window(720, 750)]
+    limits = [5.0]  # Want to charge to 5 kWh
+    # SoC lands at 4.5, 0.5 short of the limit, well over one charge step (1kW * 5 minutes = 0.0833)
+    predict_soc = make_predict_soc(minutes_now, 4.5, 60)
+
+    result_windows, result_limits = my_predbat.clip_charge_slots(minutes_now, predict_soc, windows, limits, 1, 5)
+
+    if result_limits[0] != my_predbat.soc_max:
+        print("ERROR: Expected limit clipped up to soc_max ({}) but got {}".format(my_predbat.soc_max, result_limits[0]))
+        failed = True
+    if result_windows[0]["target"] != 4.5:
+        print("ERROR: Expected target set to soc_max in window (4.5) but got {}".format(result_windows[0]["target"]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
 def test_clip_up_soc_max_equals_limit_and_dropping(my_predbat):
     """When soc_max == limit and soc_max > soc at end-1, clip up"""
     print("**** test_clip_charge_up_soc_max_equals_limit_dropping ****")
@@ -202,6 +269,96 @@ def test_clip_up_soc_max_equals_limit_and_dropping(my_predbat):
         failed = True
     if result_windows[0]["target"] != 6.0:
         print("ERROR: Expected target 6.0 but got {}".format(result_windows[0]["target"]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_clip_up_dropping_within_margin(my_predbat):
+    """When soc_max == limit but the dip at the end of the window is under one charge step, don't clip up"""
+    print("**** test_clip_charge_up_dropping_within_margin ****")
+    failed = False
+    setup(my_predbat)
+
+    minutes_now = 720
+    windows = [make_window(720, 750)]
+    limits = [6.0]  # Want to charge to 6 kWh
+    # SoC sits at the limit then dips by 0.05, less than one charge step (1kW * 5 minutes = 0.0833)
+    predict_soc = make_predict_soc_dip(6.0, 5.95, 30)
+
+    result_windows, result_limits = my_predbat.clip_charge_slots(minutes_now, predict_soc, windows, limits, 1, 5)
+
+    if result_limits[0] != 6.0:
+        print("ERROR: Expected limit unchanged at 6.0 but got {}".format(result_limits[0]))
+        failed = True
+    if result_windows[0]["target"] != 6.0:
+        print("ERROR: Expected target unchanged at 6.0 but got {}".format(result_windows[0]["target"]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_clip_margin_scales_with_charge_rate(my_predbat):
+    """The margin is one charge step, so a faster charge rate (and scaling) tolerates a bigger dip"""
+    print("**** test_clip_charge_margin_scales_with_charge_rate ****")
+    failed = False
+    setup(my_predbat)
+
+    minutes_now = 720
+    windows = [make_window(720, 750)]
+    limits = [6.0]
+    # Dip of 0.3, which is over one charge step at the default 1kW but under it at 2kW scaled by 2.5 (0.4166)
+    predict_soc = make_predict_soc_dip(6.0, 5.7, 30)
+
+    my_predbat.battery_rate_max_charge = 2 / 60.0
+    my_predbat.battery_rate_max_scaling = 2.5
+
+    result_windows, result_limits = my_predbat.clip_charge_slots(minutes_now, predict_soc, windows, limits, 1, 5)
+
+    if result_limits[0] != 6.0:
+        print("ERROR: Expected limit unchanged at 6.0 but got {}".format(result_limits[0]))
+        failed = True
+
+    # The same dip at the default charge rate is bigger than one charge step, so it does clip up
+    setup(my_predbat)
+    windows = [make_window(720, 750)]
+    limits = [6.0]
+    predict_soc = make_predict_soc_dip(6.0, 5.7, 30)
+
+    result_windows, result_limits = my_predbat.clip_charge_slots(minutes_now, predict_soc, windows, limits, 1, 5)
+
+    if result_limits[0] != my_predbat.soc_max:
+        print("ERROR: Expected limit clipped up to soc_max ({}) at the default charge rate but got {}".format(my_predbat.soc_max, result_limits[0]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_clip_margin_scales_with_step(my_predbat):
+    """The margin is one charge step, so a longer prediction step tolerates a bigger dip"""
+    print("**** test_clip_charge_margin_scales_with_step ****")
+    failed = False
+    setup(my_predbat)
+
+    minutes_now = 720
+    windows = [make_window(720, 750)]
+    limits = [6.0]
+    # Dip of 0.3, which is over one charge step at step 5 (0.0833) but under it at step 30 (0.5)
+    predict_soc = make_predict_soc_dip(6.0, 5.7, 30)
+
+    result_windows, result_limits = my_predbat.clip_charge_slots(minutes_now, predict_soc, windows, limits, 1, 30)
+
+    if result_limits[0] != 6.0:
+        print("ERROR: Expected limit unchanged at 6.0 but got {}".format(result_limits[0]))
+        failed = True
+    if result_windows[0]["target"] != 6.0:
+        print("ERROR: Expected target unchanged at 6.0 but got {}".format(result_windows[0]["target"]))
         failed = True
 
     if not failed:


### PR DESCRIPTION
## Problem

`clip_charge_slots` has two clip-up branches that raise the charge limit to the full battery, so that adjacent windows share a limit and can be merged. That is only sound when the limit had no influence on the simulated charge — but:

- charge loss leaves the achieved SoC a fraction *under* the limit even when the limit never clamped it, so `soc_max < limit` fired on rounding
- for the same reason the SoC can dip a hair below its own peak at the end of a window, so `soc_max > soc_m1` fired on rounding

In both cases the limit was raised when it shouldn't have been, which changed the costing of the plan.

## Fix

Compare with a margin of one charge step (`battery_rate_max_charge * battery_rate_max_scaling * step`) in both branches, so a real effect is told apart from rounding.

## Tests

`test_clip_charge_slots.py` already existed and is extended with:

- `test_clip_up_soc_max_within_margin_of_limit` — SoC 0.05 kWh under a 5.0 kWh limit (inside the 0.083 kWh step at 1 kW): limit and target left alone
- `test_clip_up_soc_max_beyond_margin_of_limit` — 0.5 kWh short: still clips up, pinning the behaviour the margin must not swallow
- `test_clip_up_dropping_within_margin` — `soc_max == limit` with a 0.05 kWh end-of-window dip: left alone
- `test_clip_margin_scales_with_charge_rate` — the same 0.3 kWh dip clips at 1 kW but not at 2 kW x 2.5 scaling, covering the rate and scaling factors
- `test_clip_margin_scales_with_step` — the same dip is tolerated at `step=30`, covering the step factor

Verified the four margin tests fail against the un-fixed `plan.py` while the rest stay green.

- `./run_all --test clip_charge_slots` — 15/15 pass
- `./run_all --quick` — all pass (30s)
- `./run_pre_commit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)