### PR TITLE
fix(plan): clip export windows with no SoC above reserve

### DIFF
--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -2468,6 +2468,16 @@ class Plan:
                             export_limits_best[window_n] = 100.0
                             if self.debug_enable:
                                 self.log("Clip freeze export off as already at 100% - window {} from {} - {} from limit {} to new limit {} target set to {}".format(window_n, window_start, window_end, limit, export_limits_best[window_n], window["target"]))
+                    elif dp2(soc_max) <= dp2(self.reserve):
+                        # SoC never rises above reserve anywhere in this window, so there is nothing to export
+                        # regardless of the requested limit. The "clip up" branch below only narrows the limit
+                        # towards what's achievable and can't reach 0 here (limit_soc is 0 for a 0% request,
+                        # and soc_max can never be below that), so a 0%-target window would otherwise survive
+                        # clipping with a limit that is technically "on" but physically a no-op.
+                        window["target"] = 100.0
+                        export_limits_best[window_n] = 100.0
+                        if self.debug_enable:
+                            self.log("Clip off export window {} from {} - {} from limit {} to new limit {} - no SoC above reserve in this window".format(window_n, window_start, window_end, limit, export_limits_best[window_n]))
                     elif soc_min > limit_soc:
                         # Give it 10 minute margin
                         target_soc = max(limit_soc, soc_min)

--- a/apps/predbat/tests/test_clip_export_slots.py
+++ b/apps/predbat/tests/test_clip_export_slots.py
@@ -20,6 +20,8 @@ def run_clip_export_slots_tests(my_predbat):
     failed |= test_freeze_export_kept_when_soc_below_max(my_predbat)
     failed |= test_normal_export_clipped_off_when_soc_below_limit(my_predbat)
     failed |= test_normal_export_clipped_up_when_soc_above_limit(my_predbat)
+    failed |= test_normal_export_clipped_off_when_soc_never_above_reserve(my_predbat)
+    failed |= test_normal_export_clipped_up_when_soc_above_reserve_with_zero_limit(my_predbat)
     failed |= test_disabled_window_ignored(my_predbat)
     failed |= test_passed_window_clipped(my_predbat)
     failed |= test_multiple_windows_mixed(my_predbat)
@@ -167,6 +169,59 @@ def test_normal_export_clipped_up_when_soc_above_limit(my_predbat):
     # Should be clipped up - limit should be higher than original 20.0
     if result_limits[0] <= 20.0:
         print("ERROR: Expected export limit to be clipped up from 20.0 but got {}".format(result_limits[0]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_normal_export_clipped_off_when_soc_never_above_reserve(my_predbat):
+    """A window whose SoC never rises above reserve has nothing exportable and should be clipped off,
+    even when the requested limit is 0% (drain to empty) - regression test for #4171"""
+    print("**** test_normal_export_clipped_off_when_soc_never_above_reserve ****")
+    failed = False
+    setup(my_predbat)
+    my_predbat.reserve = 0.5
+
+    minutes_now = 720
+    windows = [make_window(720, 750)]
+    limits = [0.0]  # Export to 0% (drain to empty)
+    # SoC flat at reserve throughout the window - nothing above reserve to export
+    predict_soc = make_predict_soc(minutes_now, 0.5, 60)
+
+    result_windows, result_limits = my_predbat.clip_export_slots(minutes_now, predict_soc, windows, limits, 1, 5)
+
+    if result_limits[0] != 100.0:
+        print("ERROR: Expected export clipped off (100.0) but got {}".format(result_limits[0]))
+        failed = True
+    if result_windows[0]["target"] != 100.0:
+        print("ERROR: Expected target 100.0 but got {}".format(result_windows[0]["target"]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_normal_export_clipped_up_when_soc_above_reserve_with_zero_limit(my_predbat):
+    """A 0% export request should still be clipped up (not off) when SoC genuinely rises above reserve,
+    so the reserve-floor check doesn't swallow the existing clip-up behaviour"""
+    print("**** test_normal_export_clipped_up_when_soc_above_reserve_with_zero_limit ****")
+    failed = False
+    setup(my_predbat)
+    my_predbat.reserve = 0.5
+
+    minutes_now = 720
+    windows = [make_window(720, 750)]
+    limits = [0.0]  # Export to 0% (drain to empty)
+    # SoC well above reserve - there is real energy available to export
+    predict_soc = make_predict_soc(minutes_now, 8.0, 60)
+
+    result_windows, result_limits = my_predbat.clip_export_slots(minutes_now, predict_soc, windows, limits, 1, 5)
+
+    if result_limits[0] == 100.0:
+        print("ERROR: Export was clipped off despite SoC being above reserve")
         failed = True
 
     if not failed:


### PR DESCRIPTION
## Summary
- `clip_export_slots` had a "clip off, nothing achievable" check that compared a window's predicted `soc_max` against its own *requested* limit (`limit_soc`). For a window asking to drain to 0%, `limit_soc` is 0, and `soc_max` can never be below that (the battery physically can't go below reserve) - so that branch could never fire, and the window fell into the "clip up" branch instead, surviving in the plan with a near-zero limit that's technically "on" but physically a no-op.
- Now clips the window off whenever its SoC forecast never rises above reserve anywhere in the window, regardless of what limit was originally requested.
- Fixes #4171 - confirmed against the reporter's own debug.yaml: the exact live plan state (`export_window_best`/`export_limits_best` as computed by their instance) had a window at 23:50-00:00 stuck at a 0% export target while the battery was already flat at the 4% reserve for the whole evening. Forcing that window on vs off in a replay produces an identical metric - proof no real energy ever moved, it was purely a display/plan-entry artifact.

## Test plan
- [x] Added `test_normal_export_clipped_off_when_soc_never_above_reserve` - the #4171 regression case
- [x] Added `test_normal_export_clipped_up_when_soc_above_reserve_with_zero_limit` - guards that genuine clip-up behaviour is untouched when there's real energy above reserve
- [x] `./run_all --quick` passes with no regressions
- [x] `./run_pre_commit` passes (ruff, black, cspell, markdownlint, full test suite)
- [x] Verified directly against the reporter's live plan state (`plan_preclip`): the window that was `target: 0.0` now clips to `100.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)