### PR TITLE
fix(enphase): retry POST-create on conflict, disambiguate HTTP logs, surface write failures

### DIFF
--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -64,6 +64,13 @@ ENPHASE_REFRESH_SETTINGS = 30  # profile, battery settings, schedule config - ch
 ENPHASE_REFRESH_STATUS = 5  # battery SOC/available energy - needs to stay fresh for planning
 ENPHASE_REFRESH_ENERGY = 5  # today energy totals
 ENPHASE_REFRESH_POWER = 5  # latest instantaneous power
+# How often apply_battery_schedule reconciles even without an explicit write-switch trigger, so a
+# missed/dropped trigger cannot leave the cloud diverged from the plan indefinitely - see #4461.
+ENPHASE_REFRESH_SCHEDULE_SYNC = 5
+# How many read-clean-write passes apply_battery_schedule attempts, with a short backoff between,
+# before giving up on this call and leaving it to the next periodic sync or trigger. See
+# docs/superpowers/specs/2026-08-08-enphase-schedule-reconcile-design.md.
+ENPHASE_RECONCILE_MAX_ATTEMPTS = 3
 # How many intra-day buckets to step back when deriving power from the /today energy arrays.
 # 1 would be the just-closed bucket, which the cloud is still back-filling; 2 is settled.
 ENPHASE_SETTLED_BUCKETS = 2
@@ -88,6 +95,7 @@ PROFILE_BACKUP_ONLY = "backup_only"
 SCHEDULE_CHARGE = "CFG"  # charge from grid
 SCHEDULE_EXPORT = "DTG"  # discharge to grid
 SCHEDULE_FREEZE = "RBD"  # restrict battery discharge
+FAMILY_ORDER = ("cfg", "dtg", "rbd")  # lower-case schedule family keys, in a fixed processing order
 
 ENPHASE_RETRIES = 5
 
@@ -453,6 +461,12 @@ class EnphaseAPI(ComponentBase):
             self.sync_local_schedule_from_cloud(site_id)
             await self.publish_data(site_id)
             await self.publish_schedule_settings_ha(site_id)
+            # Periodic reconcile, independent of the write-switch trigger - so a missed/dropped
+            # trigger (e.g. an HA restart mid-cycle) cannot leave the cloud diverged from the plan
+            # indefinitely. apply_battery_schedule is a no-op when nothing has changed. See #4461.
+            if self._needs_refresh("schedule_sync", ENPHASE_REFRESH_SCHEDULE_SYNC):
+                await self.apply_battery_schedule(site_id)
+                self.data_age["schedule_sync"] = datetime.now(timezone.utc)
 
         # Automatic configuration on first successful data load. A site with no controllable
         # battery (e.g. PV-only) cannot be configured as a Predbat inverter - log and report
@@ -839,8 +853,9 @@ class EnphaseAPI(ComponentBase):
     async def switch_event(self, entity_id, service):
         """Handle a switch service call routed from HA, updating the local schedule model.
 
-        Turning on a "_write" switch triggers `apply_battery_schedule(site_id)`, which
-        diffs the local schedule model against the cloud and issues only the changed writes.
+        Turning on a "_write" switch triggers `apply_battery_schedule(site_id)`, which reconciles
+        the cloud schedule/reserve state to match this model - the same reconcile that also runs
+        periodically from `run()`.
         """
         site_id, attribute = self._parse_entity(entity_id)
         if not site_id or not attribute.startswith("battery_schedule_"):
@@ -858,106 +873,6 @@ class EnphaseAPI(ComponentBase):
         """Return the IANA timezone to use for schedule writes."""
         timezone_name = self.site_settings.get(site_id, {}).get("timezone")
         return timezone_name or str(self.local_tz)
-
-    async def _write_schedule(self, site_id, family, start_time_ha, end_time_ha, limit, enabled):
-        """Create/update one Enphase schedule family if it differs from our cached cloud state.
-
-        Converts the HA "HH:MM:SS" option times to Enphase "HH:MM" format, then compares against
-        the cached cloud schedule via `schedules_equal()`. A matching schedule is a no-op. Otherwise
-        it updates the existing schedule by id (`PUT`) or creates a new one (`POST`), each retrying
-        once on a conflict via `_put_schedule_with_conflict_retry` / `_create_schedule_with_conflict_retry`.
-        On success it optimistically updates our cached copy to the written state and returns - the
-        periodic settings re-read will correct it if the write did not actually land. A create
-        additionally re-reads the schedules once, to capture the cloud-assigned scheduleId (so later
-        edits update in place rather than creating duplicates - the write responses do not return the
-        id). Every attempted write records its outcome via `_note_schedule_write_result`, so a write
-        that is attempted but never lands is visible instead of silently leaving the device on its
-        previous schedule.
-        Returns True if a write was issued.
-        """
-        start_hm = ha_time_to_enphase(start_time_ha)
-        end_hm = ha_time_to_enphase(end_time_ha)
-        family_key = family.lower()
-        cloud_entry = self.schedules.get(site_id, {}).get(family_key, {})
-        if schedules_equal(cloud_entry, start_hm, end_hm, limit, enabled):
-            return False  # already matches our cached state - nothing to do
-
-        payload = {"timezone": self._site_timezone(site_id), "startTime": start_hm, "endTime": end_hm, "scheduleType": family, "days": [1, 2, 3, 4, 5, 6, 7], "isEnabled": bool(enabled)}
-        if limit is not None:
-            payload["limit"] = int(limit)
-        schedule_id = cloud_entry.get("id")
-        if schedule_id and not enabled:
-            # The cloud ignores isEnabled=False on a PUT (it answers 200 with isEnabled still true
-            # and keeps enforcing the window), so the only way to retire a window is to delete it.
-            # A lingering window would also conflict with the other family's next write.
-            self.log(f"Enphase: Deleting {family} schedule {schedule_id} on site {site_id} (window no longer required)")
-            if not await self._delete_schedule(site_id, schedule_id, context=f"{family} disable"):
-                self._note_schedule_write_result(site_id, family_key, False)
-                return False
-            # Drop the id/window so the next apply is a no-op while disabled, and a re-enable creates
-            # a fresh schedule rather than PUTting an id the cloud no longer knows.
-            cleared = dict(cloud_entry)
-            for field in ("id", "startTime", "endTime", "limit"):
-                cleared.pop(field, None)
-            cleared["enabled"] = False
-            self.schedules.setdefault(site_id, {})[family_key] = cleared
-            self._note_schedule_write_result(site_id, family_key, True)
-            return True
-        if schedule_id:
-            self.log(f"Enphase: Updating {family} schedule {schedule_id} on site {site_id}: {start_hm}-{end_hm} limit={limit} enabled={enabled}")
-            result = await self._put_schedule_with_conflict_retry(site_id, family_key, schedule_id, payload)
-            if result is not None:
-                # Optimistically cache the new state, preserving the id and other fields.
-                updated = dict(self.schedules.get(site_id, {}).get(family_key) or cloud_entry)
-                updated.update({"startTime": start_hm, "endTime": end_hm, "limit": limit, "enabled": bool(enabled)})
-                self.schedules.setdefault(site_id, {})[family_key] = updated
-        else:
-            self.log(f"Enphase: Creating {family} schedule on site {site_id}: {start_hm}-{end_hm} limit={limit} enabled={enabled}")
-            result = await self._create_schedule_with_conflict_retry(site_id, family_key, payload)
-            if result is not None:
-                # Re-read once so we learn the new schedule's cloud-assigned id for future edits.
-                await self.get_schedules(site_id)
-        self._note_schedule_write_result(site_id, family_key, result is not None)
-        return result is not None
-
-    async def _put_schedule_with_conflict_retry(self, site_id, family_key, schedule_id, payload):
-        """PUT a schedule, re-reading and retrying once if the cloud reports a conflict.
-
-        HTTP 409 means some other schedule overlaps the window we asked for. Our cached view of the
-        account is up to 30 minutes stale, so re-read it: that both refreshes the id we should be
-        writing to and prunes any stray sibling that is causing the overlap. Retried once only - a
-        conflict that survives the re-read is a real clash (typically the other family's window)
-        and retrying it again would just burn API calls every cycle.
-        """
-        for attempt in range(2):
-            result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules/{schedule_id}", family="battery_config", json_body=payload, context=f"{family_key.upper()} schedule update")
-            if result is not None or self.last_error_status != 409 or attempt:
-                return result
-            self.log(f"Enphase: Schedule {schedule_id} on site {site_id} conflicts with another schedule; re-reading schedules and retrying once")
-            await self.get_schedules(site_id)
-            schedule_id = (self.schedules.get(site_id, {}).get(family_key) or {}).get("id") or schedule_id
-        return None
-
-    async def _create_schedule_with_conflict_retry(self, site_id, family_key, payload):
-        """POST a new schedule, re-reading and retrying once if the cloud reports a conflict.
-
-        Mirrors `_put_schedule_with_conflict_retry` for the create path, which #4428 left without a
-        retry: an HTTP 409 here means an untracked schedule already occupies the family - a sibling
-        `_prune_sibling_schedules` had not yet reached, or one left over from an earlier create whose
-        response Predbat never saw. Re-reading picks it up: `get_schedules` prunes any sibling (so
-        the retried POST no longer collides with it) and, if a schedule remains in the family, adopts
-        its id (so the retry goes out as a PUT instead of a second POST). Retried once only, matching
-        the PUT path.
-        """
-        result = await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules", family="battery_config", json_body=payload, context=f"{family_key.upper()} schedule create")
-        if result is not None or self.last_error_status != 409:
-            return result
-        self.log(f"Enphase: Create of a new {family_key.upper()} schedule on site {site_id} conflicts with another schedule; re-reading schedules and retrying once")
-        await self.get_schedules(site_id)
-        schedule_id = (self.schedules.get(site_id, {}).get(family_key) or {}).get("id")
-        if schedule_id:
-            return await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules/{schedule_id}", family="battery_config", json_body=payload, context=f"{family_key.upper()} schedule update after create conflict")
-        return await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules", family="battery_config", json_body=payload, context=f"{family_key.upper()} schedule create retry")
 
     def _is_read_only(self):
         """Return True when Predbat is in read-only mode and must not write to the account."""
@@ -994,27 +909,16 @@ class EnphaseAPI(ComponentBase):
             survivors.append(item)
         return survivors
 
-    def _is_schedule_pending(self, site_id, family):
-        """Return True when the cached cloud schedule exists but is stuck in pending status."""
-        family_key = family.lower()
-        entry = self.schedules.get(site_id, {}).get(family_key, {})
+    def _is_schedule_pending(self, site_id, family_key):
+        """Return True when the cached cloud schedule exists but is stuck in pending status.
+
+        Reflects whatever `get_schedules` last read - `_reconcile_once` always re-reads before
+        checking this, so it is never more than one API call stale.
+        """
+        entry = self.schedules.get(site_id, {}).get(family_key.lower(), {})
         # get_schedules always stores a "status" key (None when the cloud omits scheduleStatus),
         # so coalesce to "" before comparing rather than relying on the dict-get default.
         return isinstance(entry, dict) and (entry.get("status") or "").lower() == "pending"
-
-    def _invalidate_cached_schedule(self, site_id, family):
-        """Clear the cached cloud schedule so the next apply detects a diff and retries.
-
-        Sets startTime to an empty string so that schedules_equal fails its window
-        comparison for an enabled schedule (``""[:5] != start_hm``), causing
-        _write_schedule to re-issue the update on the next apply as a PUT (the id is
-        preserved). Invalidation only runs after a failed activation, which only happens
-        for enabled schedules, so the disable path is never affected.
-        """
-        family_key = family.lower()
-        entry = self.schedules.get(site_id, {}).get(family_key)
-        if isinstance(entry, dict):
-            entry["startTime"] = ""
 
     def _note_schedule_write_result(self, site_id, family_key, ok):
         """Track whether the most recent write/activation for a schedule family landed on the cloud.
@@ -1039,9 +943,9 @@ class EnphaseAPI(ComponentBase):
         A schedule write leaves the schedule in "pending" status; this follow-up PUT
         (carrying a per-mode ``body``) transitions it to active so the gateway acts on it.
         On success it clears the cached pending marker and calls ``apply_cache`` to
-        optimistically record the change in ``battery_settings``; on failure it logs and
-        invalidates the cached schedule so the next apply re-detects a diff and retries
-        write + activation. Returns True if the PUT succeeded.
+        optimistically record the change in ``battery_settings``; on failure it just logs -
+        `_reconcile_once` always re-reads from the cloud on its next attempt, so there is no local
+        cache to invalidate. Returns True if the PUT succeeded.
         """
         params = {"source": "enho"}
         if self.user_id:
@@ -1055,7 +959,6 @@ class EnphaseAPI(ComponentBase):
                 entry.pop("status", None)
         else:
             self.log(f"Warn: Enphase: {label} activation failed for site {site_id}")
-            self._invalidate_cached_schedule(site_id, family)
         self._note_schedule_write_result(site_id, family_key, result is not None)
         return result is not None
 
@@ -1092,21 +995,6 @@ class EnphaseAPI(ComponentBase):
 
         return await self._activate_control_mode(site_id, family, {"rbdControl": {"enabled": True}}, apply_cache, "RBD")
 
-    async def _write_and_activate(self, site_id, family, start_time_ha, end_time_ha, limit, enabled, activate, force_activate=False):
-        """Write one schedule family, then activate it when appropriate.
-
-        Activation fires when the mode is enabled and any of: the schedule was just written,
-        ``force_activate`` is set (e.g. the underlying battery setting still needs enabling), or
-        the cached schedule is stuck pending. Activation PUTs are not schedule writes, so the
-        return value reflects only whether _write_schedule issued a write.
-        """
-        wrote = await self._write_schedule(site_id, family, start_time_ha, end_time_ha, limit, enabled)
-        if enabled and (wrote or force_activate or self._is_schedule_pending(site_id, family)):
-            if not wrote:
-                self.log(f"Enphase: {family} schedule for site {site_id} needs activation; activating without rewrite")
-            await activate(site_id)
-        return wrote
-
     async def _ensure_charge_from_grid(self, site_id):
         """Accept the one-time ITC disclaimer required before charge-from-grid can be enabled.
 
@@ -1142,74 +1030,179 @@ class EnphaseAPI(ComponentBase):
         self._note_schedule_write_result(site_id, "reserve", result is not None)
         return result
 
-    async def apply_battery_schedule(self, site_id):
-        """Diff the local schedule model against the cloud and issue only the changed writes.
+    def _desired_schedule_families(self, local):
+        """Compute the desired {enabled, start, end, limit} state for cfg/dtg/rbd from `local`.
 
-        Reads the latest control-entity state into `local_schedule` first, then writes (only
-        where the desired state differs from the cached cloud state):
-        1. Reserve, via a profile PUT that preserves the current profile name.
-        2. Forced charge-from-grid window (schedule family "CFG"), enabling the
-           `chargeFromGrid` battery setting first if required.
-        3. The export window, derived from Predbat's export/discharge target SOC:
-           - target below 99% -> a real forced export to that floor (schedule family "DTG"),
-             only on sites that support it;
-           - target of exactly 99% -> "freeze export" (hold, don't discharge), mapped to the
-             restrict-battery-discharge family ("RBD") over the export window;
-           - target of 100% -> disabled (same as no export).
-        Each write optimistically updates our cached cloud copy on success and moves on; the
-        periodic settings re-read reconciles it later if a write did not actually land. Returns
-        True if any write was issued.
-
+        Mirrors Predbat's SOC-target encoding for the export direction: target below 99% -> a
+        real forced export to that floor (DTG); exactly 99% -> "freeze export" (hold, don't
+        discharge), mapped to restrict-battery-discharge (RBD); 100% or disabled -> neither. DTG
+        and RBD always share the same window and are mutually exclusive by construction (a target
+        cannot be both <99 and ==99), so at most one of them is ever enabled - see the "Update
+        strategy" note in docs/superpowers/specs/2026-08-08-enphase-schedule-reconcile-design.md.
         Freeze *charge* is not handled here - Predbat freezes charge via the reserve (raising it
         to the current SOC) and disabling the charge window, using the existing reserve/charge
-        controls.
+        controls. Start/end are converted to Enphase "HH:MM" format; everything downstream works
+        in that format only.
+        """
+        charge = local.get("charge", {})
+        export = local.get("export", {})
+        export_enabled = bool(export.get("enable", False))
+        export_soc = int(export.get("soc", 5))
+        export_start = ha_time_to_enphase(export.get("start_time", "00:00:00"))
+        export_end = ha_time_to_enphase(export.get("end_time", "00:00:00"))
+        # Clamp the DTG floor to at least the reserve: Enphase will not discharge below the backup
+        # reserve, and Predbat's own discharge target is max(export, reserve), so keep the written
+        # limit consistent rather than requesting an export below the reserve it can never reach.
+        dtg_limit = max(export_soc, int(local.get("reserve", 0)))
+        return {
+            "cfg": {"enabled": bool(charge.get("enable")), "start": ha_time_to_enphase(charge.get("start_time", "00:00:00")), "end": ha_time_to_enphase(charge.get("end_time", "00:00:00")), "limit": charge.get("soc", 100)},
+            "dtg": {"enabled": export_enabled and export_soc < 99, "start": export_start, "end": export_end, "limit": dtg_limit},
+            "rbd": {"enabled": export_enabled and export_soc == 99, "start": export_start, "end": export_end, "limit": None},
+        }
+
+    async def _cleanup_family(self, site_id, family_key, target, force_recreate):
+        """Delete a family's existing schedule when it must not survive into the write phase.
+
+        Covers two cases: the family is being disabled (the cloud ignores isEnabled=False on a
+        PUT, so deleting is the only way to retire a window), or - per the "Update strategy" rule
+        in the design doc - it is one of several families changing in this pass, so it is cleared
+        before any write happens anywhere. That closes the cross-family overlap gap from #4461: a
+        new window for one family can otherwise collide with a *different* family's old,
+        not-yet-updated one even when neither family's new windows overlap each other. A single
+        family changing alone skips this - `_converge_family`'s PUT-in-place is safe when nothing
+        else is moving.
+        """
+        entry = self.schedules.get(site_id, {}).get(family_key, {})
+        schedule_id = entry.get("id")
+        if not schedule_id or (target["enabled"] and not force_recreate):
+            return True
+        family = family_key.upper()
+        reason = "window no longer required" if not target["enabled"] else "clearing before a multi-family change"
+        self.log(f"Enphase: Deleting {family} schedule {schedule_id} on site {site_id} ({reason})")
+        if not await self._delete_schedule(site_id, schedule_id, context=f"{family} {reason}"):
+            if not target["enabled"]:
+                self._note_schedule_write_result(site_id, family_key, False)
+            return False
+        # Drop the id/window so a re-enable creates a fresh schedule rather than PUTting an id the
+        # cloud no longer knows about.
+        cleared = dict(entry)
+        for field in ("id", "startTime", "endTime", "limit"):
+            cleared.pop(field, None)
+        cleared["enabled"] = False
+        self.schedules.setdefault(site_id, {})[family_key] = cleared
+        if not target["enabled"]:
+            self._note_schedule_write_result(site_id, family_key, True)
+        return True
+
+    async def _converge_family(self, site_id, family_key, target, force_activate=False):
+        """Write and activate one family to match `target`, if it still needs it after cleanup.
+
+        Any id present here already survived `_cleanup_family`, so PUT-in-place is safe; its
+        absence means create. Activates when the schedule was just written, when
+        `force_activate` says the underlying battery setting still needs enabling (CFG's
+        chargeFromGrid), or when the cache already matches but the cloud still reports the family
+        pending (written on an earlier pass, activation never landed).
+        """
+        if not target["enabled"]:
+            return True  # nothing to write or activate; _cleanup_family handles disabling
+        family = family_key.upper()
+        entry = self.schedules.get(site_id, {}).get(family_key, {})
+        wrote = False
+        if not schedules_equal(entry, target["start"], target["end"], target["limit"], True):
+            payload = {"timezone": self._site_timezone(site_id), "startTime": target["start"], "endTime": target["end"], "scheduleType": family, "days": [1, 2, 3, 4, 5, 6, 7], "isEnabled": True}
+            if target["limit"] is not None:
+                payload["limit"] = int(target["limit"])
+            schedule_id = entry.get("id")
+            if schedule_id:
+                self.log(f"Enphase: Updating {family} schedule {schedule_id} on site {site_id}: {target['start']}-{target['end']} limit={target['limit']}")
+                result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules/{schedule_id}", family="battery_config", json_body=payload, context=f"{family} schedule update")
+                if result is not None:
+                    updated = dict(entry)
+                    updated.update({"startTime": target["start"], "endTime": target["end"], "limit": target["limit"], "enabled": True})
+                    self.schedules.setdefault(site_id, {})[family_key] = updated
+            else:
+                self.log(f"Enphase: Creating {family} schedule on site {site_id}: {target['start']}-{target['end']} limit={target['limit']}")
+                result = await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules", family="battery_config", json_body=payload, context=f"{family} schedule create")
+                if result is not None:
+                    # Re-read once so we learn the new schedule's cloud-assigned id for future
+                    # edits - the create response does not return it.
+                    await self.get_schedules(site_id)
+            wrote = result is not None
+            self._note_schedule_write_result(site_id, family_key, wrote)
+            if not wrote:
+                return False
+
+        if wrote or force_activate or self._is_schedule_pending(site_id, family_key):
+            activate = {"cfg": self._activate_cfg_mode, "dtg": self._activate_dtg_mode, "rbd": self._activate_rbd_mode}[family_key]
+            if family_key == "cfg":
+                await self._ensure_charge_from_grid(site_id)
+            return await activate(site_id)
+        return True
+
+    async def _converge_reserve(self, site_id, local):
+        """Write the reserve via a profile PUT if it differs from the cached cloud value."""
+        desired_reserve = int(local.get("reserve", 0))
+        cloud = self.profile.get(site_id, {})
+        if not desired_reserve or desired_reserve == int(cloud.get("reserve", -1)):
+            return True
+        return await self.set_reserve(site_id, desired_reserve) is not None
+
+    async def _reconcile_once(self, site_id):
+        """Run one read-clean-write pass, converging the cloud to Predbat's desired local model.
+
+        Always starts from a fresh cloud read - no state is trusted between passes. Cleanup
+        (deleting schedules that must not survive) runs for every changing family before any
+        family writes anything, so a cross-family collision can never happen; see
+        `_cleanup_family`. Returns True only if every step this pass succeeded;
+        `apply_battery_schedule` retries a bounded number of times on False.
         """
         await self.get_schedule_settings_ha(site_id)
         # Bootstrap a fresh XSRF token before writing (the web app GETs siteSettings first); its
         # x-csrf-token response header is absorbed by request_json for the writes below.
         await self.get_site_settings(site_id)
+        await self.get_schedules(site_id)
         local = self.local_schedule.get(site_id, self._default_local_schedule())
-        wrote = False
+        desired = self._desired_schedule_families(local)
 
-        # Reserve via profile PUT, preserving the current profile name
-        desired_reserve = int(local.get("reserve", 0))
-        cloud = self.profile.get(site_id, {})
-        if desired_reserve and desired_reserve != int(cloud.get("reserve", -1)):
-            await self.set_reserve(site_id, desired_reserve)
-            wrote = True
+        changed = [key for key in FAMILY_ORDER if not schedules_equal(self.schedules.get(site_id, {}).get(key, {}), desired[key]["start"], desired[key]["end"], desired[key]["limit"], desired[key]["enabled"])]
+        # PUT-in-place is only safe when nothing else is moving in the same pass - see
+        # _cleanup_family's docstring for why a single family changing alone is fine.
+        force_recreate = len(changed) > 1
 
-        # Forced charge window (CFG). Enabling chargeFromGrid *is* the activation PUT, so force
-        # activation whenever the setting is still off, even if the schedule already matches.
-        charge = local.get("charge", {})
-        charge_enabled = bool(charge.get("enable"))
-        if charge_enabled:
-            await self._ensure_charge_from_grid(site_id)
-        cfg_needs_enable = not self.battery_settings.get(site_id, {}).get("chargeFromGrid")
-        wrote |= await self._write_and_activate(site_id, SCHEDULE_CHARGE, charge.get("start_time", "00:00:00"), charge.get("end_time", "00:00:00"), charge.get("soc", 100), charge_enabled, self._activate_cfg_mode, force_activate=cfg_needs_enable)
+        ok = True
+        for key in changed:
+            if not await self._cleanup_family(site_id, key, desired[key], force_recreate):
+                ok = False
 
-        # Export window. Predbat encodes the mode in the export/discharge target SOC:
-        #   < 99  -> real forced export to that floor (DTG)
-        #   == 99 -> freeze export / restrict discharge (RBD)
-        #   == 100 (or disabled) -> no export
-        export = local.get("export", {})
-        export_enabled = bool(export.get("enable", False))
-        export_soc = int(export.get("soc", 5))
-        export_start = export.get("start_time", "00:00:00")
-        export_end = export.get("end_time", "00:00:00")
-        real_export = export_enabled and export_soc < 99
-        freeze_export = export_enabled and export_soc == 99
+        cfg_force_activate = desired["cfg"]["enabled"] and not self.battery_settings.get(site_id, {}).get("chargeFromGrid")
+        for key in FAMILY_ORDER:
+            force_activate = cfg_force_activate if key == "cfg" else False
+            if not await self._converge_family(site_id, key, desired[key], force_activate):
+                ok = False
 
-        # Clamp the DTG floor to at least the reserve: Enphase will not discharge below the backup
-        # reserve, and Predbat's own discharge target is max(export, reserve), so keep the written
-        # limit consistent rather than requesting an export below the reserve it can never reach.
-        dtg_limit = max(export_soc, int(local.get("reserve", 0)))
+        if not await self._converge_reserve(site_id, local):
+            ok = False
+        return ok
 
-        # Forced export to a target (DTG). A configured inverter always supports DTG.
-        wrote |= await self._write_and_activate(site_id, SCHEDULE_EXPORT, export_start, export_end, dtg_limit, real_export, self._activate_dtg_mode)
+    async def apply_battery_schedule(self, site_id):
+        """Reconcile the cloud schedule/reserve state to match Predbat's desired local model.
 
-        # Freeze export = restrict battery discharge (RBD) over the export window
-        wrote |= await self._write_and_activate(site_id, SCHEDULE_FREEZE, export_start, export_end, None, freeze_export, self._activate_rbd_mode)
-        return wrote
+        Runs `_reconcile_once` up to `ENPHASE_RECONCILE_MAX_ATTEMPTS` times, with a short jittered
+        backoff between attempts on failure (e.g. a conflict, or a family still settling from a
+        previous write). If it still cannot converge, it gives up for this call - the next
+        periodic call (`run()`, every `ENPHASE_REFRESH_SCHEDULE_SYNC` minutes) or the next
+        explicit trigger (the write switch) starts over from a clean read. Does nothing in
+        read-only mode. See docs/superpowers/specs/2026-08-08-enphase-schedule-reconcile-design.md
+        for the design. Returns True if the site converged to the desired state.
+        """
+        if self._is_read_only():
+            return True
+        for attempt in range(ENPHASE_RECONCILE_MAX_ATTEMPTS):
+            if await self._reconcile_once(site_id):
+                return True
+            if attempt < ENPHASE_RECONCILE_MAX_ATTEMPTS - 1:
+                await asyncio.sleep(1 + attempt * random.random() * 3)
+        return False
 
     async def get_battery_status(self, site_id):
         """Fetch and normalise battery SOC/capacity/power for a site."""
@@ -1961,6 +1954,59 @@ async def test_write_reserve(username, password, site_id, value):  # pragma: no 
     print("Done")
 
 
+async def test_schedule_reconcile(username, password, site_id):  # pragma: no cover
+    """Drive a scripted sequence of schedule changes against a real account.
+
+    Exercises apply_battery_schedule's reconcile path end-to-end, including the cross-family case
+    that motivated the "Update strategy" rule in
+    docs/superpowers/specs/2026-08-08-enphase-schedule-reconcile-design.md: one family's window
+    moving so that its *old* window overlaps a *different* family's brand new one, even though
+    neither family's *new* windows overlap each other. Every window used is between midnight and
+    05:00, and the export-family steps use RBD (freeze-export/restrict-discharge, soc=99) rather
+    than a real DTG target, so nothing here can actually charge from or export to the grid - it
+    only ever writes schedules a real overnight off-peak window would already contain. The final
+    step disables everything again, leaving the account in a known, inert state.
+    """
+    mock_base = MockBase()
+    api = EnphaseAPI(mock_base, username=username, password=password, site_id=site_id, automatic=False)
+
+    print("Logging in and loading current state...")
+    await api.run(seconds=0, first=True)
+    if not api.sites:
+        print("No sites found")
+        return
+    sid = api.sites[0]["site_id"]
+    base_name = f"{api.prefix}_enphase_{sid}_battery_schedule"
+
+    def _set_window(direction, start, end, soc, enabled):
+        """Push one direction's control entities into the mock HA state, as Predbat's UI would."""
+        mock_base.set_state_wrapper(f"select.{base_name}_{direction}_start_time", start)
+        mock_base.set_state_wrapper(f"select.{base_name}_{direction}_end_time", end)
+        mock_base.set_state_wrapper(f"number.{base_name}_{direction}_soc", soc)
+        mock_base.set_state_wrapper(f"switch.{base_name}_{direction}_enable", "on" if enabled else "off")
+
+    steps = [
+        ("enable charge alone (create)", {"charge": ("00:30:00", "01:00:00", 50, True)}),
+        ("move charge alone (PUT-in-place)", {"charge": ("01:00:00", "01:30:00", 50, True)}),
+        ("move charge + enable freeze-export together (crosses charge's OLD window)", {"charge": ("02:00:00", "02:30:00", 50, True), "export": ("01:15:00", "01:45:00", 99, True)}),
+        ("move both again, crossing back the other way", {"charge": ("01:30:00", "02:00:00", 50, True), "export": ("02:15:00", "02:45:00", 99, True)}),
+        ("disable everything", {"charge": ("00:00:00", "00:00:00", 50, False), "export": ("00:00:00", "00:00:00", 99, False)}),
+    ]
+
+    for label, changes in steps:
+        print(f"\n--- {label} ---")
+        for direction, (start, end, soc, enabled) in changes.items():
+            _set_window(direction, start, end, soc, enabled)
+        ok = await api.apply_battery_schedule(sid)
+        await api.get_schedules(sid)
+        print(f"apply_battery_schedule -> {ok}")
+        print(f"schedules: {json.dumps(api.schedules.get(sid, {}), default=str, indent=2)}")
+        if api.schedule_write_failed.get(sid):
+            print(f"WRITE FAILURES: {api.schedule_write_failed[sid]}")
+
+    print("\nDone")
+
+
 def main():  # pragma: no cover
     """Command-line entry point for exercising the Enphase component standalone."""
     import argparse
@@ -1974,6 +2020,7 @@ def main():  # pragma: no cover
     parser.add_argument("--end-time", default="05:00:00", help="Test charge window end (HH:MM:SS)")
     parser.add_argument("--soc", type=int, default=80, help="Test charge target SOC percent")
     parser.add_argument("--write-reserve", type=int, default=None, help="Write this reserve %% (e.g. 25), then restore the original - a safe real-write test")
+    parser.add_argument("--reconcile-sequence", action="store_true", help="Drive a scripted sequence of schedule changes (midnight-05:00 only) to exercise the reconcile path live, then disable everything again")
 
     args = parser.parse_args()
 
@@ -1981,6 +2028,8 @@ def main():  # pragma: no cover
         asyncio.run(test_write_reserve(args.username, args.password, args.site_id, args.write_reserve))
     elif args.write_schedule:
         asyncio.run(test_write_schedule(args.username, args.password, args.site_id, args.start_time, args.end_time, args.soc))
+    elif args.reconcile_sequence:
+        asyncio.run(test_schedule_reconcile(args.username, args.password, args.site_id))
     else:
         asyncio.run(test_enphase_api(args.username, args.password, args.site_id))
 

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -1080,8 +1080,10 @@ class EnphaseAPI(ComponentBase):
         reason = "window no longer required" if not target["enabled"] else "clearing before a multi-family change"
         self.log(f"Enphase: Deleting {family} schedule {schedule_id} on site {site_id} ({reason})")
         if not await self._delete_schedule(site_id, schedule_id, context=f"{family} {reason}"):
-            if not target["enabled"]:
-                self._note_schedule_write_result(site_id, family_key, False)
+            # Always recorded, even when target["enabled"] - a failure here is real even if the
+            # family's own _converge_family call (still to come this pass) goes on to self-heal it
+            # with a fallback PUT to the same id, which would then clear this again.
+            self._note_schedule_write_result(site_id, family_key, False)
             return False
         # Drop the id/window so a re-enable creates a fresh schedule rather than PUTting an id the
         # cloud no longer knows about.

--- a/apps/predbat/enphase.py
+++ b/apps/predbat/enphase.py
@@ -351,6 +351,11 @@ class EnphaseAPI(ComponentBase):
         self.last_midnight_utc = None
         self.last_error_status = None  # HTTP status (or None) of the most recent request_json() failure
 
+        # site_id -> {family_key: True} for schedule/reserve writes that failed outright (all
+        # retries exhausted), so the failure is visible on the dashboard instead of only in the
+        # log - see _note_schedule_write_result / _publish_schedule_write_health.
+        self.schedule_write_failed = {}
+
     def is_alive(self):
         """Return True when the component has started and discovered a site."""
         return self.api_started and bool(self.sites)
@@ -678,14 +683,38 @@ class EnphaseAPI(ComponentBase):
                 local[direction]["enable"] = bool(entry.get("enabled"))
         self._schedule_seeded.add(site_id)
 
+    async def _publish_schedule_write_health(self, site_id):
+        """Publish a dedicated sensor reporting whether recent schedule/reserve writes landed.
+
+        A write that fails outright (a conflict surviving every retry, a failed delete or
+        activation) previously only ever appeared as a log warning - `predbat.status` kept
+        reporting the *intended* plan with no visible sign the cloud never actually accepted it
+        (#4461). This sensor stays "on" (ok) until a write fails, and reports exactly which
+        families/writes are currently failing so the mismatch is visible on the dashboard.
+        """
+        failures = self.schedule_write_failed.get(site_id, {})
+        self.dashboard_item(
+            f"binary_sensor.{self.prefix}_enphase_{site_id}_schedule_write_ok",
+            state="off" if failures else "on",
+            attributes={
+                "friendly_name": f"Enphase {site_id} Schedule Write Ok",
+                "icon": "mdi:cloud-check-outline" if not failures else "mdi:cloud-alert-outline",
+                "failed": sorted(failures.keys()),
+            },
+            app="enphase",
+        )
+
     async def publish_schedule_settings_ha(self, site_id):
         """Publish the schedule control entities for a site.
 
         Publishes the reserve control plus both the charge-from-grid and export (discharge-to-grid)
         window controls (a configured inverter always supports both - automatic_config requires
         DTG). There is no separate freeze control: Predbat freezes charge via the reserve, and
-        freeze-export is derived automatically from an export target SOC of 99%.
+        freeze-export is derived automatically from an export target SOC of 99%. Also (re)publishes
+        the schedule-write-health sensor, so a write failure is reflected immediately after the
+        attempt (switch_event) and kept current on every subsequent poll (run()).
         """
+        await self._publish_schedule_write_health(site_id)
         local = self.local_schedule.setdefault(site_id, self._default_local_schedule())
         reserve_min = int(self.battery_settings.get(site_id, {}).get("veryLowSocMin", 5) or 5)
         base_name = f"{self.prefix}_enphase_{site_id}_battery_schedule"
@@ -835,11 +864,15 @@ class EnphaseAPI(ComponentBase):
 
         Converts the HA "HH:MM:SS" option times to Enphase "HH:MM" format, then compares against
         the cached cloud schedule via `schedules_equal()`. A matching schedule is a no-op. Otherwise
-        it updates the existing schedule by id (`PUT`) or creates a new one (`POST`). On success it
-        optimistically updates our cached copy to the written state and returns - the periodic
-        settings re-read will correct it if the write did not actually land. A create additionally
-        re-reads the schedules once, to capture the cloud-assigned scheduleId (so later edits update
-        in place rather than creating duplicates - the write responses do not return the id).
+        it updates the existing schedule by id (`PUT`) or creates a new one (`POST`), each retrying
+        once on a conflict via `_put_schedule_with_conflict_retry` / `_create_schedule_with_conflict_retry`.
+        On success it optimistically updates our cached copy to the written state and returns - the
+        periodic settings re-read will correct it if the write did not actually land. A create
+        additionally re-reads the schedules once, to capture the cloud-assigned scheduleId (so later
+        edits update in place rather than creating duplicates - the write responses do not return the
+        id). Every attempted write records its outcome via `_note_schedule_write_result`, so a write
+        that is attempted but never lands is visible instead of silently leaving the device on its
+        previous schedule.
         Returns True if a write was issued.
         """
         start_hm = ha_time_to_enphase(start_time_ha)
@@ -858,7 +891,8 @@ class EnphaseAPI(ComponentBase):
             # and keeps enforcing the window), so the only way to retire a window is to delete it.
             # A lingering window would also conflict with the other family's next write.
             self.log(f"Enphase: Deleting {family} schedule {schedule_id} on site {site_id} (window no longer required)")
-            if not await self._delete_schedule(site_id, schedule_id):
+            if not await self._delete_schedule(site_id, schedule_id, context=f"{family} disable"):
+                self._note_schedule_write_result(site_id, family_key, False)
                 return False
             # Drop the id/window so the next apply is a no-op while disabled, and a re-enable creates
             # a fresh schedule rather than PUTting an id the cloud no longer knows.
@@ -867,6 +901,7 @@ class EnphaseAPI(ComponentBase):
                 cleared.pop(field, None)
             cleared["enabled"] = False
             self.schedules.setdefault(site_id, {})[family_key] = cleared
+            self._note_schedule_write_result(site_id, family_key, True)
             return True
         if schedule_id:
             self.log(f"Enphase: Updating {family} schedule {schedule_id} on site {site_id}: {start_hm}-{end_hm} limit={limit} enabled={enabled}")
@@ -878,10 +913,11 @@ class EnphaseAPI(ComponentBase):
                 self.schedules.setdefault(site_id, {})[family_key] = updated
         else:
             self.log(f"Enphase: Creating {family} schedule on site {site_id}: {start_hm}-{end_hm} limit={limit} enabled={enabled}")
-            result = await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules", family="battery_config", json_body=payload)
+            result = await self._create_schedule_with_conflict_retry(site_id, family_key, payload)
             if result is not None:
                 # Re-read once so we learn the new schedule's cloud-assigned id for future edits.
                 await self.get_schedules(site_id)
+        self._note_schedule_write_result(site_id, family_key, result is not None)
         return result is not None
 
     async def _put_schedule_with_conflict_retry(self, site_id, family_key, schedule_id, payload):
@@ -894,7 +930,7 @@ class EnphaseAPI(ComponentBase):
         and retrying it again would just burn API calls every cycle.
         """
         for attempt in range(2):
-            result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules/{schedule_id}", family="battery_config", json_body=payload)
+            result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules/{schedule_id}", family="battery_config", json_body=payload, context=f"{family_key.upper()} schedule update")
             if result is not None or self.last_error_status != 409 or attempt:
                 return result
             self.log(f"Enphase: Schedule {schedule_id} on site {site_id} conflicts with another schedule; re-reading schedules and retrying once")
@@ -902,18 +938,39 @@ class EnphaseAPI(ComponentBase):
             schedule_id = (self.schedules.get(site_id, {}).get(family_key) or {}).get("id") or schedule_id
         return None
 
+    async def _create_schedule_with_conflict_retry(self, site_id, family_key, payload):
+        """POST a new schedule, re-reading and retrying once if the cloud reports a conflict.
+
+        Mirrors `_put_schedule_with_conflict_retry` for the create path, which #4428 left without a
+        retry: an HTTP 409 here means an untracked schedule already occupies the family - a sibling
+        `_prune_sibling_schedules` had not yet reached, or one left over from an earlier create whose
+        response Predbat never saw. Re-reading picks it up: `get_schedules` prunes any sibling (so
+        the retried POST no longer collides with it) and, if a schedule remains in the family, adopts
+        its id (so the retry goes out as a PUT instead of a second POST). Retried once only, matching
+        the PUT path.
+        """
+        result = await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules", family="battery_config", json_body=payload, context=f"{family_key.upper()} schedule create")
+        if result is not None or self.last_error_status != 409:
+            return result
+        self.log(f"Enphase: Create of a new {family_key.upper()} schedule on site {site_id} conflicts with another schedule; re-reading schedules and retrying once")
+        await self.get_schedules(site_id)
+        schedule_id = (self.schedules.get(site_id, {}).get(family_key) or {}).get("id")
+        if schedule_id:
+            return await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules/{schedule_id}", family="battery_config", json_body=payload, context=f"{family_key.upper()} schedule update after create conflict")
+        return await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules", family="battery_config", json_body=payload, context=f"{family_key.upper()} schedule create retry")
+
     def _is_read_only(self):
         """Return True when Predbat is in read-only mode and must not write to the account."""
         return self.get_state_wrapper(f"switch.{self.prefix}_set_read_only", default="off") == "on"
 
-    async def _delete_schedule(self, site_id, schedule_id):
+    async def _delete_schedule(self, site_id, schedule_id, context=None):
         """Delete one schedule by id. Returns True on success.
 
         Deletion is a POST to the schedule's /delete sub-resource. The gateway does not allow the
         DELETE verb here - it rejects it with "403 Invalid CORS request" - and because a 403 counts
         as an auth failure, using it also burned a re-login on every attempt.
         """
-        result = await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules/{schedule_id}/delete", family="battery_config", allow_empty=True)
+        result = await self.request_json("POST", f"{BATTERY_CONFIG_BASE}/battery/sites/{site_id}/schedules/{schedule_id}/delete", family="battery_config", allow_empty=True, context=context)
         return result is not None
 
     async def _prune_sibling_schedules(self, site_id, family_key, details, keep):
@@ -959,6 +1016,23 @@ class EnphaseAPI(ComponentBase):
         if isinstance(entry, dict):
             entry["startTime"] = ""
 
+    def _note_schedule_write_result(self, site_id, family_key, ok):
+        """Track whether the most recent write/activation for a schedule family landed on the cloud.
+
+        A write that fails outright (a conflict surviving every retry, a failed delete, a failed
+        activation PUT) otherwise only ever shows up as a generic HTTP warning in the log -
+        `predbat.status` keeps reporting the *intended* plan with no visible sign the device never
+        actually changed (#4461). ``count_errors`` feeds the existing per-component error count on
+        the `components_healthy` sensor; ``schedule_write_failed`` backs the dedicated per-family
+        warning published by `_publish_schedule_write_health`. Cleared on the next successful write.
+        """
+        failures = self.schedule_write_failed.setdefault(site_id, {})
+        if ok:
+            failures.pop(family_key, None)
+        else:
+            failures[family_key] = True
+            self.count_errors += 1
+
     async def _activate_control_mode(self, site_id, family, body, apply_cache, label):
         """Commit a freshly written schedule to the gateway via a batterySettings PUT.
 
@@ -972,15 +1046,17 @@ class EnphaseAPI(ComponentBase):
         params = {"source": "enho"}
         if self.user_id:
             params["userId"] = self.user_id
-        result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body)
+        result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/batterySettings/{site_id}", family="battery_config", params=params, json_body=body, context=f"{label} activation")
+        family_key = family.lower()
         if result is not None:
             apply_cache(self.battery_settings.setdefault(site_id, {}))
-            entry = self.schedules.get(site_id, {}).get(family.lower())
+            entry = self.schedules.get(site_id, {}).get(family_key)
             if isinstance(entry, dict):
                 entry.pop("status", None)
         else:
             self.log(f"Warn: Enphase: {label} activation failed for site {site_id}")
             self._invalidate_cached_schedule(site_id, family)
+        self._note_schedule_write_result(site_id, family_key, result is not None)
         return result is not None
 
     async def _activate_cfg_mode(self, site_id, family=SCHEDULE_CHARGE):
@@ -1058,11 +1134,12 @@ class EnphaseAPI(ComponentBase):
         params = {"source": "enho"}
         if self.user_id:
             params["userId"] = self.user_id
-        result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/profile/{site_id}", family="battery_config", params=params, json_body={"profile": profile_name, "batteryBackupPercentage": int(reserve)})
+        result = await self.request_json("PUT", f"{BATTERY_CONFIG_BASE}/profile/{site_id}", family="battery_config", params=params, json_body={"profile": profile_name, "batteryBackupPercentage": int(reserve)}, context="reserve update")
         if result is not None:
             # Optimistically cache the written reserve; the periodic profile re-read will correct
             # it if the write did not actually land (e.g. the gateway never activated it).
             self.profile.setdefault(site_id, {})["reserve"] = int(reserve)
+        self._note_schedule_write_result(site_id, "reserve", result is not None)
         return result
 
     async def apply_battery_schedule(self, site_id):
@@ -1677,7 +1754,7 @@ class EnphaseAPI(ComponentBase):
         stripped = (text or "").lstrip().lower()
         return stripped.startswith("<!doctype") or stripped.startswith("<html")
 
-    async def request_json(self, method, path, family="site", json_body=None, data=None, params=None, allow_empty=False):
+    async def request_json(self, method, path, family="site", json_body=None, data=None, params=None, allow_empty=False, context=None):
         """Perform an authenticated JSON request with retries and a single 401 re-login.
 
         Builds the request URL from BASE_URL + path and attaches family-appropriate headers
@@ -1688,7 +1765,10 @@ class EnphaseAPI(ComponentBase):
           attempt); otherwise it performs one login() and retries once.
         - HTTP 429 and 5xx responses, plus timeouts/connection errors, are retried with
           jittered backoff up to ENPHASE_RETRIES times.
-        - Any other non-200 status is treated as a terminal failure.
+        - Any other non-200 status is treated as a terminal failure, logged as
+          "HTTP {method} {path} -> {status}" (plus ``context`` when the caller gave one, e.g. the
+          schedule family/window being written) so a bare-path 409 is never ambiguous between the
+          GET, the POST create and the PUT update that all share that path shape.
         ``allow_empty`` additionally accepts a 204/empty body as success (returning {} rather than
         None), as a DELETE returns no content.
         Every outcome is recorded via record_api_call("enphase", ...) for metrics/health.
@@ -1732,7 +1812,8 @@ class EnphaseAPI(ComponentBase):
                 continue
 
             if status != 200 and not (allow_empty and status == 204):
-                self.log(f"Warn: Enphase: HTTP {status} on {path}")
+                context_suffix = f" ({context})" if context else ""
+                self.log(f"Warn: Enphase: HTTP {method} {path} -> {status}{context_suffix}")
                 record_api_call("enphase", False, "client_error")
                 self.last_error_status = status
                 self.failures_total += 1

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.47.6"
+THIS_VERSION = "v8.47.7"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -45,6 +45,7 @@ class MockEnphaseAPI(EnphaseAPI):
         # so it cannot be assigned directly here. MockBase has no "components" attribute, so the inherited
         # property naturally evaluates to None for these tests.
         self.api_started = False
+        self.count_errors = 0  # normally set by ComponentBase.__init__, which this mock bypasses
         self.initialize(username="user@example.com", password="secret")
 
         # Test instrumentation
@@ -55,10 +56,11 @@ class MockEnphaseAPI(EnphaseAPI):
         self.mock_ha_states = {}
         self.args_set = {}
         self.fatal_signalled = False
+        self.log_messages = []
 
     def log(self, message):
-        """Swallow log output in tests."""
-        pass
+        """Record log output for assertions instead of printing it."""
+        self.log_messages.append(message)
 
     def update_success_timestamp(self):
         """Swallow health-tracking in tests."""
@@ -2059,6 +2061,146 @@ def test_write_schedule_gives_up_after_second_conflict():
     assert [r["method"] for r in api.request_log].count("PUT") == 2  # one retry only
 
 
+def test_write_schedule_create_retries_once_after_conflict_and_adopts_id():
+    """A 409 on the POST-create path re-reads, adopts the now-visible schedule, and PUTs it.
+
+    #4428 only added conflict-retry to the PUT (update) path; the create path (taken whenever no
+    id is cached yet, e.g. right after a disable/re-enable) could still 409 forever against an
+    untracked schedule already occupying the family - the follow-up flagged in #4428 and reported
+    recurring in #4461.
+    """
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"supported": True}}  # no id yet -> takes the create path
+    api.set_http_sequence(SCHEDULES_PATH, [(409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}}), (200, _schedules_payload([_cfg_detail("existing", "03:00", "04:00")]))])
+    api.set_http_response(SCHEDULES_PATH + "/existing", 200, {"scheduleId": "existing"})
+    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
+    assert wrote is True
+    assert [r["method"] for r in api.request_log] == ["POST", "GET", "PUT", "GET"]
+    assert api.schedules["12345"]["cfg"]["id"] == "existing"
+
+
+def test_write_schedule_create_retries_once_via_post_when_still_no_id():
+    """When the re-read finds nothing to adopt, the retry goes out as a second POST, not a PUT."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"supported": True}}
+    api.set_http_sequence(
+        SCHEDULES_PATH,
+        [
+            (409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}}),
+            (200, _schedules_payload([])),
+            (200, {}),
+            (200, _schedules_payload([_cfg_detail("new2", "03:00", "04:00")])),
+        ],
+    )
+    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
+    assert wrote is True
+    assert [r["method"] for r in api.request_log] == ["POST", "GET", "POST", "GET"]
+    assert api.schedules["12345"]["cfg"]["id"] == "new2"
+
+
+def test_write_schedule_create_gives_up_after_second_conflict():
+    """A create-path conflict that survives the re-read fails the write instead of looping."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"supported": True}}
+    api.set_http_response(SCHEDULES_PATH, 409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}})
+    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
+    assert wrote is False
+    assert [r["method"] for r in api.request_log] == ["POST", "GET", "POST"]  # one retry only
+
+
+def test_request_json_failure_log_includes_method_and_context():
+    """A non-200 response logs the HTTP method and any caller-supplied context.
+
+    Before the fix a 409 on the bare .../schedules path was indistinguishable between the
+    periodic GET and a POST create sharing that same path shape (#4461).
+    """
+    api = MockEnphaseAPI()
+    api.set_http_response(SCHEDULES_PATH, 409, {"error": {"status": "CONFLICT"}})
+    run_async(api.request_json("POST", SCHEDULES_PATH, family="battery_config", context="CFG schedule create"))
+    warns = [m for m in api.log_messages if "HTTP POST" in m and "409" in m]
+    assert len(warns) == 1
+    assert "CFG schedule create" in warns[0]
+
+
+def test_write_schedule_create_conflict_log_names_method_and_family():
+    """The generic HTTP-failure log for a create-path 409 says POST and names the family."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"supported": True}}
+    api.set_http_response(SCHEDULES_PATH, 409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}})
+    run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
+    warns = [m for m in api.log_messages if m.startswith("Warn: Enphase: HTTP POST")]
+    assert warns and "CFG schedule create" in warns[0]
+
+
+def test_write_schedule_failure_is_tracked_for_dashboard():
+    """A schedule write that fails outright is counted and flagged for the dashboard.
+
+    Before the fix a persistent conflict only ever showed up as a log warning -
+    predbat.status/components_healthy kept reporting the *intended* plan with no visible sign the
+    write never landed (#4461).
+    """
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
+    api.set_http_response(SCHEDULES_PATH + "/sched-1", 409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}})
+    api.set_http_response(SCHEDULES_PATH, 200, _schedules_payload([_cfg_detail("sched-1", "02:00", "02:20")]))
+    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
+    assert wrote is False
+    assert api.count_errors == 1
+    assert api.schedule_write_failed["12345"]["cfg"] is True
+
+
+def test_write_schedule_success_clears_a_previous_failure_flag():
+    """A successful write clears the failure it previously flagged."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
+    api.schedule_write_failed["12345"] = {"cfg": True}
+    api.set_http_response(SCHEDULES_PATH + "/sched-1", 200, {"scheduleId": "sched-1"})
+    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
+    assert wrote is True
+    assert "cfg" not in api.schedule_write_failed["12345"]
+
+
+def test_activate_cfg_mode_failure_is_tracked_for_dashboard():
+    """A failed activation PUT is counted and flagged for the dashboard, like a failed write."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.schedules["12345"] = {"cfg": {"supported": True, "id": "u1", "startTime": "02:00", "endTime": "05:00", "limit": 90, "enabled": True}}
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 404, {})
+    ok = run_async(api._activate_cfg_mode("12345"))
+    assert ok is False
+    assert api.count_errors == 1
+    assert api.schedule_write_failed["12345"]["cfg"] is True
+
+
+def test_set_reserve_failure_is_tracked_for_dashboard():
+    """A failed reserve write is counted and flagged for the dashboard under the "reserve" key."""
+    api = MockEnphaseAPI()
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 10}
+    api.set_http_response("/service/batteryConfig/api/v1/profile/12345", 400, {})
+    result = run_async(api.set_reserve("12345", 20))
+    assert result is None
+    assert api.schedule_write_failed["12345"]["reserve"] is True
+
+
+def test_publish_schedule_write_health_reports_failures():
+    """The dedicated write-health sensor reports "off" and lists the failing families."""
+    api = MockEnphaseAPI()
+    api.schedule_write_failed["12345"] = {"cfg": True}
+    run_async(api._publish_schedule_write_health("12345"))
+    item = api.dashboard_items["binary_sensor.predbat_enphase_12345_schedule_write_ok"]
+    assert item["state"] == "off"
+    assert item["attributes"]["failed"] == ["cfg"]
+
+
+def test_publish_schedule_write_health_ok_when_no_failures():
+    """With no tracked failures the sensor reports "on" and an empty failed list."""
+    api = MockEnphaseAPI()
+    run_async(api._publish_schedule_write_health("12345"))
+    item = api.dashboard_items["binary_sensor.predbat_enphase_12345_schedule_write_ok"]
+    assert item["state"] == "on"
+    assert item["attributes"]["failed"] == []
+
+
 def test_consecutive_writes_stay_on_one_schedule_across_a_reorder():
     """Replay of the live failure: two writes either side of a re-read must target the same schedule.
 
@@ -2091,6 +2233,17 @@ def run_enphase_api_tests(my_predbat):
     test_write_schedule_disable_deletes_the_schedule()
     test_write_schedule_retries_once_after_conflict()
     test_write_schedule_gives_up_after_second_conflict()
+    test_write_schedule_create_retries_once_after_conflict_and_adopts_id()
+    test_write_schedule_create_retries_once_via_post_when_still_no_id()
+    test_write_schedule_create_gives_up_after_second_conflict()
+    test_request_json_failure_log_includes_method_and_context()
+    test_write_schedule_create_conflict_log_names_method_and_family()
+    test_write_schedule_failure_is_tracked_for_dashboard()
+    test_write_schedule_success_clears_a_previous_failure_flag()
+    test_activate_cfg_mode_failure_is_tracked_for_dashboard()
+    test_set_reserve_failure_is_tracked_for_dashboard()
+    test_publish_schedule_write_health_reports_failures()
+    test_publish_schedule_write_health_ok_when_no_failures()
     test_initialize_defaults()
     test_needs_refresh()
     test_is_alive()

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -10,7 +10,8 @@ from datetime import datetime, timedelta, timezone
 import base64
 import json as json_module
 import pytz
-from enphase import EnphaseAPI, ENPHASE_REFRESH_SETTINGS
+import enphase
+from enphase import EnphaseAPI, ENPHASE_REFRESH_SETTINGS, ENPHASE_REFRESH_SCHEDULE_SYNC, ENPHASE_RECONCILE_MAX_ATTEMPTS
 from tests.test_infra import run_async
 
 
@@ -1065,6 +1066,35 @@ def test_run_first_polls_all_tiers():
     assert api.latest_power["12345"]["watts"] == 450
 
 
+def test_run_reconciles_schedule_periodically_not_every_poll():
+    """run() reconciles on the schedule_sync tier, not on every 60-second poll.
+
+    Independent of the write-switch trigger, so a missed/dropped trigger cannot leave the cloud
+    diverged from the plan indefinitely (#4461) - but it must still respect its own refresh tier
+    rather than reconciling on every call.
+    """
+    api = MockEnphaseAPI()
+    api.login_last_success = datetime.now(timezone.utc)
+    api.eauth_token = "tok"
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    api.set_http_response("/pv/settings/12345/battery_status.json", 200, BATTERY_STATUS_PAYLOAD)
+    api.set_http_response("/pv/systems/12345/today", 200, {"stats": [{"totals": {"production": 1000}, "production": [1000], "start_time": 1783724400, "interval_length": 900}]})
+    api.set_http_response("/app-api/12345/get_latest_power", 200, {"latest_power": {"value": 450, "units": "w", "time": 1760000000}})
+    api.set_http_response("/service/batteryConfig/api/v1/profile/12345", 200, {"profile": "self-consumption", "batteryBackupPercentage": 20})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {"chargeFromGrid": True, "veryLowSoc": 10, "veryLowSocMin": 5, "veryLowSocMax": 25})
+    api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    assert run_async(api.run(0, True))
+    assert "schedule_sync" in api.data_age
+    calls_after_first = len(api.request_log)
+
+    run_async(api.run(60, False))  # well within ENPHASE_REFRESH_SCHEDULE_SYNC minutes
+    assert len(api.request_log) == calls_after_first  # no further schedule GET issued
+
+    api.data_age["schedule_sync"] = datetime.now(timezone.utc) - timedelta(minutes=ENPHASE_REFRESH_SCHEDULE_SYNC + 1)
+    run_async(api.run(120, False))
+    assert len(api.request_log) > calls_after_first  # tier elapsed - reconciled again
+
+
 def test_log_api_call_redacts_token():
     """API-call logging redacts JWT token fields and truncates long bodies, and is gated by debug_api."""
     api = MockEnphaseAPI()
@@ -1400,6 +1430,7 @@ def _apply_export_case(export_soc):
         "export": {"start_time": "23:00:00", "end_time": "23:30:00", "soc": export_soc, "enable": True},
     }
     api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
     run_async(api.apply_battery_schedule("12345"))
     posts = [r for r in api.request_log if r["method"] == "POST" and r["path"].endswith("/schedules")]
     return posts
@@ -1441,6 +1472,7 @@ def test_apply_export_dtg_limit_clamped_to_reserve():
         "export": {"start_time": "16:00:00", "end_time": "19:00:00", "soc": 10, "enable": True},  # target 10 < reserve 30
     }
     api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules", 200, {"cfg": {"scheduleSupported": True, "details": []}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
     run_async(api.apply_battery_schedule("12345"))
     dtg = next(r["json"] for r in api.request_log if r["method"] == "POST" and r["path"].endswith("/schedules") and r["json"]["scheduleType"] == "DTG")
     assert dtg["limit"] == 30  # clamped up to the reserve, not the requested 10
@@ -1458,10 +1490,12 @@ def test_apply_updates_existing_by_id():
     api.local_schedule["12345"] = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False}, "freeze": {"enable": False}}
     api.set_http_response("/service/batteryConfig/api/v1/battery/sites/12345/schedules/u1", 200, {})
     api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})  # activation PUT
+    # The pre-write re-read (#4461) must still show the *old* cloud state (matching the initial
+    # cache below), or the write would look like a no-op before it is even attempted.
     api.set_http_response(
         "/service/batteryConfig/api/v1/battery/sites/12345/schedules",
         200,
-        {"cfg": {"scheduleSupported": True, "details": [{"id": "u1", "startTime": "02:00", "endTime": "05:00", "limit": 90, "isEnabled": True}]}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}},
+        {"cfg": {"scheduleSupported": True, "details": [{"id": "u1", "startTime": "01:00", "endTime": "04:00", "limit": 80, "isEnabled": True}]}, "dtg": {"scheduleSupported": True, "details": []}, "rbd": {"scheduleSupported": True, "details": []}},
     )
     run_async(api.apply_battery_schedule("12345"))
     puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"].endswith("/schedules/u1")]
@@ -1758,8 +1792,12 @@ def test_apply_no_activate_dtg_when_unchanged():
     assert writes == []
 
 
-def test_activate_cfg_mode_invalidates_cache_on_failure():
-    """Cache is cleared on CFG activation failure so next apply retries write+activation."""
+def test_activate_cfg_mode_failure_leaves_cache_untouched():
+    """A failed CFG activation is tracked as a failure and does not poke the schedule cache.
+
+    _reconcile_once always re-reads from the cloud on its next attempt, so there is nothing for
+    activation to invalidate locally - unlike before #4461's reconcile rewrite.
+    """
     api = MockEnphaseAPI()
     api.user_id = "9999"
     api.battery_settings.clear()
@@ -1768,14 +1806,13 @@ def test_activate_cfg_mode_invalidates_cache_on_failure():
     api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 404, {})
     ok = run_async(api._activate_cfg_mode("12345"))
     assert ok is False
-    # Cached startTime must be cleared so schedules_equal detects a diff next time
     cached = api.schedules["12345"]["cfg"]
-    assert cached["startTime"] == ""
-    assert "id" in cached  # id preserved for PUT update
+    assert cached["startTime"] == "02:00"  # untouched
+    assert api.schedule_write_failed["12345"]["cfg"] is True
 
 
-def test_activate_dtg_mode_invalidates_cache_on_failure():
-    """Cache is cleared on DTG activation failure so next apply retries write+activation."""
+def test_activate_dtg_mode_failure_leaves_cache_untouched():
+    """A failed DTG activation is tracked as a failure and does not poke the schedule cache."""
     api = MockEnphaseAPI()
     api.user_id = "9999"
     api.battery_settings.clear()
@@ -1784,12 +1821,12 @@ def test_activate_dtg_mode_invalidates_cache_on_failure():
     ok = run_async(api._activate_dtg_mode("12345"))
     assert ok is False
     cached = api.schedules["12345"]["dtg"]
-    assert cached["startTime"] == ""
-    assert "id" in cached
+    assert cached["startTime"] == "16:00"
+    assert api.schedule_write_failed["12345"]["dtg"] is True
 
 
-def test_activate_rbd_mode_invalidates_cache_on_failure():
-    """Cache is cleared on RBD activation failure so next apply retries write+activation."""
+def test_activate_rbd_mode_failure_leaves_cache_untouched():
+    """A failed RBD activation is tracked as a failure and does not poke the schedule cache."""
     api = MockEnphaseAPI()
     api.user_id = "9999"
     api.battery_settings.clear()
@@ -1798,8 +1835,8 @@ def test_activate_rbd_mode_invalidates_cache_on_failure():
     ok = run_async(api._activate_rbd_mode("12345"))
     assert ok is False
     cached = api.schedules["12345"]["rbd"]
-    assert cached["startTime"] == ""
-    assert "id" in cached
+    assert cached["startTime"] == "22:00"
+    assert api.schedule_write_failed["12345"]["rbd"] is True
 
 
 def test_apply_activates_pending_schedule_without_rewrite():
@@ -2023,89 +2060,337 @@ def test_get_schedules_keeps_sibling_schedules_in_read_only_mode():
     assert [r for r in api.request_log if r["path"].endswith("/delete")] == []
 
 
-def test_write_schedule_disable_deletes_the_schedule():
-    """Disabling a window deletes the schedule rather than PUTting isEnabled=False.
+class _NoSleep:
+    """Context manager that replaces enphase.asyncio.sleep with a no-op.
 
-    The cloud ignores isEnabled=False on a PUT (it echoes isEnabled true and the window survives),
-    so a disabled window would otherwise linger and conflict with later writes.
+    Keeps tests exercising apply_battery_schedule's retry/backoff loop fast and deterministic.
+    """
+
+    def __enter__(self):
+        """Swap in a no-op sleep and remember the original to restore later."""
+        self._original = enphase.asyncio.sleep
+
+        async def _no_sleep(*args, **kwargs):
+            """Return immediately instead of actually sleeping."""
+
+        enphase.asyncio.sleep = _no_sleep
+        return self
+
+    def __exit__(self, *exc):
+        """Restore the real asyncio.sleep."""
+        enphase.asyncio.sleep = self._original
+
+
+def _apply_setup(api, charge=None, export=None, reserve=20):
+    """Seed a MockEnphaseAPI with the state apply_battery_schedule/_reconcile_once need to run."""
+    api.sites = [{"site_id": "12345", "name": "Home"}]
+    api.schedules.setdefault("12345", {"cfg": {}, "dtg": {}, "rbd": {}})
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": reserve}
+    api.battery_settings.setdefault("12345", {"chargeFromGrid": True, "veryLowSocMin": 5})
+    api.local_schedule["12345"] = {
+        "reserve": reserve,
+        "charge": charge or {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 100, "enable": False},
+        "export": export or {"start_time": "00:00:00", "end_time": "00:00:00", "soc": 5, "enable": False},
+    }
+
+
+def test_cleanup_family_deletes_when_disabling():
+    """A family being disabled is deleted - the cloud ignores isEnabled=False on a PUT."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
+    api.set_http_response(SCHEDULES_PATH + "/sched-1/delete", 204, None)
+    ok = run_async(api._cleanup_family("12345", "cfg", {"enabled": False, "start": "00:00", "end": "00:00", "limit": 100}, False))
+    assert ok is True
+    assert [(r["method"], r["path"]) for r in api.request_log] == [("POST", SCHEDULES_PATH + "/sched-1/delete")]
+    assert api.schedules["12345"]["cfg"].get("id") is None
+
+
+def test_cleanup_family_skips_a_single_family_change():
+    """A single family changing alone is left for PUT-in-place - nothing to delete first."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
+    ok = run_async(api._cleanup_family("12345", "cfg", {"enabled": True, "start": "03:00", "end": "04:00", "limit": 100}, False))
+    assert ok is True
+    assert api.request_log == []
+    assert api.schedules["12345"]["cfg"]["id"] == "sched-1"
+
+
+def test_cleanup_family_deletes_when_force_recreate():
+    """When several families change in the same pass, an enabled-but-moving one is cleared too.
+
+    Otherwise a new window for a different family can collide with this one's old, not-yet-updated
+    window even though neither family's *new* windows overlap each other - see the design doc's
+    "Update strategy" section and the cross-family test on _reconcile_once below.
     """
     api = MockEnphaseAPI()
     api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
     api.set_http_response(SCHEDULES_PATH + "/sched-1/delete", 204, None)
-    wrote = run_async(api._write_schedule("12345", "CFG", "00:00:00", "00:00:00", 100, False))
-    assert wrote is True
+    ok = run_async(api._cleanup_family("12345", "cfg", {"enabled": True, "start": "03:00", "end": "04:00", "limit": 100}, True))
+    assert ok is True
     assert [(r["method"], r["path"]) for r in api.request_log] == [("POST", SCHEDULES_PATH + "/sched-1/delete")]
-    assert api.schedules["12345"]["cfg"].get("id") is None  # nothing left to update in place
+    assert api.schedules["12345"]["cfg"].get("id") is None
 
 
-def test_write_schedule_retries_once_after_conflict():
-    """A 409 conflict triggers a schedules re-read and one retry of the write."""
+def test_cleanup_family_nothing_to_do_without_an_id():
+    """No id on the cloud means there is nothing to clean up."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {}}
+    ok = run_async(api._cleanup_family("12345", "cfg", {"enabled": True, "start": "03:00", "end": "04:00", "limit": 100}, True))
+    assert ok is True
+    assert api.request_log == []
+
+
+def test_cleanup_family_delete_failure_is_tracked_when_disabling():
+    """A failed delete while disabling is reported as a failure for the dashboard."""
     api = MockEnphaseAPI()
     api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
-    api.set_http_sequence(SCHEDULES_PATH + "/sched-1", [(409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}}), (200, {"scheduleId": "sched-1"})])
-    api.set_http_response(SCHEDULES_PATH, 200, _schedules_payload([_cfg_detail("sched-1", "02:00", "02:20")]))
-    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
-    assert wrote is True
-    assert [r["method"] for r in api.request_log] == ["PUT", "GET", "PUT"]  # re-read between the attempts
-    assert api.schedules["12345"]["cfg"]["startTime"] == "03:00"
+    api.set_http_response(SCHEDULES_PATH + "/sched-1/delete", 400, {})
+    ok = run_async(api._cleanup_family("12345", "cfg", {"enabled": False, "start": "00:00", "end": "00:00", "limit": 100}, False))
+    assert ok is False
+    assert api.schedule_write_failed["12345"]["cfg"] is True
 
 
-def test_write_schedule_gives_up_after_second_conflict():
-    """A conflict that survives the re-read fails the write instead of looping."""
+def test_converge_family_creates_when_no_id():
+    """No id on the cloud, family enabled - creates a new schedule and activates it."""
     api = MockEnphaseAPI()
-    api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
-    api.set_http_response(SCHEDULES_PATH + "/sched-1", 409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}})
-    api.set_http_response(SCHEDULES_PATH, 200, _schedules_payload([_cfg_detail("sched-1", "02:00", "02:20")]))
-    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
-    assert wrote is False
-    assert [r["method"] for r in api.request_log].count("PUT") == 2  # one retry only
+    api.schedules["12345"] = {"cfg": {}}
+    api.set_http_response(SCHEDULES_PATH, 200, {"scheduleId": "new1"})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "02:00", "end": "05:00", "limit": 90}))
+    assert ok is True
+    posts = [r for r in api.request_log if r["method"] == "POST" and r["path"] == SCHEDULES_PATH]
+    assert len(posts) == 1 and posts[0]["json"]["scheduleType"] == "CFG"
+    activation = [r for r in api.request_log if r["path"].endswith("/batterySettings/12345")]
+    assert len(activation) == 1
 
 
-def test_write_schedule_create_retries_once_after_conflict_and_adopts_id():
-    """A 409 on the POST-create path re-reads, adopts the now-visible schedule, and PUTs it.
+def test_converge_family_updates_in_place_when_id_present():
+    """An id surviving cleanup means the write goes out as a PUT, not a POST."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"id": "u1", "startTime": "01:00", "endTime": "04:00", "limit": 80, "enabled": True}}
+    api.set_http_response(SCHEDULES_PATH + "/u1", 200, {})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "02:00", "end": "05:00", "limit": 90}))
+    assert ok is True
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"].endswith("/schedules/u1")]
+    assert len(puts) == 1
+    assert api.schedules["12345"]["cfg"]["startTime"] == "02:00"
 
-    #4428 only added conflict-retry to the PUT (update) path; the create path (taken whenever no
-    id is cached yet, e.g. right after a disable/re-enable) could still 409 forever against an
-    untracked schedule already occupying the family - the follow-up flagged in #4428 and reported
-    recurring in #4461.
+
+def test_converge_family_no_op_when_already_matches():
+    """A family that already matches, and is not pending, needs no write or activation."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"id": "u1", "startTime": "02:00", "endTime": "05:00", "limit": 90, "enabled": True, "status": "active"}}
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "02:00", "end": "05:00", "limit": 90}))
+    assert ok is True
+    assert api.request_log == []
+
+
+def test_converge_family_activates_without_rewrite_when_matches_but_pending():
+    """A family that already matches but is still pending gets an activation-only pass."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.schedules["12345"] = {"cfg": {"id": "u1", "startTime": "02:00", "endTime": "05:00", "limit": 90, "enabled": True, "status": "pending"}}
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "02:00", "end": "05:00", "limit": 90}))
+    assert ok is True
+    schedule_writes = [r for r in api.request_log if "schedules" in r["path"] and r["method"] in ("PUT", "POST")]
+    assert schedule_writes == []
+    activation = [r for r in api.request_log if r["path"].endswith("/batterySettings/12345")]
+    assert len(activation) == 1
+
+
+def test_converge_family_force_activate_when_underlying_setting_off():
+    """force_activate fires activation even though the schedule already matches (chargeFromGrid off)."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    api.schedules["12345"] = {"cfg": {"id": "u1", "startTime": "02:00", "endTime": "05:00", "limit": 90, "enabled": True}}
+    api.battery_settings["12345"] = {"chargeFromGrid": False}
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "02:00", "end": "05:00", "limit": 90}, force_activate=True))
+    assert ok is True
+    activation = [r for r in api.request_log if r["path"].endswith("/batterySettings/12345")]
+    assert len(activation) == 1
+
+
+def test_converge_family_write_failure_skips_activation():
+    """A failed write does not attempt activation."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"id": "u1", "startTime": "01:00", "endTime": "04:00", "limit": 80, "enabled": True}}
+    api.set_http_response(SCHEDULES_PATH + "/u1", 400, {})
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "02:00", "end": "05:00", "limit": 90}))
+    assert ok is False
+    assert [r for r in api.request_log if "batterySettings" in r["path"]] == []
+    assert api.schedule_write_failed["12345"]["cfg"] is True
+
+
+def test_converge_family_disabled_target_is_a_no_op():
+    """A disabled target does nothing here - _cleanup_family already handled disabling."""
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {}}
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": False, "start": "00:00", "end": "00:00", "limit": 100}))
+    assert ok is True
+    assert api.request_log == []
+
+
+def test_desired_schedule_families_maps_export_soc_to_dtg_rbd_or_neither():
+    """Export target <99 -> DTG, ==99 -> RBD, ==100/disabled -> neither; DTG/RBD share the window."""
+    api = MockEnphaseAPI()
+    local = {"reserve": 20, "charge": {"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True}, "export": {"start_time": "23:00:00", "end_time": "23:30:00", "soc": 60, "enable": True}}
+    desired = api._desired_schedule_families(local)
+    assert desired["cfg"] == {"enabled": True, "start": "02:00", "end": "05:00", "limit": 90}
+    assert desired["dtg"]["enabled"] is True and (desired["dtg"]["start"], desired["dtg"]["end"]) == ("23:00", "23:30")
+    assert desired["rbd"]["enabled"] is False
+
+    local["export"]["soc"] = 99
+    desired = api._desired_schedule_families(local)
+    assert desired["dtg"]["enabled"] is False
+    assert desired["rbd"]["enabled"] is True and (desired["rbd"]["start"], desired["rbd"]["end"]) == ("23:00", "23:30")
+
+    local["export"]["soc"] = 100
+    desired = api._desired_schedule_families(local)
+    assert desired["dtg"]["enabled"] is False and desired["rbd"]["enabled"] is False
+
+
+def test_desired_schedule_families_clamps_dtg_limit_to_reserve():
+    """The DTG floor is clamped to at least the reserve - Enphase will not discharge below it."""
+    api = MockEnphaseAPI()
+    local = {"reserve": 30, "charge": {"enable": False}, "export": {"start_time": "23:00:00", "end_time": "23:30:00", "soc": 10, "enable": True}}
+    desired = api._desired_schedule_families(local)
+    assert desired["dtg"]["limit"] == 30
+
+
+def test_reconcile_once_single_family_change_updates_in_place():
+    """Only one family changing this pass -> PUT-in-place, no delete."""
+    api = MockEnphaseAPI()
+    api.user_id = "9999"
+    _apply_setup(api, charge={"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True})
+    api.schedules["12345"]["cfg"] = {"id": "u1", "startTime": "01:00", "endTime": "04:00", "limit": 80, "enabled": True}
+    api.set_http_response(SCHEDULES_PATH, 200, _schedules_payload([_cfg_detail("u1", "01:00", "04:00", limit=80)]))
+    api.set_http_response(SCHEDULES_PATH + "/u1", 200, {})
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    ok = run_async(api._reconcile_once("12345"))
+    assert ok is True
+    assert [r for r in api.request_log if r["path"].endswith("/delete")] == []
+    puts = [r for r in api.request_log if r["method"] == "PUT" and r["path"].endswith("/schedules/u1")]
+    assert len(puts) == 1
+
+
+def test_reconcile_once_deletes_before_writing_when_two_families_change():
+    """Two families changing at once are both cleared before either is rewritten.
+
+    Charge moves 02:00-03:30 -> 03:00-04:30 and export moves 04:00-05:00 -> 05:00-06:00 in the
+    same pass: the new charge window overlaps the OLD export window even though neither family's
+    *new* windows overlap each other, so PUT-in-place on either risks an HTTP 409 against the
+    other's stale window. Both must be deleted (phase 1) before either is rewritten (phase 2).
     """
     api = MockEnphaseAPI()
-    api.schedules["12345"] = {"cfg": {"supported": True}}  # no id yet -> takes the create path
-    api.set_http_sequence(SCHEDULES_PATH, [(409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}}), (200, _schedules_payload([_cfg_detail("existing", "03:00", "04:00")]))])
-    api.set_http_response(SCHEDULES_PATH + "/existing", 200, {"scheduleId": "existing"})
-    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
-    assert wrote is True
-    assert [r["method"] for r in api.request_log] == ["POST", "GET", "PUT", "GET"]
-    assert api.schedules["12345"]["cfg"]["id"] == "existing"
+    api.user_id = "9999"
+    _apply_setup(
+        api,
+        charge={"start_time": "03:00:00", "end_time": "04:30:00", "soc": 90, "enable": True},
+        export={"start_time": "05:00:00", "end_time": "06:00:00", "soc": 60, "enable": True},
+    )
+    api.schedules["12345"] = {
+        "cfg": {"id": "chg1", "startTime": "02:00", "endTime": "03:30", "limit": 90, "enabled": True},
+        "dtg": {"id": "exp1", "startTime": "04:00", "endTime": "05:00", "limit": 60, "enabled": True},
+        "rbd": {},
+    }
+    full_payload = {
+        "cfg": {"scheduleStatus": "active", "count": 1, "details": [_cfg_detail("chg1", "02:00", "03:30", limit=90)]},
+        "dtg": {"scheduleStatus": "active", "count": 1, "details": [{"scheduleId": "exp1", "startTime": "04:00", "endTime": "05:00", "limit": 60, "scheduleType": "DTG", "days": [1, 2, 3, 4, 5, 6, 7], "isDeleted": False, "isEnabled": True}]},
+        "rbd": {"scheduleStatus": "active", "count": 0, "details": []},
+    }
+    # SCHEDULES_PATH is shared by every GET/POST here (create has no id suffix, same as the list
+    # GET), so this sequence must cover all five calls this pass makes in order: the initial read,
+    # each family's create, and each family's post-create id-learning re-read. After the initial
+    # read (which shows both stale schedules, forcing the delete-first path) every later read shows
+    # them gone, matching what the deletes just did.
+    empty_payload = _schedules_payload([])
+    api.set_http_sequence(SCHEDULES_PATH, [(200, full_payload), (200, {}), (200, empty_payload), (200, {}), (200, empty_payload)])
+    api.set_http_response(SCHEDULES_PATH + "/chg1/delete", 204, None)
+    api.set_http_response(SCHEDULES_PATH + "/exp1/delete", 204, None)
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    ok = run_async(api._reconcile_once("12345"))
+    assert ok is True
+    indexed = list(enumerate(api.request_log))
+    delete_indices = [i for i, r in indexed if r["path"].endswith("/delete")]
+    post_indices = [i for i, r in indexed if r["method"] == "POST" and r["path"] == SCHEDULES_PATH]
+    assert sorted(r["path"] for r in api.request_log if r["path"].endswith("/delete")) == sorted([SCHEDULES_PATH + "/chg1/delete", SCHEDULES_PATH + "/exp1/delete"])
+    assert len(post_indices) == 2
+    assert max(delete_indices) < min(post_indices)  # every delete completes before any create
+    assert [r for r in api.request_log if r["method"] == "PUT" and "schedules" in r["path"]] == []  # never PUT to a stale id
 
 
-def test_write_schedule_create_retries_once_via_post_when_still_no_id():
-    """When the re-read finds nothing to adopt, the retry goes out as a second POST, not a PUT."""
+def test_reconcile_once_returns_false_when_any_step_fails():
+    """A single failing step (e.g. a failed create) makes the whole pass report not-ok."""
     api = MockEnphaseAPI()
-    api.schedules["12345"] = {"cfg": {"supported": True}}
+    _apply_setup(api, charge={"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True})
+    api.battery_settings["12345"]["chargeFromGrid"] = False
+    api.set_http_response(SCHEDULES_PATH, 400, {})
+    ok = run_async(api._reconcile_once("12345"))
+    assert ok is False
+
+
+def test_converge_reserve_writes_when_different():
+    """Reserve converges via set_reserve when it differs from the cached cloud value."""
+    api = MockEnphaseAPI()
+    api.profile["12345"] = {"profile": "self-consumption", "reserve": 10}
+    api.set_http_response("/service/batteryConfig/api/v1/profile/12345", 200, {})
+    ok = run_async(api._converge_reserve("12345", {"reserve": 25}))
+    assert ok is True
+    assert api.profile["12345"]["reserve"] == 25
+
+
+def test_converge_reserve_no_op_when_zero_or_matching():
+    """A zero (unset) or already-matching reserve issues no write."""
+    api = MockEnphaseAPI()
+    api.profile["12345"] = {"reserve": 20}
+    assert run_async(api._converge_reserve("12345", {"reserve": 20})) is True
+    assert run_async(api._converge_reserve("12345", {"reserve": 0})) is True
+    assert api.request_log == []
+
+
+def test_apply_battery_schedule_retries_then_succeeds():
+    """A failing first pass is retried and can still converge within the attempt budget."""
+    api = MockEnphaseAPI()
+    _apply_setup(api, charge={"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True})
     api.set_http_sequence(
         SCHEDULES_PATH,
         [
-            (409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}}),
-            (200, _schedules_payload([])),
-            (200, {}),
-            (200, _schedules_payload([_cfg_detail("new2", "03:00", "04:00")])),
+            (200, _schedules_payload([])),  # 1st attempt: pre-write read, nothing there
+            (409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}}),  # the create fails
+            (200, _schedules_payload([])),  # 2nd attempt: fresh read again, still nothing
+            (200, {}),  # this time the create succeeds
+            (200, _schedules_payload([_cfg_detail("new1", "02:00", "05:00", limit=90)])),  # post-success re-read
         ],
     )
-    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
-    assert wrote is True
-    assert [r["method"] for r in api.request_log] == ["POST", "GET", "POST", "GET"]
-    assert api.schedules["12345"]["cfg"]["id"] == "new2"
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    with _NoSleep():
+        ok = run_async(api.apply_battery_schedule("12345"))
+    assert ok is True
+    assert [r["method"] for r in api.request_log].count("POST") == 2  # one failed create, one that landed
 
 
-def test_write_schedule_create_gives_up_after_second_conflict():
-    """A create-path conflict that survives the re-read fails the write instead of looping."""
+def test_apply_battery_schedule_gives_up_after_max_attempts():
+    """A persistent conflict exhausts the attempt budget and returns False."""
     api = MockEnphaseAPI()
-    api.schedules["12345"] = {"cfg": {"supported": True}}
+    _apply_setup(api, charge={"start_time": "02:00:00", "end_time": "05:00:00", "soc": 90, "enable": True})
     api.set_http_response(SCHEDULES_PATH, 409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}})
-    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
-    assert wrote is False
-    assert [r["method"] for r in api.request_log] == ["POST", "GET", "POST"]  # one retry only
+    with _NoSleep():
+        ok = run_async(api.apply_battery_schedule("12345"))
+    assert ok is False
+    assert [r["method"] for r in api.request_log].count("POST") == ENPHASE_RECONCILE_MAX_ATTEMPTS
+    assert api.count_errors == ENPHASE_RECONCILE_MAX_ATTEMPTS
+
+
+def test_apply_battery_schedule_skips_everything_in_read_only_mode():
+    """Read-only mode does nothing at all - no reads, no writes, no reconcile attempted."""
+    api = MockEnphaseAPI()
+    api.mock_ha_states["switch.predbat_set_read_only"] = "on"
+    ok = run_async(api.apply_battery_schedule("12345"))
+    assert ok is True
+    assert api.request_log == []
 
 
 def test_request_json_failure_log_includes_method_and_context():
@@ -2122,17 +2407,17 @@ def test_request_json_failure_log_includes_method_and_context():
     assert "CFG schedule create" in warns[0]
 
 
-def test_write_schedule_create_conflict_log_names_method_and_family():
+def test_converge_family_create_conflict_log_names_method_and_family():
     """The generic HTTP-failure log for a create-path 409 says POST and names the family."""
     api = MockEnphaseAPI()
-    api.schedules["12345"] = {"cfg": {"supported": True}}
+    api.schedules["12345"] = {"cfg": {}}
     api.set_http_response(SCHEDULES_PATH, 409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}})
-    run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
+    run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "03:00", "end": "04:00", "limit": 100}))
     warns = [m for m in api.log_messages if m.startswith("Warn: Enphase: HTTP POST")]
     assert warns and "CFG schedule create" in warns[0]
 
 
-def test_write_schedule_failure_is_tracked_for_dashboard():
+def test_converge_family_failure_is_tracked_for_dashboard():
     """A schedule write that fails outright is counted and flagged for the dashboard.
 
     Before the fix a persistent conflict only ever showed up as a log warning -
@@ -2142,21 +2427,22 @@ def test_write_schedule_failure_is_tracked_for_dashboard():
     api = MockEnphaseAPI()
     api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
     api.set_http_response(SCHEDULES_PATH + "/sched-1", 409, {"error": {"status": "CONFLICTING_SCHEDULE_CFG"}})
-    api.set_http_response(SCHEDULES_PATH, 200, _schedules_payload([_cfg_detail("sched-1", "02:00", "02:20")]))
-    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
-    assert wrote is False
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "03:00", "end": "04:00", "limit": 100}))
+    assert ok is False
     assert api.count_errors == 1
     assert api.schedule_write_failed["12345"]["cfg"] is True
 
 
-def test_write_schedule_success_clears_a_previous_failure_flag():
+def test_converge_family_success_clears_a_previous_failure_flag():
     """A successful write clears the failure it previously flagged."""
     api = MockEnphaseAPI()
+    api.user_id = "9999"
     api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
     api.schedule_write_failed["12345"] = {"cfg": True}
     api.set_http_response(SCHEDULES_PATH + "/sched-1", 200, {"scheduleId": "sched-1"})
-    wrote = run_async(api._write_schedule("12345", "CFG", "03:00:00", "04:00:00", 100, True))
-    assert wrote is True
+    api.set_http_response("/service/batteryConfig/api/v1/batterySettings/12345", 200, {})
+    ok = run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "03:00", "end": "04:00", "limit": 100}))
+    assert ok is True
     assert "cfg" not in api.schedule_write_failed["12345"]
 
 
@@ -2207,18 +2493,20 @@ def test_consecutive_writes_stay_on_one_schedule_across_a_reorder():
     Observed on a site with two CFG schedules: Predbat wrote 22:35-23:30 to one, the re-read
     returned the pair in the opposite order, Predbat swapped to the other and wrote 22:50-23:30 -
     which the cloud rejected with CONFLICTING_SCHEDULE_CFG against the window Predbat had set
-    itself five minutes earlier. Every subsequent cycle then failed the same way.
+    itself five minutes earlier. Every subsequent cycle then failed the same way. The write path
+    changed with #4461's reconcile rewrite, but the id-pinning this guards (in get_schedules) did
+    not, so this still exercises it directly via _converge_family.
     """
     api = MockEnphaseAPI()
     api.schedules["12345"] = {"cfg": {"id": "first", "startTime": "20:30", "endTime": "21:00", "limit": 5, "enabled": True}}
     api.set_http_response(SCHEDULES_PATH + "/first", 200, {"scheduleId": "first"})
     api.set_http_response(SCHEDULES_PATH + "/second/delete", 204, None)
-    run_async(api._write_schedule("12345", "CFG", "22:35:00", "23:30:00", 5, True))
+    run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "22:35", "end": "23:30", "limit": 5}))
     # Cloud re-read now lists the sibling first, because our write made "first" the most recent
     api.set_http_response(SCHEDULES_PATH, 200, _schedules_payload([_cfg_detail("second", "20:30", "21:00", limit=5), _cfg_detail("first", "22:35", "23:30", limit=5)]))
     run_async(api.get_schedules("12345"))
-    run_async(api._write_schedule("12345", "CFG", "22:50:00", "23:30:00", 5, True))
-    written = [r["path"] for r in api.request_log if r["method"] == "PUT"]
+    run_async(api._converge_family("12345", "cfg", {"enabled": True, "start": "22:50", "end": "23:30", "limit": 5}))
+    written = [r["path"] for r in api.request_log if r["method"] == "PUT" and "schedules" in r["path"]]
     assert written == [SCHEDULES_PATH + "/first", SCHEDULES_PATH + "/first"]  # never swapped onto the sibling
 
 
@@ -2230,16 +2518,32 @@ def run_enphase_api_tests(my_predbat):
     test_get_schedules_readopts_when_pinned_id_disappears()
     test_get_schedules_deletes_sibling_schedules_in_write_mode()
     test_get_schedules_keeps_sibling_schedules_in_read_only_mode()
-    test_write_schedule_disable_deletes_the_schedule()
-    test_write_schedule_retries_once_after_conflict()
-    test_write_schedule_gives_up_after_second_conflict()
-    test_write_schedule_create_retries_once_after_conflict_and_adopts_id()
-    test_write_schedule_create_retries_once_via_post_when_still_no_id()
-    test_write_schedule_create_gives_up_after_second_conflict()
+    test_cleanup_family_deletes_when_disabling()
+    test_cleanup_family_skips_a_single_family_change()
+    test_cleanup_family_deletes_when_force_recreate()
+    test_cleanup_family_nothing_to_do_without_an_id()
+    test_cleanup_family_delete_failure_is_tracked_when_disabling()
+    test_converge_family_creates_when_no_id()
+    test_converge_family_updates_in_place_when_id_present()
+    test_converge_family_no_op_when_already_matches()
+    test_converge_family_activates_without_rewrite_when_matches_but_pending()
+    test_converge_family_force_activate_when_underlying_setting_off()
+    test_converge_family_write_failure_skips_activation()
+    test_converge_family_disabled_target_is_a_no_op()
+    test_desired_schedule_families_maps_export_soc_to_dtg_rbd_or_neither()
+    test_desired_schedule_families_clamps_dtg_limit_to_reserve()
+    test_reconcile_once_single_family_change_updates_in_place()
+    test_reconcile_once_deletes_before_writing_when_two_families_change()
+    test_reconcile_once_returns_false_when_any_step_fails()
+    test_converge_reserve_writes_when_different()
+    test_converge_reserve_no_op_when_zero_or_matching()
+    test_apply_battery_schedule_retries_then_succeeds()
+    test_apply_battery_schedule_gives_up_after_max_attempts()
+    test_apply_battery_schedule_skips_everything_in_read_only_mode()
     test_request_json_failure_log_includes_method_and_context()
-    test_write_schedule_create_conflict_log_names_method_and_family()
-    test_write_schedule_failure_is_tracked_for_dashboard()
-    test_write_schedule_success_clears_a_previous_failure_flag()
+    test_converge_family_create_conflict_log_names_method_and_family()
+    test_converge_family_failure_is_tracked_for_dashboard()
+    test_converge_family_success_clears_a_previous_failure_flag()
     test_activate_cfg_mode_failure_is_tracked_for_dashboard()
     test_set_reserve_failure_is_tracked_for_dashboard()
     test_publish_schedule_write_health_reports_failures()
@@ -2306,6 +2610,7 @@ def run_enphase_api_tests(my_predbat):
     test_get_schedules_pending_family_is_still_supported()
     test_inverter_def_enphase()
     test_run_first_polls_all_tiers()
+    test_run_reconciles_schedule_periodically_not_every_poll()
     test_get_today()
     test_publish_data_sensors()
     test_sync_local_schedule_from_cloud()
@@ -2333,9 +2638,9 @@ def run_enphase_api_tests(my_predbat):
     test_apply_no_activate_dtg_when_export_disabled()
     test_apply_no_activate_dtg_when_freeze_not_real_export()
     test_apply_no_activate_dtg_when_unchanged()
-    test_activate_cfg_mode_invalidates_cache_on_failure()
-    test_activate_dtg_mode_invalidates_cache_on_failure()
-    test_activate_rbd_mode_invalidates_cache_on_failure()
+    test_activate_cfg_mode_failure_leaves_cache_untouched()
+    test_activate_dtg_mode_failure_leaves_cache_untouched()
+    test_activate_rbd_mode_failure_leaves_cache_untouched()
     test_apply_activates_pending_schedule_without_rewrite()
     test_is_schedule_pending_null_status_is_not_pending()
     test_apply_no_crash_when_cached_status_none()

--- a/apps/predbat/tests/test_enphase_api.py
+++ b/apps/predbat/tests/test_enphase_api.py
@@ -2150,6 +2150,23 @@ def test_cleanup_family_delete_failure_is_tracked_when_disabling():
     assert api.schedule_write_failed["12345"]["cfg"] is True
 
 
+def test_cleanup_family_delete_failure_is_tracked_when_force_recreating():
+    """A failed delete during the multi-family force-recreate path is also tracked as a failure.
+
+    Not just the disable case - a family being cleared because a *different* family is also
+    changing this pass must be counted too, even though _converge_family (called next for every
+    family regardless of this outcome) may go on to self-heal it with a fallback PUT to the same
+    still-known id.
+    """
+    api = MockEnphaseAPI()
+    api.schedules["12345"] = {"cfg": {"id": "sched-1", "startTime": "02:00", "endTime": "02:20", "limit": 100, "enabled": True}}
+    api.set_http_response(SCHEDULES_PATH + "/sched-1/delete", 400, {})
+    ok = run_async(api._cleanup_family("12345", "cfg", {"enabled": True, "start": "03:00", "end": "04:00", "limit": 100}, True))
+    assert ok is False
+    assert api.schedule_write_failed["12345"]["cfg"] is True
+    assert api.count_errors == 1
+
+
 def test_converge_family_creates_when_no_id():
     """No id on the cloud, family enabled - creates a new schedule and activates it."""
     api = MockEnphaseAPI()
@@ -2523,6 +2540,7 @@ def run_enphase_api_tests(my_predbat):
     test_cleanup_family_deletes_when_force_recreate()
     test_cleanup_family_nothing_to_do_without_an_id()
     test_cleanup_family_delete_failure_is_tracked_when_disabling()
+    test_cleanup_family_delete_failure_is_tracked_when_force_recreating()
     test_converge_family_creates_when_no_id()
     test_converge_family_updates_in_place_when_id_present()
     test_converge_family_no_op_when_already_matches()

--- a/docs/superpowers/specs/2026-08-08-enphase-schedule-reconcile-design.md
+++ b/docs/superpowers/specs/2026-08-08-enphase-schedule-reconcile-design.md
@@ -1,0 +1,135 @@
+# Enphase Schedule Reconcile — Design
+
+Date: 2026-08-08
+Status: Approved (design review complete)
+
+## Goal
+
+Replace the per-family, incrementally-patched write path in `enphase.py`
+(`_write_schedule` / `_put_schedule_with_conflict_retry` /
+`_create_schedule_with_conflict_retry` / `_write_and_activate` /
+`_is_schedule_pending` / the pending-debounce mechanism) with a single
+reconcile function, driven by issue [#4461](https://github.com/springfall2008/batpred/issues/4461).
+
+## Background
+
+#4428 fixed same-family sibling conflicts (retry-once-and-prune on PUT).
+This session's work on #4461 patched three more things on top of that
+(create-path retry, a pending-status debounce, a bugfix for the debounce's
+interaction with activation) and, while investigating, surfaced a fourth,
+structural gap: a family that is *disabled* can leave a stale, still-live
+window on the cloud that a *different* family's write then collides with -
+none of the per-family retry/prune machinery looks across families. Each fix
+revealed a new problem in a different place - the signal to stop patching and
+reconsider the architecture (see `systematic-debugging` Phase 4.5).
+
+## Decision
+
+One function, `apply_battery_schedule(site_id)`, called from two places -
+the periodic component poll (`run()`, on a new 5-minute refresh tier) and the
+write-switch event handler - instead of only the latter. Both paths converge
+on the same logic.
+
+```
+apply_battery_schedule(site_id):
+    for attempt in 1..3:
+        ok = _reconcile_once(site_id)
+        if ok: return True
+        if attempt < 3: sleep(short jittered backoff)
+    return False   # give up - next periodic run or trigger tries again from scratch
+
+_reconcile_once(site_id):
+    read desired state from HA entities + fresh GET /schedules (always, no
+    cached-state trust between passes)
+    compute desired {enabled, start, end, limit} per family (cfg/dtg/rbd)
+    determine which families differ from the fresh cloud read
+    Phase 1 - cleanup, across ALL families before any writes:
+        delete a family's existing schedule when: it should now be disabled,
+        OR it has an extra/untracked sibling, OR (see "Update strategy"
+        below) more than one family is changing this pass
+        also prune any duplicate sibling within a family regardless
+    Phase 2 - converge, only after phase 1 has run for every family:
+        PUT-in-place if a matching id survived cleanup and only the
+        window/limit changed; POST a new one if none exists; activate
+        (batterySettings PUT) if needed
+    also converge the reserve (profile PUT)
+    return whether every step this pass succeeded
+```
+
+### Retry/backoff policy
+
+Up to 3 attempts per `apply_battery_schedule` call, short jittered backoff
+between attempts (a few seconds), then give up for this call and rely on the
+next periodic run (5 minutes) or the next explicit trigger. No attempt is
+made to track *why* a write failed (pending, conflict, transient error)
+across calls - a fresh, unconditional retry from a clean re-read is simpler
+and was what the removed debounce mechanism was trying to approximate badly.
+
+### Update strategy: when to delete-then-recreate vs. PUT-in-place
+
+PUT-in-place (update the existing schedule by id) is preferred when it's
+safe - it avoids a brief window where a family has no schedule at all.
+It is **not** safe whenever more than one family is changing in the same
+pass: a new window for family A can overlap the *old*, not-yet-updated
+window of family B even when neither family's *new* windows overlap each
+other (e.g. charge 02:00-03:30 -> 03:00-04:30 and export 04:00-05:00 ->
+05:00-06:00 in the same pass: new-charge overlaps old-export). Computing
+actual interval overlaps to decide case-by-case is unnecessary complexity;
+counting how many families have a pending change this pass is enough:
+
+- Exactly one family changing -> PUT-in-place is safe (nothing else is
+  moving, so no new overlap can be introduced).
+- Two or more families changing -> delete all of them first (phase 1), then
+  recreate via POST (phase 2). This costs nothing extra in the common
+  Charging<->Exporting oscillation case from #4461, since one of the two
+  families there is already being disabled (delete-required anyway) and the
+  other has no id yet (create-required anyway).
+
+DTG and RBD share the same `export_start`/`export_end` window and are
+mutually exclusive (`export_soc < 99` vs `== 99` - see
+`apply_battery_schedule`'s export-family selection), so they can never both
+be live with different windows. The only real cross-family overlap risk is
+CFG vs. the export family (DTG or RBD) - a single pairwise relationship, not
+a three-way cycle between all three families.
+
+### What is removed
+
+`_put_schedule_with_conflict_retry`, `_create_schedule_with_conflict_retry`
+(two near-duplicate retry helpers -> one outer retry), `_write_and_activate`,
+`_is_schedule_pending`, `_schedule_pending_debounce_active`,
+`schedule_pending_since` tracking (in `initialize()` and `get_schedules()`),
+`ENPHASE_SCHEDULE_PENDING_DEBOUNCE_MINUTES`.
+
+### What stays
+
+- The HTTP failure log's method + caller-supplied context (`request_json`'s
+  `context` parameter) - orthogonal, still valuable for diagnosing whatever
+  does still fail.
+- Write-failure -> dashboard visibility (`_note_schedule_write_result`,
+  `schedule_write_failed`, `count_errors`, the dedicated
+  `binary_sensor.predbat_enphase_<site>_schedule_write_ok` sensor) -
+  orthogonal to *how* we retry; fires off `apply_battery_schedule`'s final
+  give-up instead of scattered per-call-site failure paths.
+- `_delete_schedule`, `_activate_cfg_mode` / `_activate_dtg_mode` /
+  `_activate_rbd_mode` (via `_activate_control_mode`), `set_reserve`,
+  `get_schedules` (simplified - no more pending-status bookkeeping),
+  `_prune_sibling_schedules` (generalised into the phase-1 cleanup step).
+
+## Testing
+
+Unit tests (`test_enphase_api.py`) replace most of the per-family
+write-helper tests with tests against `_reconcile_once`'s two phases and the
+outer retry loop directly: phase ordering (delete before any write), the
+delete-vs-PUT-in-place decision rule (single-family vs multi-family change),
+the cross-family overlap scenario from this design discussion, retry-then-
+succeed, retry-then-give-up, and reserve convergence. The write-failure
+tracking tests stay conceptually the same, retargeted at the new call sites.
+
+A live test harness (`test_schedule_reconcile` or similar, alongside the
+existing manual `test_enphase_api` / `test_write_schedule` /
+`test_write_reserve` functions at the bottom of `enphase.py`, gated
+`# pragma: no cover` and invoked directly against a real account) drives a
+scripted sequence of schedule changes - including a deliberate
+charge/export-both-moving-simultaneously case - against the real Enphase
+cloud, using windows between midnight and 05:00 so nothing it does can
+actually trigger a real charge or export on the battery it's run against.


### PR DESCRIPTION
## Update: redesigned during review

The first commit on this PR fixed #4461's three asks with incremental, per-family patches (create-path retry, a pending-status debounce, a bugfix for the debounce interacting badly with activation). Review surfaced a fourth, structural gap on top of that - a family being disabled can leave a stale, still-live window that a *different* family's write then collides with, which none of the per-family retry/prune machinery could see across families. Four fixes each revealing a new problem in a different place was the signal to stop patching and reconsider the architecture rather than add a fifth.

The second commit replaces all of that with a single reconcile function. Design: [`docs/superpowers/specs/2026-08-08-enphase-schedule-reconcile-design.md`](docs/superpowers/specs/2026-08-08-enphase-schedule-reconcile-design.md).

## What changed

`apply_battery_schedule` now runs both periodically (a new 5-minute tier in `run()`, so a missed/dropped write-switch trigger can't leave the cloud diverged from the plan indefinitely) and from the write switch as before - both paths converge on the same logic:

```
apply_battery_schedule: up to 3 read-clean-write attempts, short backoff between,
                          then defer to the next periodic call or trigger.

_reconcile_once: fresh read, then two phases -
   1. delete anything that must not survive (a family being disabled, or an
      enabled-but-moving family whenever more than one family is changing this
      pass) BEFORE any family writes anything
   2. write/activate what's still needed
```

**Why the delete-vs-update-in-place split closes the cross-family gap:** a new window for one family can collide with a *different* family's old, not-yet-updated window even when neither family's *new* windows overlap each other (e.g. charge 02:00-03:30→03:00-04:30 and export 04:00-05:00→05:00-06:00 moving in the same pass: new-charge overlaps old-export). Counting how many families are changing this pass is enough to decide whether PUT-in-place is safe - no interval-overlap math needed. DTG and RBD are mutually exclusive by construction (they share the same window; a target can't be both <99% and ==99%), so this only ever has to reason about two families at a time, not three.

**Removed as no longer needed:** `_put_schedule_with_conflict_retry` / `_create_schedule_with_conflict_retry` (two near-duplicate per-write retry helpers → one outer retry), `_write_and_activate`, the pending-status debounce and its `schedule_pending_since` tracking, and the on-failure cache invalidation (every attempt re-reads from the cloud, so there's nothing local left to invalidate).

**Kept, orthogonal to the rewrite:** the HTTP-log method/context fix (ask 1), and write-failure → dashboard visibility via `count_errors`/`components_healthy` and the dedicated `binary_sensor.predbat_enphase_<site>_schedule_write_ok` sensor (ask 3) - both fire off the new reconcile's failure paths instead of the old scattered call sites.

## Testing

Unit tests were rewritten against the new reconcile's phases directly: cleanup delete-vs-skip rules, PUT-in-place vs create, the cross-family overlap scenario, the outer retry-then-succeed / retry-then-give-up loop, read-only mode, and the periodic-vs-every-poll run() wiring. `./run_pre_commit` passes (all hooks green) and the full `./run_all --quick` suite passes.

Also added a scripted **live** test harness (`enphase.py --reconcile-sequence`) that drives a sequence of real schedule changes - including the cross-family case - against a real account. It only ever uses midnight-05:00 windows and RBD (freeze-export) rather than a real DTG target, so nothing it does can actually charge from or export to the grid.

Bumped `THIS_VERSION` v8.47.6 → v8.47.7.

---

<details>
<summary>Original PR description (first commit, superseded above)</summary>

## Problem

Fixes #4461, filed after #4428/#4429 shipped. On an EnphaseCloud account, `apply_battery_schedule` writes were still hitting recurring nightly HTTP 409s, and the battery could keep running a stale/wrong schedule for an hour while `predbat.status`/`binary_sensor.predbat_exporting` kept showing the *intended* plan instead of the confirmed device state.

## Changes (superseded by the redesign above, but still true)

1. Ambiguous logging - `request_json` now logs `HTTP {method} {path} -> {status}` plus an optional caller-supplied context.
2. Symmetric conflict-retry for the POST-create path (superseded - the whole reconcile now retries as one unit instead).
3. Write-failure → dashboard visibility via `count_errors`/`components_healthy` and a dedicated `binary_sensor.predbat_enphase_<site>_schedule_write_ok` sensor.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)