### PR TITLE
fix(car-charging): show car charging limit as % (with kWh) in debug logs, not mislabelled kWh-as-%

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1124,14 +1124,12 @@ class Fetch:
             elif self.car_charging_planned[car_n] or self.car_charging_now[car_n]:
                 limit_percent = dp1(self.car_charging_limit[car_n] / self.car_charging_battery_size[car_n] * 100) if self.car_charging_battery_size[car_n] else 0
                 self.log(
-                    "Car {} plan charging from {} to {}, with slots {} from SoC {}kWh to {}% ({}kWh), ready by {}".format(
+                    "Car {} plan charging from {}kWh to {}% ({}kWh), with slots {}, ready by {}".format(
                         car_n,
-                        self.car_charging_soc[car_n],
-                        self.car_charging_limit[car_n],
-                        self.low_rates,
                         self.car_charging_soc[car_n],
                         limit_percent,
                         self.car_charging_limit[car_n],
+                        self.low_rates,
                         self.car_charging_plan_time[car_n],
                     )
                 )

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1122,13 +1122,15 @@ class Fetch:
                 else:
                     self.log("Car {} on Octopus Intelligent, no active plan".format(car_n))
             elif self.car_charging_planned[car_n] or self.car_charging_now[car_n]:
+                limit_percent = dp1(self.car_charging_limit[car_n] / self.car_charging_battery_size[car_n] * 100) if self.car_charging_battery_size[car_n] else 0
                 self.log(
-                    "Car {} plan charging from {} to {}, with slots {} from SoC {}% to {}%, ready by {}".format(
+                    "Car {} plan charging from {} to {}, with slots {} from SoC {}kWh to {}% ({}kWh), ready by {}".format(
                         car_n,
                         self.car_charging_soc[car_n],
                         self.car_charging_limit[car_n],
                         self.low_rates,
                         self.car_charging_soc[car_n],
+                        limit_percent,
                         self.car_charging_limit[car_n],
                         self.car_charging_plan_time[car_n],
                     )
@@ -1286,7 +1288,8 @@ class Fetch:
 
         # Log final car SoC (initialised before the IOG loop, updated per-car after Octopus battery_size is read)
         if self.num_cars:
-            self.log("Cars: SoC: {}kWh, Charge limit {}%, plan time {}, battery size {}kWh".format(self.car_charging_soc, self.car_charging_limit, self.car_charging_plan_time, self.car_charging_battery_size))
+            car_charging_limit_percent = [dp1(limit / size * 100) if size else 0 for limit, size in zip(self.car_charging_limit, self.car_charging_battery_size)]
+            self.log("Cars: SoC: {}kWh, Charge limit {}% ({}kWh), plan time {}, battery size {}kWh".format(self.car_charging_soc, car_charging_limit_percent, self.car_charging_limit, self.car_charging_plan_time, self.car_charging_battery_size))
 
     def fetch_pv_forecast(self):
         """
@@ -1979,8 +1982,9 @@ class Fetch:
             self.car_charging_exclusive[car_n] = self.get_arg("car_charging_exclusive", False, index=car_n)
 
         if self.num_cars > 0:
+            car_charging_limit_percent = [dp1(limit / size * 100) if size else 0 for limit, size in zip(self.car_charging_limit, self.car_charging_battery_size)]
             self.log(
-                "Cars {} charging from battery {} planned {}, charging_now {} smart {}, max_price {}{}, plan_time {}, battery size {}kWh, limit {}%, rate {}kW, exclusive {}".format(
+                "Cars {} charging from battery {} planned {}, charging_now {} smart {}, max_price {}{}, plan_time {}, battery size {}kWh, limit {}% ({}kWh), rate {}kW, exclusive {}".format(
                     self.num_cars,
                     self.car_charging_from_battery,
                     self.car_charging_planned,
@@ -1990,6 +1994,7 @@ class Fetch:
                     self.currency_symbols[1],
                     self.car_charging_plan_time,
                     self.car_charging_battery_size,
+                    car_charging_limit_percent,
                     self.car_charging_limit,
                     self.car_charging_rate,
                     self.car_charging_exclusive,


### PR DESCRIPTION
## Summary
- `car_charging_limit`/`car_charging_soc` are converted from the user's configured percent into kWh internally for the SoC-gap arithmetic, but three debug log lines still labelled the (by-then kWh) limit value with a `%` suffix - spotted while investigating #4416, where it looked like a scaling bug but turned out to be a pure log-label mismatch.
- Now logs the limit as both a percent (recomputed from the kWh value and battery size) and the kWh figure, e.g. `limit 80% (61.6kWh)` - percent is how users actually think about a charge target, kWh is still there for anyone debugging the underlying arithmetic.

Related to #4416

## Test plan
- [x] `./run_all --quick` passes
- [x] `run_pre_commit` clean
- No behavioural change - log-only fix, three call sites in `fetch.py` all updated for consistency