### PR TITLE
fix(solar): scale PV forecast by the detected slot length for all sources

### DIFF
--- a/apps/predbat/solcast.py
+++ b/apps/predbat/solcast.py
@@ -1372,12 +1372,14 @@ class SolarAPI(ComponentBase):
                 except (ValueError, TypeError, KeyError):
                     pass
 
-            # For the HA sensor path the divide_by was computed assuming 30-minute periods;
-            # recalculate it using the actual detected period so that the per-minute kWh
-            # values are correctly scaled regardless of the forecast resolution.
-            if not self.forecast_solar and not (self.solcast_host and self.solcast_api_key):
-                factor = divide_by / 30.0
-                divide_by = dp2(period * factor)
+            # divide_by was computed assuming 30-minute periods; recalculate it using the actual
+            # detected period so that the per-minute kWh values are correctly scaled regardless of
+            # the forecast resolution. This applies to every source: the direct API downloaders all
+            # emit kWh per slot but the slot length varies (Forecast.Solar uses plan_interval_minutes,
+            # Open-Meteo is hourly, Solcast reports PT15M or PT30M), and the HA sensor path carries
+            # its own unit factor, which this division preserves.
+            factor = divide_by / 30.0
+            divide_by = dp2(period * factor)
 
             if period != 30:
                 self.log("SolarAPI: PV Forecast data has {} minute resolution, adjusting calculations".format(period))

--- a/apps/predbat/tests/test_solcast.py
+++ b/apps/predbat/tests/test_solcast.py
@@ -21,6 +21,7 @@ import aiohttp
 from solcast import SolarAPI
 from solar_model import convert_azimuth
 from storage import StorageLocalFiles
+from const import TIME_FORMAT
 from tests.test_infra import run_async, create_aiohttp_mock_response
 
 
@@ -2471,6 +2472,335 @@ def test_publish_pv_stats_15min_resolution(my_predbat):
 
 
 # ============================================================================
+# Slot-length scaling tests (divide_by must follow the detected period)
+# ============================================================================
+
+
+def capture_unit_factor(test_api):
+    """
+    Wrap publish_pv_stats so a test can see the unit factor (divide_by / period) and the
+    forecast entries fetch_pv_forecast passed to it, while still publishing as normal.
+
+    A unit factor of 1.0 means "pv_estimate is kWh per slot", which is what all three direct
+    API downloaders emit. Any other value means the per-minute data was scaled by that factor.
+    """
+    captured = {}
+    original = test_api.solar.publish_pv_stats
+
+    def wrapper(pv_forecast_data, divide_by, period):
+        """Record the arguments then publish as normal."""
+        captured["unit_factor"] = divide_by
+        captured["period"] = period
+        captured["data"] = pv_forecast_data
+        return original(pv_forecast_data, divide_by, period)
+
+    test_api.solar.publish_pv_stats = wrapper
+    return captured
+
+
+def day_zero_kwh(pv_forecast_data, midnight_utc):
+    """Sum pv_estimate over the forecast entries that fall on the first forecast day."""
+    total = 0
+    for entry in pv_forecast_data:
+        try:
+            stamp = datetime.strptime(entry["period_start"], TIME_FORMAT)
+        except (ValueError, TypeError, KeyError):
+            continue
+        if midnight_utc <= stamp < midnight_utc + timedelta(days=1):
+            total += entry.get("pv_estimate", 0)
+    return total
+
+
+def check_slot_scaling(test_api, captured, expected_period, expected_kwh, label):
+    """
+    Assert that a fetch scaled its kWh-per-slot forecast by the detected slot length.
+
+    Checks the detected period, that the unit factor is 1.0 (no spurious rescaling), and that
+    the published day-0 total matches both the downloader's own kWh sum and the expected value.
+    """
+    failed = False
+
+    if captured.get("period") != expected_period:
+        print(f"ERROR: {label}: expected a detected period of {expected_period} minutes, got {captured.get('period')}")
+        failed = True
+
+    unit_factor = captured.get("unit_factor")
+    if unit_factor is None or abs(unit_factor - 1.0) > 0.001:
+        print(f"ERROR: {label}: expected a unit factor of 1.0 for kWh-per-slot data, got {unit_factor} - the forecast is scaled by that factor")
+        failed = True
+
+    source_kwh = day_zero_kwh(captured.get("data", []), test_api.mock_base.midnight_utc)
+    if abs(source_kwh - expected_kwh) > 0.01:
+        print(f"ERROR: {label}: the downloader returned {source_kwh} kWh on day 0, expected {expected_kwh} kWh - the test fixture is wrong, not the scaling")
+        failed = True
+
+    today_entity = f"sensor.{test_api.mock_base.prefix}_pv_today"
+    if today_entity not in test_api.dashboard_items:
+        print(f"ERROR: {label}: expected {today_entity} to be published")
+        failed = True
+    else:
+        total = test_api.dashboard_items[today_entity]["attributes"].get("total", 0)
+        if abs(total - expected_kwh) > 0.01:
+            out_by = round(total / expected_kwh, 3) if expected_kwh else 0
+            print(f"ERROR: {label}: published day-0 total {total} kWh, expected {expected_kwh} kWh (out by {out_by}x)")
+            failed = True
+        else:
+            print(f"  {label}: {expected_period}-min slots, unit factor {unit_factor}, day-0 total {total} kWh - correct!")
+
+    return failed
+
+
+def forecast_solar_two_hour_response():
+    """
+    A Forecast.Solar response holding a flat 1.2 kW from 11:00 to 13:00 UTC on 2025-06-15.
+
+    download_forecast_solar_data fills both slot edges, so minutes 660 to 780 inclusive carry
+    1.2 kW: 120 minutes of 1.2 kW is 2.4 kWh, plus the closing minute at 13:00 worth 0.02 kWh,
+    giving 2.42 kWh on day 0 whatever the plan interval slices it into.
+    """
+    return {
+        "result": {"watts": {"2025-06-15T12:00:00+0000": 1200, "2025-06-15T13:00:00+0000": 1200}},
+        "message": {"info": {"time": "2025-06-15T11:30:00+0000"}},
+    }
+
+
+def test_fetch_pv_forecast_forecast_solar_15min_slots(my_predbat):
+    """
+    Forecast.Solar emits one kWh figure per plan_interval_minutes slot, so with a 15-minute
+    plan interval the published energy must still match the raw forecast. Before divide_by
+    followed the detected period this branch published half the real forecast.
+    """
+    print("  - test_fetch_pv_forecast_forecast_solar_15min_slots")
+    failed = False
+
+    test_api = create_test_solar_api()
+    try:
+        test_api.mock_base.plan_interval_minutes = 15
+        test_api.solar.solcast_host = None
+        test_api.solar.solcast_api_key = None
+        test_api.solar.forecast_solar = [{"latitude": 51.5, "longitude": -0.1, "declination": 30, "azimuth": 0, "kwp": 3.0}]
+        test_api.set_mock_response("forecast.solar", forecast_solar_two_hour_response(), 200)
+
+        captured = capture_unit_factor(test_api)
+
+        def create_mock_session(*args, **kwargs):
+            """Create a mock aiohttp session."""
+            return test_api.mock_aiohttp_session()
+
+        with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session):
+            run_async(test_api.solar.fetch_pv_forecast())
+
+        failed |= check_slot_scaling(test_api, captured, 15, 2.42, "Forecast.Solar at a 15-minute plan interval")
+
+    finally:
+        test_api.cleanup()
+
+    return failed
+
+
+def test_fetch_pv_forecast_forecast_solar_30min_slots(my_predbat):
+    """
+    Regression guard for the plan interval that happened to work before the fix: the same
+    Forecast.Solar forecast at a 30-minute plan interval must publish the same energy.
+    """
+    print("  - test_fetch_pv_forecast_forecast_solar_30min_slots")
+    failed = False
+
+    test_api = create_test_solar_api()
+    try:
+        test_api.mock_base.plan_interval_minutes = 30
+        test_api.solar.solcast_host = None
+        test_api.solar.solcast_api_key = None
+        test_api.solar.forecast_solar = [{"latitude": 51.5, "longitude": -0.1, "declination": 30, "azimuth": 0, "kwp": 3.0}]
+        test_api.set_mock_response("forecast.solar", forecast_solar_two_hour_response(), 200)
+
+        captured = capture_unit_factor(test_api)
+
+        def create_mock_session(*args, **kwargs):
+            """Create a mock aiohttp session."""
+            return test_api.mock_aiohttp_session()
+
+        with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session):
+            run_async(test_api.solar.fetch_pv_forecast())
+
+        failed |= check_slot_scaling(test_api, captured, 30, 2.42, "Forecast.Solar at a 30-minute plan interval")
+
+    finally:
+        test_api.cleanup()
+
+    return failed
+
+
+def test_fetch_pv_forecast_solcast_direct_15min_slots(my_predbat):
+    """
+    Solcast reports its own slot length in the period field. On PT15M data the published
+    energy must match the forecast; before the fix this branch published half of it.
+    """
+    print("  - test_fetch_pv_forecast_solcast_direct_15min_slots")
+    failed = False
+
+    test_api = create_test_solar_api()
+    try:
+        test_api.solar.solcast_host = "https://api.solcast.com.au"
+        test_api.solar.solcast_api_key = "test_key"
+        test_api.solar.solcast_sites = ["site123"]
+        test_api.solar.forecast_solar = None
+
+        # Solcast reports power, converted to kWh per slot as pv_estimate / 60 * 15.
+        # Four quarter-hour slots at 2.0 kW is 4 * 0.5 = 2.0 kWh on day 0.
+        noon = test_api.mock_base.midnight_utc + timedelta(hours=12)
+        forecasts = []
+        for index in range(4):
+            period_end = noon + timedelta(minutes=15 * (index + 1))
+            forecasts.append(
+                {
+                    "period_end": period_end.strftime("%Y-%m-%dT%H:%M:%S.0000000Z"),
+                    "period": "PT15M",
+                    "pv_estimate": 2.0,
+                    "pv_estimate10": 1.0,
+                    "pv_estimate90": 3.0,
+                }
+            )
+        test_api.set_mock_response("forecasts", {"forecasts": forecasts}, 200)
+
+        captured = capture_unit_factor(test_api)
+
+        def create_mock_session(*args, **kwargs):
+            """Create a mock aiohttp session."""
+            return test_api.mock_aiohttp_session()
+
+        with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session):
+            run_async(test_api.solar.fetch_pv_forecast())
+
+        failed |= check_slot_scaling(test_api, captured, 15, 2.0, "Solcast direct with PT15M data")
+
+    finally:
+        test_api.cleanup()
+
+    return failed
+
+
+def test_fetch_pv_forecast_open_meteo_first_hourly_slots(my_predbat):
+    """
+    Open-Meteo emits kWh per hour. Used as the primary source with forecast_solar set, the
+    published energy must match those hourly figures; before the fix it was doubled.
+    """
+    print("  - test_fetch_pv_forecast_open_meteo_first_hourly_slots")
+    failed = False
+
+    test_api = create_test_solar_api()
+    try:
+        test_api.solar.forecast_solar = [{"latitude": 51.5, "longitude": -0.1, "declination": 30, "azimuth": 0, "kwp": 3.0}]
+        test_api.solar.forecast_solar_open_meteo_first = True
+        test_api.solar.open_meteo_forecast_max_age = 1.0
+        test_api.set_mock_response(
+            "api.open-meteo.com",
+            {
+                "hourly": {
+                    "time": ["2025-06-15T12:00", "2025-06-15T13:00", "2025-06-15T14:00"],
+                    "global_tilted_irradiance": [500.0, 600.0, 550.0],
+                    "temperature_2m": [25.0, 25.0, 25.0],
+                    "wind_speed_10m": [1.0, 1.0, 1.0],
+                }
+            },
+        )
+        test_api.set_mock_response(
+            "ensemble-api.open-meteo.com",
+            {
+                "hourly": {
+                    "time": ["2025-06-15T12:00", "2025-06-15T13:00", "2025-06-15T14:00"],
+                    "global_tilted_irradiance_member01": [400.0, 480.0, 440.0],
+                }
+            },
+        )
+
+        captured = capture_unit_factor(test_api)
+
+        def create_mock_session(*args, **kwargs):
+            """Create a mock aiohttp session."""
+            return test_api.mock_aiohttp_session()
+
+        with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session):
+            run_async(test_api.solar.fetch_pv_forecast())
+
+        # Two hourly periods are produced from three instant samples, trapezoidally integrated
+        # and temperature corrected by solar_model.gti_hourly_to_period_kwh.
+        expected_kwh = round(day_zero_kwh(captured.get("data", []), test_api.mock_base.midnight_utc), 2)
+        failed |= check_slot_scaling(test_api, captured, 60, expected_kwh, "Open-Meteo as the primary hourly source")
+
+        if expected_kwh <= 0:
+            print(f"ERROR: Open-Meteo fixture produced no day-0 energy ({expected_kwh} kWh), the test proves nothing")
+            failed = True
+
+    finally:
+        test_api.cleanup()
+
+    return failed
+
+
+def test_fetch_pv_forecast_ha_sensors_unit_factor_unchanged(my_predbat):
+    """
+    The HA sensor path carries its own kW/kWh unit factor in divide_by. Making the period
+    recalculation unconditional must leave that path alone, so check all three valid factors
+    (1.0 kWh per slot, 2.0 kW on 30-minute slots, 4.0 kW on 15-minute slots).
+    """
+    print("  - test_fetch_pv_forecast_ha_sensors_unit_factor_unchanged")
+    failed = False
+
+    # Two hours of steady output worth 2.0 kWh, expressed three different ways.
+    # (label, slot minutes, pv_estimate per slot, expected unit factor)
+    sensor_total = 2.0
+    cases = [
+        ("kWh per 30-minute slot", 30, 0.5, 1.0),
+        ("kW on 30-minute slots", 30, 1.0, 2.0),
+        ("kW on 15-minute slots", 15, 1.0, 4.0),
+    ]
+
+    for label, slot_minutes, estimate, expected_factor in cases:
+        test_api = create_test_solar_api()
+        try:
+            test_api.solar.solcast_host = None
+            test_api.solar.solcast_api_key = None
+            test_api.solar.forecast_solar = None
+            test_api.solar.pv_forecast_today = "sensor.pv_forecast_today"
+            test_api.solar.pv_forecast_tomorrow = None
+
+            slots = int(120 / slot_minutes)
+            detailed = []
+            for index in range(slots):
+                start = test_api.mock_base.midnight_utc + timedelta(minutes=10 * 60 + index * slot_minutes)
+                detailed.append({"period_start": start.strftime(TIME_FORMAT), "pv_estimate": estimate})
+            test_api.set_mock_ha_state("sensor.pv_forecast_today", {"state": str(sensor_total), "detailedForecast": detailed})
+
+            captured = capture_unit_factor(test_api)
+
+            def create_mock_session(*args, **kwargs):
+                """Create a mock aiohttp session."""
+                return test_api.mock_aiohttp_session()
+
+            with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session):
+                run_async(test_api.solar.fetch_pv_forecast())
+
+            unit_factor = captured.get("unit_factor")
+            if unit_factor is None or abs(unit_factor - expected_factor) > 0.001:
+                print(f"ERROR: HA sensors, {label}: expected the unit factor to stay {expected_factor}, got {unit_factor}")
+                failed = True
+
+            today_entity = f"sensor.{test_api.mock_base.prefix}_pv_today"
+            total = test_api.dashboard_items.get(today_entity, {}).get("attributes", {}).get("total", 0)
+            if abs(total - sensor_total) > 0.01:
+                print(f"ERROR: HA sensors, {label}: published day-0 total {total} kWh, expected {sensor_total} kWh")
+                failed = True
+            else:
+                print(f"  HA sensors, {label}: unit factor {unit_factor}, day-0 total {total} kWh - unchanged!")
+
+        finally:
+            test_api.cleanup()
+
+    return failed
+
+
+# ============================================================================
 # Run Function Tests
 # ============================================================================
 
@@ -4575,6 +4905,13 @@ def run_solcast_tests(my_predbat):
     failed |= test_fetch_pv_forecast_ha_sensors_15min_kwh(my_predbat)
     failed |= test_fetch_pv_forecast_ha_sensors_15min_kw(my_predbat)
     failed |= test_publish_pv_stats_15min_resolution(my_predbat)
+
+    # Slot-length scaling tests (divide_by must follow the detected period)
+    failed |= test_fetch_pv_forecast_forecast_solar_15min_slots(my_predbat)
+    failed |= test_fetch_pv_forecast_forecast_solar_30min_slots(my_predbat)
+    failed |= test_fetch_pv_forecast_solcast_direct_15min_slots(my_predbat)
+    failed |= test_fetch_pv_forecast_open_meteo_first_hourly_slots(my_predbat)
+    failed |= test_fetch_pv_forecast_ha_sensors_unit_factor_unchanged(my_predbat)
 
     # Calibration tests
     failed |= test_pv_calibration_power_conversion(my_predbat)

--- a/apps/predbat/tests/test_solcast.py
+++ b/apps/predbat/tests/test_solcast.py
@@ -2487,12 +2487,12 @@ def capture_unit_factor(test_api):
     captured = {}
     original = test_api.solar.publish_pv_stats
 
-    def wrapper(pv_forecast_data, divide_by, period):
+    def wrapper(pv_forecast_data, unit_factor, period):
         """Record the arguments then publish as normal."""
-        captured["unit_factor"] = divide_by
+        captured["unit_factor"] = unit_factor
         captured["period"] = period
         captured["data"] = pv_forecast_data
-        return original(pv_forecast_data, divide_by, period)
+        return original(pv_forecast_data, unit_factor, period)
 
     test_api.solar.publish_pv_stats = wrapper
     return captured


### PR DESCRIPTION
## Problem

`fetch_pv_forecast()` detects the real slot length of the forecast data (`period`, the block around "Detect the actual period of the forecast data") and recalculates `divide_by` from it. That recalculation was guarded by

```python
if not self.forecast_solar and not (self.solcast_host and self.solcast_api_key):
```

which excludes exactly the branches that need it.

All three direct API downloaders return `pv_estimate` as kWh per slot, but the slot length differs:

| Source | Slot length | `divide_by` before this PR | Error factor (`period / divide_by`) |
|---|---|---|---|
| Forecast.Solar | `plan_interval_minutes` | 30.0 | 0.5 at 15 min, 1.0 at 30 min, 2.0 at 60 min |
| Open-Meteo (primary or fallback, with `forecast_solar` set) | 60 min | 30.0 | 2.0 |
| Solcast direct | `PT15M` / `PT30M` from the API | 30.0 | 0.5 on PT15M |
| Open-Meteo only | 60 min | 60 | 1.0, unless Solcast credentials are also present |
| HA sensors | detected | `period * factor` | 1.0 |

`minute_data()` divides by `divide_by` once and then writes that value into every minute of the slot via `spreading=period`, so the energy per slot ends up as `period * pv_estimate / divide_by`.

The guard dates from #3525, which fixed the HA sensor path. Forecast.Solar had already moved to `plan_interval_minutes` slots by then (#2875), so the branch was correct only at the default 30-minute plan interval.

The log line "PV Forecast data has N minute resolution, adjusting calculations" fires on these branches even though no adjustment happens, which is why this was easy to miss.

Not related to #3827, which fixed slot accumulation when annotating `pv_estimateCL/10/90`; the `divide_by` scaling of the per-minute planner data is a separate step.

## Evidence

On a 36 kWp Forecast.Solar Professional install running `plan_interval_minutes: 15`, integrating the cached raw `watts` response for 2026-08-03 gives about 87.3 kWh, while Predbat published `PV Forecast for today is 43.64 kWh` and logged `divide_by 2.0`. Exactly half. The calibration loop partly masks this (`adjustment 1.296x`) but cannot converge, because it is asked to correct a systematic factor of two on top of weather noise.

## Fix

Drop the guard and always recalculate `divide_by` from the detected period.

For the direct API branches `divide_by` is 30.0, so `factor` becomes 1.0 and `divide_by` becomes `period`, which is what kWh-per-slot data requires. For the HA sensor branch `divide_by` is `dp2(30 * factor)`, so the division returns the same `factor` and the behaviour is unchanged. Because `period` is derived from the data that actually came back, this also stays correct on the Open-Meteo fallback paths, where the source switches mid-branch. If period detection fails and falls back to its default of 30, the result is identical to today's behaviour.

## Compatibility note

Users on `forecast_solar_open_meteo_first` will see their forecast drop by half. That is the correction, not a regression: hourly Open-Meteo slots were being counted twice. Users on Forecast.Solar with the default `plan_interval_minutes: 30` see no change.

## Tests

Five new cases in `test_solcast.py`, each asserting the published day-0 total against the known kWh sum of the forecast the downloader produced, plus the unit factor (`divide_by / period`, which must be 1.0 for kWh-per-slot data).

Measured on this branch with the fix reverted, so each case fails in the direction described above:

| Case | Before | After |
|---|---|---|
| Forecast.Solar, 15-min plan interval | 1.21 kWh (0.5x), unit factor 2.0 | 2.42 kWh, unit factor 1.0 |
| Forecast.Solar, 30-min plan interval | 2.42 kWh | 2.42 kWh (unchanged) |
| Solcast direct, PT15M | 1.0 kWh (0.5x), unit factor 2.0 | 2.0 kWh, unit factor 1.0 |
| Open-Meteo primary, hourly | 5.94 kWh (2.0x), unit factor 0.5 | 2.97 kWh, unit factor 1.0 |
| HA sensors, factor 1.0 / 2.0 / 4.0 | 2.0 kWh each | 2.0 kWh each (unchanged) |

The HA sensor case is the one that shows the guard can go: all three valid unit factors survive the recalculation untouched.

`unit_test.py --quick` passes on this branch (32 of 33 groups; `download` fails identically on unmodified `main` in my environment, a local `compute_sha1` issue). `black`, `ruff --select=F401` and `cspell` are clean.
