### PR TITLE
Sigenergy: stop Predbat and Axle fighting over the inverter, and make axle_control work

### DIFF
--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -82,6 +82,7 @@ except ImportError:
     HAS_AIOMQTT = False
 
 from datetime import datetime, timedelta
+from axle import fetch_axle_active
 from component_base import ComponentBase
 from mock_base import MockBase as SharedMockBase
 from predbat_metrics import record_api_call
@@ -132,6 +133,7 @@ SIGENERGY_CODE_DEVELOPER_NOT_APPROVED = 1604
 SIGENERGY_TOKEN_EXPIRY_BUFFER = 600   # refresh token 10 min before expiry
 SIGENERGY_MIN_REQUEST_INTERVAL = 6.0  # enforce ≥10 req/min API limit
 SIGENERGY_POLL_INTERVAL = 300         # realtime data poll every 5 minutes
+SIGENERGY_VPP_RECLAIM_INTERVAL = 60   # re-assert VPP ownership every minute (see _manage_vpp_registration)
 SIGENERGY_DEVICE_POLL_INTERVAL = 1800  # device list refresh every 30 minutes
 SIGENERGY_RATE_LIMIT_BACKOFF = [15, 30, 60, 120, 480]  # seconds to wait after code 1201
 SIGENERGY_BATTERY_NOMINAL_VOLTAGE_V = 28.8  # 8S LiFePO4 pack: 8 × 3.6V; used to convert ratedEnergy (Ah) → kWh
@@ -149,6 +151,11 @@ SIGENERGY_MODE_MSC = 0   # Maximum Self-Consumption (eco)
 SIGENERGY_MODE_FFG = 5   # Fully Feed-in to Grid
 SIGENERGY_MODE_VPP = 6   # VPP mode
 SIGENERGY_MODE_NBI = 8   # NorthBound (defined for completeness; not switched to by this component)
+
+# Modes that mean a third party is driving the inverter rather than the owner's app.
+# A Sigenergy accepts one controller at a time, so finding the system in one of these
+# means Predbat's VPP registration has been displaced — see _manage_vpp_registration.
+SIGENERGY_THIRD_PARTY_MODES = (SIGENERGY_MODE_NBI,)
 
 # Human-readable names for operationalMode integer values
 SIGENERGY_MODE_NAMES = {
@@ -309,6 +316,8 @@ class SigenergyAPI(ComponentBase):
         self.history_totals = {}  # systemId → {sankey node id: lifetime kWh total}
         self.mqtt_period_raw = {}  # systemId → merged raw 'period' fields (MQTT only sends fields that changed)
         self.current_mode = {}    # systemId → energyStorageOperationMode int
+        self.last_contended_by = {}  # systemId → mode name of the controller that last displaced Predbat
+        self._axle_standoff_logged = {}  # systemId → True while the Axle stand-down has been announced
         self.onboard_status = {}  # systemId → onboarding status string (published for the SaaS UI)
 
         # Age (datetime of last update) of each SIGENERGY_CACHE_KEYS category, used to avoid an
@@ -2161,6 +2170,27 @@ class SigenergyAPI(ComponentBase):
     # VPP registration management
     # -----------------------------------------------------------------------
 
+    def _axle_has_control(self):
+        """Return True while an Axle VPP event owns the inverter under the axle_control option.
+
+        Predbat's ``axle_control`` option means "let Axle drive the battery during its
+        events". Fetch.fetch_config_options() expresses that as ``set_read_only_axle``, but
+        that flag is only refreshed on the 5-minute prediction loop and is still False from
+        reset() when this component makes its first run — which is exactly the case that
+        matters, a restart in the middle of a live event. So evaluate the same condition
+        live here instead of reading the cached flag: the component runs every minute, so
+        an event start or end is picked up promptly and correctly across a restart.
+
+        Fails safe: with no ``axle_control`` and no Axle session entity this returns False,
+        leaving Predbat as the owner exactly as before.
+
+        Returns:
+            True if an Axle event currently owns the inverter, False otherwise.
+        """
+        if not self.get_arg("axle_control", False):
+            return False
+        return fetch_axle_active(self)
+
     async def _manage_vpp_registration(self, system_id, is_readonly, is_offboard=False):
         """Align the operating mode with the read-only and offboard switch settings.
 
@@ -2176,6 +2206,16 @@ class SigenergyAPI(ComponentBase):
           readonly=False + VPP active   → nothing to do (ready for controls)
           readonly=False + VPP inactive → switch to VPP mode to enable controls
 
+        An active Axle event under the ``axle_control`` option takes priority over every
+        case above: Predbat stands down and leaves the operating mode untouched so Axle can
+        drive the battery through the NorthBound Interface.
+
+        Otherwise Predbat is the owner. A Sigenergy accepts one controller at a time and
+        VPP mode and NBI are mutually exclusive, so finding the system in NBI means
+        reclaiming it — which overrides whatever the other controller had scheduled.
+        Predbat ingests Axle sessions as its own export windows (see load_axle_slot), so
+        the event still runs; it runs under Predbat's plan rather than Axle's dispatch.
+
         Args:
             system_id: Sigenergy system unique identifier.
             is_readonly: Current state of the Predbat read-only switch.
@@ -2189,13 +2229,37 @@ class SigenergyAPI(ComponentBase):
         if is_offboard:
             return False
 
+        # Axle owns the inverter for the duration of its event. Leave the mode exactly as
+        # it is: if Axle has already moved the system to NBI it stays there, and if the
+        # event has started but Axle has not switched yet, do not pull it to MSC either —
+        # that would hand control to the owner's app rather than to Axle.
+        if self._axle_has_control():
+            if not self._axle_standoff_logged.get(system_id):
+                self.log("SigenergyAPI: Axle VPP event active — leaving system {} in {} and standing down until the event ends".format(system_id, SIGENERGY_MODE_NAMES.get(self.current_mode.get(system_id, -1), "Unknown")))
+                self._axle_standoff_logged[system_id] = True
+            return False
+        if self._axle_standoff_logged.pop(system_id, False):
+            self.log("SigenergyAPI: Axle VPP event ended — resuming control of system {}".format(system_id))
+
         if is_readonly and in_vpp:
             self.log("SigenergyAPI: Read-only mode active — switching system {} from VPP to MSC".format(system_id))
             await self.set_operating_mode(system_id, SIGENERGY_MODE_MSC)
             return False
 
         if not is_readonly and not in_vpp:
-            self.log("SigenergyAPI: System {} is not in VPP mode — switching to VPP to enable controls".format(system_id))
+            current = self.current_mode.get(system_id, -1)
+            if current in SIGENERGY_THIRD_PARTY_MODES:
+                # Another controller — typically an Axle dispatch running without
+                # axle_control set — has taken the inverter. Predbat is the owner here, so
+                # reclaim, and say so plainly since this displaces the other schedule.
+                self.last_contended_by[system_id] = SIGENERGY_MODE_NAMES.get(current, "Unknown")
+                self.log(
+                    "Warn: SigenergyAPI: System {} was taken by another controller ({}) — reclaiming VPP mode, which overrides that controller's schedule".format(
+                        system_id, SIGENERGY_MODE_NAMES.get(current, "Unknown ({})".format(current))
+                    )
+                )
+            else:
+                self.log("SigenergyAPI: System {} is not in VPP mode ({}) — switching to VPP to enable controls".format(system_id, SIGENERGY_MODE_NAMES.get(current, "Unknown")))
             await self.set_operating_mode(system_id, SIGENERGY_MODE_VPP)
             return False  # current_mode will be updated by MQTT/REST on the next cycle
 
@@ -2217,6 +2281,13 @@ class SigenergyAPI(ComponentBase):
                     "friendly_name": "Sigenergy {} Onboarding Status".format(sid),
                     "system_id": sid,
                     "in_vpp": self.current_mode.get(sid) == SIGENERGY_MODE_VPP,
+                    # Records the last controller to displace Predbat's VPP registration.
+                    # Deliberately never cleared: contention often lasts less than one
+                    # publish cycle, so a marker that is reset on recovery would almost
+                    # never be seen. Support needs "has this happened", not "is it
+                    # happening right now" — which in_vpp already answers.
+                    "last_contended_by": self.last_contended_by.get(sid),
+                    "axle_has_control": self._axle_has_control(),
                 },
                 app="sigenergy",
             )
@@ -2379,10 +2450,19 @@ class SigenergyAPI(ComponentBase):
             for sid in list(self.systems.keys()):
                 await self.fetch_device_list(sid)
 
-        # VPP registration management — runs at startup and every 5 minutes.
+        # VPP registration management — runs at startup and every minute.
+        #
+        # This used to run on the 5 minute poll interval, so when another controller took
+        # the system it could hold it for up to 5 minutes before Predbat noticed. The
+        # minute cadence also means an Axle event start or end is picked up promptly, which
+        # matters now that the stand-down is evaluated here rather than read from a flag
+        # the prediction loop refreshes. set_operating_mode is an MQTT publish and only
+        # fires when the mode is actually wrong, so this costs nothing against the REST
+        # rate limit.
+        #
         # Skips any system whose operating mode is not yet known (REST bootstrap
         # may have failed; MQTT will populate current_mode once it arrives).
-        if first or seconds % SIGENERGY_POLL_INTERVAL == 0:
+        if first or seconds % SIGENERGY_VPP_RECLAIM_INTERVAL == 0:
             is_readonly_vpp = self.get_state_wrapper("switch.{}_set_read_only".format(self.prefix), default="off") == "on"
             for sid in list(self.systems.keys()):
                 if sid not in self.current_mode:
@@ -2392,17 +2472,28 @@ class SigenergyAPI(ComponentBase):
                 is_offboard = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default="off") == "on"
                 await self._manage_vpp_registration(sid, is_readonly_vpp, is_offboard)
                 # Derive the user-facing onboarding status for the visible system.
+                # A system sitting in a third-party mode is fully onboarded — another
+                # controller has simply taken it. Reporting "pending_approval" there makes
+                # the SaaS UI show an amber "waiting for your approval in the Sigenergy
+                # app" banner for the length of every Axle event, telling the user to go
+                # and approve something that needs no approval.
                 if is_offboard:
                     self.onboard_status[str(sid)] = "offboarded"
                 elif self.current_mode.get(sid) == SIGENERGY_MODE_VPP:
                     self.onboard_status[str(sid)] = "active"
+                elif self.current_mode.get(sid) in SIGENERGY_THIRD_PARTY_MODES:
+                    self.onboard_status[str(sid)] = "active"
                 else:
                     self.onboard_status[str(sid)] = "pending_approval"
-            await self._save_cache("onboard_status", self.onboard_status)
 
-        # Publish onboarding status for the SaaS UI.
-        if first or seconds % SIGENERGY_POLL_INTERVAL == 0:
+            # Publish on the same cadence as the check above, so a contention episode
+            # shorter than a poll interval still reaches the sensor.
             self._publish_onboard_status()
+
+        # Persist the derived status on the slower poll cadence — the check above runs
+        # every minute and the cache does not need rewriting that often.
+        if first or seconds % SIGENERGY_POLL_INTERVAL == 0:
+            await self._save_cache("onboard_status", self.onboard_status)
 
         # Fetch controls from HA on first run only
         if first:
@@ -2464,16 +2555,27 @@ class SigenergyAPI(ComponentBase):
             await self.automatic_config()
 
         # Apply controls
-        is_readonly = self.get_state_wrapper("switch.{}_set_read_only".format(self.prefix), default="off") == "on"
+        # Treat an active Axle event as read-only: Axle is driving the battery, so Predbat
+        # must not also be issuing charge/discharge commands at the same inverter.
+        is_readonly = self.get_state_wrapper("switch.{}_set_read_only".format(self.prefix), default="off") == "on" or self._axle_has_control()
         if self.enable_controls and not is_readonly:
             if first or seconds % 60 == 0:
                 for sid in list(self.systems.keys()):
                     if self.current_mode.get(sid) != SIGENERGY_MODE_VPP:
-                        self.log(
-                            "Warn: SigenergyAPI: System {} is not in VPP mode ({}) — controls skipped until onboard is approved".format(
-                                sid, SIGENERGY_MODE_NAMES.get(self.current_mode.get(sid, -1), "Unknown")
+                        current = self.current_mode.get(sid, -1)
+                        if current in SIGENERGY_THIRD_PARTY_MODES:
+                            # Nothing to approve — another controller holds the system.
+                            self.log(
+                                "Warn: SigenergyAPI: System {} is held by another controller ({}) — controls skipped until VPP mode is reclaimed".format(
+                                    sid, SIGENERGY_MODE_NAMES.get(current, "Unknown")
+                                )
                             )
-                        )
+                        else:
+                            self.log(
+                                "Warn: SigenergyAPI: System {} is not in VPP mode ({}) — controls skipped until onboard is approved".format(
+                                    sid, SIGENERGY_MODE_NAMES.get(current, "Unknown")
+                                )
+                            )
                         continue
                     await self.apply_controls(sid)
         else:

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -22,7 +22,9 @@ from sigenergy import (
     SIGENERGY_CODE_IN_OTHER_VPP,
     SIGENERGY_CODE_SYSTEM_PENDING_REVIEW,
     SIGENERGY_MODE_MSC,
+    SIGENERGY_MODE_NBI,
     SIGENERGY_MODE_VPP,
+    SIGENERGY_VPP_RECLAIM_INTERVAL,
     SIGENERGY_OPTIONS_TIME,
     _safe_float,
     _safe_int,
@@ -171,8 +173,13 @@ class MockSigenergyAPI(SigenergyAPI):
         """Store state."""
         self.dashboard_items[entity_id] = {"state": state, "attributes": attributes or {}}
 
-    def get_arg(self, key, default=None):
-        """Return stored arg or default."""
+    def get_arg(self, key, default=None, **kwargs):
+        """Return stored arg or default.
+
+        Accepts and ignores the wider ComponentBase.get_arg keyword arguments (indirect,
+        combine, attribute, index, domain, can_override, required_unit) so helpers that
+        pass them — such as fetch_axle_active — work against this mock.
+        """
         return self.args.get(key, default)
 
     def set_arg(self, key, value):
@@ -2466,6 +2473,224 @@ def test_sigenergy_run_pending_publishes_before_early_exit(my_predbat):
     return failed
 
 
+def _make_contended_api(sid, mode, axle_control=False, axle_event="off"):
+    """Build a MockSigenergyAPI whose system sits in the given operating mode.
+
+    Args:
+        sid: System ID to register.
+        mode: Operating mode integer to report as the system's current mode.
+        axle_control: Value of the axle_control option.
+        axle_event: State of the Axle event binary sensor ("on" or "off").
+
+    Returns:
+        A MockSigenergyAPI with run()'s async helpers stubbed out.
+    """
+    api = MockSigenergyAPI()
+    api.systems = {sid: {"deviceList": []}}
+    api.current_mode = {sid: mode}
+    api.system_id_filter = {sid}
+    api.args["axle_control"] = axle_control
+    api.args["axle_session"] = "binary_sensor.predbat_axle_event"
+    api.dashboard_items["binary_sensor.predbat_axle_event"] = {"state": axle_event}
+    task = MagicMock()
+    task.done = MagicMock(return_value=False)
+    api._mqtt_task = task
+    api.set_operating_mode = AsyncMock(return_value=True)
+    api.fetch_inverter_realtime = AsyncMock(return_value=True)
+    api.fetch_daily_summary = AsyncMock()
+    api.fetch_history_totals = AsyncMock()
+    api.publish_system_entities = AsyncMock()
+    api.apply_controls = AsyncMock()
+    return api
+
+
+def test_sigenergy_reclaims_vpp_from_third_party_controller(my_predbat):
+    """Without axle_control, a system taken into NBI is reclaimed into VPP, and says so."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_NBI)
+    run_async(api._manage_vpp_registration(sid, is_readonly=False))
+
+    api.set_operating_mode.assert_awaited_once_with(sid, SIGENERGY_MODE_VPP)
+    assert api.last_contended_by[sid] == "Northbound Integration", "records which controller displaced Predbat"
+
+    reclaim_logs = [m for m in api.log_messages if "reclaiming VPP mode" in m]
+    assert len(reclaim_logs) == 1, "reclaim is logged once, got {}".format(api.log_messages)
+    assert "Northbound Integration" in reclaim_logs[0], "log names the displacing controller"
+    assert "onboard" not in reclaim_logs[0].lower(), "reclaim log must not blame onboarding"
+
+    return failed
+
+
+def test_sigenergy_contention_does_not_report_pending_approval(my_predbat):
+    """Contention must not surface as pending_approval — that shows a false 'approve in app' banner."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_NBI)
+    api._manage_vpp_registration = AsyncMock(return_value=False)
+    run_async(api.run(seconds=300, first=False))
+    assert api.onboard_status[sid] == "active", "contended system stays active, not pending_approval"
+
+    api_msc = _make_contended_api(sid, SIGENERGY_MODE_MSC)
+    api_msc._manage_vpp_registration = AsyncMock(return_value=False)
+    run_async(api_msc.run(seconds=300, first=False))
+    assert api_msc.onboard_status[sid] == "pending_approval", "MSC still means pending approval"
+
+    return failed
+
+
+def test_sigenergy_contention_marker_published_before_recovery(my_predbat):
+    """A contention episode shorter than a poll interval must still reach the sensor.
+
+    Regression test: the marker used to be cleared on recovery while the sensor only
+    published every 5 minutes, so brief contention was never visible to support.
+    """
+    failed = False
+    sid = "SIG001"
+    sensor_key = "sensor.predbat_sigenergy_sig001_onboard_status"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_NBI)
+    # Minute tick during contention — the real _manage_vpp_registration records the marker.
+    run_async(api.run(seconds=60, first=False))
+    assert api.dashboard_items[sensor_key]["attributes"]["last_contended_by"] == "Northbound Integration", "contention published on the minute tick"
+
+    # Mode recovers. The marker must survive so the episode remains visible.
+    api.current_mode[sid] = SIGENERGY_MODE_VPP
+    run_async(api.run(seconds=120, first=False))
+    assert api.dashboard_items[sensor_key]["attributes"]["in_vpp"] is True, "in_vpp reports the live state"
+    assert api.dashboard_items[sensor_key]["attributes"]["last_contended_by"] == "Northbound Integration", "marker is not cleared on recovery"
+
+    return failed
+
+
+def test_sigenergy_reclaim_runs_on_the_minute(my_predbat):
+    """The reclaim check runs every minute, so a displaced system is not left for a full poll."""
+    failed = False
+    sid = "SIG001"
+
+    assert SIGENERGY_VPP_RECLAIM_INTERVAL == 60, "reclaim cadence is one minute"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_NBI)
+    api._manage_vpp_registration = AsyncMock(return_value=False)
+    run_async(api.run(seconds=60, first=False))
+    api._manage_vpp_registration.assert_awaited_once()
+
+    return failed
+
+
+def test_sigenergy_controls_skipped_message_distinguishes_contention(my_predbat):
+    """Skipping controls because another controller holds the system must not blame onboarding."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_NBI)
+    api._manage_vpp_registration = AsyncMock(return_value=False)
+    run_async(api.run(seconds=60, first=False))
+
+    skip_logs = [m for m in api.log_messages if "controls skipped" in m]
+    assert skip_logs, "controls-skipped message is logged"
+    assert any("held by another controller" in m for m in skip_logs), "message names contention, got {}".format(skip_logs)
+    assert not any("onboard is approved" in m for m in skip_logs), "must not tell the user to approve onboarding"
+    api.apply_controls.assert_not_awaited()
+
+    return failed
+
+
+def test_sigenergy_axle_control_off_reclaims_as_before(my_predbat):
+    """With axle_control unset, an active Axle event does not change behaviour."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_NBI, axle_control=False, axle_event="on")
+    assert api._axle_has_control() is False, "axle_control off means Predbat keeps ownership"
+    run_async(api._manage_vpp_registration(sid, is_readonly=False))
+    api.set_operating_mode.assert_awaited_once_with(sid, SIGENERGY_MODE_VPP)
+
+    return failed
+
+
+def test_sigenergy_axle_event_leaves_mode_alone(my_predbat):
+    """With axle_control on, Predbat must not touch the mode in either direction."""
+    failed = False
+    sid = "SIG001"
+
+    # Axle has already taken the system into NBI — leave it there.
+    api_nbi = _make_contended_api(sid, SIGENERGY_MODE_NBI, axle_control=True, axle_event="on")
+    result = run_async(api_nbi._manage_vpp_registration(sid, is_readonly=False))
+    assert result is False, "controls do not proceed while Axle owns the inverter"
+    api_nbi.set_operating_mode.assert_not_awaited()
+    assert any("standing down" in m for m in api_nbi.log_messages), "stand-down is logged, got {}".format(api_nbi.log_messages)
+
+    # Event started but Axle has not switched yet — do NOT drop to MSC, which would hand
+    # control to the owner's app rather than to Axle.
+    api_vpp = _make_contended_api(sid, SIGENERGY_MODE_VPP, axle_control=True, axle_event="on")
+    run_async(api_vpp._manage_vpp_registration(sid, is_readonly=False))
+    api_vpp.set_operating_mode.assert_not_awaited()
+
+    return failed
+
+
+def test_sigenergy_axle_event_skips_controls(my_predbat):
+    """Predbat must not issue battery commands while Axle is dispatching."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_VPP, axle_control=True, axle_event="on")
+    api._manage_vpp_registration = AsyncMock(return_value=False)
+    run_async(api.run(seconds=60, first=False))
+    api.apply_controls.assert_not_awaited()
+
+    api_off = _make_contended_api(sid, SIGENERGY_MODE_VPP, axle_control=True, axle_event="off")
+    api_off._manage_vpp_registration = AsyncMock(return_value=True)
+    run_async(api_off.run(seconds=60, first=False))
+    api_off.apply_controls.assert_awaited_once_with(sid)
+
+    return failed
+
+
+def test_sigenergy_axle_event_end_resumes_control(my_predbat):
+    """When the event ends Predbat reclaims VPP and says it has resumed."""
+    failed = False
+    sid = "SIG001"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_NBI, axle_control=True, axle_event="on")
+    run_async(api._manage_vpp_registration(sid, is_readonly=False))
+    api.set_operating_mode.assert_not_awaited()
+
+    # Event ends — the live sensor flips, no prediction cycle required.
+    api.dashboard_items["binary_sensor.predbat_axle_event"] = {"state": "off"}
+    run_async(api._manage_vpp_registration(sid, is_readonly=False))
+    api.set_operating_mode.assert_awaited_once_with(sid, SIGENERGY_MODE_VPP)
+    assert any("resuming control" in m for m in api.log_messages), "resume is logged, got {}".format(api.log_messages)
+
+    return failed
+
+
+def test_sigenergy_axle_standoff_survives_restart(my_predbat):
+    """A restart mid-event must not reclaim VPP.
+
+    Regression test: reading the cached set_read_only_axle flag failed here, because
+    reset() leaves it False and the component starts before the first update_pred().
+    Evaluating axle_control and the event sensor live is what makes first=True safe.
+    """
+    failed = False
+    sid = "SIG001"
+
+    api = _make_contended_api(sid, SIGENERGY_MODE_NBI, axle_control=True, axle_event="on")
+    # Simulate the parent having the stale post-reset value the prediction loop has not
+    # yet refreshed — the component must not depend on it.
+    api.base = MagicMock()
+    api.base.set_read_only_axle = False
+
+    assert api._axle_has_control() is True, "live evaluation sees the event despite the stale flag"
+    run_async(api._manage_vpp_registration(sid, is_readonly=False))
+    api.set_operating_mode.assert_not_awaited()
+
+    return failed
+
+
 def run_sigenergy_tests(my_predbat):
     """Run all Sigenergy API unit tests.
 
@@ -2542,6 +2767,16 @@ def run_sigenergy_tests(my_predbat):
         ("publish_onboard_status_sensors", test_sigenergy_publish_onboard_status_sensors),
         ("run_derives_onboard_status", test_sigenergy_run_derives_onboard_status),
         ("run_pending_publishes_before_early_exit", test_sigenergy_run_pending_publishes_before_early_exit),
+        ("reclaims_vpp_from_third_party_controller", test_sigenergy_reclaims_vpp_from_third_party_controller),
+        ("contention_does_not_report_pending_approval", test_sigenergy_contention_does_not_report_pending_approval),
+        ("contention_marker_published_before_recovery", test_sigenergy_contention_marker_published_before_recovery),
+        ("reclaim_runs_on_the_minute", test_sigenergy_reclaim_runs_on_the_minute),
+        ("controls_skipped_message_distinguishes_contention", test_sigenergy_controls_skipped_message_distinguishes_contention),
+        ("axle_control_off_reclaims_as_before", test_sigenergy_axle_control_off_reclaims_as_before),
+        ("axle_event_leaves_mode_alone", test_sigenergy_axle_event_leaves_mode_alone),
+        ("axle_event_skips_controls", test_sigenergy_axle_event_skips_controls),
+        ("axle_event_end_resumes_control", test_sigenergy_axle_event_end_resumes_control),
+        ("axle_standoff_survives_restart", test_sigenergy_axle_standoff_survives_restart),
     ]
 
     for name, fn in tests:


### PR DESCRIPTION
Supersedes #4455 and #4456, which were opened as competing alternatives. A review showed they were not actually alternatives — see #4454 for the reasoning — so this is the two of them combined, with the review findings fixed.

Fixes #4454.

## The problem

A Sigenergy accepts one controller at a time. VPP mode (Predbat) and the NorthBound Interface (Axle's dispatch channel) are mutually exclusive. Two things follow, and both are broken:

1. **Where Predbat owns the inverter, it wins by accident.** `_manage_vpp_registration()` ran on the 5-minute poll and silently switched the system back to VPP, so an Axle dispatch could hold it for up to 5 minutes before being displaced, logged only as "controls skipped until onboard is approved".

2. **Where Axle should own it, `axle_control` does not work at all.** `Fetch.fetch_config_options()` raises `set_read_only_axle` for exactly this purpose, but it was only consumed in `execute.py` and `output.py`. `sigenergy.py` read the user-facing `switch.predbat_set_read_only` instead, so it never learned Axle had the floor.

Observed live on 2026-08-06: Axle took the inverter into Northbound Integration at 19:35:18; it was back in VPP at 19:40:12 — exactly one `SIGENERGY_POLL_INTERVAL`.

## Make `axle_control` work here

- `_axle_has_control()` evaluates `axle_control` and the Axle event sensor **live**, via `fetch_axle_active()`, rather than reading the cached `set_read_only_axle`. That flag is only refreshed by the 5-minute prediction loop and is still `False` from `reset()` when this phase-1 component makes its `first=True` run — precisely the case that matters, a restart during a live event, where the cached flag would have had Predbat reclaim VPP and kill the dispatch. It also removes an up-to-5-minute lag detecting event start and end.
- During an event the operating mode is left exactly as it is. If Axle has moved the system to NBI it stays there; if the event has started but Axle has not switched yet, **do not** drop to MSC either — that hands control to the owner's app rather than to Axle.
- Battery commands are suppressed for the same window.
- VPP is reclaimed when the event ends, and that is logged.

## And where Predbat does keep ownership, make it deliberate

- Reclaim VPP every minute instead of every 5. `set_operating_mode()` is an MQTT publish that only fires when the mode is actually wrong, so this costs nothing against the REST rate limit.
- Log the reclaim naming the controller being displaced.
- Record `last_contended_by` on the status sensor, published on the same minute cadence and **never cleared**. Contention is usually shorter than one publish interval, so a marker reset on recovery would almost never be seen; "has this happened" is the useful signal, and `in_vpp` already answers "is it happening now".
- Stop reporting a system in NBI as `pending_approval`. Downstream UIs render that as an amber "approve this in the Sigenergy app" banner, so every Axle event told an already-onboarded user to approve something that needed no approval.

## Compatibility

With `axle_control` unset — which is the current state of every system we operate — behaviour is unchanged except for the faster reclaim, the clearer logs, and the status fix. Nothing here silently changes who drives the battery.

Note that `axle_control` is a **global** option: it gates `self.set_read_only`, which covers the whole inverter-write path for any inverter type, not just Sigenergy. Enabling it is a separate, wider decision than merging this.

## Tests

11 tests in `tests/test_sigenergy.py`, including two explicit regression tests for the review findings: `axle_standoff_survives_restart` (the stale-flag case) and `contention_marker_published_before_recovery` (the marker being cleared before it was ever published). Full Sigenergy suite 78 pass / 0 fail; `unit_test.py --quick` passes with 0 failures; `run_pre_commit` clean.

One test-infra note: `MockSigenergyAPI.get_arg()` had to accept `**kwargs`, because `fetch_axle_active()` passes `indirect=False` and the mock's two-argument signature rejected it. The mock had drifted from `ComponentBase.get_arg`; this widens it rather than fully realigning it.

## What this does NOT do

Two honest limits, raised in review:

- **The faster reclaim does not make Predbat and Axle coexist.** With `axle_control` unset it converts a five-minute contest into a one-minute contest and makes Predbat win deterministically. That is the intended ownership policy, not a resolution of the conflict.
- **The stand-down is best-effort mutual exclusion, not a dispatch protocol.** During an event the mode is left untouched and commands are suppressed, but a battery command issued just beforehand can carry a duration of up to 720 minutes (`apply_controls()`), and nothing revokes it. If Axle moves the system to NBI that command stops applying; if Axle does not, it can remain active with no acknowledgement from either side that control changed hands. Enable `axle_control` selectively and watch the actual mode telemetry.

Worth stating plainly for context: `load_axle_slot()` adds `pence_per_kwh` to `rate_export` and adjusts load scaling. An Axle session is a **price signal**, not a required delivery — the optimiser may still decline to export on SOC, reserve or economics. Neither this PR nor `axle_control` changes that.
