### PR TITLE
fix(sigenergy): exit VPP explicitly before offboarding, and confirm it landed

### DIFF
--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -2015,6 +2015,7 @@ class SigenergyAPI(ComponentBase):
                 # Re-onboarding — let a future offboard run both steps again.
                 self._offboard_vpp_exit_done.discard(system_id)
                 self._offboard_done.discard(system_id)
+                self._offboard_done_loaded.discard(system_id)
                 self.onboard_status[str(system_id)] = "not_onboarded"
                 await self._save_offboard_done()
                 await self._save_cache("onboard_status", self.onboard_status)
@@ -2213,32 +2214,34 @@ class SigenergyAPI(ComponentBase):
         mySigen app cannot control the battery, but with Predbat no longer driving it
         either.
 
-        Only an exit observed in current_mode is latched. A successful MQTT publish only
+        Only an owner-controlled mode observed in current_mode is latched. A successful MQTT publish only
         confirms that the command was accepted by the broker; it does not confirm that
         the inverter has changed mode. Offboarding must wait for MQTT/REST telemetry to
-        report a non-VPP mode, otherwise the REST offboard can race the mode command and
-        revoke our authorisation while the system is still in VPP.
+        report MSC or another owner-controlled mode, otherwise the REST offboard can race
+        the mode command and revoke our authorisation while the owner's app is still blocked.
 
         Args:
             system_id: Sigenergy system unique identifier.
 
         Returns:
-            True if telemetry confirms the system is out of VPP, False while the switch
-            is unknown, failed, or still waiting for confirmation.
+            True if telemetry confirms the owner's app has control, False while the
+            switch is unknown, failed, or still waiting for confirmation.
         """
         current_mode = self.current_mode.get(system_id)
-        if current_mode == SIGENERGY_MODE_VPP:
+        if current_mode == SIGENERGY_MODE_VPP or current_mode in SIGENERGY_THIRD_PARTY_MODES:
             # Live telemetry always wins over a stale latch: the system may have been
-            # moved back into VPP while an earlier offboard attempt was failing.
+            # moved back under platform control while an earlier offboard attempt was
+            # failing. NBI also blocks the owner's app, so an explicit offboard takes
+            # priority over the Axle stand-down and exits that mode too.
             self._offboard_vpp_exit_done.discard(system_id)
-            self.log("SigenergyAPI: Offboarding system {} — switching VPP to MSC so the owner's app regains control".format(system_id))
+            self.log("SigenergyAPI: Offboarding system {} — switching {} to MSC so the owner's app regains control".format(system_id, SIGENERGY_MODE_NAMES.get(current_mode, "platform control")))
             if not await self.set_operating_mode(system_id, SIGENERGY_MODE_MSC):
-                self.log("Warn: SigenergyAPI: Could not leave VPP for {} — deferring offboard rather than locking the owner out".format(system_id))
+                self.log("Warn: SigenergyAPI: Could not return {} to owner control — deferring offboard rather than locking the owner out".format(system_id))
             else:
-                self.log("SigenergyAPI: VPP exit requested for {} — waiting for operating-mode confirmation before offboarding".format(system_id))
+                self.log("SigenergyAPI: Owner control requested for {} — waiting for operating-mode confirmation before offboarding".format(system_id))
             return False
-        if current_mode is None:
-            self.log("Warn: SigenergyAPI: Operating mode unknown for {} — deferring offboard until it can be confirmed out of VPP".format(system_id))
+        if current_mode not in (SIGENERGY_MODE_MSC, SIGENERGY_MODE_FFG):
+            self.log("Warn: SigenergyAPI: Operating mode unknown for {} — deferring offboard until owner control can be confirmed".format(system_id))
             return False
         if system_id not in self._offboard_vpp_exit_done:
             self._offboard_vpp_exit_done.add(system_id)
@@ -2270,6 +2273,7 @@ class SigenergyAPI(ComponentBase):
             self.log("Warn: SigenergyAPI: Offboard failed for {} — will retry on the next poll".format(system_id))
             return False
         self._offboard_done.add(system_id)
+        self._offboard_done_loaded.discard(system_id)
         self.onboard_status[str(system_id)] = "offboarded"
         await self._save_offboard_done()
         await self._save_cache("onboard_status", self.onboard_status)
@@ -2284,16 +2288,17 @@ class SigenergyAPI(ComponentBase):
         block in run().
 
         Cases (offboard takes priority over readonly):
-          offboard=True  + VPP active   → switch to MSC so the user's app regains control
-          offboard=True  + VPP inactive → nothing to do (already out of VPP)
+          offboard=True  + VPP/NBI active → switch to MSC so the user's app regains control
+          offboard=True  + owner mode     → offboard the system
           readonly=True  + VPP active   → switch to MSC so the user's app regains control
           readonly=True  + VPP inactive → nothing to do
           readonly=False + VPP active   → nothing to do (ready for controls)
           readonly=False + VPP inactive → switch to VPP mode to enable controls
 
-        An active Axle event under the ``axle_control`` option takes priority over every
-        case above: Predbat stands down and leaves the operating mode untouched so Axle can
-        drive the battery through the NorthBound Interface.
+        An explicit offboard takes priority over an active Axle event so it can return the
+        system from NBI to the owner's app before removing authorisation. For every other
+        case an active Axle event under the ``axle_control`` option makes Predbat stand down
+        and leave the operating mode untouched.
 
         Otherwise Predbat is the owner. A Sigenergy accepts one controller at a time and
         VPP mode and NBI are mutually exclusive, so finding the system in NBI means
@@ -2392,23 +2397,35 @@ class SigenergyAPI(ComponentBase):
         action and publish an untrue status.
         """
         if self.storage:
-            await self.storage.save("sigenergy", "offboard_done", sorted(self._offboard_done), format="json")
+            # A restored completion may be provisionally cleared in memory while a still
+            # visible system is offboarded again. Keep that recovery point durable until
+            # the retry succeeds or the user explicitly requests re-onboarding.
+            await self.storage.save("sigenergy", "offboard_done", sorted(self._offboard_done | self._offboard_done_loaded), format="json")
 
     async def _reconcile_restored_offboards(self):
-        """Clear restored completions for systems now visible as authorised.
+        """Reconcile restored completions for systems now visible as authorised.
 
         This runs after any startup onboarding attempt, because a system that was absent
-        on the first discovery can become visible in the second fetch. Visibility proves
-        the durable offboard latch is stale and a future offboard must run both steps.
+        on the first discovery can become visible in the second fetch. Visibility means a
+        future offboard must run both steps again, but does not by itself prove that the
+        owner requested re-onboarding: the authorised list may still be converging after
+        a successful offboard. Only an explicit off switch clears the durable recovery
+        point; otherwise it is retained until the retry succeeds.
         """
         restored_visible = set(self.systems.keys()) & self._offboard_done_loaded
         if not restored_visible:
             return
+        save_offboard_done = False
         for sid in restored_visible:
+            slug = self._system_slug(sid)
+            offboard_state = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default=None)
             self._offboard_done.discard(sid)
-            self._offboard_done_loaded.discard(sid)
             self.onboard_status[str(sid)] = "active"
-        await self._save_offboard_done()
+            if offboard_state == "off":
+                self._offboard_done_loaded.discard(sid)
+                save_offboard_done = True
+        if save_offboard_done:
+            await self._save_offboard_done()
         await self._save_cache("onboard_status", self.onboard_status)
 
     def _data_age_minutes(self, key):
@@ -2494,7 +2511,8 @@ class SigenergyAPI(ComponentBase):
         if offboard_done is not None:
             self._offboard_done = set(offboard_done)
             # Keep track of restored entries separately. A freshly discovered authorised
-            # system proves a cached completion is stale and must be offboarded again.
+            # system must be offboarded again, but the durable completion remains a safe
+            # recovery point until that retry lands or re-onboarding is explicit.
             self._offboard_done_loaded = set(offboard_done)
             for sid in self._offboard_done:
                 self.onboard_status[str(sid)] = "offboarded"
@@ -2538,10 +2556,18 @@ class SigenergyAPI(ComponentBase):
             for sid in missing_ids:
                 self.onboard_status.setdefault(str(sid), "not_onboarded")
                 slug = self._system_slug(sid)
-                is_offboard_at_start = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default="off") == "on"
+                offboard_state = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default=None)
+                is_offboard_at_start = offboard_state == "on" or (sid in self._offboard_done and offboard_state != "off")
                 if is_offboard_at_start:
-                    self.log("SigenergyAPI: System {} offboard toggle is on — skipping onboard attempt".format(sid))
+                    self.log("SigenergyAPI: System {} is marked offboarded — skipping onboard attempt".format(sid))
                     continue
+                if sid in self._offboard_done:
+                    # An explicit off state is a re-onboarding request made while this
+                    # component was stopped, so clear the durable completion first.
+                    self._offboard_done.discard(sid)
+                    self._offboard_done_loaded.discard(sid)
+                    self.onboard_status[str(sid)] = "not_onboarded"
+                    await self._save_offboard_done()
                 self.log("SigenergyAPI: System {} not found in authorised list — attempting onboard".format(sid))
                 result = await self.onboard_systems([sid])
                 if result is not True:
@@ -2550,9 +2576,9 @@ class SigenergyAPI(ComponentBase):
                     return False
                 await self.fetch_system_list()
 
-            # The completion latch survives restarts, but the final live authorised-system
-            # list is authoritative. Reconcile after onboarding because its second fetch can
-            # make a previously absent system visible during this same startup.
+            # The completion latch survives restarts. Reconcile after onboarding because
+            # its second fetch can make a previously absent system visible during this same
+            # startup, requiring either an offboard retry or an explicit re-onboarding clear.
             await self._reconcile_restored_offboards()
 
             if not self.systems:
@@ -2602,7 +2628,15 @@ class SigenergyAPI(ComponentBase):
                     self.log("SigenergyAPI: Skipping VPP registration check for {} — operating mode not yet known".format(sid))
                     continue
                 slug = self._system_slug(sid)
-                is_offboard = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default="off") == "on"
+                offboard_state = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default=None)
+                if offboard_state == "off" and (sid in self._offboard_done or sid in self._offboard_done_loaded):
+                    # The state may have changed while this component was stopped and no
+                    # switch event was delivered. Treat an explicit off as re-onboarding.
+                    self._offboard_vpp_exit_done.discard(sid)
+                    self._offboard_done.discard(sid)
+                    self._offboard_done_loaded.discard(sid)
+                    await self._save_offboard_done()
+                is_offboard = offboard_state == "on" or (offboard_state is None and (sid in self._offboard_done or sid in self._offboard_done_loaded))
                 await self._manage_vpp_registration(sid, is_readonly_vpp, is_offboard)
                 # Derive the user-facing onboarding status for the visible system.
                 # A system sitting in a third-party mode is fully onboarded — another

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -318,6 +318,7 @@ class SigenergyAPI(ComponentBase):
         self.current_mode = {}    # systemId → energyStorageOperationMode int
         self.last_contended_by = {}  # systemId → mode name of the controller that last displaced Predbat
         self._axle_standoff_logged = {}  # systemId → True while the Axle stand-down has been announced
+        self._offboard_vpp_exit_attempted = set()  # systemIds we have already pulled out of VPP for offboarding
         self.onboard_status = {}  # systemId → onboarding status string (published for the SaaS UI)
 
         # Age (datetime of last update) of each SIGENERGY_CACHE_KEYS category, used to avoid an
@@ -2003,9 +2004,16 @@ class SigenergyAPI(ComponentBase):
         self.log("SigenergyAPI: Control update system={} direction={} field={} value={}".format(system_id, direction, field, value))
         await self.publish_controls(system_id)
 
-        if field == "offboard" and value is True:
-            self.log("SigenergyAPI: Offboard toggle turned on for {} — offboarding".format(system_id))
-            await self.offboard_systems(system_id)
+        if field == "offboard":
+            if value is True:
+                self.log("SigenergyAPI: Offboard toggle turned on for {} — offboarding".format(system_id))
+                # Exit VPP first: after offboarding we may no longer be authorised to
+                # change the operating mode, which would leave the owner locked out.
+                await self._exit_vpp_for_offboard(system_id)
+                await self.offboard_systems(system_id)
+            else:
+                # Re-onboarding — allow a future offboard to pull the system out of VPP again.
+                self._offboard_vpp_exit_attempted.discard(system_id)
 
     def _parse_entity_system(self, entity_id):
         """Extract (system_id, direction, field) from a control entity ID.
@@ -2191,6 +2199,30 @@ class SigenergyAPI(ComponentBase):
             return False
         return fetch_axle_active(self)
 
+    async def _exit_vpp_for_offboard(self, system_id):
+        """Leave VPP mode so the owner's app regains control of an offboarded system.
+
+        Sigenergy's offboard endpoint is not documented to drop the system out of VPP,
+        so we do it explicitly rather than relying on it as a side-effect. Getting this
+        wrong strands the owner in the worst possible state: still in VPP, so their
+        mySigen app cannot control the battery, but with Predbat no longer driving it
+        either.
+
+        Attempted at most once per system per process. Once offboarded we may no longer
+        be authorised to set the mode, and current_mode stops being refreshed (the MQTT
+        feed goes quiet), so retrying on every poll would never terminate.
+
+        Args:
+            system_id: Sigenergy system unique identifier.
+        """
+        if system_id in self._offboard_vpp_exit_attempted:
+            return
+        self._offboard_vpp_exit_attempted.add(system_id)
+        if self.current_mode.get(system_id) != SIGENERGY_MODE_VPP:
+            return
+        self.log("SigenergyAPI: Offboarding system {} — switching VPP to MSC so the owner's app regains control".format(system_id))
+        await self.set_operating_mode(system_id, SIGENERGY_MODE_MSC)
+
     async def _manage_vpp_registration(self, system_id, is_readonly, is_offboard=False):
         """Align the operating mode with the read-only and offboard switch settings.
 
@@ -2227,6 +2259,7 @@ class SigenergyAPI(ComponentBase):
         in_vpp = self.current_mode.get(system_id) == SIGENERGY_MODE_VPP
 
         if is_offboard:
+            await self._exit_vpp_for_offboard(system_id)
             return False
 
         # Axle owns the inverter for the duration of its event. Leave the mode exactly as

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -221,7 +221,7 @@ SIGENERGY_HISTORY_NODES = [
 # Storage cache keys for poll-interval system state persisted between restarts (see
 # load_cached_data()). System/device discovery is deliberately excluded — it is always
 # re-fetched fresh on startup.
-SIGENERGY_CACHE_KEYS = ["energy_flow", "daily_summary", "history_totals", "onboard_status"]
+SIGENERGY_CACHE_KEYS = ["energy_flow", "daily_summary", "history_totals", "onboard_status", "offboard_done"]
 
 # Sentinel returned by _request() when the API responds with code=0 but an empty/null data field.
 # Distinguishes "success with no payload" from None which always means "request failed".
@@ -320,6 +320,7 @@ class SigenergyAPI(ComponentBase):
         self._axle_standoff_logged = {}  # systemId → True while the Axle stand-down has been announced
         self._offboard_vpp_exit_done = set()  # systemIds confirmed out of VPP ahead of an offboard
         self._offboard_done = set()           # systemIds successfully offboarded
+        self._offboard_done_loaded = set()    # subset of the above restored from cache, not yet reconciled
         self.onboard_status = {}  # systemId → onboarding status string (published for the SaaS UI)
 
         # Age (datetime of last update) of each SIGENERGY_CACHE_KEYS category, used to avoid an
@@ -2014,6 +2015,10 @@ class SigenergyAPI(ComponentBase):
                 # Re-onboarding — let a future offboard run both steps again.
                 self._offboard_vpp_exit_done.discard(system_id)
                 self._offboard_done.discard(system_id)
+                self.onboard_status[str(system_id)] = "not_onboarded"
+                await self._save_offboard_done()
+                await self._save_cache("onboard_status", self.onboard_status)
+                self._publish_onboard_status()
 
     def _parse_entity_system(self, entity_id):
         """Extract (system_id, direction, field) from a control entity ID.
@@ -2208,27 +2213,35 @@ class SigenergyAPI(ComponentBase):
         mySigen app cannot control the battery, but with Predbat no longer driving it
         either.
 
-        Only a confirmed exit is latched. A failed publish (broker down, token expired)
-        must be retried on the next poll rather than recorded as done — treating an
-        attempt as success is what would let the offboard proceed over a system still
-        in VPP, producing exactly the lockout this is here to avoid.
+        Only an exit observed in current_mode is latched. A successful MQTT publish only
+        confirms that the command was accepted by the broker; it does not confirm that
+        the inverter has changed mode. Offboarding must wait for MQTT/REST telemetry to
+        report a non-VPP mode, otherwise the REST offboard can race the mode command and
+        revoke our authorisation while the system is still in VPP.
 
         Args:
             system_id: Sigenergy system unique identifier.
 
         Returns:
-            True if the system is known to be out of VPP, False if the switch failed.
+            True if telemetry confirms the system is out of VPP, False while the switch
+            is unknown, failed, or still waiting for confirmation.
         """
-        if system_id in self._offboard_vpp_exit_done:
-            return True
-        if self.current_mode.get(system_id) != SIGENERGY_MODE_VPP:
-            self._offboard_vpp_exit_done.add(system_id)
-            return True
-        self.log("SigenergyAPI: Offboarding system {} — switching VPP to MSC so the owner's app regains control".format(system_id))
-        if not await self.set_operating_mode(system_id, SIGENERGY_MODE_MSC):
-            self.log("Warn: SigenergyAPI: Could not leave VPP for {} — deferring offboard rather than locking the owner out".format(system_id))
+        current_mode = self.current_mode.get(system_id)
+        if current_mode == SIGENERGY_MODE_VPP:
+            # Live telemetry always wins over a stale latch: the system may have been
+            # moved back into VPP while an earlier offboard attempt was failing.
+            self._offboard_vpp_exit_done.discard(system_id)
+            self.log("SigenergyAPI: Offboarding system {} — switching VPP to MSC so the owner's app regains control".format(system_id))
+            if not await self.set_operating_mode(system_id, SIGENERGY_MODE_MSC):
+                self.log("Warn: SigenergyAPI: Could not leave VPP for {} — deferring offboard rather than locking the owner out".format(system_id))
+            else:
+                self.log("SigenergyAPI: VPP exit requested for {} — waiting for operating-mode confirmation before offboarding".format(system_id))
             return False
-        self._offboard_vpp_exit_done.add(system_id)
+        if current_mode is None:
+            self.log("Warn: SigenergyAPI: Operating mode unknown for {} — deferring offboard until it can be confirmed out of VPP".format(system_id))
+            return False
+        if system_id not in self._offboard_vpp_exit_done:
+            self._offboard_vpp_exit_done.add(system_id)
         return True
 
     async def _offboard_system_if_needed(self, system_id):
@@ -2250,10 +2263,17 @@ class SigenergyAPI(ComponentBase):
         if not await self._exit_vpp_for_offboard(system_id):
             return False
         self.log("SigenergyAPI: Offboarding system {}".format(system_id))
-        if await self.offboard_systems(system_id) is None:
+        result = await self.offboard_systems(system_id)
+        result_items = result if isinstance(result, list) else [result]
+        item_failed = any(isinstance(item, dict) and item.get("result") is False for item in result_items)
+        if result is None or item_failed:
             self.log("Warn: SigenergyAPI: Offboard failed for {} — will retry on the next poll".format(system_id))
             return False
         self._offboard_done.add(system_id)
+        self.onboard_status[str(system_id)] = "offboarded"
+        await self._save_offboard_done()
+        await self._save_cache("onboard_status", self.onboard_status)
+        self._publish_onboard_status()
         return True
 
     async def _manage_vpp_registration(self, system_id, is_readonly, is_offboard=False):
@@ -2364,6 +2384,33 @@ class SigenergyAPI(ComponentBase):
     # Storage cache
     # -----------------------------------------------------------------------
 
+    async def _save_offboard_done(self):
+        """Persist completed offboards without the one-day telemetry-cache expiry.
+
+        Offboarding remains true until the user explicitly re-onboards, so expiring this
+        latch like energy telemetry would make a later process restart forget the external
+        action and publish an untrue status.
+        """
+        if self.storage:
+            await self.storage.save("sigenergy", "offboard_done", sorted(self._offboard_done), format="json")
+
+    async def _reconcile_restored_offboards(self):
+        """Clear restored completions for systems now visible as authorised.
+
+        This runs after any startup onboarding attempt, because a system that was absent
+        on the first discovery can become visible in the second fetch. Visibility proves
+        the durable offboard latch is stale and a future offboard must run both steps.
+        """
+        restored_visible = set(self.systems.keys()) & self._offboard_done_loaded
+        if not restored_visible:
+            return
+        for sid in restored_visible:
+            self._offboard_done.discard(sid)
+            self._offboard_done_loaded.discard(sid)
+            self.onboard_status[str(sid)] = "active"
+        await self._save_offboard_done()
+        await self._save_cache("onboard_status", self.onboard_status)
+
     def _data_age_minutes(self, key):
         """Return the age in minutes of the in-memory data for a cache key, or None if unknown."""
         timestamp = self.data_age.get(key, None)
@@ -2443,6 +2490,15 @@ class SigenergyAPI(ComponentBase):
         if onboard_status is not None:
             self.onboard_status = onboard_status
 
+        offboard_done = await self._load_cache("offboard_done")
+        if offboard_done is not None:
+            self._offboard_done = set(offboard_done)
+            # Keep track of restored entries separately. A freshly discovered authorised
+            # system proves a cached completion is stale and must be offboarded again.
+            self._offboard_done_loaded = set(offboard_done)
+            for sid in self._offboard_done:
+                self.onboard_status[str(sid)] = "offboarded"
+
         self.log("SigenergyAPI: Restored cached poll-interval state from storage")
 
     # -----------------------------------------------------------------------
@@ -2494,7 +2550,16 @@ class SigenergyAPI(ComponentBase):
                     return False
                 await self.fetch_system_list()
 
+            # The completion latch survives restarts, but the final live authorised-system
+            # list is authoritative. Reconcile after onboarding because its second fetch can
+            # make a previously absent system visible during this same startup.
+            await self._reconcile_restored_offboards()
+
             if not self.systems:
+                # An intentionally offboarded system is absent from the authorised list.
+                # Publish the restored completion state before returning for retry so a
+                # restart does not replace a truthful "offboarded" sensor with silence.
+                self._publish_onboard_status()
                 self.log("Warn: SigenergyAPI: No systems available after discovery, will retry")
                 return False
 
@@ -2547,6 +2612,10 @@ class SigenergyAPI(ComponentBase):
                 # and approve something that needs no approval.
                 if is_offboard and sid in self._offboard_done:
                     self.onboard_status[str(sid)] = "offboarded"
+                elif is_offboard:
+                    # The system is still authorised while the VPP exit or offboard call
+                    # is pending. It is not waiting for onboarding approval.
+                    self.onboard_status[str(sid)] = "active"
                 elif self.current_mode.get(sid) == SIGENERGY_MODE_VPP:
                     self.onboard_status[str(sid)] = "active"
                 elif self.current_mode.get(sid) in SIGENERGY_THIRD_PARTY_MODES:

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -318,7 +318,8 @@ class SigenergyAPI(ComponentBase):
         self.current_mode = {}    # systemId → energyStorageOperationMode int
         self.last_contended_by = {}  # systemId → mode name of the controller that last displaced Predbat
         self._axle_standoff_logged = {}  # systemId → True while the Axle stand-down has been announced
-        self._offboard_vpp_exit_attempted = set()  # systemIds we have already pulled out of VPP for offboarding
+        self._offboard_vpp_exit_done = set()  # systemIds confirmed out of VPP ahead of an offboard
+        self._offboard_done = set()           # systemIds successfully offboarded
         self.onboard_status = {}  # systemId → onboarding status string (published for the SaaS UI)
 
         # Age (datetime of last update) of each SIGENERGY_CACHE_KEYS category, used to avoid an
@@ -2006,14 +2007,13 @@ class SigenergyAPI(ComponentBase):
 
         if field == "offboard":
             if value is True:
-                self.log("SigenergyAPI: Offboard toggle turned on for {} — offboarding".format(system_id))
-                # Exit VPP first: after offboarding we may no longer be authorised to
-                # change the operating mode, which would leave the owner locked out.
-                await self._exit_vpp_for_offboard(system_id)
-                await self.offboard_systems(system_id)
+                self.log("SigenergyAPI: Offboard toggle turned on for {}".format(system_id))
+                if not await self._offboard_system_if_needed(system_id):
+                    self.log("SigenergyAPI: Offboard of {} incomplete — the periodic check will retry".format(system_id))
             else:
-                # Re-onboarding — allow a future offboard to pull the system out of VPP again.
-                self._offboard_vpp_exit_attempted.discard(system_id)
+                # Re-onboarding — let a future offboard run both steps again.
+                self._offboard_vpp_exit_done.discard(system_id)
+                self._offboard_done.discard(system_id)
 
     def _parse_entity_system(self, entity_id):
         """Extract (system_id, direction, field) from a control entity ID.
@@ -2208,20 +2208,53 @@ class SigenergyAPI(ComponentBase):
         mySigen app cannot control the battery, but with Predbat no longer driving it
         either.
 
-        Attempted at most once per system per process. Once offboarded we may no longer
-        be authorised to set the mode, and current_mode stops being refreshed (the MQTT
-        feed goes quiet), so retrying on every poll would never terminate.
+        Only a confirmed exit is latched. A failed publish (broker down, token expired)
+        must be retried on the next poll rather than recorded as done — treating an
+        attempt as success is what would let the offboard proceed over a system still
+        in VPP, producing exactly the lockout this is here to avoid.
 
         Args:
             system_id: Sigenergy system unique identifier.
+
+        Returns:
+            True if the system is known to be out of VPP, False if the switch failed.
         """
-        if system_id in self._offboard_vpp_exit_attempted:
-            return
-        self._offboard_vpp_exit_attempted.add(system_id)
+        if system_id in self._offboard_vpp_exit_done:
+            return True
         if self.current_mode.get(system_id) != SIGENERGY_MODE_VPP:
-            return
+            self._offboard_vpp_exit_done.add(system_id)
+            return True
         self.log("SigenergyAPI: Offboarding system {} — switching VPP to MSC so the owner's app regains control".format(system_id))
-        await self.set_operating_mode(system_id, SIGENERGY_MODE_MSC)
+        if not await self.set_operating_mode(system_id, SIGENERGY_MODE_MSC):
+            self.log("Warn: SigenergyAPI: Could not leave VPP for {} — deferring offboard rather than locking the owner out".format(system_id))
+            return False
+        self._offboard_vpp_exit_done.add(system_id)
+        return True
+
+    async def _offboard_system_if_needed(self, system_id):
+        """Take a system out of VPP and then off the platform, in that order.
+
+        Ordering matters: once offboarded we may no longer be authorised to set the
+        operating mode, so the VPP exit has to land first. Both steps are latched only
+        on success, so a transient failure of either is retried by the next poll
+        instead of being silently abandoned half-done.
+
+        Args:
+            system_id: Sigenergy system unique identifier.
+
+        Returns:
+            True once the system has been offboarded, False while steps remain.
+        """
+        if system_id in self._offboard_done:
+            return True
+        if not await self._exit_vpp_for_offboard(system_id):
+            return False
+        self.log("SigenergyAPI: Offboarding system {}".format(system_id))
+        if await self.offboard_systems(system_id) is None:
+            self.log("Warn: SigenergyAPI: Offboard failed for {} — will retry on the next poll".format(system_id))
+            return False
+        self._offboard_done.add(system_id)
+        return True
 
     async def _manage_vpp_registration(self, system_id, is_readonly, is_offboard=False):
         """Align the operating mode with the read-only and offboard switch settings.
@@ -2259,7 +2292,9 @@ class SigenergyAPI(ComponentBase):
         in_vpp = self.current_mode.get(system_id) == SIGENERGY_MODE_VPP
 
         if is_offboard:
-            await self._exit_vpp_for_offboard(system_id)
+            # Retries here until both steps land, so a failed mode switch or a failed
+            # offboard is picked up on the next poll rather than left half-done.
+            await self._offboard_system_if_needed(system_id)
             return False
 
         # Axle owns the inverter for the duration of its event. Leave the mode exactly as
@@ -2510,7 +2545,7 @@ class SigenergyAPI(ComponentBase):
                 # the SaaS UI show an amber "waiting for your approval in the Sigenergy
                 # app" banner for the length of every Axle event, telling the user to go
                 # and approve something that needs no approval.
-                if is_offboard:
+                if is_offboard and sid in self._offboard_done:
                     self.onboard_status[str(sid)] = "offboarded"
                 elif self.current_mode.get(sid) == SIGENERGY_MODE_VPP:
                     self.onboard_status[str(sid)] = "active"

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -221,7 +221,7 @@ SIGENERGY_HISTORY_NODES = [
 # Storage cache keys for poll-interval system state persisted between restarts (see
 # load_cached_data()). System/device discovery is deliberately excluded — it is always
 # re-fetched fresh on startup.
-SIGENERGY_CACHE_KEYS = ["energy_flow", "daily_summary", "history_totals", "onboard_status", "offboard_done"]
+SIGENERGY_CACHE_KEYS = ["energy_flow", "daily_summary", "history_totals", "onboard_status"]
 
 # Sentinel returned by _request() when the API responds with code=0 but an empty/null data field.
 # Distinguishes "success with no payload" from None which always means "request failed".
@@ -319,8 +319,7 @@ class SigenergyAPI(ComponentBase):
         self.last_contended_by = {}  # systemId → mode name of the controller that last displaced Predbat
         self._axle_standoff_logged = {}  # systemId → True while the Axle stand-down has been announced
         self._offboard_vpp_exit_done = set()  # systemIds confirmed out of VPP ahead of an offboard
-        self._offboard_done = set()           # systemIds successfully offboarded
-        self._offboard_done_loaded = set()    # subset of the above restored from cache, not yet reconciled
+        self._offboard_done = set()           # systemIds successfully offboarded this process
         self.onboard_status = {}  # systemId → onboarding status string (published for the SaaS UI)
 
         # Age (datetime of last update) of each SIGENERGY_CACHE_KEYS category, used to avoid an
@@ -2015,9 +2014,7 @@ class SigenergyAPI(ComponentBase):
                 # Re-onboarding — let a future offboard run both steps again.
                 self._offboard_vpp_exit_done.discard(system_id)
                 self._offboard_done.discard(system_id)
-                self._offboard_done_loaded.discard(system_id)
                 self.onboard_status[str(system_id)] = "not_onboarded"
-                await self._save_offboard_done()
                 await self._save_cache("onboard_status", self.onboard_status)
                 self._publish_onboard_status()
 
@@ -2273,9 +2270,7 @@ class SigenergyAPI(ComponentBase):
             self.log("Warn: SigenergyAPI: Offboard failed for {} — will retry on the next poll".format(system_id))
             return False
         self._offboard_done.add(system_id)
-        self._offboard_done_loaded.discard(system_id)
         self.onboard_status[str(system_id)] = "offboarded"
-        await self._save_offboard_done()
         await self._save_cache("onboard_status", self.onboard_status)
         self._publish_onboard_status()
         return True
@@ -2389,45 +2384,6 @@ class SigenergyAPI(ComponentBase):
     # Storage cache
     # -----------------------------------------------------------------------
 
-    async def _save_offboard_done(self):
-        """Persist completed offboards without the one-day telemetry-cache expiry.
-
-        Offboarding remains true until the user explicitly re-onboards, so expiring this
-        latch like energy telemetry would make a later process restart forget the external
-        action and publish an untrue status.
-        """
-        if self.storage:
-            # A restored completion may be provisionally cleared in memory while a still
-            # visible system is offboarded again. Keep that recovery point durable until
-            # the retry succeeds or the user explicitly requests re-onboarding.
-            await self.storage.save("sigenergy", "offboard_done", sorted(self._offboard_done | self._offboard_done_loaded), format="json")
-
-    async def _reconcile_restored_offboards(self):
-        """Reconcile restored completions for systems now visible as authorised.
-
-        This runs after any startup onboarding attempt, because a system that was absent
-        on the first discovery can become visible in the second fetch. Visibility means a
-        future offboard must run both steps again, but does not by itself prove that the
-        owner requested re-onboarding: the authorised list may still be converging after
-        a successful offboard. Only an explicit off switch clears the durable recovery
-        point; otherwise it is retained until the retry succeeds.
-        """
-        restored_visible = set(self.systems.keys()) & self._offboard_done_loaded
-        if not restored_visible:
-            return
-        save_offboard_done = False
-        for sid in restored_visible:
-            slug = self._system_slug(sid)
-            offboard_state = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default=None)
-            self._offboard_done.discard(sid)
-            self.onboard_status[str(sid)] = "active"
-            if offboard_state == "off":
-                self._offboard_done_loaded.discard(sid)
-                save_offboard_done = True
-        if save_offboard_done:
-            await self._save_offboard_done()
-        await self._save_cache("onboard_status", self.onboard_status)
-
     def _data_age_minutes(self, key):
         """Return the age in minutes of the in-memory data for a cache key, or None if unknown."""
         timestamp = self.data_age.get(key, None)
@@ -2507,15 +2463,6 @@ class SigenergyAPI(ComponentBase):
         if onboard_status is not None:
             self.onboard_status = onboard_status
 
-        offboard_done = await self._load_cache("offboard_done")
-        if offboard_done is not None:
-            self._offboard_done = set(offboard_done)
-            # Keep track of restored entries separately. A freshly discovered authorised
-            # system must be offboarded again, but the durable completion remains a safe
-            # recovery point until that retry lands or re-onboarding is explicit.
-            self._offboard_done_loaded = set(offboard_done)
-            for sid in self._offboard_done:
-                self.onboard_status[str(sid)] = "offboarded"
 
         self.log("SigenergyAPI: Restored cached poll-interval state from storage")
 
@@ -2556,18 +2503,13 @@ class SigenergyAPI(ComponentBase):
             for sid in missing_ids:
                 self.onboard_status.setdefault(str(sid), "not_onboarded")
                 slug = self._system_slug(sid)
-                offboard_state = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default=None)
-                is_offboard_at_start = offboard_state == "on" or (sid in self._offboard_done and offboard_state != "off")
+                # The switch is the source of truth: it is a control entity, so its state
+                # is restored on startup like every other one. Onboarding a system the
+                # owner deliberately left would cost them a fresh approval email.
+                is_offboard_at_start = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default="off") == "on"
                 if is_offboard_at_start:
-                    self.log("SigenergyAPI: System {} is marked offboarded — skipping onboard attempt".format(sid))
+                    self.log("SigenergyAPI: System {} offboard toggle is on — skipping onboard attempt".format(sid))
                     continue
-                if sid in self._offboard_done:
-                    # An explicit off state is a re-onboarding request made while this
-                    # component was stopped, so clear the durable completion first.
-                    self._offboard_done.discard(sid)
-                    self._offboard_done_loaded.discard(sid)
-                    self.onboard_status[str(sid)] = "not_onboarded"
-                    await self._save_offboard_done()
                 self.log("SigenergyAPI: System {} not found in authorised list — attempting onboard".format(sid))
                 result = await self.onboard_systems([sid])
                 if result is not True:
@@ -2576,10 +2518,6 @@ class SigenergyAPI(ComponentBase):
                     return False
                 await self.fetch_system_list()
 
-            # The completion latch survives restarts. Reconcile after onboarding because
-            # its second fetch can make a previously absent system visible during this same
-            # startup, requiring either an offboard retry or an explicit re-onboarding clear.
-            await self._reconcile_restored_offboards()
 
             if not self.systems:
                 # An intentionally offboarded system is absent from the authorised list.
@@ -2628,15 +2566,7 @@ class SigenergyAPI(ComponentBase):
                     self.log("SigenergyAPI: Skipping VPP registration check for {} — operating mode not yet known".format(sid))
                     continue
                 slug = self._system_slug(sid)
-                offboard_state = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default=None)
-                if offboard_state == "off" and (sid in self._offboard_done or sid in self._offboard_done_loaded):
-                    # The state may have changed while this component was stopped and no
-                    # switch event was delivered. Treat an explicit off as re-onboarding.
-                    self._offboard_vpp_exit_done.discard(sid)
-                    self._offboard_done.discard(sid)
-                    self._offboard_done_loaded.discard(sid)
-                    await self._save_offboard_done()
-                is_offboard = offboard_state == "on" or (offboard_state is None and (sid in self._offboard_done or sid in self._offboard_done_loaded))
+                is_offboard = self.get_state_wrapper("switch.{}_sigenergy_{}_offboard".format(self.prefix, slug), default="off") == "on"
                 await self._manage_vpp_registration(sid, is_readonly_vpp, is_offboard)
                 # Derive the user-facing onboarding status for the visible system.
                 # A system sitting in a third-party mode is fully onboarded — another

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -2251,7 +2251,7 @@ def test_sigenergy_update_control_time_validation(my_predbat):
 
 
 def test_sigenergy_offboard_toggle_in_vpp(my_predbat):
-    """offboard=True → return False immediately regardless of VPP state (no mode switch)."""
+    """offboard=True + VPP active → explicitly switch to MSC, once, and return False."""
     failed = False
     sid = "SIG001"
     api = _make_api_with_system(sid)
@@ -2267,7 +2267,13 @@ def test_sigenergy_offboard_toggle_in_vpp(my_predbat):
 
     result = run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
     assert result is False, "offboard=True should return False"
-    assert not modes_set, "Should not call set_operating_mode — offboard API already changes mode"
+    assert modes_set == [SIGENERGY_MODE_MSC], "Should leave VPP explicitly rather than assume offboard does it"
+
+    # current_mode is not refreshed once offboarded (MQTT goes quiet), so a repeat poll
+    # must not retry the mode switch forever.
+    result = run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
+    assert result is False, "offboard=True should still return False"
+    assert modes_set == [SIGENERGY_MODE_MSC], "VPP exit should be attempted at most once per system"
 
     return failed
 
@@ -2295,21 +2301,25 @@ def test_sigenergy_offboard_toggle_not_in_vpp(my_predbat):
 
 
 def test_sigenergy_offboard_toggle_switch_event(my_predbat):
-    """Turning on the offboard switch triggers offboard_systems (no mode switch)."""
+    """Turning on the offboard switch leaves VPP first, then calls offboard_systems."""
     failed = False
     sid = "SIG001"
     api = _make_api_with_system(sid)
     api.controls[sid] = {"offboard": False}
+    api.current_mode[sid] = SIGENERGY_MODE_VPP
 
     offboarded = []
     modes_set = []
+    order = []
 
     async def mock_offboard(system_ids):
         offboarded.append(system_ids)
+        order.append("offboard")
         return True
 
     async def mock_set_mode(system_id, mode_int):
         modes_set.append((system_id, mode_int))
+        order.append("mode")
         return True
 
     async def mock_publish_controls(system_id=None):
@@ -2323,7 +2333,15 @@ def test_sigenergy_offboard_toggle_switch_event(my_predbat):
 
     assert api.controls[sid]["offboard"] is True, "offboard control should be True after turn_on"
     assert offboarded, "offboard_systems should be called"
-    assert not modes_set, "set_operating_mode should NOT be called — offboard API changes the mode"
+    assert modes_set == [(sid, SIGENERGY_MODE_MSC)], "Should hand control back to the owner's app explicitly"
+    assert order == ["mode", "offboard"], "Must leave VPP before offboarding, while still authorised to set the mode"
+
+    # Toggling back off clears the latch so a later offboard exits VPP again.
+    api.current_mode[sid] = SIGENERGY_MODE_VPP
+    run_async(api._update_control("switch.predbat_sigenergy_sig001_offboard", "turn_off", None, "offboard", sid))
+    assert api.controls[sid]["offboard"] is False, "offboard control should be False after turn_off"
+    run_async(api._update_control("switch.predbat_sigenergy_sig001_offboard", "turn_on", None, "offboard", sid))
+    assert modes_set == [(sid, SIGENERGY_MODE_MSC), (sid, SIGENERGY_MODE_MSC)], "Re-onboard then offboard should exit VPP again"
 
     return failed
 

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -2306,6 +2306,32 @@ def test_sigenergy_offboard_toggle_not_in_vpp(my_predbat):
     return failed
 
 
+def test_sigenergy_offboard_overrides_axle_control(my_predbat):
+    """An explicit offboard exits Axle's NBI mode before removing authorisation."""
+    failed = False
+    sid = "SIG001"
+    api = _make_api_with_system(sid)
+    api.current_mode[sid] = SIGENERGY_MODE_NBI
+    api.args["axle_control"] = True
+    api.args["axle_session"] = "binary_sensor.predbat_axle_event"
+    api.dashboard_items["binary_sensor.predbat_axle_event"] = {"state": "on"}
+    api.set_operating_mode = AsyncMock(return_value=True)
+    api.offboard_systems = AsyncMock(return_value=[])
+
+    run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
+    run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
+
+    assert api.set_operating_mode.await_count == 2, "MSC is retried while telemetry still reports NBI"
+    api.set_operating_mode.assert_awaited_with(sid, SIGENERGY_MODE_MSC)
+    api.offboard_systems.assert_not_awaited()
+
+    api.current_mode[sid] = SIGENERGY_MODE_MSC
+    run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
+    api.offboard_systems.assert_awaited_once_with(sid)
+
+    return failed
+
+
 def test_sigenergy_offboard_defers_when_the_mode_switch_fails(my_predbat):
     """A failed VPP exit must NOT offboard — that is the lockout this guards against."""
     failed = False
@@ -2406,7 +2432,7 @@ def test_sigenergy_offboard_retries_per_item_failure(my_predbat):
 
 
 def test_sigenergy_offboard_unknown_mode_defers(my_predbat):
-    """An absent current_mode is unknown, not proof that the system is out of VPP."""
+    """An absent or unrecognised mode is not proof that the owner's app has control."""
     failed = False
     sid = "SIG001"
     api = _make_api_with_system(sid)
@@ -2415,6 +2441,11 @@ def test_sigenergy_offboard_unknown_mode_defers(my_predbat):
     assert run_async(api._offboard_system_if_needed(sid)) is False
     api.offboard_systems.assert_not_awaited()
     assert sid not in api._offboard_vpp_exit_done, "Unknown mode must not latch the VPP exit"
+
+    api.current_mode[sid] = 42
+    assert run_async(api._offboard_system_if_needed(sid)) is False
+    api.offboard_systems.assert_not_awaited()
+    assert sid not in api._offboard_vpp_exit_done, "Unrecognised mode must not latch the VPP exit"
 
     return failed
 
@@ -2443,16 +2474,18 @@ def test_sigenergy_offboard_latches_survive_restart_safely(my_predbat):
     assert api_restarted.onboard_status[sid] == "offboarded", "Restart restores truthful status"
 
     api_restarted.system_id_filter = {sid}
-    api_restarted.dashboard_items["switch.predbat_sigenergy_sig001_offboard"] = {"state": "on"}
     api_restarted.get_access_token = AsyncMock(return_value="tok")
     api_restarted.fetch_system_list = AsyncMock()  # Correctly absent after offboarding.
+    api_restarted.onboard_systems = AsyncMock()
     assert run_async(api_restarted.run(seconds=0, first=True)) is False
+    api_restarted.onboard_systems.assert_not_awaited()
     sensor_key = "sensor.predbat_sigenergy_sig001_onboard_status"
-    assert api_restarted.dashboard_items[sensor_key]["state"] == "offboarded", "Restart publishes completion even though the system is no longer authorised"
+    assert api_restarted.dashboard_items[sensor_key]["state"] == "offboarded", "Restart publishes completion even when the switch state is temporarily unavailable"
 
-    # If the system is re-onboarded after restart, its live visibility invalidates the
-    # restored completion and persists that clearing for the next process too.
+    # If the owner explicitly requests re-onboarding after restart, live visibility
+    # invalidates the restored completion and persists that clearing for the next process.
     api_restarted.systems[sid] = {}
+    api_restarted.dashboard_items["switch.predbat_sigenergy_sig001_offboard"] = {"state": "off"}
     run_async(api_restarted._reconcile_restored_offboards())
     assert sid not in api_restarted._offboard_done, "Visible authorised system clears restored completion"
     assert api_restarted.onboard_status[sid] == "active", "Re-onboarded system no longer reports offboarded"
@@ -2460,6 +2493,42 @@ def test_sigenergy_offboard_latches_survive_restart_safely(my_predbat):
     api_after_re_onboard._mock_storage = storage
     run_async(api_after_re_onboard.load_cached_data())
     assert sid not in api_after_re_onboard._offboard_done, "Cleared completion remains cleared after another restart"
+
+    return failed
+
+
+def test_sigenergy_visible_restored_offboard_keeps_recovery_point(my_predbat):
+    """A lagging authorised list must not erase a completed offboard before its retry lands."""
+    failed = False
+    sid = "SIG001"
+    storage = FakeStorage()
+    storage.data[("sigenergy", "offboard_done")] = [sid]
+
+    api = MockSigenergyAPI()
+    api._mock_storage = storage
+    run_async(api.load_cached_data())
+    api.systems[sid] = {}
+    run_async(api._reconcile_restored_offboards())
+
+    assert sid not in api._offboard_done, "Visible system is retried rather than accepted as complete"
+    assert sid in api._offboard_done_loaded, "Durable recovery point remains until the retry lands"
+    assert storage.data[("sigenergy", "offboard_done")] == [sid], "Lagging visibility must not clear durable completion"
+    assert api.onboard_status[sid] == "active", "Visible authorised system is reported active while retrying"
+
+    api.current_mode[sid] = SIGENERGY_MODE_MSC
+    api.offboard_systems = AsyncMock(return_value=None)
+    api.enable_controls = False
+    mqtt_task = MagicMock()
+    mqtt_task.done = MagicMock(return_value=False)
+    api._mqtt_task = mqtt_task
+    assert run_async(api.run(seconds=60, first=False)) is True
+    api.offboard_systems.assert_awaited_once_with(sid)
+    assert api.onboard_status[sid] == "active", "Unavailable switch state preserves the offboard retry instead of reclaiming VPP"
+
+    api_after_failure = MockSigenergyAPI()
+    api_after_failure._mock_storage = storage
+    run_async(api_after_failure.load_cached_data())
+    assert sid in api_after_failure._offboard_done, "A restart after retry failure restores the last confirmed completion"
 
     return failed
 
@@ -2959,12 +3028,14 @@ def run_sigenergy_tests(my_predbat):
         ("apply_controls_skipped_when_not_vpp", test_sigenergy_apply_controls_skipped_when_not_vpp),
         ("offboard_toggle_in_vpp", test_sigenergy_offboard_toggle_in_vpp),
         ("offboard_toggle_not_in_vpp", test_sigenergy_offboard_toggle_not_in_vpp),
+        ("offboard_overrides_axle_control", test_sigenergy_offboard_overrides_axle_control),
         ("offboard_toggle_switch_event", test_sigenergy_offboard_toggle_switch_event),
         ("offboard_defers_when_mode_switch_fails", test_sigenergy_offboard_defers_when_the_mode_switch_fails),
         ("offboard_retries_when_api_call_fails", test_sigenergy_offboard_retries_when_the_api_call_fails),
         ("offboard_retries_per_item_failure", test_sigenergy_offboard_retries_per_item_failure),
         ("offboard_unknown_mode_defers", test_sigenergy_offboard_unknown_mode_defers),
         ("offboard_latches_survive_restart_safely", test_sigenergy_offboard_latches_survive_restart_safely),
+        ("visible_restored_offboard_keeps_recovery_point", test_sigenergy_visible_restored_offboard_keeps_recovery_point),
         ("publish_onboard_status_sensors", test_sigenergy_publish_onboard_status_sensors),
         ("run_derives_onboard_status", test_sigenergy_run_derives_onboard_status),
         ("run_pending_publishes_before_early_exit", test_sigenergy_run_pending_publishes_before_early_exit),

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -2269,11 +2269,11 @@ def test_sigenergy_offboard_toggle_in_vpp(my_predbat):
     assert result is False, "offboard=True should return False"
     assert modes_set == [SIGENERGY_MODE_MSC], "Should leave VPP explicitly rather than assume offboard does it"
 
-    # current_mode is not refreshed once offboarded (MQTT goes quiet), so a repeat poll
-    # must not retry the mode switch forever.
+    # Once the exit has landed, current_mode stops being refreshed (MQTT goes quiet),
+    # so a repeat poll must not keep re-issuing the switch.
     result = run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
     assert result is False, "offboard=True should still return False"
-    assert modes_set == [SIGENERGY_MODE_MSC], "VPP exit should be attempted at most once per system"
+    assert modes_set == [SIGENERGY_MODE_MSC], "A confirmed VPP exit should not be repeated"
 
     return failed
 
@@ -2296,6 +2296,85 @@ def test_sigenergy_offboard_toggle_not_in_vpp(my_predbat):
     result = run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
     assert result is False, "offboard=True should return False"
     assert not modes_set, "No mode switch needed"
+
+    return failed
+
+
+def test_sigenergy_offboard_defers_when_the_mode_switch_fails(my_predbat):
+    """A failed VPP exit must NOT offboard — that is the lockout this guards against."""
+    failed = False
+    sid = "SIG001"
+    api = _make_api_with_system(sid)
+    api.controls[sid] = {"offboard": False}
+    api.current_mode[sid] = SIGENERGY_MODE_VPP
+
+    offboarded = []
+    mode_attempts = []
+
+    async def mock_set_mode(system_id, mode_int):
+        mode_attempts.append(mode_int)
+        return False  # broker down / token expired
+
+    async def mock_offboard(system_ids):
+        offboarded.append(system_ids)
+        return True
+
+    async def mock_publish_controls(system_id=None):
+        pass
+
+    api.set_operating_mode = mock_set_mode
+    api.offboard_systems = mock_offboard
+    api.publish_controls = mock_publish_controls
+
+    run_async(api._update_control("switch.predbat_sigenergy_sig001_offboard", "turn_on", None, "offboard", sid))
+    assert not offboarded, "Must not revoke authorisation while the system is still in VPP"
+
+    # Retried by the periodic check; once the switch lands the offboard follows.
+    run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
+    assert len(mode_attempts) == 2, "A failed VPP exit must be retried, not latched"
+    assert not offboarded, "Still no offboard while the exit keeps failing"
+
+    api.set_operating_mode = _make_ok_set_mode(mode_attempts)
+    run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
+    assert offboarded, "Offboard proceeds once the system is out of VPP"
+
+    return failed
+
+
+def _make_ok_set_mode(recorder):
+    """Return a set_operating_mode stub that records and succeeds."""
+
+    async def _ok(system_id, mode_int):
+        recorder.append(mode_int)
+        return True
+
+    return _ok
+
+
+def test_sigenergy_offboard_retries_when_the_api_call_fails(my_predbat):
+    """A failed offboard is retried rather than reported as done."""
+    failed = False
+    sid = "SIG001"
+    api = _make_api_with_system(sid)
+    api.current_mode[sid] = SIGENERGY_MODE_MSC  # already out of VPP
+
+    attempts = []
+
+    async def mock_offboard(system_ids):
+        attempts.append(system_ids)
+        return None if len(attempts) == 1 else []
+
+    api.offboard_systems = mock_offboard
+
+    done = run_async(api._offboard_system_if_needed(sid))
+    assert done is False, "A failed offboard must not be latched as complete"
+
+    done = run_async(api._offboard_system_if_needed(sid))
+    assert done is True, "The retry succeeds"
+    assert len(attempts) == 2, "Offboard retried exactly once after the failure"
+
+    run_async(api._offboard_system_if_needed(sid))
+    assert len(attempts) == 2, "A completed offboard is not repeated"
 
     return failed
 
@@ -2460,11 +2539,19 @@ def test_sigenergy_run_derives_onboard_status(my_predbat):
     assert api_pending.onboard_status[sid] == "pending_approval", "pending_approval derived from MSC mode"
     assert api_pending.dashboard_items[sensor_key]["state"] == "pending_approval"
 
-    # Offboard toggle on → offboarded regardless of mode
+    # Offboard COMPLETED → offboarded regardless of mode.
     api_offboard = _make_api(SIGENERGY_MODE_VPP, offboard_on=True)
+    api_offboard._offboard_done.add(sid)
     run_async(api_offboard.run(seconds=300, first=False))
-    assert api_offboard.onboard_status[sid] == "offboarded", "offboarded when toggle is on"
+    assert api_offboard.onboard_status[sid] == "offboarded", "offboarded once the offboard has landed"
     assert api_offboard.dashboard_items[sensor_key]["state"] == "offboarded"
+
+    # Toggle on but the offboard has NOT landed yet (mode switch or API call still
+    # failing): the status must not claim offboarded, or support reads a lie while
+    # the system is still live on the platform.
+    api_inflight = _make_api(SIGENERGY_MODE_VPP, offboard_on=True)
+    run_async(api_inflight.run(seconds=300, first=False))
+    assert api_inflight.onboard_status[sid] != "offboarded", "not offboarded until the offboard succeeds"
 
     return failed
 
@@ -2782,6 +2869,8 @@ def run_sigenergy_tests(my_predbat):
         ("offboard_toggle_in_vpp", test_sigenergy_offboard_toggle_in_vpp),
         ("offboard_toggle_not_in_vpp", test_sigenergy_offboard_toggle_not_in_vpp),
         ("offboard_toggle_switch_event", test_sigenergy_offboard_toggle_switch_event),
+        ("offboard_defers_when_mode_switch_fails", test_sigenergy_offboard_defers_when_the_mode_switch_fails),
+        ("offboard_retries_when_api_call_fails", test_sigenergy_offboard_retries_when_the_api_call_fails),
         ("publish_onboard_status_sensors", test_sigenergy_publish_onboard_status_sensors),
         ("run_derives_onboard_status", test_sigenergy_run_derives_onboard_status),
         ("run_pending_publishes_before_early_exit", test_sigenergy_run_pending_publishes_before_early_exit),

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -2450,85 +2450,31 @@ def test_sigenergy_offboard_unknown_mode_defers(my_predbat):
     return failed
 
 
-def test_sigenergy_offboard_latches_survive_restart_safely(my_predbat):
-    """Restart restores only completed offboards; an in-flight exit is re-confirmed live."""
+def test_sigenergy_offboard_switch_survives_restart(my_predbat):
+    """A restart must not re-onboard a system the owner deliberately left.
+
+    The offboard switch is a control entity, so its state is restored on startup like
+    every other one — no separate durable latch is needed, and re-onboarding would cost
+    the owner a fresh approval email.
+    """
     failed = False
     sid = "SIG001"
-    storage = FakeStorage()
-
-    # A restart after the mode command landed but before offboarding has no in-memory
-    # exit latch. The REST/MQTT-repopulated MSC mode is enough to resume safely.
-    api_inflight = _make_api_with_system(sid)
-    api_inflight._mock_storage = storage
-    api_inflight.current_mode[sid] = SIGENERGY_MODE_MSC
-    api_inflight.offboard_systems = AsyncMock(return_value=[])
-    assert run_async(api_inflight._offboard_system_if_needed(sid)) is True
-
-    # Completion is persisted, so a restart after authorisation disappears does not
-    # lose the truthful status or retry an endpoint it may no longer be allowed to call.
-    api_restarted = MockSigenergyAPI()
-    api_restarted._mock_storage = storage
-    run_async(api_restarted.load_cached_data())
-    assert sid in api_restarted._offboard_done, "Completed offboard latch restored"
-    assert sid not in api_restarted._offboard_vpp_exit_done, "VPP-exit latch remains live-state only"
-    assert api_restarted.onboard_status[sid] == "offboarded", "Restart restores truthful status"
-
-    api_restarted.system_id_filter = {sid}
-    api_restarted.get_access_token = AsyncMock(return_value="tok")
-    api_restarted.fetch_system_list = AsyncMock()  # Correctly absent after offboarding.
-    api_restarted.onboard_systems = AsyncMock()
-    assert run_async(api_restarted.run(seconds=0, first=True)) is False
-    api_restarted.onboard_systems.assert_not_awaited()
-    sensor_key = "sensor.predbat_sigenergy_sig001_onboard_status"
-    assert api_restarted.dashboard_items[sensor_key]["state"] == "offboarded", "Restart publishes completion even when the switch state is temporarily unavailable"
-
-    # If the owner explicitly requests re-onboarding after restart, live visibility
-    # invalidates the restored completion and persists that clearing for the next process.
-    api_restarted.systems[sid] = {}
-    api_restarted.dashboard_items["switch.predbat_sigenergy_sig001_offboard"] = {"state": "off"}
-    run_async(api_restarted._reconcile_restored_offboards())
-    assert sid not in api_restarted._offboard_done, "Visible authorised system clears restored completion"
-    assert api_restarted.onboard_status[sid] == "active", "Re-onboarded system no longer reports offboarded"
-    api_after_re_onboard = MockSigenergyAPI()
-    api_after_re_onboard._mock_storage = storage
-    run_async(api_after_re_onboard.load_cached_data())
-    assert sid not in api_after_re_onboard._offboard_done, "Cleared completion remains cleared after another restart"
-
-    return failed
-
-
-def test_sigenergy_visible_restored_offboard_keeps_recovery_point(my_predbat):
-    """A lagging authorised list must not erase a completed offboard before its retry lands."""
-    failed = False
-    sid = "SIG001"
-    storage = FakeStorage()
-    storage.data[("sigenergy", "offboard_done")] = [sid]
-
     api = MockSigenergyAPI()
-    api._mock_storage = storage
-    run_async(api.load_cached_data())
-    api.systems[sid] = {}
-    run_async(api._reconcile_restored_offboards())
+    api.system_id_filter = {sid}
+    api.systems = {}
+    slug = api._system_slug(sid)
+    api.dashboard_items["switch.predbat_sigenergy_{}_offboard".format(slug)] = {"state": "on"}
 
-    assert sid not in api._offboard_done, "Visible system is retried rather than accepted as complete"
-    assert sid in api._offboard_done_loaded, "Durable recovery point remains until the retry lands"
-    assert storage.data[("sigenergy", "offboard_done")] == [sid], "Lagging visibility must not clear durable completion"
-    assert api.onboard_status[sid] == "active", "Visible authorised system is reported active while retrying"
+    onboarded = []
 
-    api.current_mode[sid] = SIGENERGY_MODE_MSC
-    api.offboard_systems = AsyncMock(return_value=None)
-    api.enable_controls = False
-    mqtt_task = MagicMock()
-    mqtt_task.done = MagicMock(return_value=False)
-    api._mqtt_task = mqtt_task
-    assert run_async(api.run(seconds=60, first=False)) is True
-    api.offboard_systems.assert_awaited_once_with(sid)
-    assert api.onboard_status[sid] == "active", "Unavailable switch state preserves the offboard retry instead of reclaiming VPP"
+    async def mock_onboard(system_ids):
+        onboarded.append(system_ids)
+        return True
 
-    api_after_failure = MockSigenergyAPI()
-    api_after_failure._mock_storage = storage
-    run_async(api_after_failure.load_cached_data())
-    assert sid in api_after_failure._offboard_done, "A restart after retry failure restores the last confirmed completion"
+    api.onboard_systems = mock_onboard
+
+    run_async(api.run(seconds=0, first=True))
+    assert not onboarded, "A restart must not re-onboard a system whose offboard switch is on"
 
     return failed
 
@@ -3034,8 +2980,7 @@ def run_sigenergy_tests(my_predbat):
         ("offboard_retries_when_api_call_fails", test_sigenergy_offboard_retries_when_the_api_call_fails),
         ("offboard_retries_per_item_failure", test_sigenergy_offboard_retries_per_item_failure),
         ("offboard_unknown_mode_defers", test_sigenergy_offboard_unknown_mode_defers),
-        ("offboard_latches_survive_restart_safely", test_sigenergy_offboard_latches_survive_restart_safely),
-        ("visible_restored_offboard_keeps_recovery_point", test_sigenergy_visible_restored_offboard_keeps_recovery_point),
+        ("offboard_switch_survives_restart", test_sigenergy_offboard_switch_survives_restart),
         ("publish_onboard_status_sensors", test_sigenergy_publish_onboard_status_sensors),
         ("run_derives_onboard_status", test_sigenergy_run_derives_onboard_status),
         ("run_pending_publishes_before_early_exit", test_sigenergy_run_pending_publishes_before_early_exit),

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -2251,7 +2251,7 @@ def test_sigenergy_update_control_time_validation(my_predbat):
 
 
 def test_sigenergy_offboard_toggle_in_vpp(my_predbat):
-    """offboard=True + VPP active → explicitly switch to MSC, once, and return False."""
+    """offboard=True + VPP active waits for observed MSC before offboarding."""
     failed = False
     sid = "SIG001"
     api = _make_api_with_system(sid)
@@ -2264,16 +2264,20 @@ def test_sigenergy_offboard_toggle_in_vpp(my_predbat):
         return True
 
     api.set_operating_mode = mock_set_mode
+    api.offboard_systems = AsyncMock(return_value=[])
 
     result = run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
     assert result is False, "offboard=True should return False"
     assert modes_set == [SIGENERGY_MODE_MSC], "Should leave VPP explicitly rather than assume offboard does it"
+    api.offboard_systems.assert_not_awaited()
 
-    # Once the exit has landed, current_mode stops being refreshed (MQTT goes quiet),
-    # so a repeat poll must not keep re-issuing the switch.
+    # MQTT publish success is not mode confirmation. Only observed telemetry allows the
+    # REST offboard to follow, preventing a race between the two transports.
+    api.current_mode[sid] = SIGENERGY_MODE_MSC
     result = run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
     assert result is False, "offboard=True should still return False"
     assert modes_set == [SIGENERGY_MODE_MSC], "A confirmed VPP exit should not be repeated"
+    api.offboard_systems.assert_awaited_once_with(sid)
 
     return failed
 
@@ -2292,10 +2296,12 @@ def test_sigenergy_offboard_toggle_not_in_vpp(my_predbat):
         return True
 
     api.set_operating_mode = mock_set_mode
+    api.offboard_systems = AsyncMock(return_value=[])
 
     result = run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
     assert result is False, "offboard=True should return False"
     assert not modes_set, "No mode switch needed"
+    api.offboard_systems.assert_awaited_once_with(sid)
 
     return failed
 
@@ -2329,14 +2335,18 @@ def test_sigenergy_offboard_defers_when_the_mode_switch_fails(my_predbat):
     run_async(api._update_control("switch.predbat_sigenergy_sig001_offboard", "turn_on", None, "offboard", sid))
     assert not offboarded, "Must not revoke authorisation while the system is still in VPP"
 
-    # Retried by the periodic check; once the switch lands the offboard follows.
+    # Retried by the periodic check. A successful MQTT publish still is not enough.
     run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
     assert len(mode_attempts) == 2, "A failed VPP exit must be retried, not latched"
     assert not offboarded, "Still no offboard while the exit keeps failing"
 
     api.set_operating_mode = _make_ok_set_mode(mode_attempts)
     run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
-    assert offboarded, "Offboard proceeds once the system is out of VPP"
+    assert not offboarded, "MQTT acceptance alone must not allow offboarding"
+
+    api.current_mode[sid] = SIGENERGY_MODE_MSC
+    run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
+    assert offboarded, "Offboard proceeds once telemetry confirms the system is out of VPP"
 
     return failed
 
@@ -2379,8 +2389,83 @@ def test_sigenergy_offboard_retries_when_the_api_call_fails(my_predbat):
     return failed
 
 
+def test_sigenergy_offboard_retries_per_item_failure(my_predbat):
+    """A per-system failure payload must not be latched as a successful offboard."""
+    failed = False
+    sid = "SIG001"
+    api = _make_api_with_system(sid)
+    api.current_mode[sid] = SIGENERGY_MODE_MSC
+    api.offboard_systems = AsyncMock(side_effect=[[{"systemId": sid, "result": False, "codeList": [1200]}], []])
+
+    assert run_async(api._offboard_system_if_needed(sid)) is False
+    assert sid not in api._offboard_done, "Per-item failure must leave the completion latch clear"
+    assert run_async(api._offboard_system_if_needed(sid)) is True
+    assert api.offboard_systems.await_count == 2, "Per-item failure is retried"
+
+    return failed
+
+
+def test_sigenergy_offboard_unknown_mode_defers(my_predbat):
+    """An absent current_mode is unknown, not proof that the system is out of VPP."""
+    failed = False
+    sid = "SIG001"
+    api = _make_api_with_system(sid)
+    api.offboard_systems = AsyncMock(return_value=[])
+
+    assert run_async(api._offboard_system_if_needed(sid)) is False
+    api.offboard_systems.assert_not_awaited()
+    assert sid not in api._offboard_vpp_exit_done, "Unknown mode must not latch the VPP exit"
+
+    return failed
+
+
+def test_sigenergy_offboard_latches_survive_restart_safely(my_predbat):
+    """Restart restores only completed offboards; an in-flight exit is re-confirmed live."""
+    failed = False
+    sid = "SIG001"
+    storage = FakeStorage()
+
+    # A restart after the mode command landed but before offboarding has no in-memory
+    # exit latch. The REST/MQTT-repopulated MSC mode is enough to resume safely.
+    api_inflight = _make_api_with_system(sid)
+    api_inflight._mock_storage = storage
+    api_inflight.current_mode[sid] = SIGENERGY_MODE_MSC
+    api_inflight.offboard_systems = AsyncMock(return_value=[])
+    assert run_async(api_inflight._offboard_system_if_needed(sid)) is True
+
+    # Completion is persisted, so a restart after authorisation disappears does not
+    # lose the truthful status or retry an endpoint it may no longer be allowed to call.
+    api_restarted = MockSigenergyAPI()
+    api_restarted._mock_storage = storage
+    run_async(api_restarted.load_cached_data())
+    assert sid in api_restarted._offboard_done, "Completed offboard latch restored"
+    assert sid not in api_restarted._offboard_vpp_exit_done, "VPP-exit latch remains live-state only"
+    assert api_restarted.onboard_status[sid] == "offboarded", "Restart restores truthful status"
+
+    api_restarted.system_id_filter = {sid}
+    api_restarted.dashboard_items["switch.predbat_sigenergy_sig001_offboard"] = {"state": "on"}
+    api_restarted.get_access_token = AsyncMock(return_value="tok")
+    api_restarted.fetch_system_list = AsyncMock()  # Correctly absent after offboarding.
+    assert run_async(api_restarted.run(seconds=0, first=True)) is False
+    sensor_key = "sensor.predbat_sigenergy_sig001_onboard_status"
+    assert api_restarted.dashboard_items[sensor_key]["state"] == "offboarded", "Restart publishes completion even though the system is no longer authorised"
+
+    # If the system is re-onboarded after restart, its live visibility invalidates the
+    # restored completion and persists that clearing for the next process too.
+    api_restarted.systems[sid] = {}
+    run_async(api_restarted._reconcile_restored_offboards())
+    assert sid not in api_restarted._offboard_done, "Visible authorised system clears restored completion"
+    assert api_restarted.onboard_status[sid] == "active", "Re-onboarded system no longer reports offboarded"
+    api_after_re_onboard = MockSigenergyAPI()
+    api_after_re_onboard._mock_storage = storage
+    run_async(api_after_re_onboard.load_cached_data())
+    assert sid not in api_after_re_onboard._offboard_done, "Cleared completion remains cleared after another restart"
+
+    return failed
+
+
 def test_sigenergy_offboard_toggle_switch_event(my_predbat):
-    """Turning on the offboard switch leaves VPP first, then calls offboard_systems."""
+    """Turning on offboard leaves VPP, then waits for telemetry before offboarding."""
     failed = False
     sid = "SIG001"
     api = _make_api_with_system(sid)
@@ -2411,9 +2496,14 @@ def test_sigenergy_offboard_toggle_switch_event(my_predbat):
     run_async(api._update_control("switch.predbat_sigenergy_sig001_offboard", "turn_on", None, "offboard", sid))
 
     assert api.controls[sid]["offboard"] is True, "offboard control should be True after turn_on"
-    assert offboarded, "offboard_systems should be called"
+    assert not offboarded, "offboard_systems must wait for telemetry confirmation"
     assert modes_set == [(sid, SIGENERGY_MODE_MSC)], "Should hand control back to the owner's app explicitly"
-    assert order == ["mode", "offboard"], "Must leave VPP before offboarding, while still authorised to set the mode"
+    assert order == ["mode"], "Only the mode request is sent while telemetry still says VPP"
+
+    api.current_mode[sid] = SIGENERGY_MODE_MSC
+    run_async(api._manage_vpp_registration(sid, is_readonly=False, is_offboard=True))
+    assert offboarded, "offboard_systems follows once MSC is observed"
+    assert order == ["mode", "offboard"], "Must confirm the VPP exit before offboarding"
 
     # Toggling back off clears the latch so a later offboard exits VPP again.
     api.current_mode[sid] = SIGENERGY_MODE_VPP
@@ -2421,6 +2511,7 @@ def test_sigenergy_offboard_toggle_switch_event(my_predbat):
     assert api.controls[sid]["offboard"] is False, "offboard control should be False after turn_off"
     run_async(api._update_control("switch.predbat_sigenergy_sig001_offboard", "turn_on", None, "offboard", sid))
     assert modes_set == [(sid, SIGENERGY_MODE_MSC), (sid, SIGENERGY_MODE_MSC)], "Re-onboard then offboard should exit VPP again"
+    assert order == ["mode", "offboard", "mode"], "Second offboard also waits for live confirmation"
 
     return failed
 
@@ -2549,9 +2640,9 @@ def test_sigenergy_run_derives_onboard_status(my_predbat):
     # Toggle on but the offboard has NOT landed yet (mode switch or API call still
     # failing): the status must not claim offboarded, or support reads a lie while
     # the system is still live on the platform.
-    api_inflight = _make_api(SIGENERGY_MODE_VPP, offboard_on=True)
+    api_inflight = _make_api(SIGENERGY_MODE_MSC, offboard_on=True)
     run_async(api_inflight.run(seconds=300, first=False))
-    assert api_inflight.onboard_status[sid] != "offboarded", "not offboarded until the offboard succeeds"
+    assert api_inflight.onboard_status[sid] == "active", "pending offboard stays active rather than falsely requesting onboarding approval"
 
     return failed
 
@@ -2871,6 +2962,9 @@ def run_sigenergy_tests(my_predbat):
         ("offboard_toggle_switch_event", test_sigenergy_offboard_toggle_switch_event),
         ("offboard_defers_when_mode_switch_fails", test_sigenergy_offboard_defers_when_the_mode_switch_fails),
         ("offboard_retries_when_api_call_fails", test_sigenergy_offboard_retries_when_the_api_call_fails),
+        ("offboard_retries_per_item_failure", test_sigenergy_offboard_retries_per_item_failure),
+        ("offboard_unknown_mode_defers", test_sigenergy_offboard_unknown_mode_defers),
+        ("offboard_latches_survive_restart_safely", test_sigenergy_offboard_latches_survive_restart_safely),
         ("publish_onboard_status_sensors", test_sigenergy_publish_onboard_status_sensors),
         ("run_derives_onboard_status", test_sigenergy_run_derives_onboard_status),
         ("run_pending_publishes_before_early_exit", test_sigenergy_run_pending_publishes_before_early_exit),


### PR DESCRIPTION
## The bug

`_manage_vpp_registration` returned early on the offboard toggle without ever calling `set_operating_mode`, so leaving Predbat relied on Sigenergy's offboard endpoint dropping the system out of VPP as a side-effect. That is not documented anywhere, and if it does not happen the owner is left in the worst state available: still in VPP, so their mySigen app cannot control the battery, but with Predbat no longer driving it either.

The docstring on `_manage_vpp_registration` and `docs/inverter-setup.md` both already promised the MSC switch. Only the code disagreed.

Found via a real customer who disconnected and spent six days unable to get their system released.

## The fix

**Exit VPP explicitly** rather than assuming offboard does it, and do it *before* the offboard call — once offboarded we may no longer be authorised to change the mode.

**Require telemetry confirmation, not a successful publish.** `set_operating_mode` returning True only means the broker accepted the command; it says nothing about the inverter having changed mode. Offboarding immediately after raced it. The exit is now latched only once `current_mode` reports an owner-controlled mode.

**Require MSC or FFG specifically, not merely "not VPP".** NBI blocks the owner's app just as VPP does, so a system under a third-party controller on the NorthBound Interface previously passed the gate and got offboarded while the owner was still locked out. An unknown mode now defers rather than being read as safe.

This makes an explicit offboard override the Axle stand-down, which is the intended precedence: standing down for an Axle event is right while Predbat is still the controller, but a user who has asked to leave must get their inverter back. It only applies when the offboard switch is on — a deliberate action, not a scheduling decision.

**Latch each step only on success.** A failed publish (broker down, token expired) or a per-item failure in the offboard response is retried on the next poll rather than recorded as done. `offboard_systems` returns per-system result dicts, and a batch can report failure per item while the request itself succeeds — matched against the same `item.get("result")` convention `onboard_systems` already uses.

**`onboard_status` reports `offboarded` only once the offboard has actually succeeded.** Keying it off the toggle meant the UI claimed a system was offboarded while it was still live on the platform.

## What was removed again before opening this

An earlier iteration added a persisted `offboard_done` set, a restore path, a tracking set for restored entries, and a reconcile function whose clearing depended on switch state. It was redundant twice over:

- the offboard switch is a control entity, so its state is restored on startup like every other one — which is why the pre-existing startup guard already read it;
- `onboard_status` was already in `SIGENERGY_CACHE_KEYS`, so the user-visible state persisted through the existing cache regardless.

It was defending against a restart the switch already covered and preserving a status the cache already preserved, while generating half the findings in its own review round. Removing it also let the two `run()` blocks go back to reading the switch directly instead of reconciling two sources of truth. 184 insertions down to 110.

## Testing

Sigenergy suite: **84 pass**. Includes new coverage for a failed mode switch deferring the offboard, a failed offboard retrying, an unknown mode deferring, NBI being treated as not-owner-controlled, and a restart not re-onboarding a system whose switch is on.

Note `unit_test.py` cannot run in this environment — `tests/test_gateway.py` fails at import on a protobuf gencode/runtime mismatch unrelated to this change. The suite was run directly via `run_sigenergy_tests`.

## Still open

Whether `POST /openapi/board/offboard` drops VPP by itself is unconfirmed with Sigenergy. This change makes that question moot for correctness — we now always make the switch ourselves — but it would let us simplify if they confirm it. Likewise whether offboard is idempotent for an already-offboarded system: unknown codes are deliberately treated as failure rather than guessed.
