### PR TITLE
feat(gecloud): use the customer account timezone for the start/end time registers

### DIFF
--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -52,6 +52,8 @@ GE_REGISTER_BATTERY_CUTOFF_LIMIT = 75
 
 # How long the cached customer account details stay valid for before they are fetched again
 ACCOUNT_MAX_AGE_MINUTES = 24 * 60
+# How long to wait before retrying a failed account fetch
+ACCOUNT_RETRY_MINUTES = 30
 
 # 0	Current.Export	Instantaneous current flow from EV
 # 1	Current.Import	Instantaneous current flow to EV
@@ -263,6 +265,7 @@ class GECloudDirect(ComponentBase):
         self.account_timezone = None
         self.account_timezone_name = None
         self.account_stamp = None
+        self.account_fetch_stamp = None
 
         # API request metrics for monitoring
         self.requests_total = 0
@@ -1664,17 +1667,29 @@ class GECloudDirect(ComponentBase):
         """
         if first:
             await self.load_account_from_storage()
+            if self.account:
+                await self.publish_account(self.account)
 
-        expired = self.account_stamp is None or (self.now_utc_exact - self.account_stamp) >= timedelta(minutes=ACCOUNT_MAX_AGE_MINUTES)
-        if not expired and not first:
+        now_utc = self.now_utc_exact
+
+        # Nothing to do while the details we hold are still within their lifetime
+        if self.account_stamp is not None and (now_utc - self.account_stamp) < timedelta(minutes=ACCOUNT_MAX_AGE_MINUTES):
             return
 
-        if expired:
-            self.account_stamp = self.now_utc_exact
-            account = await self.async_get_account()
-            if account and self.storage:
-                await self.storage.save("gecloud", "account", account, format="json", expiry=None)
+        # A failed fetch retries after a short delay rather than a full day, but not on every 60 second
+        # run() tick, so a sustained API outage does not turn into a poll loop
+        if self.account_fetch_stamp is not None and (now_utc - self.account_fetch_stamp) < timedelta(minutes=ACCOUNT_RETRY_MINUTES):
+            return
 
+        self.account_fetch_stamp = now_utc
+        account = await self.async_get_account()
+        if not account:
+            return
+
+        # Only treat the details as fresh once we actually have them
+        self.account_stamp = now_utc
+        if self.storage:
+            await self.storage.save("gecloud", "account", account, format="json", expiry=None)
         await self.publish_account(self.account)
 
     async def async_get_account(self):

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -14,6 +14,7 @@ management via the GivEnergy Cloud REST API.
 
 import re
 import aiohttp
+import pytz
 from datetime import timedelta, datetime, timezone
 from utils import str2time, dp1, dp2, dp4
 from predbat_metrics import record_api_call
@@ -28,6 +29,7 @@ GE Cloud data download
 """
 
 GE_API_URL = "https://api.givenergy.cloud/v1/"
+GE_API_ACCOUNT = "account"
 GE_API_INVERTER_STATUS = "inverter/{inverter_serial_number}/system-data/latest"
 GE_API_INVERTER_METER = "inverter/{inverter_serial_number}/meter-data/latest"
 GE_API_INVERTER_SETTINGS = "inverter/{inverter_serial_number}/settings"
@@ -47,6 +49,9 @@ GE_API_EVC_SEND_COMMAND = "ev-charger/{uuid}/commands/{command}"
 GE_API_EVC_SESSIONS = "ev-charger/{uuid}/charging-sessions?start_time={start_time}&end_time={end_time}&pageSize=32"
 
 GE_REGISTER_BATTERY_CUTOFF_LIMIT = 75
+
+# How long the cached customer account details stay valid for before they are fetched again
+ACCOUNT_MAX_AGE_MINUTES = 24 * 60
 
 # 0	Current.Export	Instantaneous current flow from EV
 # 1	Current.Import	Instantaneous current flow to EV
@@ -204,6 +209,8 @@ attribute_table = {
     "battery_soh": {"friendly_name": "Battery State of Health", "icon": "mdi:battery", "unit_of_measurement": "*", "device_class": "battery"},
     "battery_dod_soh": {"friendly_name": "Battery Depth of Discharge Adjusted for State of Health", "icon": "mdi:battery", "unit_of_measurement": "*", "device_class": "battery"},
     "model": {"friendly_name": "Model", "icon": "mdi:information", "unit_of_measurement": None},
+    "account": {"friendly_name": "GE Cloud Account", "icon": "mdi:account", "unit_of_measurement": None},
+    "timezone": {"friendly_name": "GE Cloud Account Timezone", "icon": "mdi:map-clock", "unit_of_measurement": None},
 }
 
 BASE_TIME = datetime.strptime("00:00", "%H:%M")
@@ -251,9 +258,88 @@ class GECloudDirect(ComponentBase):
         self.settings_from_cache = False
         self.default_options_stamp = None
 
+        # Customer account details, including the timezone the inverter register times are expressed in
+        self.account = {}
+        self.account_timezone = None
+        self.account_timezone_name = None
+        self.account_stamp = None
+
         # API request metrics for monitoring
         self.requests_total = 0
         self.failures_total = 0
+
+    def set_account_timezone(self, account):
+        """
+        Record the customer timezone taken from the GE Cloud account details.
+
+        The inverter start/end time registers are held in the account timezone, which is not
+        necessarily the timezone Predbat is running in, so it is stored here to translate them.
+        """
+        tz_name = account.get("standard_timezone", None) or account.get("timezone", None)
+        if not tz_name:
+            self.log("GECloud: Warn: No timezone found in account details, using the Predbat timezone for register times")
+            return
+        if tz_name == self.account_timezone_name:
+            return
+
+        try:
+            account_tz = pytz.timezone(tz_name)
+        except pytz.exceptions.UnknownTimeZoneError:
+            self.log("GECloud: Warn: Unknown account timezone {}, using the Predbat timezone for register times".format(tz_name))
+            return
+
+        self.account_timezone = account_tz
+        self.account_timezone_name = tz_name
+        self.log("GECloud: Account timezone is {}, offset from the Predbat timezone is {} minutes".format(tz_name, self.get_timezone_offset_minutes()))
+
+    def get_timezone_offset_minutes(self):
+        """
+        Return how many minutes ahead of the Predbat timezone the customer account timezone is right now.
+
+        Returns 0 when the account timezone is unknown, so times are left as-is.
+        """
+        if self.account_timezone is None or self.local_tz is None:
+            return 0
+
+        now = datetime.now(timezone.utc)
+        account_offset = now.astimezone(self.account_timezone).utcoffset()
+        local_offset = now.astimezone(self.local_tz).utcoffset()
+        if account_offset is None or local_offset is None:
+            return 0
+        return int((account_offset - local_offset).total_seconds() // 60)
+
+    def shift_time_string(self, value, offset_minutes):
+        """
+        Shift a HH:MM or HH:MM:SS register time string by the given number of minutes, wrapping at midnight.
+        """
+        if not offset_minutes or not isinstance(value, str):
+            return value
+
+        parts = value.strip().split(":")
+        if len(parts) < 2:
+            return value
+        try:
+            total = int(parts[0]) * 60 + int(parts[1])
+        except ValueError:
+            return value
+
+        total = (total + offset_minutes) % (24 * 60)
+        shifted = "{:02d}:{:02d}".format(total // 60, total % 60)
+        if len(parts) > 2:
+            shifted += ":" + parts[2]
+        return shifted
+
+    def register_time_to_local(self, value):
+        """
+        Convert a time register value from the customer account timezone into the Predbat timezone.
+        """
+        return self.shift_time_string(value, -self.get_timezone_offset_minutes())
+
+    def local_time_to_register(self, value):
+        """
+        Convert a time from the Predbat timezone into the customer account timezone for writing to a register.
+        """
+        return self.shift_time_string(value, self.get_timezone_offset_minutes())
 
     async def switch_event(self, entity_id, service):
         """
@@ -357,6 +443,8 @@ class GECloudDirect(ComponentBase):
 
                     is_time = mapping.get("time", False)
                     if is_time:
+                        # The register is held in the customer account timezone, the value we are given is in the Predbat timezone
+                        new_value = self.local_time_to_register(new_value)
                         # We actually write as HH:MM
                         new_value = new_value[:5]
 
@@ -391,6 +479,33 @@ class GECloudDirect(ComponentBase):
             except ValueError:
                 pass
         return max_charge_rate
+
+    async def publish_account(self, account):
+        """
+        Publish the customer account details and the account timezone as sensors.
+
+        Each sensor holds the name as its state and the remaining values in a 'data' attribute.
+        """
+        if not account:
+            return
+
+        entity_name = f"sensor.{self.prefix}_gecloud".lower()
+
+        account_data = {key: value for key, value in account.items() if key != "name"}
+        attributes = dict(attribute_table.get("account", {}))
+        attributes["data"] = account_data
+        self.dashboard_item(entity_name + "_account", state=account.get("name", "unknown"), attributes=attributes, app="gecloud")
+
+        timezone_name = self.account_timezone_name or account.get("standard_timezone", None) or account.get("timezone", None)
+        timezone_data = {
+            "timezone": account.get("timezone", None),
+            "standard_timezone": account.get("standard_timezone", None),
+            "predbat_timezone": str(self.local_tz) if self.local_tz else None,
+            "offset_minutes": self.get_timezone_offset_minutes(),
+        }
+        attributes = dict(attribute_table.get("timezone", {}))
+        attributes["data"] = timezone_data
+        self.dashboard_item(entity_name + "_timezone", state=timezone_name if timezone_name else "unknown", attributes=attributes, app="gecloud")
 
     async def publish_info(self, device, device_info):
         """
@@ -758,6 +873,8 @@ class GECloudDirect(ComponentBase):
                 if validation_rule.startswith("date_format:H:i"):
                     is_select_time = True
                     options_text = OPTIONS_TIME_FULL
+                    # The register is held in the customer account timezone, publish it in the Predbat timezone
+                    value = self.register_time_to_local(value)
                     if isinstance(value, str) and len(value) == 5:
                         value = value + ":00"
                     attributes["device_class"] = "time"
@@ -1053,6 +1170,9 @@ class GECloudDirect(ComponentBase):
         """
         Start the client
         """
+
+        # The account details change rarely, so they are cached in storage and only re-fetched once a day
+        await self.update_account(first)
 
         if first:
             self.polling_mode = True
@@ -1511,6 +1631,68 @@ class GECloudDirect(ComponentBase):
                     if this_serial and this_serial.lower() == serial.lower():
                         return inverter
         return previous
+
+    async def load_account_from_storage(self):
+        """
+        Restore the customer account details cached by a previous run so a restart does not have to fetch them again.
+        """
+        if not self.storage:
+            return
+
+        cached_account = await self.storage.load("gecloud", "account")
+        if not isinstance(cached_account, dict) or not cached_account:
+            self.log("GECloud: No valid account details found in storage cache, will fetch")
+            return
+
+        account_age = await self.storage.age("gecloud", "account")
+
+        # Keep the cached details even when stale so that a failed fetch still leaves something usable
+        self.account = cached_account
+        self.set_account_timezone(cached_account)
+
+        if account_age is not None and account_age < ACCOUNT_MAX_AGE_MINUTES:
+            self.account_stamp = self.now_utc_exact - timedelta(minutes=account_age)
+            self.log("GECloud: Restored account details from storage cache (age {:.1f} minutes)".format(account_age))
+        else:
+            self.log("GECloud: Storage cache for the account details is stale (age {}), will re-fetch".format("{:.1f} minutes".format(account_age) if account_age is not None else "unknown"))
+
+    async def update_account(self, first):
+        """
+        Keep the customer account details up to date and published.
+
+        On startup they are restored from storage, and they are only re-fetched from the API once a day.
+        """
+        if first:
+            await self.load_account_from_storage()
+
+        expired = self.account_stamp is None or (self.now_utc_exact - self.account_stamp) >= timedelta(minutes=ACCOUNT_MAX_AGE_MINUTES)
+        if not expired and not first:
+            return
+
+        if expired:
+            self.account_stamp = self.now_utc_exact
+            account = await self.async_get_account()
+            if account and self.storage:
+                await self.storage.save("gecloud", "account", account, format="json", expiry=None)
+
+        await self.publish_account(self.account)
+
+    async def async_get_account(self):
+        """
+        Get the customer account details from GE Cloud and record the account timezone.
+
+        {'id': 2, 'name': 'francesca.holmes.285', 'first_name': 'Maisie', 'surname': 'Walker', 'role': 'VIEWER',
+         'email': 'joshua94@martin.com', 'address': '18 Hunt Landing', 'postcode': 'CT6 9AR', 'country': 'UNITED_KINGDOM',
+         'telephone_number': '+44(0)7559 260236', 'timezone': 'GMT', 'standard_timezone': 'Europe/London',
+         'company': None, 'flags': []}
+        """
+        account = await self.async_get_inverter_data_retry(GE_API_ACCOUNT)
+        if not account:
+            return self.account
+
+        self.account = account
+        self.set_account_timezone(account)
+        return account
 
     async def async_get_devices(self):
         """

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -484,7 +484,7 @@ class GECloudDirect(ComponentBase):
         """
         Publish the customer account details and the account timezone as sensors.
 
-        Each sensor holds the name as its state and the remaining values in a 'data' attribute.
+        The account sensor uses the account name as its state; the timezone sensor uses the timezone name as its state. All remaining values are stored in a 'data' attribute.
         """
         if not account:
             return

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.47.6"
+THIS_VERSION = "v8.47.7"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -10,10 +10,11 @@
 # fmt on
 
 from gecloud import GECloudDirect, GECloudData, regname_to_ha
-from gecloud import GE_API_DEVICES, GE_API_EVC_SEND_COMMAND
+from gecloud import GE_API_ACCOUNT, GE_API_DEVICES, GE_API_EVC_SEND_COMMAND
 from utils import dp4
 import asyncio
 import json
+import pytz
 from unittest.mock import MagicMock, patch, AsyncMock
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -60,6 +61,11 @@ class MockGECloudDirect(GECloudDirect):
         self.settings_from_cache = False
         self.default_options_stamp = None
         self._read_only = False
+        self.local_tz = pytz.timezone("Europe/London")
+        self.account = {}
+        self.account_timezone = None
+        self.account_timezone_name = None
+        self.account_stamp = None
 
         class MockHAInterface:
             def __init__(self):
@@ -171,6 +177,7 @@ def test_ge_cloud(my_predbat=None):
     ======================================================================
     Comprehensive test suite for GivEnergy Cloud integration including:
     - API infrastructure (success, auth errors, rate limits, timeouts, JSON errors, retry logic)
+    - Account details (customer timezone used for the start/end time registers)
     - Device management (EMS, gateway, batteries, EV chargers, smart devices)
     - EVC operations (commands, device data, sessions)
     - Inverter operations (status, meter, device info, settings read/write)
@@ -200,6 +207,18 @@ def test_ge_cloud(my_predbat=None):
         ("api_json_error", _test_async_get_inverter_data_json_error, "API JSON error handling"),
         ("api_retry", _test_async_get_inverter_data_retry, "API retry logic"),
         ("api_post", _test_async_get_inverter_data_post, "API POST with/without datain"),
+        ("account", _test_async_get_account, "Get account details and timezone"),
+        ("account_failure", _test_async_get_account_failure, "Failed account fetch retains previous details"),
+        ("account_saved_to_storage", _test_account_saved_to_storage, "Account details saved to storage"),
+        ("account_restored_from_cache", _test_account_restored_from_cache, "Account restored from a fresh storage cache"),
+        ("account_stale_cache", _test_account_stale_cache_refetch, "Stale cached account is re-fetched"),
+        ("account_no_cache", _test_account_no_cache_fetches, "Account fetched when nothing is cached"),
+        ("account_timezone", _test_set_account_timezone, "Account timezone parsing and fallbacks"),
+        ("publish_account", _test_publish_account, "Publish account and timezone sensors"),
+        ("publish_account_empty", _test_publish_account_empty, "Publish account with missing details"),
+        ("shift_time_string", _test_shift_time_string, "Shift register time strings across midnight"),
+        ("register_time_timezone", _test_register_time_timezone, "Time registers use the account timezone"),
+        ("register_time_no_timezone", _test_register_time_no_timezone, "Time registers unchanged with no account timezone"),
         ("devices_ems", _test_async_get_devices_with_ems, "Get devices with EMS"),
         ("devices_gateway", _test_async_get_devices_with_gateway, "Get devices with Gateway"),
         ("devices_batteries", _test_async_get_devices_with_batteries, "Get devices with batteries"),
@@ -833,6 +852,485 @@ def _test_async_get_inverter_data_post(my_predbat):
                 if result != [{"serial": "test456"}]:
                     print(f"ERROR: Expected device list, got {result}")
                     return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_async_get_account(my_predbat):
+    """Test fetching the customer account details and recording the account timezone"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+
+        account_data = {
+            "id": 2,
+            "name": "francesca.holmes.285",
+            "email": "joshua94@martin.com",
+            "country": "GREECE",
+            "timezone": "GMT",
+            "standard_timezone": "Europe/Athens",
+        }
+        mock_response = create_aiohttp_mock_response(status=200, json_data={"data": account_data})
+        mock_session = create_aiohttp_mock_session(mock_response)
+
+        with patch("aiohttp.ClientSession") as mock_session_class:
+            with patch("gecloud.asyncio.sleep", new_callable=AsyncMock):
+                mock_session_class.return_value = mock_session
+
+                result = await ge_cloud.async_get_account()
+
+                if result != account_data:
+                    print("ERROR: Expected account data returned, got {}".format(result))
+                    return 1
+                if ge_cloud.account != account_data:
+                    print("ERROR: Expected account stored, got {}".format(ge_cloud.account))
+                    return 1
+                if ge_cloud.account_timezone_name != "Europe/Athens":
+                    print("ERROR: Expected account timezone Europe/Athens, got {}".format(ge_cloud.account_timezone_name))
+                    return 1
+                # Athens is always 2 hours ahead of London as both follow the same DST rules
+                if ge_cloud.get_timezone_offset_minutes() != 120:
+                    print("ERROR: Expected offset of 120 minutes, got {}".format(ge_cloud.get_timezone_offset_minutes()))
+                    return 1
+
+                # Verify the account endpoint was used
+                call_url = mock_session.get.call_args[0][0]
+                if not call_url.endswith(GE_API_ACCOUNT):
+                    print("ERROR: Expected account endpoint to be called, got {}".format(call_url))
+                    return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_async_get_account_failure(my_predbat):
+    """Test that a failed account fetch leaves the previously known account details alone"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.account = {"standard_timezone": "Europe/Athens"}
+        ge_cloud.account_timezone = pytz.timezone("Europe/Athens")
+        ge_cloud.account_timezone_name = "Europe/Athens"
+
+        mock_response = create_aiohttp_mock_response(status=404, json_data={"error": "Not found"})
+        mock_session = create_aiohttp_mock_session(mock_response)
+
+        with patch("aiohttp.ClientSession") as mock_session_class:
+            with patch("gecloud.asyncio.sleep", new_callable=AsyncMock):
+                mock_session_class.return_value = mock_session
+
+                result = await ge_cloud.async_get_account()
+
+                if result != {"standard_timezone": "Europe/Athens"}:
+                    print("ERROR: Expected previous account to be returned, got {}".format(result))
+                    return 1
+                if ge_cloud.account_timezone_name != "Europe/Athens":
+                    print("ERROR: Expected timezone to be retained, got {}".format(ge_cloud.account_timezone_name))
+                    return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_publish_account(my_predbat):
+    """Test publishing the account and timezone sensors"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.account_timezone = pytz.timezone("Europe/Athens")
+        ge_cloud.account_timezone_name = "Europe/Athens"
+
+        account_data = {
+            "id": 2,
+            "name": "francesca.holmes.285",
+            "email": "joshua94@martin.com",
+            "country": "GREECE",
+            "timezone": "EET",
+            "standard_timezone": "Europe/Athens",
+        }
+        await ge_cloud.publish_account(account_data)
+
+        entity_id = "sensor.predbat_gecloud_account"
+        if entity_id not in ge_cloud.dashboard_items:
+            print("ERROR: Expected account sensor to be published")
+            return 1
+        item = ge_cloud.dashboard_items[entity_id]
+        if item["state"] != "francesca.holmes.285":
+            print("ERROR: Expected account state to be the account name, got {}".format(item["state"]))
+            return 1
+        data = item["attributes"].get("data", None)
+        if data is None:
+            print("ERROR: Expected a data attribute on the account sensor")
+            return 1
+        if "name" in data:
+            print("ERROR: Expected name to be excluded from the account data attribute, got {}".format(data))
+            return 1
+        if data.get("email") != "joshua94@martin.com" or data.get("country") != "GREECE" or data.get("id") != 2:
+            print("ERROR: Expected the remaining account values in the data attribute, got {}".format(data))
+            return 1
+
+        entity_id = "sensor.predbat_gecloud_timezone"
+        if entity_id not in ge_cloud.dashboard_items:
+            print("ERROR: Expected timezone sensor to be published")
+            return 1
+        item = ge_cloud.dashboard_items[entity_id]
+        if item["state"] != "Europe/Athens":
+            print("ERROR: Expected timezone state Europe/Athens, got {}".format(item["state"]))
+            return 1
+        data = item["attributes"].get("data", None)
+        if data is None:
+            print("ERROR: Expected a data attribute on the timezone sensor")
+            return 1
+        if data.get("timezone") != "EET" or data.get("standard_timezone") != "Europe/Athens":
+            print("ERROR: Expected the timezone values in the data attribute, got {}".format(data))
+            return 1
+        if data.get("predbat_timezone") != "Europe/London":
+            print("ERROR: Expected the Predbat timezone in the data attribute, got {}".format(data))
+            return 1
+        if data.get("offset_minutes") != 120:
+            print("ERROR: Expected an offset of 120 minutes in the data attribute, got {}".format(data))
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_publish_account_empty(my_predbat):
+    """Test that no sensors are published when the account details are unavailable"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        await ge_cloud.publish_account({})
+
+        if ge_cloud.dashboard_items:
+            print("ERROR: Expected no entities published for an empty account, got {}".format(list(ge_cloud.dashboard_items)))
+            return 1
+
+        # An account with no timezone still publishes, falling back to an unknown timezone
+        await ge_cloud.publish_account({"name": "someone"})
+        if ge_cloud.dashboard_items.get("sensor.predbat_gecloud_timezone", {}).get("state", None) != "unknown":
+            print("ERROR: Expected unknown timezone state, got {}".format(ge_cloud.dashboard_items.get("sensor.predbat_gecloud_timezone", None)))
+            return 1
+        if ge_cloud.dashboard_items.get("sensor.predbat_gecloud_account", {}).get("state", None) != "someone":
+            print("ERROR: Expected account name state, got {}".format(ge_cloud.dashboard_items.get("sensor.predbat_gecloud_account", None)))
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_account_saved_to_storage(my_predbat):
+    """Account details fetched from the API are saved to storage"""
+
+    async def test():
+        storage = _make_async_storage_mock()
+        ge_cloud = MockGECloudDirect()
+        ge_cloud._mock_storage = storage
+
+        account_data = {"name": "someone", "standard_timezone": "Europe/Athens"}
+
+        async def mock_get_account():
+            ge_cloud.account = account_data
+            ge_cloud.set_account_timezone(account_data)
+            return account_data
+
+        ge_cloud.async_get_account = mock_get_account
+
+        await ge_cloud.update_account(first=True)
+
+        account_saves = [call for call in storage.save_calls if call["filename"] == "account"]
+        if len(account_saves) != 1:
+            print("ERROR: Expected the account to be saved once, got {}".format(storage.save_calls))
+            return 1
+        if account_saves[0]["module"] != "gecloud" or account_saves[0]["data"] != account_data:
+            print("ERROR: Unexpected account save {}".format(account_saves[0]))
+            return 1
+        if "sensor.predbat_gecloud_account" not in ge_cloud.dashboard_items:
+            print("ERROR: Expected the account sensor to be published")
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_account_restored_from_cache(my_predbat):
+    """A fresh cached account is restored on restart without hitting the API"""
+
+    async def test():
+        storage = _make_async_storage_mock()
+        account_data = {"name": "someone", "standard_timezone": "Europe/Athens", "timezone": "EET"}
+        await storage.save("gecloud", "account", account_data, format="json")
+        storage.age_overrides[("gecloud", "account")] = 60
+
+        ge_cloud = MockGECloudDirect()
+        ge_cloud._mock_storage = storage
+
+        fetch_calls = []
+
+        async def mock_get_account():
+            fetch_calls.append(True)
+            return {}
+
+        ge_cloud.async_get_account = mock_get_account
+
+        await ge_cloud.update_account(first=True)
+
+        if fetch_calls:
+            print("ERROR: Expected no API fetch when the cached account is fresh")
+            return 1
+        if ge_cloud.account != account_data:
+            print("ERROR: Expected the cached account to be restored, got {}".format(ge_cloud.account))
+            return 1
+        if ge_cloud.account_timezone_name != "Europe/Athens":
+            print("ERROR: Expected the cached timezone to be restored, got {}".format(ge_cloud.account_timezone_name))
+            return 1
+        if ge_cloud.dashboard_items.get("sensor.predbat_gecloud_timezone", {}).get("state", None) != "Europe/Athens":
+            print("ERROR: Expected the timezone sensor to be published from the cache")
+            return 1
+
+        # A subsequent run should not fetch either, as the details are still within their lifetime
+        await ge_cloud.update_account(first=False)
+        if fetch_calls:
+            print("ERROR: Expected no API fetch on a later run within the cache lifetime")
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_account_stale_cache_refetch(my_predbat):
+    """A stale cached account is used as a fallback but re-fetched from the API"""
+
+    async def test():
+        storage = _make_async_storage_mock()
+        cached_account = {"name": "old-name", "standard_timezone": "Europe/Athens"}
+        await storage.save("gecloud", "account", cached_account, format="json")
+        storage.age_overrides[("gecloud", "account")] = 48 * 60
+
+        ge_cloud = MockGECloudDirect()
+        ge_cloud._mock_storage = storage
+
+        fresh_account = {"name": "new-name", "standard_timezone": "Europe/Paris"}
+        fetch_calls = []
+
+        async def mock_get_account():
+            fetch_calls.append(True)
+            ge_cloud.account = fresh_account
+            ge_cloud.set_account_timezone(fresh_account)
+            return fresh_account
+
+        ge_cloud.async_get_account = mock_get_account
+
+        await ge_cloud.update_account(first=True)
+
+        if len(fetch_calls) != 1:
+            print("ERROR: Expected the stale cache to trigger one API fetch, got {}".format(len(fetch_calls)))
+            return 1
+        if ge_cloud.account != fresh_account:
+            print("ERROR: Expected the freshly fetched account to be used, got {}".format(ge_cloud.account))
+            return 1
+        account_saves = [call for call in storage.save_calls if call["filename"] == "account" and call["data"] == fresh_account]
+        if not account_saves:
+            print("ERROR: Expected the freshly fetched account to be saved to storage")
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_account_no_cache_fetches(my_predbat):
+    """With no cached account the details are fetched from the API"""
+
+    async def test():
+        storage = _make_async_storage_mock()
+        ge_cloud = MockGECloudDirect()
+        ge_cloud._mock_storage = storage
+
+        fetch_calls = []
+
+        async def mock_get_account():
+            fetch_calls.append(True)
+            return {}
+
+        ge_cloud.async_get_account = mock_get_account
+
+        await ge_cloud.update_account(first=True)
+
+        if len(fetch_calls) != 1:
+            print("ERROR: Expected one API fetch with no cached account, got {}".format(len(fetch_calls)))
+            return 1
+        if not any("No valid account details found" in message for message in ge_cloud.log_messages):
+            print("ERROR: Expected a log message about the missing account cache")
+            return 1
+        # Nothing to save or publish when the fetch returns nothing
+        if [call for call in storage.save_calls if call["filename"] == "account"]:
+            print("ERROR: Expected no account save when the fetch returned nothing")
+            return 1
+        if ge_cloud.dashboard_items:
+            print("ERROR: Expected no entities published for an empty account, got {}".format(list(ge_cloud.dashboard_items)))
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_set_account_timezone(my_predbat):
+    """Test recording the account timezone including bad and missing values"""
+
+    ge_cloud = MockGECloudDirect()
+
+    # Falls back to the non-standard timezone name when standard_timezone is absent
+    ge_cloud.set_account_timezone({"timezone": "Europe/Athens"})
+    if ge_cloud.account_timezone_name != "Europe/Athens":
+        print("ERROR: Expected fallback to timezone field, got {}".format(ge_cloud.account_timezone_name))
+        return 1
+
+    # An unknown timezone is ignored and the previous value retained
+    ge_cloud.set_account_timezone({"standard_timezone": "Mars/Olympus_Mons"})
+    if ge_cloud.account_timezone_name != "Europe/Athens":
+        print("ERROR: Expected unknown timezone to be ignored, got {}".format(ge_cloud.account_timezone_name))
+        return 1
+    if not any("Unknown account timezone" in message for message in ge_cloud.log_messages):
+        print("ERROR: Expected a warning to be logged for an unknown timezone")
+        return 1
+
+    # No timezone at all leaves things unchanged and warns
+    ge_cloud.log_messages = []
+    ge_cloud.set_account_timezone({"name": "someone"})
+    if ge_cloud.account_timezone_name != "Europe/Athens":
+        print("ERROR: Expected missing timezone to be ignored, got {}".format(ge_cloud.account_timezone_name))
+        return 1
+    if not any("No timezone found" in message for message in ge_cloud.log_messages):
+        print("ERROR: Expected a warning to be logged for a missing timezone")
+        return 1
+
+    # No account timezone at all means no shift is applied
+    ge_cloud = MockGECloudDirect()
+    if ge_cloud.get_timezone_offset_minutes() != 0:
+        print("ERROR: Expected zero offset with no account timezone, got {}".format(ge_cloud.get_timezone_offset_minutes()))
+        return 1
+
+    return 0
+
+
+def _test_shift_time_string(my_predbat):
+    """Test shifting register time strings across the midnight boundary"""
+
+    ge_cloud = MockGECloudDirect()
+
+    cases = [
+        ("02:00:00", -120, "00:00:00"),
+        ("23:30", 120, "01:30"),
+        ("01:00:00", -120, "23:00:00"),
+        ("00:15:00", -30, "23:45:00"),
+        ("24:00", -60, "23:00"),
+        ("12:00:00", 0, "12:00:00"),
+        ("bad", 60, "bad"),
+        ("aa:bb", 60, "aa:bb"),
+        (None, 60, None),
+        (45, 60, 45),
+    ]
+    for value, offset, expected in cases:
+        result = ge_cloud.shift_time_string(value, offset)
+        if result != expected:
+            print("ERROR: shift_time_string({}, {}) expected {}, got {}".format(value, offset, expected, result))
+            return 1
+
+    return 0
+
+
+def _test_register_time_timezone(my_predbat):
+    """Test that time registers are published and written using the customer account timezone"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.account_timezone = pytz.timezone("Europe/Athens")
+        ge_cloud.account_timezone_name = "Europe/Athens"
+
+        # Register value is in the account timezone (Athens, 2 hours ahead of the Predbat timezone)
+        registers = {77: {"name": "AC Charge 1 Start Time", "validation_rules": ["date_format:H:i"], "validation": "", "value": "02:00"}}
+        ge_cloud.settings["test123"] = registers
+        await ge_cloud.publish_registers("test123", registers)
+
+        entity_id = "select.predbat_gecloud_test123_ac_charge_1_start_time"
+        if entity_id not in ge_cloud.dashboard_items:
+            print("ERROR: Expected time select entity to be published")
+            return 1
+        state = ge_cloud.dashboard_items[entity_id]["state"]
+        if state != "00:00:00":
+            print("ERROR: Expected published state 00:00:00 in the Predbat timezone, got {}".format(state))
+            return 1
+
+        # Writing back a Predbat local time should be converted into the account timezone
+        write_calls = []
+
+        async def mock_write(serial, setting_id, value):
+            write_calls.append({"serial": serial, "id": setting_id, "value": value})
+            return {"value": value}
+
+        async def mock_publish(*args, **kwargs):
+            pass
+
+        ge_cloud.async_write_inverter_setting = mock_write
+        ge_cloud.publish_registers = mock_publish
+
+        await ge_cloud.select_event(entity_id, "23:30:00")
+
+        if len(write_calls) != 1:
+            print("ERROR: Expected 1 write call, got {}".format(len(write_calls)))
+            return 1
+        if write_calls[0]["value"] != "01:30":
+            print("ERROR: Expected 01:30 written in the account timezone, got {}".format(write_calls[0]["value"]))
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_register_time_no_timezone(my_predbat):
+    """Test that time registers are left untouched when the account timezone is unknown"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+
+        registers = {77: {"name": "AC Charge 1 Start Time", "validation_rules": ["date_format:H:i"], "validation": "", "value": "02:00"}}
+        ge_cloud.settings["test123"] = registers
+        await ge_cloud.publish_registers("test123", registers)
+
+        entity_id = "select.predbat_gecloud_test123_ac_charge_1_start_time"
+        state = ge_cloud.dashboard_items[entity_id]["state"]
+        if state != "02:00:00":
+            print("ERROR: Expected unshifted state 02:00:00, got {}".format(state))
+            return 1
+
+        write_calls = []
+
+        async def mock_write(serial, setting_id, value):
+            write_calls.append({"serial": serial, "id": setting_id, "value": value})
+            return {"value": value}
+
+        async def mock_publish(*args, **kwargs):
+            pass
+
+        ge_cloud.async_write_inverter_setting = mock_write
+        ge_cloud.publish_registers = mock_publish
+
+        await ge_cloud.select_event(entity_id, "23:30:00")
+
+        if write_calls[0]["value"] != "23:30":
+            print("ERROR: Expected unshifted write of 23:30, got {}".format(write_calls[0]["value"]))
+            return 1
 
         return 0
 
@@ -1836,6 +2334,8 @@ def _make_async_storage_mock():
         def __init__(self):
             self._data = {}
             self.save_calls = []
+            # Ages in minutes keyed by (module, filename), overriding the default of 0 (fresh)
+            self.age_overrides = {}
 
         async def load(self, module, filename, format="json"):
             import copy
@@ -1850,8 +2350,10 @@ def _make_async_storage_mock():
             return True
 
         async def age(self, module, filename):
-            # Return 0 (fresh) for any stored key, None for missing keys
-            return 0 if (module, filename) in self._data else None
+            # Return 0 (fresh) for any stored key unless overridden, None for missing keys
+            if (module, filename) not in self._data:
+                return None
+            return self.age_overrides.get((module, filename), 0)
 
     return _AsyncStorageMock()
 
@@ -2027,6 +2529,13 @@ def _test_run_method(my_predbat):
         call_order = []
 
         # Mock all the async functions called by run()
+        async def mock_get_account():
+            call_order.append("async_get_account")
+            return {"standard_timezone": "Europe/London"}
+
+        async def mock_publish_account(account):
+            call_order.append("publish_account")
+
         async def mock_get_devices():
             call_order.append("async_get_devices")
             return {"battery": ["inv001"], "ems": None, "gateway": None, "pv": [], "battery_meters": {}}
@@ -2085,6 +2594,8 @@ def _test_run_method(my_predbat):
             call_order.append(f"enable_default_options:{device}")
 
         # Assign all mocks
+        ge_cloud.async_get_account = mock_get_account
+        ge_cloud.publish_account = mock_publish_account
         ge_cloud.async_get_devices = mock_get_devices
         ge_cloud.async_get_evc_devices = mock_get_evc_devices
         ge_cloud.async_get_inverter_status = mock_get_inverter_status
@@ -2112,6 +2623,8 @@ def _test_run_method(my_predbat):
 
         # Verify expected call order for first run
         expected_order = [
+            "async_get_account",
+            "publish_account",
             "async_get_devices",
             "async_get_evc_devices",
             # Device polling (every 60 seconds, also on first)
@@ -3871,6 +4384,12 @@ def _test_enable_default_options(my_predbat):
 def _make_run_mocks(ge_cloud, enable_default_calls=None):
     """Attach minimal async mocks to ge_cloud so run() can execute without real I/O."""
 
+    async def mock_get_account():
+        return {"standard_timezone": "Europe/London"}
+
+    async def mock_publish_account(_account):
+        pass
+
     async def mock_get_devices():
         return {"battery": ["inv001"], "ems": None, "gateway": None, "pv": [], "battery_meters": {}}
 
@@ -3908,6 +4427,8 @@ def _make_run_mocks(ge_cloud, enable_default_calls=None):
         if enable_default_calls is not None:
             enable_default_calls.append(device)
 
+    ge_cloud.async_get_account = mock_get_account
+    ge_cloud.publish_account = mock_publish_account
     ge_cloud.async_get_devices = mock_get_devices
     ge_cloud.async_get_evc_devices = mock_get_evc_devices
     ge_cloud.async_get_inverter_status = mock_get_inverter_status

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -66,6 +66,7 @@ class MockGECloudDirect(GECloudDirect):
         self.account_timezone = None
         self.account_timezone_name = None
         self.account_stamp = None
+        self.account_fetch_stamp = None
 
         class MockHAInterface:
             def __init__(self):
@@ -213,6 +214,7 @@ def test_ge_cloud(my_predbat=None):
         ("account_restored_from_cache", _test_account_restored_from_cache, "Account restored from a fresh storage cache"),
         ("account_stale_cache", _test_account_stale_cache_refetch, "Stale cached account is re-fetched"),
         ("account_no_cache", _test_account_no_cache_fetches, "Account fetched when nothing is cached"),
+        ("account_failed_fetch_retry", _test_account_failed_fetch_retries, "Failed account fetch retries without polling"),
         ("account_timezone", _test_set_account_timezone, "Account timezone parsing and fallbacks"),
         ("publish_account", _test_publish_account, "Publish account and timezone sensors"),
         ("publish_account_empty", _test_publish_account_empty, "Publish account with missing details"),
@@ -1177,6 +1179,75 @@ def _test_account_no_cache_fetches(my_predbat):
             return 1
         if ge_cloud.dashboard_items:
             print("ERROR: Expected no entities published for an empty account, got {}".format(list(ge_cloud.dashboard_items)))
+            return 1
+
+        return 0
+
+    return run_async(test())
+
+
+def _test_account_failed_fetch_retries(my_predbat):
+    """A failed account fetch retries after the retry interval rather than waiting a full day"""
+
+    async def test():
+        ge_cloud = MockGECloudDirect()
+        start = ge_cloud._now_utc_exact
+
+        fetch_calls = []
+        account_data = {"name": "someone", "standard_timezone": "Europe/Athens"}
+        fail = True
+
+        async def mock_get_account():
+            fetch_calls.append(True)
+            if fail:
+                return {}
+            ge_cloud.account = account_data
+            ge_cloud.set_account_timezone(account_data)
+            return account_data
+
+        ge_cloud.async_get_account = mock_get_account
+
+        # First attempt fails, so the details must not be marked fresh
+        await ge_cloud.update_account(first=True)
+        if len(fetch_calls) != 1:
+            print("ERROR: Expected 1 fetch attempt, got {}".format(len(fetch_calls)))
+            return 1
+        if ge_cloud.account_stamp is not None:
+            print("ERROR: Expected account_stamp to stay None after a failed fetch, got {}".format(ge_cloud.account_stamp))
+            return 1
+
+        # A run within the retry interval must not hammer the API
+        ge_cloud._now_utc_exact = start + timedelta(minutes=5)
+        await ge_cloud.update_account(first=False)
+        if len(fetch_calls) != 1:
+            print("ERROR: Expected no retry within the retry interval, got {} fetches".format(len(fetch_calls)))
+            return 1
+
+        # Once the retry interval has passed it tries again, well before the 24 hour lifetime
+        fail = False
+        ge_cloud._now_utc_exact = start + timedelta(minutes=31)
+        await ge_cloud.update_account(first=False)
+        if len(fetch_calls) != 2:
+            print("ERROR: Expected a retry after the retry interval, got {} fetches".format(len(fetch_calls)))
+            return 1
+        if ge_cloud.account_stamp != ge_cloud._now_utc_exact:
+            print("ERROR: Expected account_stamp to be set after a successful fetch, got {}".format(ge_cloud.account_stamp))
+            return 1
+        if ge_cloud.dashboard_items.get("sensor.predbat_gecloud_timezone", {}).get("state", None) != "Europe/Athens":
+            print("ERROR: Expected the timezone sensor to be published after the successful retry")
+            return 1
+
+        # Now that it succeeded there should be no further fetches until the details expire
+        ge_cloud._now_utc_exact = start + timedelta(hours=12)
+        await ge_cloud.update_account(first=False)
+        if len(fetch_calls) != 2:
+            print("ERROR: Expected no fetch while the details are fresh, got {} fetches".format(len(fetch_calls)))
+            return 1
+
+        ge_cloud._now_utc_exact = start + timedelta(hours=25)
+        await ge_cloud.update_account(first=False)
+        if len(fetch_calls) != 3:
+            print("ERROR: Expected a fetch once the details expired, got {} fetches".format(len(fetch_calls)))
             return 1
 
         return 0

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -170,6 +170,8 @@ This is being worked on by the author of GivTCP, e.g. see [GivTCP issue: unable 
 - If you set **ge_cloud_automatic** to `true` in `apps.yaml` then Predbat will auto-configure itself to use the appropriate GE Cloud controls and will ignore any inverter and battery controls set in `apps.yaml`
 - Make sure that the 'discharge down to' registers are set to 4% and charge and discharge slots 2, 3 and 4 are disabled in the portal by setting the start and end times to 00:00 (if you have them).
 - If you have set **ge_cloud_automatic** to `true` and the GE Cloud does not return accurate **load_today** energy information, you can [override the GE Cloud load data](apps-yaml.md) by creating a custom template sensor and setting **ge_cloud_load_today_ignore** to true in `apps.yaml`.
+- The charge/export slot start and end times are stored by GivEnergy in the timezone set on your GivEnergy account. Predbat reads this timezone from the GivEnergy account details and translates the slot times into
+  the Predbat **timezone** setting, so the times shown on the Predbat select entities may differ from those shown in the GivEnergy portal if the two timezones do not match.
 
 ## GivEnergy with GE Cloud EMS
 


### PR DESCRIPTION
## Problem

The GivEnergy charge/export slot start and end times are held in the timezone set on the customer's **GivEnergy account**, which is not necessarily the timezone Predbat is running in. Predbat read and wrote those registers as if they were already in its own timezone, so for anyone whose two timezones differ the slots landed at the wrong time of day.

## Changes

**Fetch the account details** — new `/v1/account` call (`async_get_account`), recording the timezone from `standard_timezone` (IANA, e.g. `Europe/London`), falling back to `timezone`. Unknown or missing names are logged and ignored.

**Translate the time registers at the API boundary**, so the rest of Predbat is untouched:

- `publish_registers()` converts `date_format:H:i` registers from account time into Predbat time before publishing the select entity
- `select_event()` converts back into account time before writing
- `get_timezone_offset_minutes()` is evaluated at call time, so DST is handled on both sides
- `shift_time_string()` wraps correctly at midnight

When the account timezone is unknown the offset is 0 and nothing shifts, so existing behaviour is preserved.

**Cache the account in storage** — restored on startup and only re-fetched once a day (`ACCOUNT_MAX_AGE_MINUTES`). A stale cache is still loaded as a fallback, so if the API call then fails the timezone conversion keeps working with the last known values rather than silently reverting to no conversion.

**Publish two sensors:**

| Entity | State | `data` attribute |
|---|---|---|
| `sensor.predbat_gecloud_account` | account `name` | everything else from the response |
| `sensor.predbat_gecloud_timezone` | IANA timezone name | `timezone`, `standard_timezone`, `predbat_timezone`, `offset_minutes` |

`offset_minutes` makes it visible at a glance whether any shift is being applied.

`enable_default_options()` is deliberately untouched — the `00:00` it writes to unused slots is a disable sentinel (start == end), so shifting it would serve no purpose.

Version bumped to v8.47.7.

## User-visible change

For anyone whose GivEnergy account timezone differs from their Predbat `timezone`, the HA select entities will now show times shifted relative to the GivEnergy portal. That is the point of the change, but it is a visible difference when cross-checking the two. Documented in `docs/inverter-setup.md`.

## Testing

```
./run_all --test ge_cloud   → RESULTS: 79 passed, 0 failed out of 79 tests
./run_all --quick           → All tests passed (5 slow tests skipped)
pre-commit run --all-files  → exit 0
```

Ten new sub-tests cover the account fetch and its failure path, timezone parsing and fallbacks, the time-string shift (including midnight wrap and malformed input), the round-trip conversion through publish/select with and without a known timezone, both sensors, and the four storage-cache paths (save, fresh restore with no API call, stale re-fetch, no cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)