### PR TITLE
feat(lattice): publish materializable Gateway and GE auto config

### DIFF
--- a/apps/predbat/gateway_autoconfig.py
+++ b/apps/predbat/gateway_autoconfig.py
@@ -1,0 +1,177 @@
+"""Pure Gateway-to-PredBat auto-configuration mapping."""
+
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+class GatewayAutoConfigError(ValueError):
+    """Gateway discovery cannot produce a safe configuration plan."""
+
+
+def _freeze_value(value):
+    """Detach mutable legacy list values from the compiled plan."""
+    if isinstance(value, list):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
+    return value
+
+
+@dataclass(frozen=True)
+class GatewayAutoConfigPlan:
+    """Detached configuration values and selected Gateway identities."""
+
+    arguments: object
+    selected_serials: tuple
+    discovered_serials: tuple
+    hybrid: object = None
+    model_name: str = ""
+
+    def __post_init__(self):
+        """Freeze the top-level mapping and normalized serial tuples."""
+        arguments = {name: _freeze_value(value) for name, value in self.arguments.items()}
+        object.__setattr__(self, "arguments", MappingProxyType(arguments))
+        object.__setattr__(self, "selected_serials", tuple(self.selected_serials))
+        object.__setattr__(self, "discovered_serials", tuple(self.discovered_serials))
+
+    def legacy_arguments(self):
+        """Return fresh list values suitable for ``ComponentBase.set_arg``."""
+        return {name: list(value) if isinstance(value, tuple) else value for name, value in self.arguments.items()}
+
+
+def _field(item, name, default=None):
+    """Read one normalized field from a mapping or immutable snapshot object."""
+    if isinstance(item, dict):
+        return item.get(name, default)
+    return getattr(item, name, default)
+
+
+def _serial_suffix(serial):
+    """Match the existing Gateway entity suffix convention."""
+    return serial[-6:].lower() if len(serial) > 6 else serial.lower()
+
+
+def compile_gateway_auto_config(inverters, prefix="predbat", serial_filter=()):
+    """Return the exact non-EV arguments currently written by GatewayMQTT."""
+    inverters = tuple(inverters)
+    if not inverters:
+        raise GatewayAutoConfigError("Gateway discovery contains no inverters")
+    if not isinstance(prefix, str) or not prefix.strip():
+        raise ValueError("Gateway entity prefix must be non-empty")
+    prefix = prefix.strip()
+
+    def serial(item):
+        value = _field(item, "serial", "")
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("Gateway inverter serial must be non-empty")
+        return value.strip()
+
+    def kind(item):
+        return str(_field(item, "kind", "inverter")).strip().lower()
+
+    ems_units = [item for item in inverters if kind(item) == "ems"]
+    gateway_units = [item for item in inverters if kind(item) == "gateway"]
+    candidate_aios = [item for item in inverters if kind(item) not in ("ems", "gateway")]
+    any_primary = any(bool(_field(item, "primary", False)) for item in candidate_aios)
+    if any_primary:
+        aios = [item for item in candidate_aios if bool(_field(item, "primary", False)) and bool(_field(item, "battery_present", False))]
+        if not aios:
+            aios = [item for item in candidate_aios if int(_field(item, "battery_capacity_wh", 0) or 0) > 0]
+    else:
+        aios = [item for item in candidate_aios if bool(_field(item, "battery_present", False))]
+
+    if ems_units:
+        selected = ems_units[:1]
+    elif gateway_units and len(aios) > 1:
+        selected = gateway_units[:1]
+    else:
+        selected = aios
+    if not selected:
+        selected = candidate_aios or list(inverters)
+
+    if isinstance(serial_filter, str):
+        serial_filter = (serial_filter,)
+    wanted = frozenset(str(value).strip().upper() for value in serial_filter if value is not None and str(value).strip())
+    if wanted:
+        filtered = [item for item in selected if serial(item).upper() in wanted]
+        if not filtered:
+            available = ", ".join(serial(item) for item in selected)
+            raise GatewayAutoConfigError("Gateway serial filter matched no selected inverter; available: {}".format(available))
+        selected = filtered
+    selected = tuple(sorted(selected, key=serial))
+
+    bases = tuple("{}_gateway_{}".format(prefix, _serial_suffix(serial(item))) for item in selected)
+    first_base = bases[0]
+    count = len(selected)
+    arguments = {
+        "inverter_type": ["GWMQTT"] * count,
+        "num_inverters": count,
+        "soc_percent": ["sensor.{}_soc".format(base) for base in bases],
+        "soc_max": ["sensor.{}_battery_capacity".format(base) if int(_field(item, "battery_capacity_wh", 0) or 0) > 0 else None for base, item in zip(bases, selected)],
+        "battery_power": ["sensor.{}_battery_power".format(base) for base in bases],
+        "pv_power": ["sensor.{}_pv_power".format(base) for base in bases],
+        "grid_power": ["sensor.{}_grid_power".format(base) for base in bases],
+        "load_power": ["sensor.{}_load_power".format(base) for base in bases],
+        "charge_rate": ["number.{}_charge_rate".format(base) for base in bases],
+        "discharge_rate": ["number.{}_discharge_rate".format(base) for base in bases],
+        "reserve": ["number.{}_reserve_soc".format(base) for base in bases],
+        "charge_limit": ["number.{}_target_soc".format(base) for base in bases],
+        "battery_temperature": ["sensor.{}_battery_temperature".format(base) for base in bases],
+        "charge_start_time": ["select.{}_charge_slot1_start".format(base) for base in bases],
+        "charge_end_time": ["select.{}_charge_slot1_end".format(base) for base in bases],
+        "discharge_start_time": ["select.{}_discharge_slot1_start".format(base) for base in bases],
+        "discharge_end_time": ["select.{}_discharge_slot1_end".format(base) for base in bases],
+        "scheduled_charge_enable": ["switch.{}_charge_enabled".format(base) for base in bases],
+        "scheduled_discharge_enable": ["switch.{}_discharge_enabled".format(base) for base in bases],
+        "export_limit": ["sensor.{}_export_limit_w".format(base) for base in bases],
+        "inverter_limit": ["sensor.{}_inverter_rate_max".format(base) for base in bases],
+        "pv_today": ["sensor.{}_pv_today".format(first_base)],
+        "import_today": ["sensor.{}_import_today".format(first_base)],
+        "export_today": ["sensor.{}_export_today".format(first_base)],
+        "load_today": ["sensor.{}_load_today".format(first_base)],
+        "battery_temperature_history": "sensor.{}_battery_temperature".format(first_base),
+        "battery_scaling": ["sensor.{}_battery_dod".format(first_base)],
+        "battery_rate_max": ["sensor.{}_battery_rate_max".format(first_base)],
+        "inverter_time": ["sensor.{}_inverter_time".format(first_base)],
+        "givtcp_rest": None,
+        "charge_rate_percent": None,
+        "discharge_rate_percent": None,
+        "pause_mode": None,
+        "pause_start_time": None,
+        "pause_end_time": None,
+        "discharge_target_soc": None,
+        "ge_cloud_data": False,
+        "ge_cloud_direct": False,
+    }
+    first = selected[0]
+    if kind(first) == "ems" and int(_field(first, "ems_num_inverters", 0) or 0) > 0:
+        aggregate = "{}_gateway".format(prefix)
+        arguments.update(
+            {
+                "ems_total_soc": "sensor.{}_ems_total_soc".format(aggregate),
+                "ems_total_charge": "sensor.{}_ems_total_charge".format(aggregate),
+                "ems_total_discharge": "sensor.{}_ems_total_discharge".format(aggregate),
+                "ems_total_grid": "sensor.{}_ems_total_grid".format(aggregate),
+                "ems_total_pv": "sensor.{}_ems_total_pv".format(aggregate),
+                "ems_total_load": "sensor.{}_ems_total_load".format(aggregate),
+                "idle_start_time": ["select.{}_discharge_slot1_start".format(first_base) for _index in range(count)],
+                "idle_end_time": ["select.{}_discharge_slot1_end".format(first_base) for _index in range(count)],
+            }
+        )
+
+    hybrid = None
+    model_name = ""
+    for item in candidate_aios:
+        model = str(_field(item, "model", "") or "")
+        if model:
+            model_name = model
+            hybrid = not any(token in model.lower() for token in ("ac", "aio", "all-in-one"))
+            if not hybrid:
+                break
+    return GatewayAutoConfigPlan(
+        arguments,
+        tuple(serial(item) for item in selected),
+        tuple(serial(item) for item in inverters),
+        hybrid,
+        model_name,
+    )

--- a/apps/predbat/gecloud_autoconfig.py
+++ b/apps/predbat/gecloud_autoconfig.py
@@ -1,0 +1,280 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System - pure GivEnergy Cloud automatic configuration
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+"""Side-effect-free GivEnergy Cloud automatic-configuration mapping."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+class GECloudAutoConfigError(ValueError):
+    """Raised when an automatic-configuration snapshot is incomplete."""
+
+
+def normalize_register_name(name):
+    """Convert one GE register name to its legacy Home Assistant suffix."""
+    return str(name).lower().replace(" ", "_").replace("%", "percent").replace("-", "_")
+
+
+@dataclass(frozen=True)
+class GECloudAutoConfigInput:
+    """Complete detached input used by the legacy GE auto-config policy."""
+
+    batteries: tuple
+    ems: Optional[str]
+    gateway: Optional[str]
+    pv: tuple
+    battery_meters: tuple
+    register_names: tuple
+    models: tuple
+    prefix: str
+    load_today_ignore: bool = False
+    split_pv: bool = False
+    split_ct: bool = False
+    shared_ct: bool = False
+
+
+@dataclass(frozen=True)
+class GECloudAutoConfigPlan:
+    """Immutable mapper result with exact legacy values and decisions."""
+
+    arguments: tuple
+    primary_targets: tuple
+    inverter_targets: tuple
+    pv_sources: tuple
+    grid_energy_sources: tuple
+    ac_coupled: bool
+    model_name: str
+    shared_ct: Optional[bool]
+    shared_ct_reason: Optional[str]
+    ems_serial: Optional[str]
+
+    def legacy_arguments(self):
+        """Return fresh list values suitable for ``ComponentBase.set_arg``."""
+        result = {}
+        for name, value in self.arguments:
+            result[name] = list(value) if isinstance(value, tuple) else value
+        return result
+
+
+def _pairs(values):
+    """Return a detached lookup from an iterable of two-item pairs."""
+    return {key: value for key, value in values}
+
+
+def compile_gecloud_auto_config(config):
+    """Compile the current GE Cloud discovery policy without side effects."""
+    if not isinstance(config, GECloudAutoConfigInput):
+        raise TypeError("config must be GECloudAutoConfigInput")
+    batteries_real = tuple(config.batteries)
+    if not batteries_real:
+        raise GECloudAutoConfigError("GE Cloud discovery contains no batteries")
+    batteries = batteries_real
+    if not config.ems and config.gateway and len(batteries) > 1:
+        batteries = (config.gateway,)
+    count = len(batteries)
+    register_names = {device: frozenset(names) for device, names in config.register_names}
+    models = _pairs(config.models)
+    meters = _pairs(config.battery_meters)
+
+    def entity(domain, device, suffix):
+        return "{}.{}_gecloud_{}_{}".format(
+            domain,
+            config.prefix,
+            device,
+            suffix,
+        ).lower()
+
+    def first_existing(domain, device, candidates):
+        available = register_names.get(device, frozenset())
+        for candidate in candidates:
+            if candidate in available:
+                return entity(domain, device, candidate)
+        return None
+
+    def build(domain, candidates):
+        values = tuple(first_existing(domain, device, candidates) for device in batteries)
+        return None if all(value is None for value in values) else values
+
+    all_registers = frozenset(name for device in batteries for name in register_names.get(device, frozenset()))
+    has_charge_rate = "battery_charge_power" in all_registers
+    has_discharge_rate = "battery_discharge_power" in all_registers
+    has_charge_percent = bool(all_registers & {"inverter_charge_power_percentage", "charge_power_rate"})
+    has_discharge_percent = bool(all_registers & {"inverter_discharge_power_percentage", "discharge_power_rate"})
+    has_pause = "pause_battery" in all_registers
+    has_pause_time = "pause_battery_start_time" in all_registers
+    has_discharge_target = "dc_discharge_1_lower_soc_percent_limit" in all_registers
+
+    arguments = {
+        "inverter_type": tuple("GEC" for _device in batteries),
+        "num_inverters": count,
+        "inverter_mode": build("switch", ("enable_eco_mode",)),
+        "import_today": tuple(entity("sensor", device, "grid_import_total") for device in batteries),
+        "export_today": tuple(entity("sensor", device, "grid_export_total") for device in batteries),
+        "charge_rate": build("number", ("battery_charge_power",)),
+        "battery_rate_max": tuple(entity("sensor", device, "max_charge_rate") for device in batteries),
+        "discharge_rate": build("number", ("battery_discharge_power",)),
+        "battery_power": tuple(entity("sensor", device, "battery_power") for device in batteries),
+        "load_power": tuple(entity("sensor", device, "consumption_power") for device in batteries),
+        "grid_power": tuple(entity("sensor", device, "grid_power") for device in batteries),
+        "soc_percent": tuple(entity("sensor", device, "battery_percent") for device in batteries),
+        "soc_max": tuple(entity("sensor", device, "battery_size") for device in batteries),
+        "reserve": build(
+            "number",
+            ("battery_reserve_percent_limit", "battery_reserve_percent"),
+        ),
+        "inverter_time": tuple(entity("sensor", device, "time") for device in batteries),
+        "charge_start_time": tuple(entity("select", device, "ac_charge_1_start_time") for device in batteries),
+        "charge_end_time": tuple(entity("select", device, "ac_charge_1_end_time") for device in batteries),
+        "charge_limit": build(
+            "number",
+            ("ac_charge_upper_percent_limit", "ac_charge_1_upper_soc_percent_limit"),
+        ),
+        "charge_limit_enable": build(
+            "switch",
+            ("enable_ac_charge_upper_percent_limit", "enable_ac_charge_1_upper_soc_percent_limit"),
+        ),
+        "discharge_start_time": tuple(entity("select", device, "dc_discharge_1_start_time") for device in batteries),
+        "discharge_end_time": tuple(entity("select", device, "dc_discharge_1_end_time") for device in batteries),
+        "scheduled_charge_enable": build(
+            "switch",
+            ("ac_charge_enable", "enable_ac_charge"),
+        ),
+        "scheduled_discharge_enable": build(
+            "switch",
+            ("enable_dc_discharge", "enable_force_discharge"),
+        ),
+        "battery_temperature": tuple(entity("sensor", device, "battery_temperature") for device in batteries),
+        "battery_scaling": tuple(entity("sensor", device, "battery_dod_soh") for device in batteries),
+        "inverter_limit": tuple(entity("sensor", device, "max_inverter_rate") for device in batteries),
+    }
+    if not config.load_today_ignore:
+        arguments["load_today"] = tuple(entity("sensor", device, "consumption_total") for device in batteries)
+
+    pv_sources = batteries + tuple(config.pv) if config.split_pv else batteries
+    arguments["pv_today"] = tuple(entity("sensor", device, "solar_total") for device in pv_sources)
+    arguments["pv_power"] = tuple(entity("sensor", device, "solar_power") for device in pv_sources)
+    arguments["battery_temperature_history"] = entity(
+        "sensor",
+        batteries[0],
+        "battery_temperature",
+    )
+
+    if has_pause:
+        arguments["pause_mode"] = tuple(entity("select", device, "pause_battery") for device in batteries)
+        if has_pause_time:
+            arguments["pause_start_time"] = tuple(entity("select", device, "pause_battery_start_time") for device in batteries)
+            arguments["pause_end_time"] = tuple(entity("select", device, "pause_battery_end_time") for device in batteries)
+    else:
+        arguments["pause_mode"] = None
+        arguments["pause_start_time"] = None
+        arguments["pause_end_time"] = None
+
+    arguments["discharge_target_soc"] = (
+        tuple(
+            entity(
+                "number",
+                device,
+                "dc_discharge_1_lower_soc_percent_limit",
+            )
+            for device in batteries
+        )
+        if has_discharge_target
+        else None
+    )
+    arguments["charge_rate_percent"] = (
+        build(
+            "number",
+            ("inverter_charge_power_percentage", "charge_power_rate"),
+        )
+        if has_charge_percent and not has_charge_rate
+        else None
+    )
+    arguments["discharge_rate_percent"] = (
+        build(
+            "number",
+            ("inverter_discharge_power_percentage", "discharge_power_rate"),
+        )
+        if has_discharge_percent and not has_discharge_rate
+        else None
+    )
+    arguments["givtcp_rest"] = None
+    arguments["ge_cloud_serial"] = batteries_real[0]
+
+    shared = None
+    shared_reason = None
+    grid_energy_sources = batteries
+    if count > 1 and not config.ems:
+        meter_serials = tuple(meter for battery in batteries for meter in meters.get(battery, ()))
+        duplicate_meters = len(meter_serials) != len(set(meter_serials))
+        shared = duplicate_meters
+        shared_reason = "duplicate meter serials" if duplicate_meters else "meters are not duplicated"
+        if config.split_ct:
+            shared = False
+            shared_reason = "split CT override"
+        elif config.shared_ct:
+            shared = True
+            shared_reason = "shared CT override"
+        if shared:
+            first = batteries[0]
+            arguments["grid_power"] = (entity("sensor", first, "grid_power"),) + tuple(0 for _index in range(count - 1))
+            arguments["load_power"] = (entity("sensor", first, "consumption_power"),) + tuple(0 for _index in range(count - 1))
+            arguments["import_today"] = (entity("sensor", first, "grid_import_total"),)
+            arguments["export_today"] = (entity("sensor", first, "grid_export_total"),)
+            if not config.load_today_ignore:
+                arguments["load_today"] = (entity("sensor", first, "consumption_total"),)
+            grid_energy_sources = (first,)
+
+    inverter_targets = batteries
+    primary_targets = batteries
+    if config.ems:
+        ems = config.ems
+        arguments["inverter_type"] = tuple("GEE" for _index in range(count))
+        arguments["ge_cloud_serial"] = ems
+        arguments["ge_cloud_data"] = False
+        if not config.load_today_ignore:
+            arguments["load_today"] = (entity("sensor", ems, "consumption_total"),)
+        arguments["import_today"] = (entity("sensor", ems, "grid_import_total"),)
+        arguments["export_today"] = (entity("sensor", ems, "grid_export_total"),)
+        arguments["pv_today"] = (entity("sensor", ems, "solar_total"),)
+        arguments["charge_start_time"] = tuple(entity("select", ems, "charge_start_time_slot_1") for _index in range(count))
+        arguments["charge_end_time"] = tuple(entity("select", ems, "charge_end_time_slot_1") for _index in range(count))
+        arguments["idle_start_time"] = tuple(entity("select", ems, "discharge_start_time_slot_1") for _index in range(count))
+        arguments["idle_end_time"] = tuple(entity("select", ems, "discharge_end_time_slot_1") for _index in range(count))
+        arguments["charge_limit"] = tuple(entity("number", ems, "charge_soc_percent_limit_1") for _index in range(count))
+        arguments["discharge_start_time"] = tuple(entity("select", ems, "export_start_time_slot_1") for _index in range(count))
+        arguments["discharge_end_time"] = tuple(entity("select", ems, "export_end_time_slot_1") for _index in range(count))
+        for name, suffix in (
+            ("battery_power", "battery_power"),
+            ("pv_power", "solar_power"),
+            ("load_power", "consumption_power"),
+            ("grid_power", "grid_power"),
+        ):
+            arguments[name] = (entity("sensor", ems, suffix),) + tuple(0 for _index in range(count - 1))
+        inverter_targets = tuple(ems for _index in range(count))
+        pv_sources = (ems,)
+        grid_energy_sources = (ems,)
+
+    ac_coupled = False
+    model_name = "Unknown"
+    for device in batteries_real:
+        model = str(models.get(device, "") or "")
+        if model:
+            model_name = model
+            if any(token in model.lower() for token in ("ac", "aio", "all-in-one")):
+                ac_coupled = True
+                break
+    return GECloudAutoConfigPlan(
+        tuple(arguments.items()),
+        tuple(primary_targets),
+        tuple(inverter_targets),
+        tuple(pv_sources),
+        tuple(grid_energy_sources),
+        ac_coupled,
+        model_name,
+        shared,
+        shared_reason,
+        config.ems,
+    )

--- a/apps/predbat/lattice_gateway_fragment.py
+++ b/apps/predbat/lattice_gateway_fragment.py
@@ -1,0 +1,401 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System - Gateway retained-topology Lattice adapter
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+"""Pure, default-off Gateway retained-topology fragment publisher.
+
+The live Gateway component already receives a provider-owned retained topology
+document and a separate liveness signal.  This module adapts those two inputs
+to the common ``lattice_fragment_adapter()`` surface without registering
+itself, mutating PredBat configuration, or publishing control.
+
+Gateway retained topology remains on the existing v0.2/v0.3 document surface
+in this tranche.  The v0.4 schedule transport is independent; retained v0.4
+topology is rejected until the shared topology compiler is promoted explicitly.
+
+Gateway aliases are deliberately REFERENCE-only.  The adapter exposes
+provider-local capability projection metadata for inspection and future
+composition, but publishes no PRIMARY/CONTROL role assignment and no
+configuration projection ready for materialization.
+"""
+
+# cspell:ignore autoconfig
+
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from lattice_autoconfig import (
+    AliasRole,
+    ProviderAlias,
+    ProviderHealth,
+    ProviderIdentityAlias,
+    ProviderSnapshot,
+    _plain,
+)
+from lattice_fragment_adapters import (
+    DurableFragmentAdapter,
+    FragmentAdapterReadError,
+    FragmentAdapterRemoved,
+)
+from lattice_topology import TopologyValidationError, decode_topology
+
+
+_LIVENESS_UNCHANGED = object()
+
+
+@dataclass(frozen=True)
+class GatewayCapabilityProjection:
+    """One provider-local capability coordinate from the retained document."""
+
+    node_id: str
+    capability: str
+    access_path_id: str
+    cap_ref: Optional[int]
+    readable: bool
+    controllable: bool
+
+
+@dataclass(frozen=True)
+class GatewayTopologyProjection:
+    """Immutable inspection metadata for one durable Gateway fragment."""
+
+    provider_id: str
+    generation: int
+    semantic_fingerprint: str
+    health: ProviderHealth
+    topology_version: str
+    document_version: int
+    node_ids: tuple
+    capabilities: tuple
+    removed: bool
+
+
+def _document_version(document):
+    """Return an explicit version or the legacy v0.2 retained-doc default."""
+    value = document.get("docVersion")
+    if value is None:
+        return 0
+    return value
+
+
+def _health_from_liveness(online):
+    """Map the independent Gateway liveness signal to provider health."""
+    if online is True:
+        return ProviderHealth.HEALTHY
+    if online is False:
+        return ProviderHealth.OFFLINE
+    if online is None:
+        return ProviderHealth.DEGRADED
+    raise ValueError("online must be True, False, or None")
+
+
+def _live_nodes(document):
+    """Return provider nodes that are not topology tombstones."""
+    return tuple(node for node in document.get("nodes", ()) if node.get("removed") is not True)
+
+
+def _reference_aliases(document):
+    """Build deterministic REFERENCE-only aliases for every provider node."""
+    return tuple(
+        ProviderAlias(
+            name="node:{}".format(node_id),
+            node_id=node_id,
+            roles=frozenset((AliasRole.REFERENCE,)),
+        )
+        for node_id in sorted(str(node["id"]) for node in _live_nodes(document))
+    )
+
+
+def _identity_aliases(document):
+    """Publish strong identities asserted by the provider-owned fragment."""
+    aliases = []
+    for node in _live_nodes(document):
+        node_id = str(node["id"])
+        aliases.append(
+            ProviderIdentityAlias(
+                kind="lattice-node-id",
+                value=node_id,
+                node_id=node_id,
+            )
+        )
+        attributes = node.get("attributes")
+        serial = attributes.get("serial") if isinstance(attributes, dict) else None
+        if isinstance(serial, str) and serial.strip():
+            aliases.append(
+                ProviderIdentityAlias(
+                    kind="serial",
+                    value=serial.strip(),
+                    node_id=node_id,
+                )
+            )
+    return tuple(
+        sorted(
+            aliases,
+            key=lambda item: (item.kind, item.value, item.node_id),
+        )
+    )
+
+
+def _valid_binding(binding):
+    """Return whether a read/control binding has usable protocol coordinates."""
+    if not isinstance(binding, dict):
+        return False
+    protocol = binding.get("protocol")
+    if not isinstance(protocol, str) or not protocol.strip():
+        return False
+    if "address" not in binding:
+        return False
+    address = binding["address"]
+    if isinstance(address, bool):
+        return False
+    if isinstance(address, str):
+        return bool(address.strip())
+    return isinstance(address, (int, dict))
+
+
+def _capability_projections(document):
+    """Extract immutable provider-local refs without inferring brand behavior."""
+    projections = []
+    for node in _live_nodes(document):
+        node_id = str(node["id"])
+        for offer in node.get("capabilities", ()):
+            if not isinstance(offer, dict) or offer.get("removed") is True:
+                continue
+            capability = offer.get("capability")
+            if capability is None:
+                continue
+            cap_ref = offer.get("ref")
+            if not isinstance(cap_ref, int) or isinstance(cap_ref, bool) or cap_ref <= 0:
+                cap_ref = None
+            projections.append(
+                GatewayCapabilityProjection(
+                    node_id=node_id,
+                    capability=str(capability),
+                    access_path_id=str(offer.get("accessPath", "")),
+                    cap_ref=cap_ref,
+                    readable=_valid_binding(offer.get("read")) or isinstance(offer.get("derived"), dict),
+                    controllable=_valid_binding(offer.get("control")),
+                )
+            )
+    return tuple(
+        sorted(
+            projections,
+            key=lambda item: (
+                item.node_id,
+                item.capability,
+                item.access_path_id,
+                item.cap_ref or 0,
+            ),
+        )
+    )
+
+
+def _validate_fragment(document, provider_id):
+    """Require one provider-local fragment owned by this exact adapter."""
+    if document.get("scope") != "fragment":
+        raise TopologyValidationError("Gateway retained topology scope must be fragment")
+    document_provider = document["producer"]["provider"]
+    if document_provider != provider_id:
+        raise TopologyValidationError(
+            "Gateway adapter {} cannot publish fragment owned by {}".format(
+                provider_id,
+                document_provider,
+            )
+        )
+
+
+class GatewayRetainedTopologyFragmentPublisher:
+    """Adapt retained topology and liveness into a durable fragment publisher."""
+
+    def __init__(self, provider_id, state_store, enabled=False):
+        """Create an unwired publisher; disabled is the safe default."""
+        if not isinstance(enabled, bool):
+            raise ValueError("enabled must be a boolean")
+        self._enabled = enabled
+        self._adapter = DurableFragmentAdapter(provider_id, state_store)
+        self.provider_id = self._adapter.provider_id
+        self._lock = threading.RLock()
+        try:
+            self._adapter.read_state()
+        except FragmentAdapterReadError as exc:
+            expected = "provider {} has no durable fragment".format(self.provider_id)
+            if str(exc) != expected:
+                raise
+            self._seeded = False
+        else:
+            self._seeded = True
+
+    @property
+    def enabled(self):
+        """Return whether this explicitly constructed reference publisher runs."""
+        return self._enabled
+
+    @property
+    def generation(self):
+        """Fresh-read the current durable adapter generation."""
+        return self.read_state().generation
+
+    @property
+    def semantic_fingerprint(self):
+        """Fresh-read the generation-bound semantic fingerprint."""
+        return self.read_state().semantic_fingerprint
+
+    @property
+    def projection_metadata(self):
+        """Return immutable provider-local projection metadata."""
+        state = self.read_state()
+        document = _plain(state.snapshot.topology_fragment)
+        return GatewayTopologyProjection(
+            provider_id=state.provider_id,
+            generation=state.generation,
+            semantic_fingerprint=state.semantic_fingerprint,
+            health=state.snapshot.health,
+            topology_version=document["topologyVersion"],
+            document_version=_document_version(document),
+            node_ids=tuple(sorted(str(node["id"]) for node in _live_nodes(document))),
+            capabilities=_capability_projections(document),
+            removed=state.removed,
+        )
+
+    def lattice_fragment_adapter(self):
+        """Expose the structural registry surface only when enabled and seeded."""
+        if not self._enabled or not self._seeded:
+            return None
+        self.read_state()
+        return self
+
+    def read_state(self):
+        """Fresh-read the complete durable adapter state."""
+        return self._adapter.read_state()
+
+    def read_snapshot(self):
+        """Fresh-read the current immutable provider snapshot."""
+        return self._adapter.read_snapshot()
+
+    def subscribe_invalidation(self, listener):
+        """Subscribe to topology, liveness, and removal invalidations."""
+        return self._adapter.subscribe_invalidation(listener)
+
+    def _current_state(self):
+        """Return the current state, treating an unseeded store as empty."""
+        if not self._seeded:
+            return None
+        return self._adapter.read_state()
+
+    def ingest_retained_topology(self, payload, online=_LIVENESS_UNCHANGED):
+        """Publish one accepted retained fragment and invalidate subscribers."""
+        if not self._enabled:
+            return False
+        document = decode_topology(payload)
+        _validate_fragment(document, self.provider_id)
+
+        with self._lock:
+            current = self._current_state()
+            if online is _LIVENESS_UNCHANGED and current is not None:
+                health = current.snapshot.health
+            elif online is _LIVENESS_UNCHANGED:
+                health = ProviderHealth.DEGRADED
+            else:
+                health = _health_from_liveness(online)
+            if current is not None and current.removed:
+                raise FragmentAdapterRemoved(
+                    "provider {} was removed at generation {}; retained topology "
+                    "cannot re-enrol it".format(
+                        self.provider_id,
+                        current.generation,
+                    )
+                )
+            if current is not None:
+                previous = _plain(current.snapshot.topology_fragment)
+                previous_explicit = "docVersion" in previous
+                incoming_explicit = "docVersion" in document
+                previous_version = _document_version(previous)
+                incoming_version = _document_version(document)
+                if previous_explicit and not incoming_explicit:
+                    return False
+                if previous_explicit and incoming_explicit:
+                    if incoming_version < previous_version:
+                        return False
+                    if incoming_version == previous_version:
+                        if document != previous:
+                            raise TopologyValidationError(
+                                "provider {} reused docVersion {} for different "
+                                "content".format(
+                                    self.provider_id,
+                                    incoming_version,
+                                )
+                            )
+                        if health is current.snapshot.health:
+                            return False
+                elif document == previous and health is current.snapshot.health:
+                    return False
+
+            generation = 1 if current is None else current.generation + 1
+            snapshot = ProviderSnapshot(
+                provider_id=self.provider_id,
+                generation=generation,
+                health=health,
+                topology_fragment=document,
+                aliases=_reference_aliases(document),
+                identity_aliases=_identity_aliases(document),
+                role_assignments=(),
+                config_projections=(),
+            )
+            published = self._adapter.publish(
+                snapshot,
+                "gateway retained topology changed",
+            )
+            if published:
+                self._seeded = True
+            return published
+
+    def set_liveness(self, online):
+        """Publish a liveness-only generation when provider health changes."""
+        if not self._enabled:
+            return False
+        health = _health_from_liveness(online)
+        with self._lock:
+            current = self._current_state()
+            if current is None:
+                raise FragmentAdapterReadError("Gateway topology must be seeded before liveness")
+            if current.removed:
+                raise FragmentAdapterRemoved(
+                    "provider {} was removed at generation {}".format(
+                        self.provider_id,
+                        current.generation,
+                    )
+                )
+            if current.snapshot.health is health:
+                return False
+            previous = current.snapshot
+            snapshot = ProviderSnapshot(
+                provider_id=self.provider_id,
+                generation=current.generation + 1,
+                health=health,
+                topology_fragment=_plain(previous.topology_fragment),
+                aliases=previous.aliases,
+                identity_aliases=previous.identity_aliases,
+                role_assignments=(),
+                config_projections=(),
+            )
+            return self._adapter.publish(
+                snapshot,
+                "gateway liveness changed to {}".format(health.value),
+            )
+
+    def remove(self):
+        """Publish a durable provider-removal tombstone and invalidate."""
+        if not self._enabled:
+            return False
+        with self._lock:
+            current = self._current_state()
+            if current is None:
+                raise FragmentAdapterReadError("Gateway topology must be seeded before removal")
+            if current.removed:
+                return False
+            return self._adapter.remove(
+                current.generation + 1,
+                "gateway integration removed",
+            )

--- a/apps/predbat/lattice_gateway_fragment.py
+++ b/apps/predbat/lattice_gateway_fragment.py
@@ -20,7 +20,7 @@ composition, but publishes no PRIMARY/CONTROL role assignment and no
 configuration projection ready for materialization.
 """
 
-# cspell:ignore autoconfig
+# cspell:ignore autoconfig materializable
 
 import threading
 from dataclasses import dataclass
@@ -28,12 +28,20 @@ from typing import Optional
 
 from lattice_autoconfig import (
     AliasRole,
+    ProjectionCardinality,
+    ProjectionRouting,
+    ProjectionValueKind,
     ProviderAlias,
+    ProviderConfigProjection,
     ProviderHealth,
     ProviderIdentityAlias,
+    ProviderProjectionValue,
+    ProviderRoleAssignment,
     ProviderSnapshot,
+    _fingerprint_snapshot,
     _plain,
 )
+from gateway_autoconfig import GatewayAutoConfigPlan
 from lattice_fragment_adapters import (
     DurableFragmentAdapter,
     FragmentAdapterReadError,
@@ -43,6 +51,228 @@ from lattice_topology import TopologyValidationError, decode_topology
 
 
 _LIVENESS_UNCHANGED = object()
+_CONFIG_ACCESS_PATH = "predbat-config"
+
+_CONTROL_ARGUMENTS = frozenset(
+    (
+        "charge_rate",
+        "discharge_rate",
+        "reserve",
+        "charge_limit",
+        "charge_start_time",
+        "charge_end_time",
+        "discharge_start_time",
+        "discharge_end_time",
+        "scheduled_charge_enable",
+        "scheduled_discharge_enable",
+        "export_limit",
+        "charge_rate_percent",
+        "discharge_rate_percent",
+        "pause_mode",
+        "pause_start_time",
+        "pause_end_time",
+        "discharge_target_soc",
+        "idle_start_time",
+        "idle_end_time",
+    )
+)
+_FIRST_SOURCE_ARGUMENTS = frozenset(
+    (
+        "pv_today",
+        "import_today",
+        "export_today",
+        "load_today",
+        "battery_scaling",
+        "battery_rate_max",
+        "inverter_time",
+    )
+)
+_SCALAR_ARGUMENTS = frozenset(
+    (
+        "num_inverters",
+        "battery_temperature_history",
+        "givtcp_rest",
+        "ge_cloud_serial",
+        "ge_cloud_data",
+        "ge_cloud_direct",
+        "ems_total_soc",
+        "ems_total_charge",
+        "ems_total_discharge",
+        "ems_total_grid",
+        "ems_total_pv",
+        "ems_total_load",
+    )
+)
+
+
+def _serial_nodes(document):
+    """Index retained nodes by normalized physical serial identity."""
+    result = {}
+    for node in _live_nodes(document):
+        attributes = node.get("attributes") or {}
+        serial = attributes.get("serial")
+        if isinstance(serial, str) and serial.strip():
+            result[serial.strip().upper()] = str(node["id"])
+    return result
+
+
+def _projection_sources(plan, argument, value):
+    """Return the selected serial owning each raw legacy value."""
+    serials = plan.selected_serials
+    if not serials:
+        raise TopologyValidationError("Gateway auto-config plan has no targets")
+    if isinstance(value, tuple):
+        if argument in _FIRST_SOURCE_ARGUMENTS:
+            return (serials[0],) * len(value)
+        if len(value) == len(serials):
+            return serials
+        raise TopologyValidationError(
+            "Gateway projection {} has {} values for {} targets".format(
+                argument,
+                len(value),
+                len(serials),
+            )
+        )
+    return (serials[0],)
+
+
+def _projection_group(argument):
+    """Keep variable-width source arrays independent from inverter slots."""
+    if argument == "pv_power":
+        return "pv_power_sources"
+    if argument == "pv_today":
+        return "pv_energy_sources"
+    if argument in ("import_today", "export_today", "load_today"):
+        return "grid_energy_sources"
+    if argument in ("battery_scaling", "battery_rate_max", "inverter_time"):
+        return "battery_metadata_sources"
+    if argument == "num_inverters" or not isinstance(argument, str):
+        return "site"
+    return "inverters"
+
+
+def _value_kind(value):
+    """Map a raw immutable mapper value to the compiler value kind."""
+    if value is None:
+        return ProjectionValueKind.NONE
+    if isinstance(value, str) and "." in value:
+        return ProjectionValueKind.ENTITY
+    return ProjectionValueKind.CONSTANT
+
+
+def _materializable_snapshot(document, plan, provider_id, generation, health):
+    """Bind one pure Gateway plan to retained topology identities."""
+    if not isinstance(plan, GatewayAutoConfigPlan):
+        raise TypeError("plan must be GatewayAutoConfigPlan")
+    document = _plain(document)
+    nodes_by_serial = _serial_nodes(document)
+    missing = sorted(serial for serial in plan.selected_serials if serial.upper() not in nodes_by_serial)
+    if missing:
+        raise TopologyValidationError("Gateway auto-config serials are absent from retained topology: {}".format(", ".join(missing)))
+    node_lookup = {str(node["id"]): node for node in document.get("nodes", ())}
+    selected_nodes = tuple(nodes_by_serial[serial.upper()] for serial in plan.selected_serials)
+    if any(node_lookup[node_id].get("kind") == "energy-management-system" for node_id in selected_nodes):
+        raise TopologyValidationError("Gateway EMS plans require the multi-battery coordinator model")
+
+    assignments = set()
+    for index, node_id in enumerate(selected_nodes):
+        assignments.add((AliasRole.PRIMARY, "inverters", index, node_id))
+        assignments.add((AliasRole.CONTROL, "inverters", index, node_id))
+
+    projections = []
+    for argument, raw_value in sorted(plan.arguments.items()):
+        if not isinstance(raw_value, tuple) and argument not in _SCALAR_ARGUMENTS:
+            raw_value = tuple(raw_value for _serial in plan.selected_serials)
+        values = raw_value if isinstance(raw_value, tuple) else (raw_value,)
+        serials = _projection_sources(plan, argument, raw_value)
+        node_ids = tuple(nodes_by_serial[serial.upper()] for serial in serials)
+        cardinality = ProjectionCardinality.PER_INDEX if isinstance(raw_value, tuple) else ProjectionCardinality.SCALAR
+        group = _projection_group(argument) if cardinality is ProjectionCardinality.PER_INDEX else "site"
+        role = AliasRole.CONTROL if argument in _CONTROL_ARGUMENTS else AliasRole.PRIMARY
+        for index, node_id in enumerate(node_ids):
+            assignments.add((role, group, index, node_id))
+
+        projection_values = []
+        for node_id, serial, value in zip(node_ids, serials, values):
+            kind = _value_kind(value)
+            capability = None
+            access_path_id = None
+            identity_kind = None
+            identity_value = None
+            if kind is not ProjectionValueKind.NONE:
+                identity_kind = "serial"
+                identity_value = serial.upper()
+                access_path_id = _CONFIG_ACCESS_PATH
+            if kind is ProjectionValueKind.ENTITY:
+                capability = "predbat.config.{}".format(argument)
+                node = node_lookup[node_id]
+                access_paths = node.setdefault("accessPaths", [])
+                if not any(str(path.get("id")) == _CONFIG_ACCESS_PATH for path in access_paths):
+                    access_paths.append(
+                        {
+                            "id": _CONFIG_ACCESS_PATH,
+                            "provider": provider_id,
+                            "preference": 100,
+                        }
+                    )
+                capabilities = node.setdefault("capabilities", [])
+                if not any(offer.get("capability") == capability and offer.get("accessPath") == _CONFIG_ACCESS_PATH for offer in capabilities):
+                    capabilities.append(
+                        {
+                            "capability": capability,
+                            "accessPath": _CONFIG_ACCESS_PATH,
+                            "read": {
+                                "protocol": "home-assistant",
+                                "address": value,
+                            },
+                        }
+                    )
+            projection_values.append(
+                ProviderProjectionValue(
+                    node_id=node_id,
+                    kind=kind,
+                    value=value,
+                    capability=capability,
+                    identity_kind=identity_kind,
+                    identity_value=identity_value,
+                    access_path_id=access_path_id,
+                )
+            )
+        projections.append(
+            ProviderConfigProjection(
+                argument=argument,
+                role=role,
+                group=group,
+                routing=ProjectionRouting.LEAF,
+                cardinality=cardinality,
+                values=tuple(projection_values),
+                required=False,
+            )
+        )
+
+    for node in document.get("nodes", ()):
+        attributes = node.get("attributes")
+        if isinstance(attributes, dict):
+            serial = attributes.get("serial")
+            if isinstance(serial, str) and serial.strip():
+                attributes["serial"] = serial.strip().upper()
+    roles = tuple(
+        ProviderRoleAssignment(role, group, index, node_id)
+        for role, group, index, node_id in sorted(
+            assignments,
+            key=lambda item: (item[1], item[0].value, item[2], item[3]),
+        )
+    )
+    return ProviderSnapshot(
+        provider_id=provider_id,
+        generation=generation,
+        health=health,
+        topology_fragment=document,
+        aliases=_reference_aliases(document),
+        identity_aliases=_identity_aliases(document),
+        role_assignments=roles,
+        config_projections=tuple(projections),
+    )
 
 
 @dataclass(frozen=True)
@@ -377,12 +607,48 @@ class GatewayRetainedTopologyFragmentPublisher:
                 topology_fragment=_plain(previous.topology_fragment),
                 aliases=previous.aliases,
                 identity_aliases=previous.identity_aliases,
-                role_assignments=(),
-                config_projections=(),
+                role_assignments=previous.role_assignments,
+                config_projections=previous.config_projections,
             )
             return self._adapter.publish(
                 snapshot,
                 "gateway liveness changed to {}".format(health.value),
+            )
+
+    def ingest_auto_config(self, plan):
+        """Attach one pure mapper plan to the current retained fragment."""
+        if not self._enabled:
+            return False
+        with self._lock:
+            current = self._current_state()
+            if current is None:
+                raise FragmentAdapterReadError("Gateway topology must be seeded before auto-config")
+            if current.removed:
+                raise FragmentAdapterRemoved(
+                    "provider {} was removed at generation {}".format(
+                        self.provider_id,
+                        current.generation,
+                    )
+                )
+            snapshot = _materializable_snapshot(
+                current.snapshot.topology_fragment,
+                plan,
+                self.provider_id,
+                current.generation,
+                current.snapshot.health,
+            )
+            if _fingerprint_snapshot(snapshot) == _fingerprint_snapshot(current.snapshot):
+                return False
+            snapshot = _materializable_snapshot(
+                current.snapshot.topology_fragment,
+                plan,
+                self.provider_id,
+                current.generation + 1,
+                current.snapshot.health,
+            )
+            return self._adapter.publish(
+                snapshot,
+                "gateway auto-config plan changed",
             )
 
     def remove(self):

--- a/apps/predbat/lattice_ge_cloud_fragment.py
+++ b/apps/predbat/lattice_ge_cloud_fragment.py
@@ -17,7 +17,7 @@ and provider-local topology for composition, but grants no materialization-ready
 PRIMARY/CONTROL roles and publishes no PredBat configuration or control write.
 """
 
-# cspell:ignore autoconfig
+# cspell:ignore autoconfig materializable
 
 import threading
 from dataclasses import dataclass
@@ -25,11 +25,24 @@ from typing import Optional
 
 from lattice_autoconfig import (
     AliasRole,
+    ProjectionCardinality,
+    ProjectionRouting,
+    ProjectionValueKind,
     ProviderAlias,
+    ProviderConfigProjection,
     ProviderHealth,
     ProviderIdentityAlias,
+    ProviderProjectionValue,
+    ProviderRoleAssignment,
     ProviderSnapshot,
+    _fingerprint_snapshot,
     _plain,
+)
+from gecloud_autoconfig import (
+    GECloudAutoConfigError,
+    GECloudAutoConfigInput,
+    GECloudAutoConfigPlan,
+    compile_gecloud_auto_config,
 )
 from lattice_fragment_adapters import (
     DurableFragmentAdapter,
@@ -40,6 +53,256 @@ from lattice_fragment_adapters import (
 
 
 _HEALTH_UNCHANGED = object()
+_CONTROL_ARGUMENTS = frozenset(
+    (
+        "charge_rate",
+        "discharge_rate",
+        "reserve",
+        "charge_limit",
+        "charge_limit_enable",
+        "charge_start_time",
+        "charge_end_time",
+        "discharge_start_time",
+        "discharge_end_time",
+        "scheduled_charge_enable",
+        "scheduled_discharge_enable",
+        "charge_rate_percent",
+        "discharge_rate_percent",
+        "pause_mode",
+        "pause_start_time",
+        "pause_end_time",
+        "discharge_target_soc",
+        "idle_start_time",
+        "idle_end_time",
+    )
+)
+_METADATA_ARGUMENTS = frozenset(("battery_scaling", "battery_rate_max", "inverter_time"))
+_SCALAR_ARGUMENTS = frozenset(
+    (
+        "num_inverters",
+        "battery_temperature_history",
+        "givtcp_rest",
+        "ge_cloud_serial",
+        "ge_cloud_data",
+        "ge_cloud_direct",
+    )
+)
+
+
+def _plan_group(argument):
+    """Select the role group matching one raw legacy source list."""
+    if argument == "pv_power":
+        return "pv_power_sources"
+    if argument == "pv_today":
+        return "pv_energy_sources"
+    if argument in ("import_today", "export_today", "load_today"):
+        return "grid_energy_sources"
+    if argument in _METADATA_ARGUMENTS:
+        return "battery_metadata_sources"
+    return "inverters"
+
+
+def _plan_kind(value):
+    """Map one raw mapper value to the compiler projection kind."""
+    if value is None:
+        return ProjectionValueKind.NONE
+    if isinstance(value, str) and "." in value:
+        return ProjectionValueKind.ENTITY
+    return ProjectionValueKind.CONSTANT
+
+
+def _nodes_by_serial(document):
+    """Index GE topology nodes using normalized serial identity."""
+    result = {}
+    for node in document.get("nodes", ()):
+        attributes = node.get("attributes") or {}
+        serial = attributes.get("serial")
+        if isinstance(serial, str) and serial.strip():
+            result[serial.strip().upper()] = str(node["id"])
+    return result
+
+
+def _devices_from_document(document):
+    """Restore normalized device snapshots from durable GE topology."""
+    devices = []
+    for node in document.get("nodes", ()):
+        attributes = node.get("attributes") or {}
+        devices.append(
+            GECloudDeviceSnapshot(
+                serial=attributes.get("serial"),
+                kind=attributes.get("geCloudKind", "inverter"),
+                online=attributes.get("online"),
+                model=attributes.get("model"),
+                site_id=attributes.get("siteId"),
+                uuid=attributes.get("geCloudUuid"),
+            )
+        )
+    return _normalize_devices(devices)
+
+
+_EMS_COORDINATOR_ARGUMENTS = frozenset(
+    (
+        "battery_power",
+        "pv_power",
+        "load_power",
+        "grid_power",
+        "charge_start_time",
+        "charge_end_time",
+        "idle_start_time",
+        "idle_end_time",
+        "charge_limit",
+        "discharge_start_time",
+        "discharge_end_time",
+    )
+)
+
+
+def _plan_sources(config, plan, argument, raw_value):
+    """Return the physical source serial for every raw mapper value."""
+    if not isinstance(raw_value, tuple):
+        source = plan.ems_serial or plan.primary_targets[0]
+        return (source,)
+    if plan.ems_serial and argument in _EMS_COORDINATOR_ARGUMENTS:
+        return tuple(plan.ems_serial for _value in raw_value)
+    if argument in ("pv_power", "pv_today"):
+        sources = plan.pv_sources
+    elif argument in ("import_today", "export_today", "load_today"):
+        sources = plan.grid_energy_sources
+    else:
+        sources = plan.primary_targets
+    if len(sources) != len(raw_value):
+        raise GECloudAutoConfigError(
+            "GE projection {} has {} values for {} sources".format(
+                argument,
+                len(raw_value),
+                len(sources),
+            )
+        )
+    return tuple(sources)
+
+
+def _materializable_snapshot(
+    document,
+    devices,
+    config,
+    plan,
+    provider_id,
+    generation,
+    health,
+):
+    """Bind one pure GE mapper plan to its discovered topology nodes."""
+    if not isinstance(config, GECloudAutoConfigInput):
+        raise TypeError("config must be GECloudAutoConfigInput")
+    if not isinstance(plan, GECloudAutoConfigPlan):
+        raise TypeError("plan must be GECloudAutoConfigPlan")
+    document = _plain(document)
+    nodes_by_serial = _nodes_by_serial(document)
+    referenced = set(plan.primary_targets)
+    referenced.update(plan.inverter_targets)
+    referenced.update(plan.pv_sources)
+    referenced.update(plan.grid_energy_sources)
+    if plan.ems_serial:
+        referenced.add(plan.ems_serial)
+    missing = sorted(serial for serial in referenced if serial.upper() not in nodes_by_serial)
+    if missing:
+        raise GECloudAutoConfigError("GE auto-config serials are absent from discovery: {}".format(", ".join(missing)))
+    node_lookup = {str(node["id"]): node for node in document.get("nodes", ())}
+    assignments = set()
+    for index, serial in enumerate(plan.primary_targets):
+        assignments.add(
+            (
+                AliasRole.PRIMARY,
+                "inverters",
+                index,
+                nodes_by_serial[serial.upper()],
+            )
+        )
+
+    projections = []
+    for argument, raw_value in plan.arguments:
+        if not isinstance(raw_value, tuple) and argument not in _SCALAR_ARGUMENTS:
+            raw_value = tuple(raw_value for _serial in plan.primary_targets)
+        values = raw_value if isinstance(raw_value, tuple) else (raw_value,)
+        sources = _plan_sources(config, plan, argument, raw_value)
+        node_ids = tuple(nodes_by_serial[serial.upper()] for serial in sources)
+        cardinality = ProjectionCardinality.PER_INDEX if isinstance(raw_value, tuple) else ProjectionCardinality.SCALAR
+        coordinator = bool(plan.ems_serial and argument in _EMS_COORDINATOR_ARGUMENTS)
+        if coordinator:
+            role = AliasRole.CONTROL
+            group = "ems_controls"
+            routing = ProjectionRouting.COORDINATOR
+        else:
+            role = AliasRole.CONTROL if argument in _CONTROL_ARGUMENTS else AliasRole.PRIMARY
+            group = _plan_group(argument) if cardinality is ProjectionCardinality.PER_INDEX else "site"
+            routing = ProjectionRouting.LEAF
+        for index, node_id in enumerate(node_ids):
+            assignments.add((role, group, index, node_id))
+
+        projection_values = []
+        for node_id, serial, value in zip(node_ids, sources, values):
+            kind = _plan_kind(value)
+            capability = None
+            identity_kind = None
+            identity_value = None
+            if kind is not ProjectionValueKind.NONE:
+                identity_kind = "serial"
+                identity_value = serial.upper()
+            if kind is ProjectionValueKind.ENTITY:
+                capability = "predbat.config.{}".format(argument)
+                node = node_lookup[node_id]
+                capabilities = node.setdefault("capabilities", [])
+                if not any(offer.get("capability") == capability and offer.get("accessPath") == "ge-cloud-api" for offer in capabilities):
+                    capabilities.append(
+                        {
+                            "capability": capability,
+                            "accessPath": "ge-cloud-api",
+                            "read": {
+                                "protocol": "home-assistant",
+                                "address": value,
+                            },
+                        }
+                    )
+            projection_values.append(
+                ProviderProjectionValue(
+                    node_id=node_id,
+                    kind=kind,
+                    value=value,
+                    capability=capability,
+                    identity_kind=identity_kind,
+                    identity_value=identity_value,
+                )
+            )
+        projections.append(
+            ProviderConfigProjection(
+                argument=argument,
+                role=role,
+                group=group,
+                routing=routing,
+                cardinality=cardinality,
+                values=tuple(projection_values),
+                required=False,
+            )
+        )
+
+    roles = tuple(
+        ProviderRoleAssignment(role, group, index, node_id)
+        for role, group, index, node_id in sorted(
+            assignments,
+            key=lambda item: (item[1], item[0].value, item[2], item[3]),
+        )
+    )
+    return ProviderSnapshot(
+        provider_id=provider_id,
+        generation=generation,
+        health=health,
+        topology_fragment=document,
+        aliases=_reference_aliases(devices),
+        identity_aliases=_identity_aliases(devices),
+        role_assignments=roles,
+        config_projections=tuple(projections),
+    )
+
+
 _DEVICE_KINDS = frozenset(
     (
         "battery-inverter",
@@ -429,12 +692,54 @@ class GECloudFragmentPublisher:
                 topology_fragment=_plain(previous.topology_fragment),
                 aliases=previous.aliases,
                 identity_aliases=previous.identity_aliases,
-                role_assignments=(),
-                config_projections=(),
+                role_assignments=previous.role_assignments,
+                config_projections=previous.config_projections,
             )
             return self._adapter.publish(
                 snapshot,
                 "GE Cloud liveness changed to {}".format(health.value),
+            )
+
+    def ingest_auto_config(self, config):
+        """Compile and attach one complete GE discovery/config snapshot."""
+        if not self._enabled:
+            return False
+        plan = compile_gecloud_auto_config(config)
+        with self._lock:
+            current = self._current_state()
+            if current is None:
+                raise FragmentAdapterReadError("GE Cloud discovery must be seeded before auto-config")
+            if current.removed:
+                raise FragmentAdapterRemoved(
+                    "provider {} was removed at generation {}".format(
+                        self.provider_id,
+                        current.generation,
+                    )
+                )
+            document = _plain(current.snapshot.topology_fragment)
+            snapshot = _materializable_snapshot(
+                document,
+                _devices_from_document(document),
+                config,
+                plan,
+                self.provider_id,
+                current.generation,
+                current.snapshot.health,
+            )
+            if _fingerprint_snapshot(snapshot) == _fingerprint_snapshot(current.snapshot):
+                return False
+            snapshot = _materializable_snapshot(
+                document,
+                _devices_from_document(document),
+                config,
+                plan,
+                self.provider_id,
+                current.generation + 1,
+                current.snapshot.health,
+            )
+            return self._adapter.publish(
+                snapshot,
+                "GE Cloud auto-config plan changed",
             )
 
     def remove(self):

--- a/apps/predbat/lattice_ge_cloud_fragment.py
+++ b/apps/predbat/lattice_ge_cloud_fragment.py
@@ -1,0 +1,455 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System - GE Cloud Lattice fragment adapter
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+"""Pure, default-off GivEnergy Cloud fragment publisher.
+
+The live ``GECloudDirect`` component owns API discovery and polling.  This
+module deliberately does not import, register, or mutate that component.  A
+future gated seam may pass explicit discovery/device snapshots here after a
+successful cloud read.
+
+Every accepted discovery version, device change, liveness change, or removal
+publishes a new durable generation through the common fragment-adapter
+surface.  Published aliases are REFERENCE-only: this tranche exposes identity
+and provider-local topology for composition, but grants no materialization-ready
+PRIMARY/CONTROL roles and publishes no PredBat configuration or control write.
+"""
+
+# cspell:ignore autoconfig
+
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from lattice_autoconfig import (
+    AliasRole,
+    ProviderAlias,
+    ProviderHealth,
+    ProviderIdentityAlias,
+    ProviderSnapshot,
+    _plain,
+)
+from lattice_fragment_adapters import (
+    DurableFragmentAdapter,
+    FragmentAdapterConflict,
+    FragmentAdapterReadError,
+    FragmentAdapterRemoved,
+)
+
+
+_HEALTH_UNCHANGED = object()
+_DEVICE_KINDS = frozenset(
+    (
+        "battery-inverter",
+        "ems",
+        "ev-charger",
+        "gateway",
+        "inverter",
+        "pv-inverter",
+    )
+)
+_TOPOLOGY_KINDS = {
+    "battery-inverter": "inverter",
+    "ems": "energy-management-system",
+    "ev-charger": "ev-charger",
+    "gateway": "gateway",
+    "inverter": "inverter",
+    "pv-inverter": "inverter",
+}
+
+
+def _required_text(value, name):
+    """Return one normalized non-empty text field."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("{} must be a non-empty string".format(name))
+    return value.strip()
+
+
+def _optional_text(value, name):
+    """Return one normalized optional text field."""
+    if value is None:
+        return None
+    return _required_text(value, name)
+
+
+def _optional_identifier(value, name):
+    """Normalize an optional cloud identifier without accepting booleans."""
+    if value is None:
+        return None
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    return _required_text(value, name)
+
+
+def _discovery_version(value):
+    """Validate one provider-owned monotonic discovery version."""
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError("discovery_version must be a non-negative integer")
+    return value
+
+
+def _provider_health(value):
+    """Normalize explicit integration liveness into compiler health."""
+    if isinstance(value, ProviderHealth):
+        return value
+    if value is True:
+        return ProviderHealth.HEALTHY
+    if value is False:
+        return ProviderHealth.OFFLINE
+    if value is None:
+        return ProviderHealth.DEGRADED
+    raise ValueError(
+        "health must be ProviderHealth, True, False, or None",
+    )
+
+
+@dataclass(frozen=True)
+class GECloudDeviceSnapshot:
+    """One explicit provider-local device discovered by GivEnergy Cloud."""
+
+    serial: str
+    kind: str = "inverter"
+    online: Optional[bool] = None
+    model: Optional[str] = None
+    site_id: Optional[object] = None
+    uuid: Optional[str] = None
+
+    def __post_init__(self):
+        """Normalize stable identities and reject ambiguous device state."""
+        serial = _required_text(self.serial, "serial").upper()
+        kind = _required_text(self.kind, "kind").lower().replace("_", "-")
+        if kind not in _DEVICE_KINDS:
+            raise ValueError(
+                "kind must be one of {}".format(
+                    ", ".join(sorted(_DEVICE_KINDS)),
+                )
+            )
+        if self.online is not None and not isinstance(self.online, bool):
+            raise ValueError("online must be True, False, or None")
+        object.__setattr__(self, "serial", serial)
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "model", _optional_text(self.model, "model"))
+        object.__setattr__(
+            self,
+            "site_id",
+            _optional_identifier(self.site_id, "site_id"),
+        )
+        object.__setattr__(self, "uuid", _optional_text(self.uuid, "uuid"))
+
+    @property
+    def node_id(self):
+        """Return the deterministic provider-local node identity."""
+        return "ge-cloud:{}".format(self.serial)
+
+
+def _normalize_devices(devices):
+    """Freeze, sort, and collision-check explicit device snapshots."""
+    try:
+        devices = tuple(devices)
+    except TypeError as exc:
+        raise ValueError("devices must be an iterable of GECloudDeviceSnapshot") from exc
+    if any(not isinstance(device, GECloudDeviceSnapshot) for device in devices):
+        raise ValueError("devices must contain only GECloudDeviceSnapshot values")
+    if not devices:
+        raise ValueError("devices must contain at least one GECloudDeviceSnapshot")
+
+    by_serial = {}
+    uuid_owners = {}
+    for device in devices:
+        if device.serial in by_serial:
+            raise FragmentAdapterConflict(
+                "GE Cloud discovery contains duplicate serial {}".format(
+                    device.serial,
+                )
+            )
+        by_serial[device.serial] = device
+        if device.uuid is not None:
+            owner = uuid_owners.get(device.uuid)
+            if owner is not None and owner != device.serial:
+                raise FragmentAdapterConflict(
+                    "GE Cloud UUID {} belongs to both {} and {}".format(
+                        device.uuid,
+                        owner,
+                        device.serial,
+                    )
+                )
+            uuid_owners[device.uuid] = device.serial
+    return tuple(sorted(devices, key=lambda item: (item.serial, item.kind)))
+
+
+def _device_node(device, provider_id):
+    """Project one device without claiming read or control capabilities."""
+    attributes = {
+        "serial": device.serial,
+        "geCloudKind": device.kind,
+    }
+    if device.online is not None:
+        attributes["online"] = device.online
+    if device.model is not None:
+        attributes["model"] = device.model
+    if device.site_id is not None:
+        attributes["siteId"] = device.site_id
+    if device.uuid is not None:
+        attributes["geCloudUuid"] = device.uuid
+    return {
+        "id": device.node_id,
+        "kind": _TOPOLOGY_KINDS[device.kind],
+        "attributes": attributes,
+        "accessPaths": [
+            {
+                "id": "ge-cloud-api",
+                "provider": provider_id,
+                "preference": 0,
+            }
+        ],
+        "capabilities": [],
+    }
+
+
+def _topology_document(provider_id, discovery_version, devices):
+    """Build one deterministic provider-owned v0.3 topology fragment."""
+    return {
+        "topologyVersion": "0.3.0",
+        "scope": "fragment",
+        "docVersion": discovery_version,
+        "producer": {
+            "name": "GivEnergy Cloud",
+            "provider": provider_id,
+            "authority": 0,
+        },
+        "nodes": [_device_node(device, provider_id) for device in devices],
+    }
+
+
+def _reference_aliases(devices):
+    """Publish provider-local names that never grant materialization roles."""
+    return tuple(
+        ProviderAlias(
+            name="serial:{}".format(device.serial),
+            node_id=device.node_id,
+            roles=frozenset((AliasRole.REFERENCE,)),
+        )
+        for device in devices
+    )
+
+
+def _identity_aliases(devices):
+    """Publish strong serial and optional provider UUID identities.
+
+    The deterministic node id remains provider-local metadata.  It is not
+    asserted as a cross-provider ``lattice-node-id`` identity because another
+    integration may legitimately name the same serial differently.
+    """
+    aliases = []
+    for device in devices:
+        aliases.append(
+            ProviderIdentityAlias(
+                kind="serial",
+                value=device.serial,
+                node_id=device.node_id,
+            )
+        )
+        if device.uuid is not None:
+            aliases.append(
+                ProviderIdentityAlias(
+                    kind="ge-cloud-uuid",
+                    value=device.uuid,
+                    node_id=device.node_id,
+                )
+            )
+    return tuple(
+        sorted(
+            aliases,
+            key=lambda item: (item.kind, item.value, item.node_id),
+        )
+    )
+
+
+class GECloudFragmentPublisher:
+    """Adapt explicit cloud snapshots into one durable compiler fragment."""
+
+    def __init__(self, provider_id, state_store, enabled=False):
+        """Create an unwired publisher; disabled is the safe default."""
+        if not isinstance(enabled, bool):
+            raise ValueError("enabled must be a boolean")
+        self._enabled = enabled
+        self._adapter = DurableFragmentAdapter(provider_id, state_store)
+        self.provider_id = self._adapter.provider_id
+        self._lock = threading.RLock()
+        try:
+            self._adapter.read_state()
+        except FragmentAdapterReadError as exc:
+            expected = "provider {} has no durable fragment".format(self.provider_id)
+            if str(exc) != expected:
+                raise
+            self._seeded = False
+        else:
+            self._seeded = True
+
+    @property
+    def enabled(self):
+        """Return whether this explicitly constructed publisher accepts input."""
+        return self._enabled
+
+    @property
+    def generation(self):
+        """Fresh-read the current durable adapter generation."""
+        return self.read_state().generation
+
+    @property
+    def semantic_fingerprint(self):
+        """Fresh-read the generation-bound semantic fingerprint."""
+        return self.read_state().semantic_fingerprint
+
+    @property
+    def discovery_version(self):
+        """Fresh-read the current provider-owned discovery version."""
+        state = self.read_state()
+        return _plain(state.snapshot.topology_fragment)["docVersion"]
+
+    def lattice_fragment_adapter(self):
+        """Expose structural discovery only when enabled and durably seeded."""
+        if not self._enabled or not self._seeded:
+            return None
+        self.read_state()
+        return self
+
+    def read_state(self):
+        """Fresh-read the complete durable adapter state."""
+        return self._adapter.read_state()
+
+    def read_snapshot(self):
+        """Fresh-read the current immutable provider snapshot."""
+        return self._adapter.read_snapshot()
+
+    def subscribe_invalidation(self, listener):
+        """Subscribe to discovery, device, liveness, and removal changes."""
+        return self._adapter.subscribe_invalidation(listener)
+
+    def _current_state(self):
+        """Return the current state, treating an unseeded store as empty."""
+        if not self._seeded:
+            return None
+        return self._adapter.read_state()
+
+    def ingest_discovery(
+        self,
+        discovery_version,
+        devices,
+        health=_HEALTH_UNCHANGED,
+    ):
+        """Publish one accepted complete discovery/device snapshot."""
+        if not self._enabled:
+            return False
+        discovery_version = _discovery_version(discovery_version)
+        devices = _normalize_devices(devices)
+        document = _topology_document(
+            self.provider_id,
+            discovery_version,
+            devices,
+        )
+
+        with self._lock:
+            current = self._current_state()
+            if current is not None and current.removed:
+                raise FragmentAdapterRemoved(
+                    "provider {} was removed at generation {}; GE Cloud "
+                    "discovery cannot re-enrol it".format(
+                        self.provider_id,
+                        current.generation,
+                    )
+                )
+            if current is None:
+                next_health = ProviderHealth.DEGRADED if health is _HEALTH_UNCHANGED else _provider_health(health)
+            else:
+                previous = _plain(current.snapshot.topology_fragment)
+                previous_version = previous["docVersion"]
+                if discovery_version < previous_version:
+                    return False
+                if discovery_version == previous_version and document != previous:
+                    raise FragmentAdapterConflict(
+                        "provider {} reused GE Cloud discovery version {} "
+                        "for different content".format(
+                            self.provider_id,
+                            discovery_version,
+                        )
+                    )
+                next_health = current.snapshot.health if health is _HEALTH_UNCHANGED else _provider_health(health)
+                if discovery_version == previous_version and next_health is current.snapshot.health:
+                    return False
+
+            generation = 1 if current is None else current.generation + 1
+            snapshot = ProviderSnapshot(
+                provider_id=self.provider_id,
+                generation=generation,
+                health=next_health,
+                topology_fragment=document,
+                aliases=_reference_aliases(devices),
+                identity_aliases=_identity_aliases(devices),
+                role_assignments=(),
+                config_projections=(),
+            )
+            published = self._adapter.publish(
+                snapshot,
+                "GE Cloud discovery changed to version {}".format(
+                    discovery_version,
+                ),
+            )
+            if published:
+                self._seeded = True
+            return published
+
+    def set_liveness(self, health):
+        """Publish provider liveness without changing the discovery document."""
+        if not self._enabled:
+            return False
+        health = _provider_health(health)
+        with self._lock:
+            current = self._current_state()
+            if current is None:
+                raise FragmentAdapterReadError(
+                    "GE Cloud discovery must be seeded before liveness",
+                )
+            if current.removed:
+                raise FragmentAdapterRemoved(
+                    "provider {} was removed at generation {}".format(
+                        self.provider_id,
+                        current.generation,
+                    )
+                )
+            if current.snapshot.health is health:
+                return False
+            previous = current.snapshot
+            snapshot = ProviderSnapshot(
+                provider_id=self.provider_id,
+                generation=current.generation + 1,
+                health=health,
+                topology_fragment=_plain(previous.topology_fragment),
+                aliases=previous.aliases,
+                identity_aliases=previous.identity_aliases,
+                role_assignments=(),
+                config_projections=(),
+            )
+            return self._adapter.publish(
+                snapshot,
+                "GE Cloud liveness changed to {}".format(health.value),
+            )
+
+    def remove(self):
+        """Publish an irreversible provider-removal tombstone."""
+        if not self._enabled:
+            return False
+        with self._lock:
+            current = self._current_state()
+            if current is None:
+                raise FragmentAdapterReadError(
+                    "GE Cloud discovery must be seeded before removal",
+                )
+            if current.removed:
+                return False
+            return self._adapter.remove(
+                current.generation + 1,
+                "GE Cloud integration removed",
+            )

--- a/apps/predbat/tests/test_gateway_autoconfig.py
+++ b/apps/predbat/tests/test_gateway_autoconfig.py
@@ -1,0 +1,126 @@
+# cspell:ignore autoconfig
+"""Tests for the pure Gateway automatic-configuration mapper."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from gateway_autoconfig import (  # noqa: E402
+    GatewayAutoConfigError,
+    compile_gateway_auto_config,
+)
+
+
+def inverter(serial="CE123456789", **overrides):
+    """Build one detached Gateway inverter snapshot."""
+    value = {
+        "serial": serial,
+        "kind": "inverter",
+        "primary": False,
+        "battery_present": True,
+        "battery_capacity_wh": 9600,
+        "model": "",
+        "ems_num_inverters": 0,
+    }
+    value.update(overrides)
+    return value
+
+
+class TestGatewayAutoConfig(unittest.TestCase):
+    """The pure plan preserves existing Gateway selection and entity shapes."""
+
+    def test_single_inverter_exact_core_values_and_immutability(self):
+        plan = compile_gateway_auto_config((inverter(),))
+
+        self.assertEqual(plan.selected_serials, ("CE123456789",))
+        self.assertEqual(plan.arguments["inverter_type"], ("GWMQTT",))
+        self.assertEqual(plan.arguments["num_inverters"], 1)
+        self.assertEqual(
+            plan.arguments["battery_power"],
+            ("sensor.predbat_gateway_456789_battery_power",),
+        )
+        self.assertEqual(
+            plan.arguments["charge_start_time"],
+            ("select.predbat_gateway_456789_charge_slot1_start",),
+        )
+        self.assertIsNone(plan.arguments["pause_mode"])
+        self.assertFalse(plan.arguments["ge_cloud_data"])
+        with self.assertRaises(TypeError):
+            plan.arguments["num_inverters"] = 2
+        legacy = plan.legacy_arguments()
+        self.assertIsInstance(legacy["battery_power"], list)
+
+    def test_multi_direct_inverters_are_serial_stable(self):
+        plan = compile_gateway_auto_config(
+            (inverter("SER-B"), inverter("SER-A")),
+        )
+
+        self.assertEqual(plan.selected_serials, ("SER-A", "SER-B"))
+        self.assertEqual(plan.arguments["num_inverters"], 2)
+        self.assertEqual(
+            plan.arguments["battery_power"],
+            (
+                "sensor.predbat_gateway_ser-a_battery_power",
+                "sensor.predbat_gateway_ser-b_battery_power",
+            ),
+        )
+
+    def test_gateway_coordinator_requires_multiple_aios(self):
+        gateway = inverter(
+            "GW-1",
+            kind="gateway",
+            battery_present=False,
+            battery_capacity_wh=0,
+        )
+        one = compile_gateway_auto_config((gateway, inverter("AIO-1")))
+        two = compile_gateway_auto_config(
+            (gateway, inverter("AIO-1"), inverter("AIO-2")),
+        )
+
+        self.assertEqual(one.selected_serials, ("AIO-1",))
+        self.assertEqual(two.selected_serials, ("GW-1",))
+        self.assertEqual(two.arguments["soc_max"], (None,))
+
+    def test_ems_adds_aggregate_values(self):
+        ems = inverter(
+            "EMS-1",
+            kind="ems",
+            battery_present=False,
+            battery_capacity_wh=0,
+            ems_num_inverters=3,
+        )
+        plan = compile_gateway_auto_config((inverter("AIO-1"), ems))
+
+        self.assertEqual(plan.selected_serials, ("EMS-1",))
+        self.assertEqual(
+            plan.arguments["ems_total_soc"],
+            "sensor.predbat_gateway_ems_total_soc",
+        )
+        self.assertEqual(
+            plan.arguments["idle_start_time"],
+            ("select.predbat_gateway_ems-1_discharge_slot1_start",),
+        )
+
+    def test_filter_primary_fallback_and_hybrid_decision(self):
+        empty_primary = inverter(
+            "EMPTY",
+            primary=True,
+            battery_present=False,
+            battery_capacity_wh=0,
+        )
+        fallback = inverter("FALLBACK", model="All-in-One")
+        plan = compile_gateway_auto_config(
+            (empty_primary, fallback),
+            serial_filter=("fallback",),
+        )
+
+        self.assertEqual(plan.selected_serials, ("FALLBACK",))
+        self.assertFalse(plan.hybrid)
+        with self.assertRaises(GatewayAutoConfigError):
+            compile_gateway_auto_config((fallback,), serial_filter=("missing",))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/predbat/tests/test_gecloud_autoconfig.py
+++ b/apps/predbat/tests/test_gecloud_autoconfig.py
@@ -1,0 +1,149 @@
+# cspell:ignore autoconfig
+"""Tests for the pure GivEnergy Cloud auto-configuration mapper."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from gecloud_autoconfig import (  # noqa: E402
+    GECloudAutoConfigError,
+    GECloudAutoConfigInput,
+    compile_gecloud_auto_config,
+)
+
+
+def config(**overrides):
+    """Build one complete single-battery GE discovery input."""
+    values = {
+        "batteries": ("bat1",),
+        "ems": None,
+        "gateway": None,
+        "pv": (),
+        "battery_meters": (("bat1", ("meter1",)),),
+        "register_names": (
+            (
+                "bat1",
+                (
+                    "battery_charge_power",
+                    "battery_discharge_power",
+                    "battery_reserve_percent_limit",
+                    "ac_charge_upper_percent_limit",
+                    "enable_ac_charge_upper_percent_limit",
+                    "ac_charge_enable",
+                    "enable_dc_discharge",
+                ),
+            ),
+        ),
+        "models": (("bat1", "Hybrid"),),
+        "prefix": "predbat",
+    }
+    values.update(overrides)
+    return GECloudAutoConfigInput(**values)
+
+
+class TestGECloudAutoConfig(unittest.TestCase):
+    """The pure plan preserves current GE policy and argument shapes."""
+
+    def test_single_battery_core_values(self):
+        plan = compile_gecloud_auto_config(config())
+        arguments = plan.legacy_arguments()
+
+        self.assertEqual(arguments["inverter_type"], ["GEC"])
+        self.assertEqual(arguments["num_inverters"], 1)
+        self.assertEqual(
+            arguments["battery_power"],
+            ["sensor.predbat_gecloud_bat1_battery_power"],
+        )
+        self.assertEqual(
+            arguments["charge_rate"],
+            ["number.predbat_gecloud_bat1_battery_charge_power"],
+        )
+        self.assertIsNone(arguments["charge_rate_percent"])
+        self.assertEqual(arguments["ge_cloud_serial"], "bat1")
+        self.assertFalse(plan.ac_coupled)
+
+    def test_percentage_fallback_and_missing_controls(self):
+        plan = compile_gecloud_auto_config(
+            config(
+                register_names=(("bat1", ("inverter_charge_power_percentage",)),),
+            )
+        )
+        arguments = plan.legacy_arguments()
+
+        self.assertIsNone(arguments["charge_rate"])
+        self.assertEqual(
+            arguments["charge_rate_percent"],
+            ["number.predbat_gecloud_bat1_" "inverter_charge_power_percentage"],
+        )
+        self.assertIsNone(arguments["pause_mode"])
+        self.assertIsNone(arguments["discharge_target_soc"])
+
+    def test_gateway_coordinator_and_split_pv(self):
+        plan = compile_gecloud_auto_config(
+            config(
+                batteries=("bat2", "bat1"),
+                gateway="gateway1",
+                pv=("pv1",),
+                split_pv=True,
+                register_names=(("gateway1", ()),),
+            )
+        )
+
+        self.assertEqual(plan.inverter_targets, ("gateway1",))
+        self.assertEqual(plan.pv_sources, ("gateway1", "pv1"))
+        self.assertEqual(plan.legacy_arguments()["num_inverters"], 1)
+        self.assertEqual(
+            len(plan.legacy_arguments()["pv_power"]),
+            2,
+        )
+
+    def test_shared_ct_uses_one_daily_source_and_zero_power_slots(self):
+        plan = compile_gecloud_auto_config(
+            config(
+                batteries=("bat1", "bat2"),
+                battery_meters=(
+                    ("bat1", ("shared",)),
+                    ("bat2", ("shared",)),
+                ),
+                register_names=(("bat1", ()), ("bat2", ())),
+            )
+        )
+        arguments = plan.legacy_arguments()
+
+        self.assertTrue(plan.shared_ct)
+        self.assertEqual(plan.grid_energy_sources, ("bat1",))
+        self.assertEqual(arguments["grid_power"][1], 0)
+        self.assertEqual(len(arguments["import_today"]), 1)
+
+    def test_ems_fans_out_controls_and_aggregate_power(self):
+        plan = compile_gecloud_auto_config(
+            config(
+                batteries=("bat1", "bat2"),
+                ems="ems1",
+                register_names=(("bat1", ()), ("bat2", ())),
+            )
+        )
+        arguments = plan.legacy_arguments()
+
+        self.assertEqual(plan.inverter_targets, ("ems1", "ems1"))
+        self.assertEqual(arguments["inverter_type"], ["GEE", "GEE"])
+        self.assertEqual(
+            arguments["battery_power"],
+            ["sensor.predbat_gecloud_ems1_battery_power", 0],
+        )
+        self.assertEqual(len(arguments["charge_start_time"]), 2)
+        self.assertFalse(arguments["ge_cloud_data"])
+
+    def test_load_today_omission_model_and_empty_input(self):
+        plan = compile_gecloud_auto_config(config(load_today_ignore=True, models=(("bat1", "All-in-One"),)))
+
+        self.assertNotIn("load_today", plan.legacy_arguments())
+        self.assertTrue(plan.ac_coupled)
+        with self.assertRaises(GECloudAutoConfigError):
+            compile_gecloud_auto_config(config(batteries=()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/predbat/tests/test_lattice_gateway_fragment.py
+++ b/apps/predbat/tests/test_lattice_gateway_fragment.py
@@ -1,0 +1,450 @@
+"""Tests for the pure Gateway retained-topology Lattice fragment publisher."""
+
+# cspell:ignore autoconfig
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lattice_autoconfig import (  # noqa: E402
+    AliasRole,
+    CompileStatus,
+    ProviderHealth,
+    compile_auto_config,
+)
+from lattice_compiled_publication import (  # noqa: E402
+    InMemoryCompiledLatticeStateStore,
+)
+from lattice_fragment_adapters import (  # noqa: E402
+    FragmentAdapterReadError,
+    FragmentAdapterRegistry,
+    FragmentAdapterRemoved,
+    InMemoryFragmentAdapterStateStore,
+)
+from lattice_gateway_fragment import (  # noqa: E402
+    GatewayCapabilityProjection,
+    GatewayRetainedTopologyFragmentPublisher,
+    GatewayTopologyProjection,
+)
+from lattice_topology import TopologyValidationError  # noqa: E402
+
+
+def topology(
+    doc_version=1,
+    provider="predbat-gateway",
+    node_id="GW-INV-1",
+    capability="battery.target_soc",
+    online_binding=True,
+):
+    """Build one compact provider-owned retained Gateway fragment."""
+    offer = {
+        "capability": capability,
+        "accessPath": "gateway-mqtt",
+        "ref": 41,
+        "shape": "setpoint",
+        "read": {"protocol": "mqtt", "address": "state"},
+    }
+    if online_binding:
+        offer["control"] = {"protocol": "mqtt", "address": "setpoint"}
+    return {
+        "topologyVersion": "0.3.0",
+        "scope": "fragment",
+        "docVersion": doc_version,
+        "producer": {
+            "name": "PredBat Gateway",
+            "provider": provider,
+            "authority": 10,
+        },
+        "nodes": [
+            {
+                "id": node_id,
+                "kind": "inverter",
+                "attributes": {"serial": node_id},
+                "accessPaths": [
+                    {
+                        "id": "gateway-mqtt",
+                        "provider": provider,
+                        "preference": 10,
+                    }
+                ],
+                "capabilities": [offer],
+            }
+        ],
+    }
+
+
+def publisher(enabled=True, state_store=None):
+    """Build one reference publisher and its in-memory durable store."""
+    if state_store is None:
+        state_store = InMemoryFragmentAdapterStateStore()
+    return (
+        GatewayRetainedTopologyFragmentPublisher(
+            "predbat-gateway",
+            state_store,
+            enabled=enabled,
+        ),
+        state_store,
+    )
+
+
+class TestGatewayRetainedTopologyFragmentPublisher(unittest.TestCase):
+    """Gateway inputs publish immutable, REFERENCE-only provider snapshots."""
+
+    def test_default_off_has_no_discovery_or_durable_side_effect(self):
+        """Disabled construction never parses, publishes, or registers."""
+        adapter, state_store = publisher(enabled=False)
+
+        self.assertIsNone(adapter.lattice_fragment_adapter())
+        self.assertFalse(adapter.ingest_retained_topology(b"{not json"))
+        self.assertFalse(adapter.set_liveness(True))
+        self.assertFalse(adapter.remove())
+        self.assertEqual(state_store.writes, 0)
+        with self.assertRaises(FragmentAdapterReadError):
+            adapter.read_state()
+
+    def test_seeded_store_failure_is_not_hidden_as_absent_discovery(self):
+        """A registered provider read fault fails closed instead of disappearing."""
+
+        class FailingAfterSeedStore(InMemoryFragmentAdapterStateStore):
+            """Make durable reads fail only after a valid seed."""
+
+            def __init__(self):
+                super().__init__()
+                self.fail_reads = False
+
+            def load(self):
+                if self.fail_reads:
+                    raise OSError("durable Gateway fragment unavailable")
+                return super().load()
+
+        state_store = FailingAfterSeedStore()
+        adapter, _state_store = publisher(state_store=state_store)
+        adapter.ingest_retained_topology(topology(), online=True)
+        state_store.fail_reads = True
+
+        with self.assertRaisesRegex(
+            FragmentAdapterReadError,
+            "durable Gateway fragment unavailable",
+        ):
+            adapter.lattice_fragment_adapter()
+        with self.assertRaisesRegex(
+            FragmentAdapterReadError,
+            "durable Gateway fragment unavailable",
+        ):
+            adapter.set_liveness(False)
+
+    def test_retained_topology_publishes_immutable_reference_snapshot(self):
+        """A retained fragment becomes detached provider-local metadata."""
+        adapter, state_store = publisher()
+        document = topology()
+
+        self.assertTrue(adapter.ingest_retained_topology(document, online=True))
+        document["nodes"][0]["id"] = "MUTATED"
+        snapshot = adapter.read_snapshot()
+
+        self.assertIs(adapter.lattice_fragment_adapter(), adapter)
+        self.assertEqual(state_store.writes, 1)
+        self.assertEqual(adapter.generation, 1)
+        self.assertEqual(len(adapter.semantic_fingerprint), 64)
+        self.assertEqual(snapshot.health, ProviderHealth.HEALTHY)
+        self.assertEqual(snapshot.topology_fragment["nodes"][0]["id"], "GW-INV-1")
+        self.assertEqual(snapshot.role_assignments, ())
+        self.assertEqual(snapshot.config_projections, ())
+        self.assertEqual(len(snapshot.aliases), 1)
+        self.assertEqual(snapshot.aliases[0].roles, frozenset((AliasRole.REFERENCE,)))
+        self.assertEqual(
+            tuple((alias.kind, alias.value) for alias in snapshot.identity_aliases),
+            (
+                ("lattice-node-id", "GW-INV-1"),
+                ("serial", "GW-INV-1"),
+            ),
+        )
+
+    def test_projection_metadata_retains_provider_local_capability_coordinates(self):
+        """Projection inspection exposes refs but no materialization authority."""
+        adapter, _state_store = publisher()
+        adapter.ingest_retained_topology(topology(), online=None)
+
+        projection = adapter.projection_metadata
+
+        self.assertIsInstance(projection, GatewayTopologyProjection)
+        self.assertEqual(projection.provider_id, "predbat-gateway")
+        self.assertEqual(projection.health, ProviderHealth.DEGRADED)
+        self.assertEqual(projection.document_version, 1)
+        self.assertEqual(projection.node_ids, ("GW-INV-1",))
+        self.assertEqual(
+            projection.capabilities,
+            (
+                GatewayCapabilityProjection(
+                    node_id="GW-INV-1",
+                    capability="battery.target_soc",
+                    access_path_id="gateway-mqtt",
+                    cap_ref=41,
+                    readable=True,
+                    controllable=True,
+                ),
+            ),
+        )
+
+    def test_projection_metadata_requires_valid_bindings(self):
+        """Malformed binding keys do not claim readable or controllable paths."""
+        adapter, _state_store = publisher()
+        document = topology()
+        offer = document["nodes"][0]["capabilities"][0]
+        offer["read"] = None
+        offer["control"] = {"protocol": "mqtt"}
+
+        adapter.ingest_retained_topology(document, online=True)
+
+        self.assertEqual(
+            adapter.projection_metadata.capabilities,
+            (
+                GatewayCapabilityProjection(
+                    node_id="GW-INV-1",
+                    capability="battery.target_soc",
+                    access_path_id="gateway-mqtt",
+                    cap_ref=41,
+                    readable=False,
+                    controllable=False,
+                ),
+            ),
+        )
+
+    def test_removed_nodes_publish_no_reference_or_projection_metadata(self):
+        """A node tombstone cannot survive as an alias, identity, or capability."""
+        adapter, _state_store = publisher()
+        document = topology()
+        document["nodes"][0]["removed"] = True
+
+        adapter.ingest_retained_topology(document, online=True)
+        snapshot = adapter.read_snapshot()
+        projection = adapter.projection_metadata
+
+        self.assertEqual(snapshot.aliases, ())
+        self.assertEqual(snapshot.identity_aliases, ())
+        self.assertEqual(projection.node_ids, ())
+        self.assertEqual(projection.capabilities, ())
+
+    def test_serial_and_stable_node_id_correlate_mixed_provider_views(self):
+        """A provider with only the stable node id still joins a serial view."""
+        gateway, _gateway_store = publisher()
+        gateway.ingest_retained_topology(topology(), online=True)
+        cloud_document = topology(provider="cloud")
+        del cloud_document["nodes"][0]["attributes"]["serial"]
+        cloud = GatewayRetainedTopologyFragmentPublisher(
+            "cloud",
+            InMemoryFragmentAdapterStateStore(),
+            enabled=True,
+        )
+        cloud.ingest_retained_topology(cloud_document, online=True)
+
+        plan = compile_auto_config(
+            (
+                gateway.read_snapshot(),
+                cloud.read_snapshot(),
+            )
+        )
+
+        self.assertEqual(len(plan.topology["nodes"]), 1)
+        self.assertEqual(plan.topology["nodes"][0]["id"], "identity:serial:GW-INV-1")
+
+    def test_retained_topology_version_matrix_is_explicit(self):
+        """Retained topology stays on v0.2/v0.3 while v0.4 remains separate."""
+        for version in ("0.2.0", "0.3.0"):
+            with self.subTest(version=version):
+                adapter, _state_store = publisher()
+                document = topology()
+                document["topologyVersion"] = version
+                if version == "0.2.0":
+                    del document["docVersion"]
+                self.assertTrue(adapter.ingest_retained_topology(document))
+
+        adapter, _state_store = publisher()
+        document = topology()
+        document["topologyVersion"] = "0.4.0"
+        with self.assertRaisesRegex(
+            TopologyValidationError,
+            "unsupported topologyVersion '0.4.0'",
+        ):
+            adapter.ingest_retained_topology(document)
+
+    def test_topology_and_liveness_changes_invalidate_for_fresh_recompile(self):
+        """Every accepted input change notifies the common registry compiler."""
+        adapter, _state_store = publisher()
+        adapter.ingest_retained_topology(topology(), online=True)
+        registry = FragmentAdapterRegistry(enabled=True)
+        self.assertEqual(registry.discover((adapter,)), ("predbat-gateway",))
+        compiler = registry.create_compiler(
+            InMemoryCompiledLatticeStateStore(),
+        )
+        first = compiler.drain()
+        self.assertEqual(first.status, CompileStatus.FRESH)
+        plan = first.publication.plan
+        self.assertFalse(plan.materialization_readiness.ready)
+        self.assertEqual(plan.role_assignments, ())
+        self.assertEqual(plan.primary_targets, ())
+        self.assertEqual(plan.control_targets, ())
+        self.assertEqual(plan.config_arguments, ())
+        self.assertEqual(dict(plan.projected_config), {})
+
+        self.assertTrue(adapter.set_liveness(False))
+        offline = compiler.drain()
+        self.assertEqual(offline.status, CompileStatus.STALE)
+        self.assertTrue(offline.pending)
+        self.assertEqual(offline.publication, first.publication)
+        self.assertEqual(adapter.generation, 2)
+
+        self.assertTrue(
+            adapter.ingest_retained_topology(
+                topology(doc_version=2, capability="battery.charge_power_limit"),
+                online=True,
+            )
+        )
+        changed = compiler.drain()
+        self.assertEqual(changed.status, CompileStatus.FRESH)
+        self.assertEqual(
+            changed.publication.provider_generations,
+            (("predbat-gateway", 3),),
+        )
+
+    def test_duplicate_stale_and_reused_versions_do_not_recompile(self):
+        """Retained replay is idempotent and explicit generations fail closed."""
+        adapter, state_store = publisher()
+        reasons = []
+        adapter.subscribe_invalidation(lambda provider_id, generation, reason, feedback_token: reasons.append((provider_id, generation, reason, feedback_token)))
+        first = topology(doc_version=5)
+        adapter.ingest_retained_topology(first, online=True)
+
+        self.assertFalse(adapter.ingest_retained_topology(first, online=True))
+        self.assertFalse(
+            adapter.ingest_retained_topology(
+                topology(doc_version=4),
+                online=True,
+            )
+        )
+        with self.assertRaisesRegex(TopologyValidationError, "reused docVersion"):
+            adapter.ingest_retained_topology(
+                topology(doc_version=5, capability="battery.charge_power_limit"),
+                online=True,
+            )
+        self.assertEqual(adapter.generation, 1)
+        self.assertEqual(state_store.writes, 1)
+        self.assertEqual(len(reasons), 1)
+
+    def test_legacy_retained_changes_use_adapter_owned_monotonic_generation(self):
+        """Unversioned v0.2 arrival changes remain monotonic and replay-safe."""
+        adapter, _state_store = publisher()
+        first = topology(doc_version=1)
+        second = topology(doc_version=1, capability="battery.charge_power_limit")
+        for document in (first, second):
+            document["topologyVersion"] = "0.2.0"
+            del document["docVersion"]
+
+        self.assertTrue(adapter.ingest_retained_topology(first, online=True))
+        self.assertFalse(adapter.ingest_retained_topology(first, online=True))
+        self.assertTrue(adapter.ingest_retained_topology(second, online=True))
+        self.assertEqual(adapter.generation, 2)
+        self.assertEqual(adapter.projection_metadata.document_version, 0)
+
+    def test_invalid_or_foreign_fragment_preserves_durable_state(self):
+        """Malformed ownership and site documents cannot replace good state."""
+        adapter, state_store = publisher()
+        adapter.ingest_retained_topology(topology(), online=True)
+        before = adapter.read_state()
+
+        with self.assertRaisesRegex(TopologyValidationError, "owned by cloud"):
+            adapter.ingest_retained_topology(
+                topology(doc_version=2, provider="cloud"),
+                online=True,
+            )
+        site = topology(doc_version=2)
+        site["scope"] = "site"
+        with self.assertRaisesRegex(TopologyValidationError, "scope"):
+            adapter.ingest_retained_topology(site, online=True)
+
+        self.assertEqual(adapter.read_state(), before)
+        self.assertEqual(state_store.writes, 1)
+
+    def test_liveness_is_independent_idempotent_and_requires_topology(self):
+        """LWT health changes preserve exact topology and skip duplicates."""
+        unseeded, _store = publisher()
+        with self.assertRaisesRegex(FragmentAdapterReadError, "seeded"):
+            unseeded.set_liveness(True)
+
+        adapter, state_store = publisher()
+        adapter.ingest_retained_topology(topology(), online=None)
+        before_fragment = adapter.read_snapshot().topology_fragment
+
+        self.assertTrue(adapter.set_liveness(True))
+        self.assertFalse(adapter.set_liveness(True))
+        self.assertTrue(adapter.set_liveness(False))
+        self.assertEqual(adapter.read_snapshot().health, ProviderHealth.OFFLINE)
+        self.assertEqual(adapter.read_snapshot().topology_fragment, before_fragment)
+        self.assertEqual(adapter.generation, 3)
+        self.assertEqual(state_store.writes, 3)
+
+    def test_topology_change_without_liveness_preserves_current_health(self):
+        """An independent retained update does not invent a liveness change."""
+        adapter, _state_store = publisher()
+        adapter.ingest_retained_topology(topology(), online=True)
+
+        adapter.ingest_retained_topology(
+            topology(
+                doc_version=2,
+                capability="battery.charge_power_limit",
+            )
+        )
+
+        self.assertEqual(adapter.read_snapshot().health, ProviderHealth.HEALTHY)
+        self.assertEqual(adapter.generation, 2)
+
+    def test_removal_is_durable_invalidating_and_restart_visible(self):
+        """Integration removal publishes a tombstone rather than disappearing."""
+        adapter, state_store = publisher()
+        adapter.ingest_retained_topology(topology(), online=True)
+        invalidations = []
+        adapter.subscribe_invalidation(lambda provider_id, generation, reason, feedback_token: invalidations.append((provider_id, generation, reason)))
+
+        self.assertTrue(adapter.remove())
+        self.assertFalse(adapter.remove())
+        self.assertTrue(adapter.read_state().removed)
+        self.assertTrue(adapter.projection_metadata.removed)
+        with self.assertRaises(FragmentAdapterRemoved):
+            adapter.read_snapshot()
+        self.assertEqual(
+            invalidations[-1],
+            ("predbat-gateway", 2, "gateway integration removed"),
+        )
+
+        restarted = GatewayRetainedTopologyFragmentPublisher(
+            "predbat-gateway",
+            state_store,
+            enabled=True,
+        )
+        self.assertTrue(restarted.read_state().removed)
+        self.assertTrue(restarted.projection_metadata.removed)
+        with self.assertRaises(FragmentAdapterRemoved):
+            restarted.read_snapshot()
+
+    def test_removal_cannot_be_reversed_by_retained_replay(self):
+        """Ambient retained topology cannot re-enrol a removed integration."""
+        adapter, state_store = publisher()
+        adapter.ingest_retained_topology(topology(doc_version=5), online=True)
+        adapter.remove()
+        before = adapter.read_state()
+
+        with self.assertRaisesRegex(
+            FragmentAdapterRemoved,
+            "retained topology cannot re-enrol",
+        ):
+            adapter.ingest_retained_topology(topology(doc_version=1), online=True)
+
+        self.assertEqual(adapter.read_state(), before)
+        self.assertTrue(adapter.read_state().removed)
+        self.assertEqual(state_store.writes, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/predbat/tests/test_lattice_gateway_fragment.py
+++ b/apps/predbat/tests/test_lattice_gateway_fragment.py
@@ -1,6 +1,6 @@
 """Tests for the pure Gateway retained-topology Lattice fragment publisher."""
 
-# cspell:ignore autoconfig
+# cspell:ignore autoconfig materializable
 
 import os
 import sys
@@ -29,6 +29,7 @@ from lattice_gateway_fragment import (  # noqa: E402
     GatewayTopologyProjection,
 )
 from lattice_topology import TopologyValidationError  # noqa: E402
+from gateway_autoconfig import compile_gateway_auto_config  # noqa: E402
 
 
 def topology(
@@ -160,6 +161,39 @@ class TestGatewayRetainedTopologyFragmentPublisher(unittest.TestCase):
                 ("lattice-node-id", "GW-INV-1"),
                 ("serial", "GW-INV-1"),
             ),
+        )
+
+    def test_pure_plan_publishes_materializable_roles_and_config(self):
+        """A plan generation compiles real Gateway PredBat arguments."""
+        adapter, _state_store = publisher()
+        adapter.ingest_retained_topology(topology(), online=True)
+        plan = compile_gateway_auto_config(
+            (
+                {
+                    "serial": "GW-INV-1",
+                    "kind": "inverter",
+                    "battery_present": True,
+                    "battery_capacity_wh": 9600,
+                },
+            )
+        )
+
+        self.assertTrue(adapter.ingest_auto_config(plan))
+        snapshot = adapter.read_snapshot()
+        compiled = compile_auto_config((snapshot,))
+
+        self.assertTrue(snapshot.role_assignments)
+        self.assertTrue(snapshot.config_projections)
+        self.assertEqual(compiled.primary_targets[0].index, 0)
+        self.assertEqual(compiled.control_targets[0].index, 0)
+        self.assertEqual(compiled.projected_config["num_inverters"], 1)
+        self.assertEqual(
+            compiled.projected_config["battery_power"],
+            ("sensor.predbat_gateway_-inv-1_battery_power",),
+        )
+        self.assertEqual(
+            snapshot.identity_aliases[-1].value,
+            "GW-INV-1",
         )
 
     def test_projection_metadata_retains_provider_local_capability_coordinates(self):

--- a/apps/predbat/tests/test_lattice_gateway_ge_composition.py
+++ b/apps/predbat/tests/test_lattice_gateway_ge_composition.py
@@ -1,0 +1,165 @@
+# cspell:ignore autoconfig
+"""Cross-provider tests for Gateway and GE Cloud auto-config fragments."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from gateway_autoconfig import compile_gateway_auto_config  # noqa: E402
+from gecloud_autoconfig import GECloudAutoConfigInput  # noqa: E402
+from lattice_autoconfig import (  # noqa: E402
+    LatticeAutoConfigCompiler,
+    compile_auto_config,
+)
+from lattice_fragment_adapters import (  # noqa: E402
+    InMemoryFragmentAdapterStateStore,
+)
+from lattice_gateway_fragment import (  # noqa: E402
+    GatewayRetainedTopologyFragmentPublisher,
+)
+from lattice_ge_cloud_fragment import (  # noqa: E402
+    GECloudDeviceSnapshot,
+    GECloudFragmentPublisher,
+)
+
+
+def gateway_topology(serial):
+    """Build one provider-owned retained topology fragment."""
+    return {
+        "topologyVersion": "0.3.0",
+        "scope": "fragment",
+        "docVersion": 1,
+        "producer": {
+            "name": "PredBat Gateway",
+            "provider": "predbat-gateway",
+            "authority": 10,
+        },
+        "nodes": [
+            {
+                "id": "gateway-inverter",
+                "kind": "inverter",
+                "attributes": {"serial": serial.lower()},
+                "accessPaths": [
+                    {
+                        "id": "gateway-mqtt",
+                        "provider": "predbat-gateway",
+                        "preference": 10,
+                    }
+                ],
+                "capabilities": [],
+            }
+        ],
+    }
+
+
+def ge_config(serial):
+    """Build one complete single-inverter cloud mapping input."""
+    return GECloudAutoConfigInput(
+        batteries=(serial.lower(),),
+        ems=None,
+        gateway=None,
+        pv=(),
+        battery_meters=((serial.lower(), ("meter1",)),),
+        register_names=(
+            (
+                serial.lower(),
+                (
+                    "battery_charge_power",
+                    "battery_discharge_power",
+                    "battery_reserve_percent_limit",
+                ),
+            ),
+        ),
+        models=((serial.lower(), "Hybrid"),),
+        prefix="predbat",
+    )
+
+
+class TestGatewayGEComposition(unittest.TestCase):
+    """Local Gateway candidates outrank correlated cloud candidates."""
+
+    def test_gateway_wins_and_cloud_takes_over_when_gateway_offline(self):
+        serial = "SER123"
+        gateway = GatewayRetainedTopologyFragmentPublisher(
+            "predbat-gateway",
+            InMemoryFragmentAdapterStateStore(),
+            enabled=True,
+        )
+        gateway.ingest_retained_topology(
+            gateway_topology(serial),
+            online=True,
+        )
+        gateway.ingest_auto_config(
+            compile_gateway_auto_config(
+                (
+                    {
+                        "serial": serial,
+                        "kind": "inverter",
+                        "battery_present": True,
+                        "battery_capacity_wh": 9600,
+                        "model": "Hybrid",
+                    },
+                )
+            )
+        )
+
+        cloud = GECloudFragmentPublisher(
+            "ge-cloud",
+            InMemoryFragmentAdapterStateStore(),
+            enabled=True,
+        )
+        cloud.ingest_discovery(
+            1,
+            (
+                GECloudDeviceSnapshot(
+                    serial=serial.lower(),
+                    kind="battery-inverter",
+                    model="Hybrid",
+                    online=True,
+                ),
+            ),
+            health=True,
+        )
+        cloud.ingest_auto_config(ge_config(serial))
+
+        compiled = compile_auto_config((gateway.read_snapshot(), cloud.read_snapshot()))
+        battery_power = next(item for item in compiled.config_arguments if item.name == "battery_power")
+
+        self.assertEqual(
+            compiled.projected_config["battery_power"],
+            ("sensor.predbat_gateway_ser123_battery_power",),
+        )
+        self.assertEqual(
+            {candidate.provider_id for candidate in battery_power.candidates},
+            {"predbat-gateway", "ge-cloud"},
+        )
+        self.assertEqual(
+            len(tuple(target for target in compiled.primary_targets if target.group == "inverters")),
+            1,
+        )
+        self.assertEqual(
+            len(tuple(target for target in compiled.control_targets if target.group == "inverters")),
+            1,
+        )
+
+        gateway.set_liveness(False)
+        fallback = (
+            LatticeAutoConfigCompiler(
+                {
+                    "predbat-gateway": gateway.read_snapshot,
+                    "ge-cloud": cloud.read_snapshot,
+                }
+            )
+            .drain()
+            .plan
+        )
+        self.assertEqual(
+            fallback.projected_config["battery_power"],
+            ("sensor.predbat_gecloud_ser123_battery_power",),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/predbat/tests/test_lattice_ge_cloud_fragment.py
+++ b/apps/predbat/tests/test_lattice_ge_cloud_fragment.py
@@ -1,0 +1,393 @@
+"""Tests for the pure GivEnergy Cloud Lattice fragment publisher."""
+
+# cspell:ignore autoconfig
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lattice_autoconfig import (  # noqa: E402
+    AliasRole,
+    CompileStatus,
+    ProviderHealth,
+    compile_auto_config,
+)
+from lattice_compiled_publication import (  # noqa: E402
+    InMemoryCompiledLatticeStateStore,
+)
+from lattice_fragment_adapters import (  # noqa: E402
+    FragmentAdapterConflict,
+    FragmentAdapterReadError,
+    FragmentAdapterRegistry,
+    FragmentAdapterRemoved,
+    InMemoryFragmentAdapterStateStore,
+)
+from lattice_gateway_fragment import (  # noqa: E402
+    GatewayRetainedTopologyFragmentPublisher,
+)
+from lattice_ge_cloud_fragment import (  # noqa: E402
+    GECloudDeviceSnapshot,
+    GECloudFragmentPublisher,
+)
+
+
+def device(
+    serial="SA2243G277",
+    kind="battery-inverter",
+    online=True,
+    model="All-In-One",
+    site_id=61435,
+    uuid=None,
+):
+    """Build one explicit provider-local cloud device snapshot."""
+    return GECloudDeviceSnapshot(
+        serial=serial,
+        kind=kind,
+        online=online,
+        model=model,
+        site_id=site_id,
+        uuid=uuid,
+    )
+
+
+def publisher(enabled=True, state_store=None, provider_id="ge-cloud"):
+    """Build one reference publisher and its in-memory durable store."""
+    if state_store is None:
+        state_store = InMemoryFragmentAdapterStateStore()
+    return (
+        GECloudFragmentPublisher(
+            provider_id,
+            state_store,
+            enabled=enabled,
+        ),
+        state_store,
+    )
+
+
+def gateway_topology(serial="SA2243G277", doc_version=1):
+    """Build a compact Gateway view of the same physical inverter."""
+    return {
+        "topologyVersion": "0.3.0",
+        "scope": "fragment",
+        "docVersion": doc_version,
+        "producer": {
+            "name": "PredBat Gateway",
+            "provider": "predbat-gateway",
+            "authority": 10,
+        },
+        "nodes": [
+            {
+                "id": "gateway-inverter",
+                "kind": "inverter",
+                "attributes": {"serial": serial},
+                "accessPaths": [
+                    {
+                        "id": "gateway-mqtt",
+                        "provider": "predbat-gateway",
+                        "preference": 10,
+                    }
+                ],
+                "capabilities": [],
+            }
+        ],
+    }
+
+
+class TestGECloudFragmentPublisher(unittest.TestCase):
+    """Cloud discovery publishes immutable, REFERENCE-only snapshots."""
+
+    def test_default_off_has_no_discovery_or_durable_side_effect(self):
+        """Disabled construction never validates, publishes, or registers."""
+        adapter, state_store = publisher(enabled=False)
+
+        self.assertIsNone(adapter.lattice_fragment_adapter())
+        self.assertFalse(adapter.ingest_discovery(-1, (object(),)))
+        self.assertFalse(adapter.set_liveness(True))
+        self.assertFalse(adapter.remove())
+        self.assertEqual(state_store.writes, 0)
+        with self.assertRaises(FragmentAdapterReadError):
+            adapter.read_state()
+
+    def test_discovery_publishes_immutable_reference_only_snapshot(self):
+        """Explicit device state is detached and carries no write authority."""
+        adapter, state_store = publisher()
+        devices = [
+            device(serial="sa2243g277"),
+            device(
+                serial="evc-1",
+                kind="ev-charger",
+                online=None,
+                model="EVC",
+                uuid="evc-uuid-1",
+            ),
+        ]
+
+        self.assertTrue(
+            adapter.ingest_discovery(
+                7,
+                devices,
+                health=ProviderHealth.HEALTHY,
+            )
+        )
+        devices.append(device(serial="MUTATED"))
+        snapshot = adapter.read_snapshot()
+        nodes = snapshot.topology_fragment["nodes"]
+
+        self.assertIs(adapter.lattice_fragment_adapter(), adapter)
+        self.assertEqual(state_store.writes, 1)
+        self.assertEqual(adapter.generation, 1)
+        self.assertEqual(adapter.discovery_version, 7)
+        self.assertEqual(len(adapter.semantic_fingerprint), 64)
+        self.assertEqual(snapshot.health, ProviderHealth.HEALTHY)
+        self.assertEqual(nodes[1]["attributes"]["siteId"], "61435")
+        self.assertEqual(
+            tuple(node["id"] for node in nodes),
+            ("ge-cloud:EVC-1", "ge-cloud:SA2243G277"),
+        )
+        self.assertEqual(snapshot.role_assignments, ())
+        self.assertEqual(snapshot.config_projections, ())
+        self.assertTrue(all(alias.roles == frozenset((AliasRole.REFERENCE,)) for alias in snapshot.aliases))
+        self.assertTrue(all(node["capabilities"] == () for node in nodes))
+        self.assertEqual(
+            tuple((alias.kind, alias.value, alias.node_id) for alias in snapshot.identity_aliases),
+            (
+                ("ge-cloud-uuid", "evc-uuid-1", "ge-cloud:EVC-1"),
+                ("serial", "EVC-1", "ge-cloud:EVC-1"),
+                ("serial", "SA2243G277", "ge-cloud:SA2243G277"),
+            ),
+        )
+
+    def test_device_order_and_serial_case_are_replay_stable(self):
+        """Equivalent provider snapshots do not invent new generations."""
+        adapter, state_store = publisher()
+        first = (
+            device(serial="inv-2", kind="pv-inverter"),
+            device(serial="inv-1"),
+        )
+        replay = (
+            device(serial="INV-1"),
+            device(serial="INV-2", kind="pv_inverter"),
+        )
+
+        self.assertTrue(adapter.ingest_discovery(3, first, health=True))
+        self.assertFalse(adapter.ingest_discovery(3, replay, health=True))
+        self.assertEqual(adapter.generation, 1)
+        self.assertEqual(state_store.writes, 1)
+
+    def test_versions_are_monotonic_and_reuse_collision_fails_closed(self):
+        """Stale replay is ignored and same-version content reuse is rejected."""
+        adapter, state_store = publisher()
+        adapter.ingest_discovery(5, (device(),), health=True)
+        before = adapter.read_state()
+
+        self.assertFalse(
+            adapter.ingest_discovery(
+                4,
+                (device(model="Newer-looking stale data"),),
+                health=False,
+            )
+        )
+        with self.assertRaisesRegex(
+            FragmentAdapterConflict,
+            "reused GE Cloud discovery version 5",
+        ):
+            adapter.ingest_discovery(
+                5,
+                (device(model="Different"),),
+            )
+
+        self.assertEqual(adapter.read_state(), before)
+        self.assertEqual(state_store.writes, 1)
+
+    def test_serial_and_uuid_collisions_fail_before_publication(self):
+        """Ambiguous strong identities cannot enter durable provider state."""
+        adapter, state_store = publisher()
+
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            adapter.ingest_discovery(1, ())
+        with self.assertRaisesRegex(ValueError, "online"):
+            device(online=1)
+        with self.assertRaisesRegex(
+            FragmentAdapterConflict,
+            "duplicate serial SA2243G277",
+        ):
+            adapter.ingest_discovery(
+                1,
+                (device(), device(serial="sa2243g277")),
+            )
+        with self.assertRaisesRegex(
+            FragmentAdapterConflict,
+            "belongs to both INV-1 and INV-2",
+        ):
+            adapter.ingest_discovery(
+                1,
+                (
+                    device(serial="INV-1", uuid="shared-uuid"),
+                    device(serial="INV-2", uuid="shared-uuid"),
+                ),
+            )
+
+        self.assertEqual(state_store.writes, 0)
+        with self.assertRaises(FragmentAdapterReadError):
+            adapter.read_state()
+
+    def test_discovery_and_liveness_changes_trigger_fresh_read_composition(self):
+        """Every accepted integration change invalidates the common compiler."""
+        adapter, _state_store = publisher()
+        adapter.ingest_discovery(1, (device(),), health=True)
+        reasons = []
+        adapter.subscribe_invalidation(
+            lambda provider_id, generation, reason, feedback_token: reasons.append(
+                (provider_id, generation, reason, feedback_token),
+            )
+        )
+        registry = FragmentAdapterRegistry(enabled=True)
+        self.assertEqual(registry.discover((adapter,)), ("ge-cloud",))
+        compiler = registry.create_compiler(
+            InMemoryCompiledLatticeStateStore(),
+        )
+
+        first = compiler.drain()
+        self.assertEqual(first.status, CompileStatus.FRESH)
+        self.assertEqual(
+            first.publication.provider_generations,
+            (("ge-cloud", 1),),
+        )
+
+        self.assertTrue(
+            adapter.ingest_discovery(
+                2,
+                (
+                    device(),
+                    device(serial="PV-1", kind="pv-inverter"),
+                ),
+            )
+        )
+        changed = compiler.drain()
+        self.assertEqual(changed.status, CompileStatus.FRESH)
+        self.assertEqual(
+            changed.publication.provider_generations,
+            (("ge-cloud", 2),),
+        )
+        self.assertEqual(
+            tuple(node["id"] for node in changed.publication.plan.topology["nodes"]),
+            ("identity:serial:PV-1", "identity:serial:SA2243G277"),
+        )
+
+        self.assertTrue(adapter.set_liveness(False))
+        offline = compiler.drain()
+        self.assertEqual(offline.status, CompileStatus.STALE)
+        self.assertTrue(offline.pending)
+        self.assertEqual(adapter.generation, 3)
+        self.assertEqual(
+            tuple(reasons),
+            (
+                (
+                    "ge-cloud",
+                    2,
+                    "GE Cloud discovery changed to version 2",
+                    None,
+                ),
+                (
+                    "ge-cloud",
+                    3,
+                    "GE Cloud liveness changed to offline",
+                    None,
+                ),
+            ),
+        )
+
+    def test_liveness_is_independent_monotonic_and_preserves_topology(self):
+        """Provider health changes retain exact discovery contents."""
+        adapter, state_store = publisher()
+        with self.assertRaisesRegex(FragmentAdapterReadError, "seeded"):
+            adapter.set_liveness(True)
+        adapter.ingest_discovery(1, (device(),))
+        topology = adapter.read_snapshot().topology_fragment
+
+        self.assertTrue(adapter.set_liveness(True))
+        self.assertFalse(adapter.set_liveness(True))
+        self.assertTrue(adapter.set_liveness(None))
+        self.assertEqual(adapter.read_snapshot().health, ProviderHealth.DEGRADED)
+        self.assertEqual(adapter.read_snapshot().topology_fragment, topology)
+        self.assertEqual(adapter.generation, 3)
+        self.assertEqual(state_store.writes, 3)
+
+    def test_serial_identity_composes_with_gateway_without_materialization(self):
+        """Cloud and Gateway references join without creating control roles."""
+        cloud, _cloud_store = publisher()
+        cloud.ingest_discovery(1, (device(),), health=True)
+        gateway = GatewayRetainedTopologyFragmentPublisher(
+            "predbat-gateway",
+            InMemoryFragmentAdapterStateStore(),
+            enabled=True,
+        )
+        gateway.ingest_retained_topology(
+            gateway_topology(),
+            online=True,
+        )
+
+        plan = compile_auto_config(
+            (
+                gateway.read_snapshot(),
+                cloud.read_snapshot(),
+            )
+        )
+
+        self.assertEqual(len(plan.topology["nodes"]), 1)
+        self.assertEqual(
+            plan.topology["nodes"][0]["id"],
+            "identity:serial:SA2243G277",
+        )
+        self.assertEqual(
+            plan.provider_generations,
+            (("ge-cloud", 1), ("predbat-gateway", 1)),
+        )
+        self.assertEqual(plan.role_assignments, ())
+        self.assertEqual(plan.primary_targets, ())
+        self.assertEqual(plan.control_targets, ())
+        self.assertEqual(plan.config_arguments, ())
+        self.assertEqual(dict(plan.projected_config), {})
+        self.assertFalse(plan.materialization_readiness.ready)
+
+    def test_removal_is_durable_invalidating_and_irreversible_by_replay(self):
+        """Ordinary discovery replay cannot re-enrol a removed integration."""
+        adapter, state_store = publisher()
+        adapter.ingest_discovery(5, (device(),), health=True)
+        invalidations = []
+        adapter.subscribe_invalidation(lambda provider_id, generation, reason, feedback_token: (invalidations.append((provider_id, generation, reason))))
+
+        self.assertTrue(adapter.remove())
+        self.assertFalse(adapter.remove())
+        before = adapter.read_state()
+        self.assertTrue(before.removed)
+        with self.assertRaises(FragmentAdapterRemoved):
+            adapter.read_snapshot()
+        with self.assertRaisesRegex(
+            FragmentAdapterRemoved,
+            "discovery cannot re-enrol",
+        ):
+            adapter.ingest_discovery(1, (device(),), health=True)
+        self.assertEqual(adapter.read_state(), before)
+        self.assertEqual(state_store.writes, 2)
+        self.assertEqual(
+            invalidations[-1],
+            ("ge-cloud", 2, "GE Cloud integration removed"),
+        )
+
+        restarted = GECloudFragmentPublisher(
+            "ge-cloud",
+            state_store,
+            enabled=True,
+        )
+        self.assertTrue(restarted.read_state().removed)
+        with self.assertRaises(FragmentAdapterRemoved):
+            restarted.read_snapshot()
+        with self.assertRaises(FragmentAdapterRemoved):
+            restarted.ingest_discovery(99, (device(),))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/predbat/tests/test_lattice_ge_cloud_fragment.py
+++ b/apps/predbat/tests/test_lattice_ge_cloud_fragment.py
@@ -1,6 +1,6 @@
 """Tests for the pure GivEnergy Cloud Lattice fragment publisher."""
 
-# cspell:ignore autoconfig
+# cspell:ignore autoconfig materializable
 
 import os
 import sys
@@ -31,6 +31,7 @@ from lattice_ge_cloud_fragment import (  # noqa: E402
     GECloudDeviceSnapshot,
     GECloudFragmentPublisher,
 )
+from gecloud_autoconfig import GECloudAutoConfigInput  # noqa: E402
 
 
 def device(
@@ -157,6 +158,51 @@ class TestGECloudFragmentPublisher(unittest.TestCase):
                 ("serial", "EVC-1", "ge-cloud:EVC-1"),
                 ("serial", "SA2243G277", "ge-cloud:SA2243G277"),
             ),
+        )
+
+    def test_pure_plan_publishes_materializable_roles_and_config(self):
+        """A complete GE input compiles real PredBat arguments."""
+        adapter, _state_store = publisher()
+        adapter.ingest_discovery(
+            1,
+            (device(serial="bat1", model="Hybrid"),),
+            health=ProviderHealth.HEALTHY,
+        )
+        config = GECloudAutoConfigInput(
+            batteries=("bat1",),
+            ems=None,
+            gateway=None,
+            pv=(),
+            battery_meters=(("bat1", ("meter1",)),),
+            register_names=(
+                (
+                    "bat1",
+                    (
+                        "battery_charge_power",
+                        "battery_discharge_power",
+                        "battery_reserve_percent_limit",
+                    ),
+                ),
+            ),
+            models=(("bat1", "Hybrid"),),
+            prefix="predbat",
+        )
+
+        self.assertTrue(adapter.ingest_auto_config(config))
+        self.assertFalse(adapter.ingest_auto_config(config))
+        snapshot = adapter.read_snapshot()
+        compiled = compile_auto_config((snapshot,))
+
+        self.assertTrue(snapshot.role_assignments)
+        self.assertTrue(snapshot.config_projections)
+        self.assertEqual(compiled.projected_config["num_inverters"], 1)
+        self.assertEqual(
+            compiled.projected_config["battery_power"],
+            ("sensor.predbat_gecloud_bat1_battery_power",),
+        )
+        self.assertEqual(
+            compiled.projected_config["charge_rate"],
+            ("number.predbat_gecloud_bat1_battery_charge_power",),
         )
 
     def test_device_order_and_serial_case_are_replay_stable(self):


### PR DESCRIPTION
Stacked on #4444.

## What this adds

- pure, side-effect-free mappers for the existing Gateway and GivEnergy Cloud automatic-configuration policies
- materializable Lattice roles and config projections from both fragment publishers
- stable mixed-case serial correlation across Gateway and cloud views
- deterministic preference for the more-specific local Gateway source, with GE Cloud fallback when the Gateway fragment is offline
- durable invalidation/generation behavior preserved through topology and liveness changes

## Safety boundary

This PR remains default-off and does not register either publisher with the live PredBat runtime. It does not mutate `self.args`, gate the existing automatic-config writers, or activate control. Those live adapters, atomic materialization, precedence rules, restart behavior, and feature flag are the next stacked PR.

Current fail-closed boundary: Gateway EMS plans are not materialized because the legacy Gateway EMS shape collapses multiple batteries into one slot while the shared compiler models the coordinator and leaves explicitly. Multiple independent EMS islands are also outside this tranche.

## Validation

- 143 focused Gateway/GE/Lattice tests pass
- all pre-commit hooks pass
- GitNexus comparison: 9 changed files, MEDIUM breadth, one affected flow; the flow is entirely new additive GE fragment ingestion and does not enter an existing live runtime path

Immediate product focus remains the XIAO/Gateway path. Broader intent-control and arbitrary-provider arbitration remain parked behind runtime auto-configuration delivery.