### PR TITLE
fix(inverter): only invoke discharge_freeze_service on an explicit freeze request

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2811,10 +2811,17 @@ class Inverter:
             self.call_service_template("charge_stop_service", service_data_stop, domain="charge")
 
             # Start discharge or discharge freeze
-            if target_soc == self.soc_percent or freeze:
+            # Only the caller's explicit freeze request should invoke discharge_freeze_service -
+            # reaching the target by ordinary export (target_soc == self.soc_percent with no
+            # freeze) is not a deliberate freeze, it just means there's nothing left to discharge,
+            # so it belongs with the "target already at/above current SoC" stop case below.
+            # Conflating the two used to fire discharge_freeze_service (and any automation wired
+            # to it) whenever export naturally reached its target, regardless of set_export_freeze
+            # (batpred#4464).
+            if freeze:
                 if not self.call_service_template("discharge_freeze_service", service_data, domain="discharge", extra_data=extra_data):
                     self.call_service_template("discharge_start_service", service_data, domain="discharge", extra_data=extra_data)
-            elif target_soc > self.soc_percent:
+            elif target_soc >= self.soc_percent:
                 self.call_service_template("discharge_stop_service", service_data_stop, domain="discharge")
             else:
                 self.call_service_template("discharge_start_service", service_data, domain="discharge", extra_data=extra_data)

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1225,6 +1225,10 @@ def test_call_adjust_export_immediate(test_name, my_predbat, ha, inv, dummy_item
     ha.service_store_enable = True
     if clear:
         ha.service_store = []
+        # Also drop discharge-domain dedup memory so this call is judged fresh rather than
+        # against whatever the previous sub-test happened to send - needed now that several
+        # target_soc values collapse onto the same discharge_stop call (batpred#4464 fix).
+        my_predbat.last_service_hash.pop("discharge", None)
 
     print("**** Running Test: {} ****".format(test_name))
 
@@ -1249,7 +1253,7 @@ def test_call_adjust_export_immediate(test_name, my_predbat, ha, inv, dummy_item
 
     if repeat:
         pass
-    elif freeze or soc == inv.soc_percent:
+    elif freeze:
         if charge_stop:
             expected.append(["charge_stop", {"device_id": "DID0"}])
         expected.append(["discharge_freeze", {"device_id": "DID0", "target_soc": int(soc), "power": power}])
@@ -1258,6 +1262,8 @@ def test_call_adjust_export_immediate(test_name, my_predbat, ha, inv, dummy_item
             expected.append(["charge_stop", {"device_id": "DID0"}])
         expected.append(["discharge_start", {"device_id": "DID0", "target_soc": int(soc), "power": power}])
     else:
+        # soc >= inv.soc_percent (including exact equality - target reached, nothing left to
+        # discharge, not a deliberate freeze - batpred#4464)
         if charge_stop:
             expected.append(["charge_stop", {"device_id": "DID0"}])
         else:
@@ -2697,9 +2703,9 @@ charge_start_service:
     failed |= test_call_adjust_export_immediate("export_immediate1", my_predbat, ha, inv, dummy_items, 100, repeat=True)
     failed |= test_call_adjust_export_immediate("export_immediate3", my_predbat, ha, inv, dummy_items, 0, repeat=False, charge_stop=True)
     failed |= test_call_adjust_export_immediate("export_immediate4", my_predbat, ha, inv, dummy_items, 50)
-    failed |= test_call_adjust_export_immediate("export_immediate5", my_predbat, ha, inv, dummy_items, 49)
+    failed |= test_call_adjust_export_immediate("export_immediate5", my_predbat, ha, inv, dummy_items, 49, clear=True)
     failed |= test_call_adjust_export_immediate("export_immediate6", my_predbat, ha, inv, dummy_items, 49, repeat=True)
-    failed |= test_call_adjust_export_immediate("export_immediate6", my_predbat, ha, inv, dummy_items, 49, discharge_start_time="00:00:00", discharge_end_time="09:00:00")
+    failed |= test_call_adjust_export_immediate("export_immediate6", my_predbat, ha, inv, dummy_items, 49, discharge_start_time="00:00:00", discharge_end_time="09:00:00", clear=True)
     failed |= test_call_adjust_export_immediate("export_immediate7", my_predbat, ha, inv, dummy_items, 50, freeze=True)
     failed |= test_call_adjust_export_immediate("export_immediate8", my_predbat, ha, inv, dummy_items, 50, freeze=False, no_freeze=True)
     failed |= test_call_adjust_export_immediate("export_immediate9", my_predbat, ha, inv, dummy_items, 30.0)


### PR DESCRIPTION
## Summary

`adjust_export_immediate()` (`inverter.py`) called `discharge_freeze_service` whenever an active export reached its target SoC (`target_soc == self.soc_percent`), regardless of the `freeze` argument the caller passed - so it fired independently of `set_export_freeze` any time export naturally completed, not just for a deliberate Freeze Export.

`execute.py`'s own call site already gated the genuine freeze case correctly:

```python
if self.set_export_freeze and self.export_limits_best[0] == 99:
    inverter.adjust_export_immediate(inverter.soc_percent, freeze=True)
elif not disabled_export:
    inverter.adjust_export_immediate(int(self.export_limits_best[0]))
```

The bug was one level down - `adjust_export_immediate` re-derived its own independent freeze decision from SoC equality alone, so the ordinary `elif` branch (active export, `freeze` defaults `False`) still ended up calling the freeze service the moment the export target was reached.

Confirmed live via a reporter's log on #4464 - exporting down to a 0% target reliably produced:

```
Inverter 0 Current Target SoC is 0%, already at target
Inverter 0 Calling service discharge_freeze_service ... {'option': 'Freeze Discharging'}
```

with `switch.predbat_set_export_freeze` off the whole time.

## Fix

Reaching the target via ordinary export isn't a freeze - it's "nothing left to discharge," which already had its own correct handling one branch over (`target_soc > self.soc_percent` -> `discharge_stop_service`). Merged the equality case into that branch instead, so `discharge_freeze_service` only fires when the caller explicitly passes `freeze=True` (i.e. `set_export_freeze`'s own path).

## Test plan

- [x] `tests/test_inverter.py` updated - two sub-cases that pinned the old "target reached -> freeze" behaviour now expect `discharge_stop`; added a discharge-domain dedup reset (`clear=True`) on those two so they're judged independently of whatever the preceding sub-test happened to send, now that several target values collapse onto the same `discharge_stop` call
- [x] `./run_all --test inverter` / `--test execute` pass
- [x] `./run_all --quick` - all tests pass
- [x] `./run_pre_commit` - clean

Fixes #4464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
