### PR TITLE
Sigenergy: let Axle keep the inverter during its events (option B for #4454)

### DIFF
--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -309,6 +309,7 @@ class SigenergyAPI(ComponentBase):
         self.history_totals = {}  # systemId → {sankey node id: lifetime kWh total}
         self.mqtt_period_raw = {}  # systemId → merged raw 'period' fields (MQTT only sends fields that changed)
         self.current_mode = {}    # systemId → energyStorageOperationMode int
+        self._axle_standoff_logged = {}  # systemId → True while the Axle stand-down has been announced
         self.onboard_status = {}  # systemId → onboarding status string (published for the SaaS UI)
 
         # Age (datetime of last update) of each SIGENERGY_CACHE_KEYS category, used to avoid an
@@ -2161,12 +2162,33 @@ class SigenergyAPI(ComponentBase):
     # VPP registration management
     # -----------------------------------------------------------------------
 
+    def _axle_has_control(self):
+        """Return True while Predbat has stood down for an active Axle VPP event.
+
+        Predbat sets ``set_read_only_axle`` in Fetch.fetch_config_options() when the
+        ``axle_control`` option is enabled and the Axle event sensor is on. That flag is
+        the signal that Axle — not Predbat — is driving the battery for the duration of
+        the event, so this component must leave the inverter alone rather than pulling it
+        back into VPP mode and cutting across Axle's NBI dispatch.
+
+        Read defensively: unit tests build the component without a ComponentBase parent.
+
+        Returns:
+            True if an Axle event currently owns the inverter, False otherwise.
+        """
+        return bool(getattr(getattr(self, "base", None), "set_read_only_axle", False))
+
     async def _manage_vpp_registration(self, system_id, is_readonly, is_offboard=False):
         """Align the operating mode with the read-only and offboard switch settings.
 
         Assumes the system is already visible in self.systems (i.e. onboarded).
         Onboarding of missing systems is handled separately by the missing_ids
         block in run().
+
+        An active Axle event takes priority over every case below: Predbat stands down
+        and leaves the operating mode untouched so Axle can drive the battery through the
+        NorthBound Interface. This only engages when the ``axle_control`` option is set —
+        without it Predbat keeps ownership and reclaims VPP as before.
 
         Cases (offboard takes priority over readonly):
           offboard=True  + VPP active   → switch to MSC so the user's app regains control
@@ -2188,6 +2210,20 @@ class SigenergyAPI(ComponentBase):
 
         if is_offboard:
             return False
+
+        # Axle owns the inverter for the duration of its event. VPP mode and the
+        # NorthBound Interface are mutually exclusive on a Sigenergy, so reclaiming VPP
+        # here would evict Axle mid-dispatch. Leave the mode exactly as it is: if Axle has
+        # already moved the system to NBI it stays there, and if the event has started but
+        # Axle has not switched it yet, do not pull it to MSC either — that would hand
+        # control to the owner's app rather than to Axle.
+        if self._axle_has_control():
+            if not self._axle_standoff_logged.get(system_id):
+                self.log("SigenergyAPI: Axle VPP event active — leaving system {} in {} and standing down until the event ends".format(system_id, SIGENERGY_MODE_NAMES.get(self.current_mode.get(system_id, -1), "Unknown")))
+                self._axle_standoff_logged[system_id] = True
+            return False
+        if self._axle_standoff_logged.pop(system_id, False):
+            self.log("SigenergyAPI: Axle VPP event ended — resuming control of system {}".format(system_id))
 
         if is_readonly and in_vpp:
             self.log("SigenergyAPI: Read-only mode active — switching system {} from VPP to MSC".format(system_id))
@@ -2392,9 +2428,15 @@ class SigenergyAPI(ComponentBase):
                 is_offboard = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default="off") == "on"
                 await self._manage_vpp_registration(sid, is_readonly_vpp, is_offboard)
                 # Derive the user-facing onboarding status for the visible system.
+                # A system sitting in NBI is fully onboarded — Axle is simply driving it.
+                # Reporting "pending_approval" there makes the SaaS UI show an amber
+                # "approve this in the Sigenergy app" banner for the length of every Axle
+                # event, telling the user to approve something that needs no approval.
                 if is_offboard:
                     self.onboard_status[str(sid)] = "offboarded"
                 elif self.current_mode.get(sid) == SIGENERGY_MODE_VPP:
+                    self.onboard_status[str(sid)] = "active"
+                elif self.current_mode.get(sid) == SIGENERGY_MODE_NBI:
                     self.onboard_status[str(sid)] = "active"
                 else:
                     self.onboard_status[str(sid)] = "pending_approval"
@@ -2464,7 +2506,9 @@ class SigenergyAPI(ComponentBase):
             await self.automatic_config()
 
         # Apply controls
-        is_readonly = self.get_state_wrapper("switch.{}_set_read_only".format(self.prefix), default="off") == "on"
+        # Treat an active Axle event as read-only: Axle is driving the battery, so Predbat
+        # must not also be issuing charge/discharge commands at it.
+        is_readonly = self.get_state_wrapper("switch.{}_set_read_only".format(self.prefix), default="off") == "on" or self._axle_has_control()
         if self.enable_controls and not is_readonly:
             if first or seconds % 60 == 0:
                 for sid in list(self.systems.keys()):

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -22,6 +22,7 @@ from sigenergy import (
     SIGENERGY_CODE_IN_OTHER_VPP,
     SIGENERGY_CODE_SYSTEM_PENDING_REVIEW,
     SIGENERGY_MODE_MSC,
+    SIGENERGY_MODE_NBI,
     SIGENERGY_MODE_VPP,
     SIGENERGY_OPTIONS_TIME,
     _safe_float,
@@ -2466,6 +2467,117 @@ def test_sigenergy_run_pending_publishes_before_early_exit(my_predbat):
     return failed
 
 
+def _make_axle_api(sid, mode, axle_active):
+    """Build a MockSigenergyAPI with an Axle event either running or not.
+
+    Args:
+        sid: System ID to register.
+        mode: Operating mode integer to report as the system's current mode.
+        axle_active: Value for the parent's set_read_only_axle flag.
+
+    Returns:
+        A MockSigenergyAPI with run()'s async helpers stubbed out.
+    """
+    api = MockSigenergyAPI()
+    api.systems = {sid: {"deviceList": []}}
+    api.current_mode = {sid: mode}
+    api.system_id_filter = {sid}
+    api.base = MagicMock()
+    api.base.set_read_only_axle = axle_active
+    task = MagicMock()
+    task.done = MagicMock(return_value=False)
+    api._mqtt_task = task
+    api.set_operating_mode = AsyncMock(return_value=True)
+    api.fetch_inverter_realtime = AsyncMock(return_value=True)
+    api.fetch_daily_summary = AsyncMock()
+    api.fetch_history_totals = AsyncMock()
+    api.publish_system_entities = AsyncMock()
+    api.apply_controls = AsyncMock()
+    return api
+
+
+def test_sigenergy_axle_event_leaves_mode_alone(my_predbat):
+    """During an Axle event Predbat must not touch the operating mode in either direction."""
+    failed = False
+    sid = "SIG001"
+
+    # Axle has already taken the system into NBI — leave it there.
+    api_nbi = _make_axle_api(sid, SIGENERGY_MODE_NBI, axle_active=True)
+    result = run_async(api_nbi._manage_vpp_registration(sid, is_readonly=False))
+    assert result is False, "controls do not proceed while Axle owns the inverter"
+    api_nbi.set_operating_mode.assert_not_awaited()
+    assert any("standing down" in m for m in api_nbi.log_messages), "stand-down is logged, got {}".format(api_nbi.log_messages)
+
+    # Event started but Axle has not switched yet — do NOT drop to MSC, which would hand
+    # control to the owner's app rather than to Axle.
+    api_vpp = _make_axle_api(sid, SIGENERGY_MODE_VPP, axle_active=True)
+    run_async(api_vpp._manage_vpp_registration(sid, is_readonly=False))
+    api_vpp.set_operating_mode.assert_not_awaited()
+
+    # Without an Axle event the existing reclaim behaviour is unchanged.
+    api_off = _make_axle_api(sid, SIGENERGY_MODE_NBI, axle_active=False)
+    run_async(api_off._manage_vpp_registration(sid, is_readonly=False))
+    api_off.set_operating_mode.assert_awaited_once_with(sid, SIGENERGY_MODE_VPP)
+
+    return failed
+
+
+def test_sigenergy_axle_event_skips_controls(my_predbat):
+    """Predbat must not issue battery commands while Axle is dispatching."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_axle_api(sid, SIGENERGY_MODE_VPP, axle_active=True)
+    api._manage_vpp_registration = AsyncMock(return_value=False)
+    run_async(api.run(seconds=60, first=False))
+    api.apply_controls.assert_not_awaited()
+
+    # Same system, no Axle event → controls run as normal.
+    api_off = _make_axle_api(sid, SIGENERGY_MODE_VPP, axle_active=False)
+    api_off._manage_vpp_registration = AsyncMock(return_value=True)
+    run_async(api_off.run(seconds=60, first=False))
+    api_off.apply_controls.assert_awaited_once_with(sid)
+
+    return failed
+
+
+def test_sigenergy_axle_event_end_resumes_control(my_predbat):
+    """When the event ends Predbat reclaims VPP and says it has resumed."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_axle_api(sid, SIGENERGY_MODE_NBI, axle_active=True)
+    run_async(api._manage_vpp_registration(sid, is_readonly=False))
+    api.set_operating_mode.assert_not_awaited()
+
+    # Event ends — Axle no longer owns the inverter.
+    api.base.set_read_only_axle = False
+    run_async(api._manage_vpp_registration(sid, is_readonly=False))
+    api.set_operating_mode.assert_awaited_once_with(sid, SIGENERGY_MODE_VPP)
+    assert any("resuming control" in m for m in api.log_messages), "resume is logged, got {}".format(api.log_messages)
+
+    return failed
+
+
+def test_sigenergy_axle_nbi_not_reported_pending_approval(my_predbat):
+    """A system in NBI is onboarded, so it must not raise the 'approve in app' banner."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_axle_api(sid, SIGENERGY_MODE_NBI, axle_active=True)
+    api._manage_vpp_registration = AsyncMock(return_value=False)
+    run_async(api.run(seconds=300, first=False))
+    assert api.onboard_status[sid] == "active", "NBI is an onboarded system, not pending approval"
+
+    # MSC still means the user really has not approved onboarding.
+    api_msc = _make_axle_api(sid, SIGENERGY_MODE_MSC, axle_active=False)
+    api_msc._manage_vpp_registration = AsyncMock(return_value=False)
+    run_async(api_msc.run(seconds=300, first=False))
+    assert api_msc.onboard_status[sid] == "pending_approval", "MSC still means pending approval"
+
+    return failed
+
+
 def run_sigenergy_tests(my_predbat):
     """Run all Sigenergy API unit tests.
 
@@ -2542,6 +2654,10 @@ def run_sigenergy_tests(my_predbat):
         ("publish_onboard_status_sensors", test_sigenergy_publish_onboard_status_sensors),
         ("run_derives_onboard_status", test_sigenergy_run_derives_onboard_status),
         ("run_pending_publishes_before_early_exit", test_sigenergy_run_pending_publishes_before_early_exit),
+        ("axle_event_leaves_mode_alone", test_sigenergy_axle_event_leaves_mode_alone),
+        ("axle_event_skips_controls", test_sigenergy_axle_event_skips_controls),
+        ("axle_event_end_resumes_control", test_sigenergy_axle_event_end_resumes_control),
+        ("axle_nbi_not_reported_pending_approval", test_sigenergy_axle_nbi_not_reported_pending_approval),
     ]
 
     for name, fn in tests:


### PR DESCRIPTION
> **Option B of two mutually-exclusive alternatives for #4454. Only one of this and #4455 should merge.**

## What this does

Lets Axle keep the Sigenergy inverter for the duration of its events, by finishing a feature that already exists.

Predbat already has an `axle_control` option: when it is set and an Axle event is active, `Fetch.fetch_config_options()` raises `set_read_only_axle` so Predbat stands down and lets Axle drive. **That flag was only ever consumed by `execute.py:63` and `output.py:955`, so it never reached the Sigenergy component.**

The result is that the stand-down does not work on Sigenergy. VPP mode and the NorthBound Interface are mutually exclusive, and `_manage_vpp_registration()` reads the user-facing `switch.predbat_set_read_only` rather than the effective read-only state — so it never learns Axle has the floor and pulls the system back into VPP, evicting Axle mid-dispatch.

Observed live on 2026-08-06: Axle took the inverter into Northbound Integration at 19:35:18 and it was back in VPP at 19:40:12.

## Changes

- **`_axle_has_control()`** reads `set_read_only_axle` from the parent (defensively, so unit tests without a `ComponentBase` parent still work).
- **Leave the operating mode exactly as it is during an event.** If Axle has moved the system to NBI it stays there. If the event has started but Axle has not switched yet, *do not* drop to MSC either — that would hand control to the owner's app rather than to Axle. Logged once per event, not per cycle.
- **Suppress battery commands** for the same window, so Predbat is not issuing charge/discharge at an inverter Axle is dispatching.
- **Reclaim VPP when the event ends**, and log the resume.
- **Stop reporting a system in NBI as `pending_approval`** — same downstream false "approve in app" banner as #4455 fixes.

## Trade-off

Behaviour is **unchanged unless `axle_control` is enabled** — without it Predbat keeps ownership and reclaims VPP exactly as before. That makes this safe to merge, but it also means it does nothing on its own: `axle_control` is currently not set for any of our fleet, so adopting this position also requires a config/template change.

It also means Predbat's own plan for that window becomes redundant — Predbat still ingests the Axle session as an export window via `load_axle_slot()` but won't execute it. Worth deciding in #4454 whether `axle_control` should also suppress that planning.

## Tests

4 new tests in `tests/test_sigenergy.py`: mode-untouched in both NBI and VPP during an event, controls suppressed, resume-on-event-end, and NBI-not-pending-approval. Full Sigenergy suite 72 pass / 0 fail; `axle`, `fetch_config_options` and `execute` suites pass; `unit_test.py --quick` passes with 0 failures. `run_pre_commit` clean.
