### PR TITLE
docs(solis): note that the inverter's own timezone must match Predbat's

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -666,6 +666,7 @@ Integrates with Solis inverters for monitoring and controlling Solis battery sys
     - Leave `soc_max` unset and allow Predbat to automatically detect battery size from historical charging data (requires several days of data)
 - Supports both V1 (older firmware) and V2 (newer firmware) time window formats
 - Automatic configuration available - sets up all required Predbat sensors automatically
+- **Inverter timezone must match Predbat's `timezone` setting**: charge/discharge slot times are written to the inverter as plain `HH:MM` values with no timezone attached. The inverter interprets these using its own configured timezone, not Predbat's. If your inverter's timezone is set to UTC (or anything other than Predbat's `timezone`, `Europe/London` by default), the resulting charge/discharge windows will be offset by the difference - for example, a full hour out whenever British Summer Time is in effect. Set the inverter's own timezone to match Predbat's `timezone` setting to avoid this.
 
 #### Configuration Options (solis)
 


### PR DESCRIPTION
## Summary
- Charge/discharge slot times are written to the Solis inverter as plain `HH:MM` values with no timezone attached, so the inverter interprets them using its own configured timezone rather than Predbat's.
- A mismatch (e.g. inverter left on UTC while Predbat runs `Europe/London`) shifts the resulting charge/discharge windows by the difference - most visibly a full hour out whenever BST is in effect.
- Documents the requirement that the inverter's own timezone be set to match Predbat's `timezone` setting.

Ref: #4448

## Test plan
- [x] Docs-only change, `mkdocs.yml` unaffected (existing page)
- [x] `./run_pre_commit` passes (markdownlint, cspell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)