### PR TITLE
fix(gateway): dispatch MQTT publishes onto the owning event loop

### DIFF
--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -244,6 +244,13 @@ class GatewayMQTT(ComponentBase):
         self._mqtt_client = None
         self._mqtt_task = None
         self._mqtt_connected = False
+        # Event loop that owns self._mqtt_client (captured in run()). Control writes
+        # arrive via ha.py::run_async(), which runs on its own throwaway loop on the
+        # calling thread — publishing directly from there would bind the aiomqtt
+        # publish-confirmation Future to the wrong loop and stall for the client's
+        # ~10s default timeout instead of completing near-instantly. _publish_raw()
+        # dispatches onto this loop when called from elsewhere.
+        self._loop = None
         self._gateway_online = False
         self._last_telemetry_time = 0
         self._last_plan_data = None
@@ -536,6 +543,9 @@ class GatewayMQTT(ComponentBase):
             return False
 
         if first:
+            # Capture the loop that will own the MQTT client/listener task, so
+            # cross-loop callers (ha.py::run_async()) can dispatch onto it later.
+            self._loop = asyncio.get_running_loop()
             # Start MQTT listener as a background task
             self._mqtt_task = asyncio.ensure_future(self._mqtt_loop())
             self.log("Info: GatewayMQTT: MQTT listener task started")
@@ -1622,12 +1632,30 @@ class GatewayMQTT(ComponentBase):
     async def _publish_raw(self, topic, payload, retain=False):
         """Publish raw bytes to an MQTT topic.
 
+        Must run the actual client.publish() on the event loop that owns
+        self._mqtt_client (self._loop). Callers reached via ha.py::run_async()
+        (i.e. every control write issued from the synchronous engine thread)
+        run on a different, throwaway loop — publishing directly from there
+        binds aiomqtt's publish-confirmation Future to the wrong loop and
+        stalls for the client's ~10s default timeout instead of completing
+        near-instantly. When we're already on the owning loop (e.g. internal
+        periodic publishes from run()/housekeeping), publish directly.
+
         Args:
             topic: MQTT topic string.
             payload: Bytes to publish.
             retain: Whether to set the retain flag.
         """
-        if self._mqtt_client and self._mqtt_connected:
+        if not (self._mqtt_client and self._mqtt_connected):
+            return
+
+        if self._loop is not None and self._loop is not asyncio.get_running_loop():
+            future = asyncio.run_coroutine_threadsafe(
+                self._mqtt_client.publish(topic, payload, qos=1, retain=retain),
+                self._loop,
+            )
+            await asyncio.wrap_future(future)
+        else:
             await self._mqtt_client.publish(topic, payload, qos=1, retain=retain)
 
     def is_alive(self):

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -4440,6 +4440,51 @@ class TestRateAnchors(unittest.TestCase):
         self.assertIsNone(extract_rate_anchors(8.0, float("inf"), 15.0, 12.0))
 
 
+class TestPublishRawLoopSafety:
+    """_publish_raw() must run the actual client.publish() on the event loop that
+    owns the aiomqtt Client (self._loop), even when invoked from a different loop —
+    otherwise the publish confirmation Future is bound to the wrong loop and stalls
+    for aiomqtt's ~10s default timeout instead of completing near-instantly. This is
+    what happens today when a control write reaches GatewayMQTT via
+    ha.py::run_async(), which runs the whole call chain on a fresh, throwaway
+    event loop distinct from GatewayMQTT's own persistent MQTT loop.
+    """
+
+    def test_publish_dispatches_to_owning_loop_when_called_cross_loop(self):
+        """A cross-loop _publish_raw() call must execute client.publish() on the
+        thread that owns self._loop, not on the calling thread."""
+        import asyncio
+        import threading
+        from gateway import GatewayMQTT
+
+        gw = GatewayMQTT.__new__(GatewayMQTT)
+        gw._mqtt_connected = True
+        observed = {}
+
+        class FakeClient:
+            async def publish(self, topic, payload, qos=0, retain=False):
+                observed["thread_ident"] = threading.get_ident()
+
+        gw._mqtt_client = FakeClient()
+
+        # Real second event loop on its own thread — mimics GatewayMQTT's
+        # persistent MQTT loop (owned by a dedicated thread via hass.py::create_task).
+        owner_loop = asyncio.new_event_loop()
+        owner_thread = threading.Thread(target=owner_loop.run_forever, daemon=True)
+        owner_thread.start()
+        gw._loop = owner_loop
+
+        try:
+            # Call _publish_raw from a DIFFERENT, freshly-created loop on THIS
+            # thread — mirrors ha.py::run_async()'s asyncio.run(coro) pattern.
+            asyncio.run(gw._publish_raw("predbat/devices/test/command", b"payload"))
+        finally:
+            owner_loop.call_soon_threadsafe(owner_loop.stop)
+            owner_thread.join(timeout=2)
+
+        assert observed.get("thread_ident") == owner_thread.ident, "client.publish() ran on the wrong thread/loop"
+
+
 def run_gateway_tests(my_predbat=None):
     """Run all GatewayMQTT tests. Returns True on failure, False on success."""
     from tests.test_gateway_token_refresh import TestIsAuthFailure, TestApplyRefreshResponse, TestMaybeRefreshOnAuthError
@@ -4476,6 +4521,7 @@ def run_gateway_tests(my_predbat=None):
         TestApplyRefreshResponse,
         TestMaybeRefreshOnAuthError,
         TestRateAnchors,
+        TestPublishRawLoopSafety,
     ]
     for cls in test_classes:
         instance = cls()

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -4481,7 +4481,8 @@ class TestPublishRawLoopSafety:
         finally:
             owner_loop.call_soon_threadsafe(owner_loop.stop)
             owner_thread.join(timeout=2)
-
+            assert not owner_thread.is_alive(), "owner MQTT loop thread did not stop"
+            owner_loop.close()
         assert observed.get("thread_ident") == owner_thread.ident, "client.publish() ran on the wrong thread/loop"
 
 


### PR DESCRIPTION
## Summary
- Every gateway control write (`set_reserve`, `set_charge_rate`, slot times, mode, ...) reaches `GatewayMQTT` via `ha.py::run_async()`, which runs the call chain on a fresh, throwaway event loop distinct from the persistent loop that owns `GatewayMQTT`'s `aiomqtt.Client`.
- Calling `client.publish()` from that other loop binds the QoS-1 publish-confirmation `Future` to the wrong loop, so **every control write currently stalls for the client's ~10s default timeout** before completing successfully.
- Confirmed with a live reproduction against a local mosquitto broker mirroring the real architecture: **10.001s** for a cross-loop publish vs **0.001s** for the same publish issued on the owning loop.
- This also explains the ~12s-per-retry cadence observed in production logs on an EMS site with a separately-broken Modbus link (10s hidden stall + the inverter type's 2s `write_and_poll_sleep`).

## Fix
- `GatewayMQTT.run()` now captures the loop it's running on (`self._loop`) on first start — this is the loop that owns `self._mqtt_client`.
- `_publish_raw()` now checks whether it's executing on `self._loop`. If not (i.e. reached via `run_async()`'s throwaway loop), it hands the actual `client.publish()` coroutine off via `asyncio.run_coroutine_threadsafe(..., self._loop)` and awaits the result with `asyncio.wrap_future`, so it runs on the loop that actually owns the client. If already on the owning loop (internal periodic publishes from `run()`/housekeeping), it publishes directly as before.

## Test plan
- [x] New test `TestPublishRawLoopSafety.test_publish_dispatches_to_owning_loop_when_called_cross_loop` — asserts the real `client.publish()` executes on the thread that owns `self._loop`, not the calling thread. Watched it fail (RED) against the old code, then pass (GREEN) after the fix.
- [x] `./run_all --test gateway` — all gateway tests pass.
- [x] `./run_all --quick` — full quick suite passes.
- [x] `./run_pre_commit` — ruff/black/cspell/etc. all pass.
- [x] Standalone reproduction against a real local mosquitto broker, before and after the fix (10.001s → 0.001s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)