### PR TITLE
fix(inverter): re-assert timed charge/discharge current every cycle, not just on rate change

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1831,12 +1831,18 @@ class Inverter:
                     self.write_and_poll_value("charge_rate", self.base.get_arg("charge_rate", indirect=False, index=self.id, required_unit="W"), new_rate, fuzzy=(self.battery_rate_max_charge * MINUTE_WATT / 20), required_unit="W")
                 if "charge_rate_percent" in self.base.args:
                     self.write_and_poll_value("charge_rate_percent", self.base.get_arg("charge_rate_percent", indirect=False, index=self.id, required_unit="%"), min(int(new_rate / self.battery_rate_max_raw * 100), 100), fuzzy=5, required_unit="%")
-                if self.inv_output_charge_control == "current":
-                    self.set_current_from_power("charge", new_rate)
 
             if notify and self.base.set_inverter_notify:
                 self.base.call_notify("Predbat: Inverter {} charge rate changes to {}W at {}".format(self.id, new_rate, self.base.time_now_str()))
             self.mqtt_message(topic="set/charge_rate", payload=new_rate)
+
+        # Re-assert the timed current register on every call, not just when charge_rate itself
+        # changes - it's a separate register that can drift/reset independently (#4415). Mirrors
+        # the pattern used for the charge window time registers in adjust_charge_window(): call
+        # every cycle and let write_and_poll_value()'s own read-compare decide whether a write is
+        # actually needed, which is a no-op when nothing has drifted.
+        if not self.rest_data and self.inv_output_charge_control == "current":
+            self.set_current_from_power("charge", new_rate)
 
     def adjust_discharge_rate(self, new_rate, notify=True):
         """
@@ -1869,12 +1875,18 @@ class Inverter:
                     self.write_and_poll_value("discharge_rate", self.base.get_arg("discharge_rate", indirect=False, index=self.id), new_rate, fuzzy=(self.battery_rate_max_discharge * MINUTE_WATT / 20), required_unit="W")
                 if "discharge_rate_percent" in self.base.args:
                     self.write_and_poll_value("discharge_rate_percent", self.base.get_arg("discharge_rate_percent", indirect=False, index=self.id, required_unit="%"), min(int(new_rate / self.battery_rate_max_raw * 100), 100), fuzzy=5, required_unit="%")
-                if self.inv_output_charge_control == "current":
-                    self.set_current_from_power("discharge", new_rate)
 
             if notify and self.base.set_inverter_notify:
                 self.base.call_notify("Predbat: Inverter {} discharge rate changes to {}W at {}".format(self.id, new_rate, self.base.time_now_str()))
             self.mqtt_message(topic="set/discharge_rate", payload=new_rate)
+
+        # Re-assert the timed current register on every call, not just when discharge_rate itself
+        # changes - it's a separate register that can drift/reset independently (#4415). Mirrors
+        # the pattern used for the charge window time registers in adjust_charge_window(): call
+        # every cycle and let write_and_poll_value()'s own read-compare decide whether a write is
+        # actually needed, which is a no-op when nothing has drifted.
+        if not self.rest_data and self.inv_output_charge_control == "current":
+            self.set_current_from_power("discharge", new_rate)
 
     def adjust_battery_target(self, soc, isCharging=False, isExporting=False):
         """
@@ -1987,7 +1999,7 @@ class Inverter:
             self.base.record_status("Warn: Inverter {} write to {} failed".format(self.id, name), had_errors=True)
             return False
 
-    def write_and_poll_value(self, name, entity_id, new_value, fuzzy=0, ignore_fail=False, required_unit=None):
+    def write_and_poll_value(self, name, entity_id, new_value, fuzzy=0, ignore_fail=False, required_unit=None, refresh=False):
         # Modified to cope with sensor entities and writing strings
         # Re-written to minimise writes
         if not entity_id:
@@ -1995,7 +2007,7 @@ class Inverter:
             self.base.record_status("Warn: Inverter {} write_and_poll_value: No entity_id for {} to write {}".format(self.id, name, new_value), had_errors=True)
             return False
         domain, entity_name = entity_id.split(".")
-        current_state = self.base.get_state_wrapper(entity_id, required_unit=required_unit)
+        current_state = self.base.get_state_wrapper(entity_id, required_unit=required_unit, refresh=refresh)
 
         if isinstance(new_value, str):
             matched = current_state == new_value
@@ -2700,10 +2712,17 @@ class Inverter:
 
     def set_current_from_power(self, direction, power):
         """
-        Set the timed charge/discharge current setting by converting power to current
+        Set the timed charge/discharge current setting by converting power to current.
+
+        Called on every adjust_charge_rate()/adjust_discharge_rate() invocation, not just when
+        the power target itself changes - this register can drift or get reset independently
+        (#4415). write_and_poll_value() already no-ops when the live value already matches, so
+        this is cheap when nothing has drifted. refresh=True forces a fresh state fetch on setups
+        not relying on HA's push-based WebSocket updates (DB-primary mode); it's a no-op for the
+        common live-HA-connection case.
         """
         new_current = round(power / self.battery_voltage, self.inv_current_dp)
-        self.write_and_poll_value(f"timed_{direction}_current", self.base.get_arg(f"timed_{direction}_current", indirect=False, index=self.id), new_current, fuzzy=1)
+        self.write_and_poll_value(f"timed_{direction}_current", self.base.get_arg(f"timed_{direction}_current", indirect=False, index=self.id), new_current, fuzzy=1, refresh=True)
 
     def call_service_template(self, service, data, domain="charge", extra_data={}):
         """

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1999,7 +1999,7 @@ class Inverter:
             self.base.record_status("Warn: Inverter {} write to {} failed".format(self.id, name), had_errors=True)
             return False
 
-    def write_and_poll_value(self, name, entity_id, new_value, fuzzy=0, ignore_fail=False, required_unit=None, refresh=False):
+    def write_and_poll_value(self, name, entity_id, new_value, fuzzy=0, ignore_fail=False, required_unit=None):
         # Modified to cope with sensor entities and writing strings
         # Re-written to minimise writes
         if not entity_id:
@@ -2007,7 +2007,7 @@ class Inverter:
             self.base.record_status("Warn: Inverter {} write_and_poll_value: No entity_id for {} to write {}".format(self.id, name, new_value), had_errors=True)
             return False
         domain, entity_name = entity_id.split(".")
-        current_state = self.base.get_state_wrapper(entity_id, required_unit=required_unit, refresh=refresh)
+        current_state = self.base.get_state_wrapper(entity_id, required_unit=required_unit)
 
         if isinstance(new_value, str):
             matched = current_state == new_value
@@ -2717,12 +2717,10 @@ class Inverter:
         Called on every adjust_charge_rate()/adjust_discharge_rate() invocation, not just when
         the power target itself changes - this register can drift or get reset independently
         (#4415). write_and_poll_value() already no-ops when the live value already matches, so
-        this is cheap when nothing has drifted. refresh=True forces a fresh state fetch on setups
-        not relying on HA's push-based WebSocket updates (DB-primary mode); it's a no-op for the
-        common live-HA-connection case.
+        this is cheap when nothing has drifted.
         """
         new_current = round(power / self.battery_voltage, self.inv_current_dp)
-        self.write_and_poll_value(f"timed_{direction}_current", self.base.get_arg(f"timed_{direction}_current", indirect=False, index=self.id), new_current, fuzzy=1, refresh=True)
+        self.write_and_poll_value(f"timed_{direction}_current", self.base.get_arg(f"timed_{direction}_current", indirect=False, index=self.id), new_current, fuzzy=1)
 
     def call_service_template(self, service, data, domain="charge", extra_data={}):
         """

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -460,6 +460,51 @@ def test_adjust_charge_rate(test_name, ha, inv, dummy_rest, prev_rate, rate, exp
     return failed
 
 
+def test_current_reasserted_on_unchanged_rate(test_name, ha, inv, prev_current, rate, discharge=False):
+    """
+    Test that timed_charge_current / timed_discharge_current is re-asserted on every call to
+    adjust_charge_rate()/adjust_discharge_rate(), even when the rate itself is unchanged between
+    calls - regression test for #4415. The register can be reset externally (observed on Solis
+    GS_fb00); before this fix the write was only attempted when the rate itself changed, so an
+    external reset between rate changes was never corrected.
+    """
+    failed = False
+    inv.rest_data = None
+    inv.rest_api = None
+    inv.inv_output_charge_control = "current"
+    inv.battery_voltage = 50.0
+    inv.inv_current_dp = 1
+
+    entity = "number.timed_discharge_current" if discharge else "number.timed_charge_current"
+    expect_current = round(rate / inv.battery_voltage, 1)
+
+    # First call establishes the rate and writes the current register correctly
+    if discharge:
+        inv.adjust_discharge_rate(rate)
+    else:
+        inv.adjust_charge_rate(rate)
+
+    if ha.get_state(entity) != expect_current:
+        print("ERROR: {} expected initial current {} got {}".format(test_name, expect_current, ha.get_state(entity)))
+        failed = True
+
+    # Simulate something external (firmware reset, etc.) resetting the register between cycles
+    ha.dummy_items[entity] = prev_current
+
+    # Second call with the SAME rate - before the fix this would be a no-op, since the write was
+    # gated behind "did the rate change" rather than the current register's own live state
+    if discharge:
+        inv.adjust_discharge_rate(rate)
+    else:
+        inv.adjust_charge_rate(rate)
+
+    if ha.get_state(entity) != expect_current:
+        print("ERROR: {} expected current re-asserted to {} after external reset, got {}".format(test_name, expect_current, ha.get_state(entity)))
+        failed = True
+
+    return failed
+
+
 def test_adjust_inverter_mode(test_name, ha, inv, dummy_rest, prev_mode, mode, expect_mode=None):
     """
     Test the adjust_inverter_mode function
@@ -2137,6 +2182,8 @@ def run_inverter_tests(my_predbat_dummy):
         "sensor.predbat_GE_0_scheduled_discharge_enable": "off",
         "number.discharge_target_soc": 4,
         "switch.inverter_button": False,
+        "number.timed_charge_current": 0.0,
+        "number.timed_discharge_current": 0.0,
     }
     my_predbat.ha_interface.dummy_items = dummy_items
     my_predbat.args["auto_restart"] = [{"service": "switch/turn_on", "entity_id": "switch.restart"}]
@@ -2458,6 +2505,13 @@ def run_inverter_tests(my_predbat_dummy):
     failed |= test_adjust_charge_rate("adjust_discharge_rate1", ha, inv, dummy_rest, 0, 250.1, 250, discharge=True)
     failed |= test_adjust_charge_rate("adjust_discharge_rate2", ha, inv, dummy_rest, 250, 0, 0, discharge=True)
     failed |= test_adjust_charge_rate("adjust_discharge_rate3", ha, inv, dummy_rest, 200, 210, 200, discharge=True)
+    if failed:
+        return failed
+
+    # #4415: timed_charge_current/timed_discharge_current must be re-asserted every call, not
+    # just when the rate itself changes
+    failed |= test_current_reasserted_on_unchanged_rate("current_reassert_charge", ha, inv, 0, 200)
+    failed |= test_current_reasserted_on_unchanged_rate("current_reassert_discharge", ha, inv, 0, 250, discharge=True)
     if failed:
         return failed
 


### PR DESCRIPTION
## Summary
- Fixes #4415 - on current-controlled inverters (`inv_output_charge_control == "current"`, e.g. Solis `GS_fb00`), `timed_charge_current`/`timed_discharge_current` were only written inside `adjust_charge_rate()`/`adjust_discharge_rate()`'s "did the rate change" guard - piggybacked on a *different* register's (`charge_rate`/`discharge_rate`) change-detection rather than having their own.
- The reporter's evidence shows the current register getting reset independently (deterministically, every Predbat cycle, on their Solis/`solax_modbus` setup) while the target rate stayed constant - so the write was never re-attempted, and forced export/charge windows opened correctly on the time registers but moved no power, since the current stayed at 0A indefinitely.
- Moves the current-register write out of the rate-changed guard so it runs on every call, matching the existing pattern already used for the charge window time registers in `adjust_charge_window()` (called every cycle; each register compared against its own live state via `write_and_poll_value()`, which no-ops when nothing has drifted). Confirmed via the reporter's own log that `solax_modbus` actively re-polls and reports the live register value to HA (not just an echo of the last write), so the passive HA-state read this relies on is not stale relative to Predbat's 5-minute cycle.
- Also resolves what the reporter flagged as a possibly-separate gap (`timed_charge_current` never written at all in their log) - same root cause, not separate: their charge rate simply never changed during the observed window, so the gate never opened even once for charge.

## Test plan
- [x] Added `test_current_reasserted_on_unchanged_rate` (both charge and discharge) - simulates an external reset of the current register between two calls with an unchanged rate, and confirms it's re-asserted on the second call (would have been a no-op before this fix)
- [x] `./run_all --quick` passes with no regressions
- [x] `./run_pre_commit` passes (ruff, black, cspell, markdownlint, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)