### PR TITLE
fix(fetch): warn loudly when car_charging_energy is configured but has no data

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -2569,19 +2569,25 @@ class Fetch:
             self.car_charging_energy = self.minute_data_import_export(self.max_days_previous, now_utc, "car_charging_energy", scale=self.car_charging_energy_scale, required_unit="kWh")
             if self.car_charging_hold and not self.car_charging_energy:
                 # car_charging_energy is configured (an entity is set) but resolved to nothing at
-                # all - most likely the entity no longer exists (e.g. removed upstream, see #4458)
-                # rather than a transient gap. minute_data_import_export() already logs a benign
-                # "Unable to fetch history" warning per entity with no had_errors flag, so this
-                # degrades to the car_charging_threshold heuristic below completely silently
-                # otherwise - loud enough here that it doesn't get missed, since car_charging_hold
-                # defaults on and this quietly degrades load-forecast accuracy on every car-charging
-                # day until fixed, not just a single wrong sensor reading.
-                self.log(
-                    "Warn: car_charging_hold is enabled and car_charging_energy is configured ({}) but no data could be loaded for it - falling back to the car_charging_threshold heuristic instead of precise car energy subtraction. Check the entity still exists.".format(
-                        self.get_arg("car_charging_energy", indirect=False)
+                # all - most likely the entity no longer exists (e.g. removed upstream, see #4458),
+                # though it can also happen for a recorder-excluded entity or a fresh install with
+                # no history yet, which aren't necessarily broken and can persist indefinitely.
+                # minute_data_import_export() already logs a benign "Unable to fetch history"
+                # warning per entity with no had_errors flag, so this degrades to the
+                # car_charging_threshold heuristic below completely silently otherwise. Log the
+                # loud warning only once per incident (not every cycle - see PR review on #4469)
+                # so a persistent-but-intentional setup doesn't get spammed every 5 minutes; the
+                # status sensor still reflects the degraded state every cycle via record_status.
+                if not self.car_charging_energy_warned:
+                    self.log(
+                        "Warn: car_charging_hold is enabled and car_charging_energy is configured ({}) but no data could be loaded for it - falling back to the car_charging_threshold heuristic instead of precise car energy subtraction. Check the entity still exists.".format(
+                            self.get_arg("car_charging_energy", indirect=False)
+                        )
                     )
-                )
+                    self.car_charging_energy_warned = True
                 self.record_status("Warn: car_charging_energy entity has no data, falling back to car_charging_threshold heuristic", had_errors=True)
+            else:
+                self.car_charging_energy_warned = False
         else:
             self.log("Car charging hold {}, threshold {}kWh".format(self.car_charging_hold, self.car_charging_threshold * 60.0))
         return self.car_charging_energy

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -2567,6 +2567,21 @@ class Fetch:
         self.car_charging_energy = {}
         if "car_charging_energy" in self.args:
             self.car_charging_energy = self.minute_data_import_export(self.max_days_previous, now_utc, "car_charging_energy", scale=self.car_charging_energy_scale, required_unit="kWh")
+            if self.car_charging_hold and not self.car_charging_energy:
+                # car_charging_energy is configured (an entity is set) but resolved to nothing at
+                # all - most likely the entity no longer exists (e.g. removed upstream, see #4458)
+                # rather than a transient gap. minute_data_import_export() already logs a benign
+                # "Unable to fetch history" warning per entity with no had_errors flag, so this
+                # degrades to the car_charging_threshold heuristic below completely silently
+                # otherwise - loud enough here that it doesn't get missed, since car_charging_hold
+                # defaults on and this quietly degrades load-forecast accuracy on every car-charging
+                # day until fixed, not just a single wrong sensor reading.
+                self.log(
+                    "Warn: car_charging_hold is enabled and car_charging_energy is configured ({}) but no data could be loaded for it - falling back to the car_charging_threshold heuristic instead of precise car energy subtraction. Check the entity still exists.".format(
+                        self.get_arg("car_charging_energy", indirect=False)
+                    )
+                )
+                self.record_status("Warn: car_charging_energy entity has no data, falling back to car_charging_threshold heuristic", had_errors=True)
         else:
             self.log("Car charging hold {}, threshold {}kWh".format(self.car_charging_hold, self.car_charging_threshold * 60.0))
         return self.car_charging_energy

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -480,6 +480,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.car_charging_manual_soc = []
         self.car_charging_threshold = 99
         self.car_charging_energy = {}
+        self.car_charging_energy_warned = False
         self.octopus_intelligent_charging = False
         self.octopus_intelligent_ignore_unplugged = False
         self.octopus_intelligent_consider_full = False

--- a/apps/predbat/tests/test_load_car_energy.py
+++ b/apps/predbat/tests/test_load_car_energy.py
@@ -12,6 +12,12 @@
 no data at all - e.g. the entity was removed upstream (#4458) rather than a transient gap. Without
 this, car_charging_hold (on by default) silently degrades to the load-threshold heuristic with only
 a benign, error-free log line, on every car-charging day, until someone notices by chance.
+
+The loud log line is throttled to once per incident (not every cycle) since the condition can also
+be persistent-but-intentional (a recorder-excluded entity, a fresh install with no history yet), not
+only a genuine break - see the PR review discussion on #4469. record_status/had_errors still fire on
+every cycle the condition persists, so the status sensor stays accurate; only the log spam is
+suppressed.
 """
 
 
@@ -33,6 +39,8 @@ def test_load_car_energy_warns_when_configured_entity_has_no_data(my_predbat):
     original_had_errors = my_predbat.had_errors
     original_status = my_predbat.current_status
     original_minute_data_import_export = my_predbat.minute_data_import_export
+    original_warned = my_predbat.car_charging_energy_warned
+    original_log = my_predbat.log
 
     try:
         my_predbat.args["car_charging_energy"] = "sensor.ohme_test_energy"
@@ -76,6 +84,40 @@ def test_load_car_energy_warns_when_configured_entity_has_no_data(my_predbat):
         if my_predbat.had_errors:
             print("  ERROR: expected no error when car_charging_hold is off, even with an empty entity")
             failed = True
+
+        print("Test: the loud log warning fires once per incident, not every cycle (PR review on #4469)")
+        my_predbat.car_charging_hold = True
+        my_predbat.car_charging_energy_warned = False
+        my_predbat.minute_data_import_export = lambda *args, **kwargs: {}
+        captured = []
+        my_predbat.log = lambda msg, quiet=True: captured.append(msg)
+
+        my_predbat.had_errors = False
+        my_predbat.load_car_energy(my_predbat.now_utc)  # 1st occurrence - should log
+        if not my_predbat.had_errors:
+            print("  ERROR: expected had_errors on the first occurrence of the empty-entity condition")
+            failed = True
+        if sum(1 for m in captured if "no data could be loaded" in m) != 1:
+            print("  ERROR: expected exactly one loud warning on the first occurrence, captured: {}".format(captured))
+            failed = True
+
+        my_predbat.had_errors = False
+        my_predbat.load_car_energy(my_predbat.now_utc)  # 2nd occurrence, same incident - should not re-log
+        if not my_predbat.had_errors:
+            print("  ERROR: expected had_errors to keep being set on every cycle the condition persists")
+            failed = True
+        if sum(1 for m in captured if "no data could be loaded" in m) != 1:
+            print("  ERROR: expected the loud warning to stay suppressed on a repeat of the same incident, captured: {}".format(captured))
+            failed = True
+
+        my_predbat.minute_data_import_export = lambda *args, **kwargs: {0: 1.5}
+        my_predbat.load_car_energy(my_predbat.now_utc)  # data recovers - clears the incident
+
+        my_predbat.minute_data_import_export = lambda *args, **kwargs: {}
+        my_predbat.load_car_energy(my_predbat.now_utc)  # a fresh incident - should log again
+        if sum(1 for m in captured if "no data could be loaded" in m) != 2:
+            print("  ERROR: expected a fresh occurrence after data recovered to warn again, captured: {}".format(captured))
+            failed = True
     finally:
         my_predbat.minute_data_import_export = original_minute_data_import_export
         if had_car_charging_energy_arg:
@@ -87,5 +129,7 @@ def test_load_car_energy_warns_when_configured_entity_has_no_data(my_predbat):
         my_predbat.car_charging_hold = original_hold
         my_predbat.had_errors = original_had_errors
         my_predbat.current_status = original_status
+        my_predbat.car_charging_energy_warned = original_warned
+        my_predbat.log = original_log
 
     return failed

--- a/apps/predbat/tests/test_load_car_energy.py
+++ b/apps/predbat/tests/test_load_car_energy.py
@@ -1,0 +1,91 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""Tests for load_car_energy()'s warning when car_charging_energy is configured but resolves to
+no data at all - e.g. the entity was removed upstream (#4458) rather than a transient gap. Without
+this, car_charging_hold (on by default) silently degrades to the load-threshold heuristic with only
+a benign, error-free log line, on every car-charging day, until someone notices by chance.
+"""
+
+
+def test_load_car_energy_warns_when_configured_entity_has_no_data(my_predbat):
+    """Verify a loud, error-flagged warning fires when car_charging_hold is on and
+    car_charging_energy is configured but minute_data_import_export() returns nothing, and that
+    the same setup with actual data, or with car_charging_hold off, stays silent.
+    """
+    failed = False
+    print("**** Testing load_car_energy warns on a configured-but-empty car_charging_energy ****")
+
+    # my_predbat is a shared fixture across the whole test run - save everything this test touches
+    # so it can be restored afterward regardless of outcome, or later tests get a poisoned instance.
+    had_car_charging_energy_arg = "car_charging_energy" in my_predbat.args
+    original_arg = my_predbat.args.get("car_charging_energy")
+    original_scale = my_predbat.car_charging_energy_scale
+    original_max_days = my_predbat.max_days_previous
+    original_hold = my_predbat.car_charging_hold
+    original_had_errors = my_predbat.had_errors
+    original_status = my_predbat.current_status
+    original_minute_data_import_export = my_predbat.minute_data_import_export
+
+    try:
+        my_predbat.args["car_charging_energy"] = "sensor.ohme_test_energy"
+        my_predbat.car_charging_energy_scale = 1.0
+        my_predbat.max_days_previous = 7
+
+        print("Test: car_charging_hold on, entity configured but empty - warns and flags an error")
+        my_predbat.car_charging_hold = True
+        my_predbat.had_errors = False
+        my_predbat.current_status = ""
+        my_predbat.minute_data_import_export = lambda *args, **kwargs: {}
+        result = my_predbat.load_car_energy(my_predbat.now_utc)
+        if result != {}:
+            print("  ERROR: expected an empty result when the entity has no data, got {}".format(result))
+            failed = True
+        if not my_predbat.had_errors:
+            print("  ERROR: expected had_errors to be set when a configured car_charging_energy entity has no data")
+            failed = True
+        if "car_charging_energy" not in my_predbat.current_status:
+            print("  ERROR: expected the warning to be recorded to current_status, got {!r}".format(my_predbat.current_status))
+            failed = True
+
+        print("Test: car_charging_hold on, entity configured and has real data - stays silent")
+        my_predbat.had_errors = False
+        my_predbat.current_status = ""
+        my_predbat.minute_data_import_export = lambda *args, **kwargs: {0: 1.5}
+        result = my_predbat.load_car_energy(my_predbat.now_utc)
+        if result != {0: 1.5}:
+            print("  ERROR: expected the real data to pass through unchanged, got {}".format(result))
+            failed = True
+        if my_predbat.had_errors:
+            print("  ERROR: expected no error when the entity genuinely has data")
+            failed = True
+
+        print("Test: car_charging_hold off, entity configured but empty - stays silent (hold isn't in play)")
+        my_predbat.car_charging_hold = False
+        my_predbat.had_errors = False
+        my_predbat.current_status = ""
+        my_predbat.minute_data_import_export = lambda *args, **kwargs: {}
+        my_predbat.load_car_energy(my_predbat.now_utc)
+        if my_predbat.had_errors:
+            print("  ERROR: expected no error when car_charging_hold is off, even with an empty entity")
+            failed = True
+    finally:
+        my_predbat.minute_data_import_export = original_minute_data_import_export
+        if had_car_charging_energy_arg:
+            my_predbat.args["car_charging_energy"] = original_arg
+        else:
+            my_predbat.args.pop("car_charging_energy", None)
+        my_predbat.car_charging_energy_scale = original_scale
+        my_predbat.max_days_previous = original_max_days
+        my_predbat.car_charging_hold = original_hold
+        my_predbat.had_errors = original_had_errors
+        my_predbat.current_status = original_status
+
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -22,6 +22,7 @@ from tests.test_model import run_model_tests
 from tests.test_predict_pv_power import run_predict_pv_power_tests
 from tests.test_kernel_parity import run_kernel_parity_tests, run_model_kernel_tests
 from tests.test_execute import run_execute_tests
+from tests.test_load_car_energy import test_load_car_energy_warns_when_configured_entity_has_no_data
 from tests.test_octopus_slots import run_load_octopus_slots_tests
 from tests.test_multi_car_iog import run_multi_car_iog_tests
 from tests.test_fetch_config_options import test_fetch_config_options
@@ -272,6 +273,7 @@ def main():
         ("kernel_parity", run_kernel_parity_tests, "C++ prediction kernel vs Python engine parity tests", False),
         ("inverter", run_inverter_tests, "Inverter tests", False),
         ("execute", run_execute_tests, "Execute tests", False),
+        ("load_car_energy", test_load_car_energy_warns_when_configured_entity_has_no_data, "car_charging_energy configured-but-empty warning tests (#4458 follow-up)", False),
         ("basic_rates", test_basic_rates, "Basic rates tests", False),
         ("rate_min_forward_calc", test_rate_min_forward_calc, "Rate min forward calc tests", False),
         ("window_sort", run_window_sort_tests, "Window sort tests", False),


### PR DESCRIPTION
## Summary
Follow-up to #4465/#4458. `car_charging_hold` is on by default, and its precise per-minute car-energy subtraction path silently falls back to the load-threshold heuristic whenever `car_charging_energy` resolves empty - previously only a benign, error-free `Unable to fetch history` log line, easy to miss.

This affects any Ohme HA in-built-integration user still pointed at the energy sensor HA 2026.8.0 removed (see #4465) - it degrades load-forecast accuracy on every car-charging day rather than just showing one wrong display value.

- Traced the failure path: `minute_data_import_export()` already handles a missing/removed entity gracefully (empty history → benign warn, no `had_errors`), so `self.car_charging_energy` ends up `{}` rather than crashing - by design, this already falls through to the existing `car_charging_threshold` heuristic. The gap was purely visibility.
- Added a distinct, error-flagged warning in `load_car_energy()` specifically for "configured but empty" (not "not configured at all", which already logs its own message and is a normal, expected setup for non-EV users).

## Test plan
- [x] New `test_load_car_energy.py`: warns + flags error when configured-but-empty, stays silent with real data, stays silent when `car_charging_hold` is off
- [x] Full `./run_all --quick` suite passes
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)