### PR TITLE
fix(plan): widen forecast_minutes before building yesterday_load_step/yesterday_pv_step

### DIFF
--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -2870,11 +2870,19 @@ class Output:
 
         self.log("Calculating data from yesterday for savings calculation")
 
+        # step_data_history() only fills in offsets up to self.forecast_minutes + plan_interval_minutes.
+        # The History view built below needs a full "yesterday" (24h) plus "today so far" up to now, i.e.
+        # offsets up to 24*60 + self.minutes_now - widen forecast_minutes before building these step arrays,
+        # not just later when the "yesterday" plan_html is rendered, or any offset beyond the live plan's
+        # normal horizon silently reads back as zero load/PV for the rest of the day.
+        end_record = 24 * 60
+        forecast_minutes_before_yesterday_step = self.forecast_minutes
+        self.forecast_minutes = max(self.forecast_minutes, end_record + self.minutes_now)
         yesterday_load_step = self.step_data_history(self.load_minutes, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
         yesterday_pv_step = self.step_data_history(self.pv_today, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
         yesterday_pv_step_zero = self.step_data_history(None, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
+        self.forecast_minutes = forecast_minutes_before_yesterday_step
         minutes_back = self.minutes_now + 1
-        end_record = 24 * 60
 
         # Get yesterday's SoC
         try:

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -2878,10 +2878,12 @@ class Output:
         end_record = 24 * 60
         forecast_minutes_before_yesterday_step = self.forecast_minutes
         self.forecast_minutes = max(self.forecast_minutes, end_record + self.minutes_now)
-        yesterday_load_step = self.step_data_history(self.load_minutes, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
-        yesterday_pv_step = self.step_data_history(self.pv_today, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
-        yesterday_pv_step_zero = self.step_data_history(None, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
-        self.forecast_minutes = forecast_minutes_before_yesterday_step
+        try:
+            yesterday_load_step = self.step_data_history(self.load_minutes, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
+            yesterday_pv_step = self.step_data_history(self.pv_today, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
+            yesterday_pv_step_zero = self.step_data_history(None, 0, forward=False, scale_today=1.0, scale_fixed=1.0, base_offset=24 * 60 + self.minutes_now)
+        finally:
+            self.forecast_minutes = forecast_minutes_before_yesterday_step
         minutes_back = self.minutes_now + 1
 
         # Get yesterday's SoC

--- a/apps/predbat/tests/test_calculate_yesterday.py
+++ b/apps/predbat/tests/test_calculate_yesterday.py
@@ -191,6 +191,26 @@ def _make_history_mock(my_predbat, now_utc, cost_value=100.0, soc_value=5.0):
     return _get_history_wrapper
 
 
+def _make_recording_step_data(pv_today_ref, my_predbat, forecast_minutes_snapshots):
+    """Like _make_mock_step_data, but also records self.forecast_minutes at
+    the moment of each call, so a test can verify it was already widened
+    before yesterday_load_step/yesterday_pv_step are built (issue #4418:
+    step_data_history() only fills offsets up to forecast_minutes, so a
+    late minutes_now needs forecast_minutes widened *before* these calls,
+    not just later when the "yesterday" plan_html is rendered)."""
+
+    def _mock(item, minutes_now, forward, step=5, scale_today=1.0, scale_fixed=1.0, **kwargs):
+        forecast_minutes_snapshots.append(my_predbat.forecast_minutes)
+        if item is None:
+            return {minute: 0.0 for minute in range(0, 24 * 60, 5)}
+        elif item is pv_today_ref:
+            return {minute: FLAT_PV_KWH for minute in range(0, 24 * 60, 5)}
+        else:
+            return {minute: FLAT_LOAD_KWH for minute in range(0, 24 * 60, 5)}
+
+    return _mock
+
+
 def _apply_mocks(my_predbat, now_utc, cost_value=100.0, soc_value=5.0):
     """Apply all mocks and return the captured-load list."""
     captured_load_steps = []
@@ -331,6 +351,57 @@ def _test_basic_no_car(my_predbat, failed):
     # --- run_prediction was called (once for baseline, once for no-pvbat) ---
     if len(captured_load) < 2:
         print("ERROR: run_prediction should have been called at least twice, got {} captures".format(len(captured_load)))
+        failed = True
+
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    return failed
+
+
+def _test_forecast_minutes_widened_before_step_data(my_predbat, failed):
+    """Regression test for #4418.
+
+    step_data_history() only fills in offsets up to
+    self.forecast_minutes + plan_interval_minutes. The "History" view needs
+    a full "yesterday" (24h) plus "today so far" up to minutes_now, i.e.
+    offsets up to 24*60 + minutes_now. If forecast_minutes is not widened
+    to at least that *before* yesterday_load_step/yesterday_pv_step are
+    built, any offset beyond the live plan's normal horizon silently reads
+    back as zero load/PV for the rest of the day (reproduced live with
+    forecast_plan_hours=30 i.e. forecast_minutes=1800, minutes_now=910 -
+    Load kWh read 0 from ~06:00 onward every day in the History tab).
+
+    Uses a late minutes_now (910, i.e. 15:10) with a forecast_minutes
+    (1800) too small to cover 24*60 + minutes_now (2350) unless widened
+    first, matching the real-world reproduction.
+    """
+    print("calculate_yesterday: Test – forecast_minutes widened before yesterday_load_step/yesterday_pv_step (#4418)")
+    now_utc = _setup_base(my_predbat, minutes_now=910)
+    my_predbat.forecast_minutes = 1800
+
+    forecast_minutes_snapshots = []
+    my_predbat.step_data_history = _make_recording_step_data(my_predbat.pv_today, my_predbat, forecast_minutes_snapshots)
+    my_predbat.get_history_wrapper = _make_history_mock(my_predbat, now_utc)
+    my_predbat.plan_write_debug = lambda *a, **kw: ("", "{}")
+    my_predbat.publish_html_plan = lambda *a, **kw: ("", "{}")
+    original_run_pred = my_predbat.run_prediction
+    my_predbat.run_prediction = lambda *a, **kw: _make_mock_run_prediction([])(my_predbat, *a, **kw)
+
+    my_predbat.calculate_yesterday()
+
+    required_minutes = 24 * 60 + 910
+    if not forecast_minutes_snapshots:
+        print("ERROR: step_data_history was never called")
+        failed = True
+    elif forecast_minutes_snapshots[0] < required_minutes:
+        print("ERROR: forecast_minutes was only {} at the first step_data_history call, needed >= {} " "(yesterday_load_step/yesterday_pv_step built before widening)".format(forecast_minutes_snapshots[0], required_minutes))
+        failed = True
+    elif any(snap < required_minutes for snap in forecast_minutes_snapshots):
+        print("ERROR: forecast_minutes dropped below {} partway through the step_data_history calls: {}".format(required_minutes, forecast_minutes_snapshots))
+        failed = True
+
+    if my_predbat.forecast_minutes != 1800:
+        print("ERROR: forecast_minutes was not restored to its original value (expected 1800, got {})".format(my_predbat.forecast_minutes))
         failed = True
 
     _restore_methods(my_predbat, original_run_pred)
@@ -1067,6 +1138,7 @@ def test_calculate_yesterday(my_predbat):
 
     failed = _test_early_exit(my_predbat, failed)
     failed = _test_basic_no_car(my_predbat, failed)
+    failed = _test_forecast_minutes_widened_before_step_data(my_predbat, failed)
     failed = _test_car_slot_subtraction(my_predbat, failed)
     failed = _test_car_slot_from_energy_sensor(my_predbat, failed)
     failed = _test_early_exit_respects_day_rollover(my_predbat, failed)

--- a/apps/predbat/tests/test_calculate_yesterday.py
+++ b/apps/predbat/tests/test_calculate_yesterday.py
@@ -202,11 +202,11 @@ def _make_recording_step_data(pv_today_ref, my_predbat, forecast_minutes_snapsho
     def _mock(item, minutes_now, forward, step=5, scale_today=1.0, scale_fixed=1.0, **kwargs):
         forecast_minutes_snapshots.append(my_predbat.forecast_minutes)
         if item is None:
-            return {minute: 0.0 for minute in range(0, 24 * 60, 5)}
+            return {minute: 0.0 for minute in range(0, 24 * 60, step)}
         elif item is pv_today_ref:
-            return {minute: FLAT_PV_KWH for minute in range(0, 24 * 60, 5)}
+            return {minute: FLAT_PV_KWH for minute in range(0, 24 * 60, step)}
         else:
-            return {minute: FLAT_LOAD_KWH for minute in range(0, 24 * 60, 5)}
+            return {minute: FLAT_LOAD_KWH for minute in range(0, 24 * 60, step)}
 
     return _mock
 


### PR DESCRIPTION
## Summary
- The web plan "History" tab's Load kWh column reads 0 from ~6am onward every day, self-healing the next day - `calculate_yesterday()` built `yesterday_load_step`/`yesterday_pv_step` via `step_data_history()` while `self.forecast_minutes` was still the live plan's normal (too-small) horizon, so any offset past it silently read back as zero for the rest of the day.
- Widens `forecast_minutes` before building those step-data dicts (the widening already existed later in the function, just applied too late), restoring it immediately after.
- Added a regression test reproducing the exact real-world numbers that exposed this (`forecast_plan_hours=30`, `minutes_now=910`), verified it fails without the fix and passes with it.

Fixes #4418

## Test plan
- [x] `./run_all --quick` passes
- [x] New regression test (`test_calculate_yesterday.py`) fails on the pre-fix code, passes on the fix
- [x] `run_pre_commit` clean