### PR TITLE
fix(web): stop double-marking manually overridden plan rate cells

### DIFF
--- a/apps/predbat/tests/test_plan_why_reason.py
+++ b/apps/predbat/tests/test_plan_why_reason.py
@@ -504,6 +504,39 @@ def run_test_plan_why_reason(my_predbat):
             print("ERROR: SyntaxWarning in web_helper.py line {}: {}".format(item.lineno, item.message))
         failed = True
 
+    # --- Test 15: editable rate cells don't double-mark a manual override (batpred#4474) ---
+    # row.{import,export}_rate_adjust_type === 'manual' and renderRateCell()'s own isOverride
+    # check both independently render the same turned-F glyph for the same single override -
+    # visually stacking two identical markers, and since only isOverride gates the Clear link,
+    # the two signals can disagree and leave a marker with no working Clear behind it. The fix
+    # skips the adjust-type marker specifically for 'manual' when editable, leaving isOverride as
+    # the sole source of truth for both the marker and the Clear control in that case.
+    print("Test editable rate cells don't double-render the manual-override marker")
+    for label, adjust_var in (("import", "importAdjustType"), ("export", "exportAdjustType")):
+        rate_field = "{}_rate_adjust_type".format(label)
+        expected = "const {} = (editable && row.{} === 'manual') ? null : row.{};".format(adjust_var, rate_field, rate_field)
+        if expected not in renderer_js:
+            print("ERROR: expected {} to null out a 'manual' adjust type in editable mode (found: {})".format(adjust_var, expected in renderer_js))
+            failed = True
+        # The old unconditional form must be gone, not just superseded - if it's still present
+        # anywhere the double-render bug is still reachable.
+        old_unconditional = "const {} = row.{} ? ` ${{getAdjustSymbol(row.{})}}` : '';".format({"import": "importAdjust", "export": "exportAdjust"}[label], rate_field, rate_field)
+        if old_unconditional in renderer_js:
+            print("ERROR: old unconditional {} form is still present alongside the fix".format({"import": "importAdjust", "export": "exportAdjust"}[label]))
+            failed = True
+
+    # --- Test 16: toggleForceDropdown doesn't throw on a stale/missing dropdown id (#4474 follow-up) ---
+    # Lives in get_plan_css() alongside the rest of the dropdown open/close JS, not
+    # get_plan_renderer_js() (which only covers the table-building functions).
+    print("Test toggleForceDropdown guards against a missing dropdown element")
+    plan_css_full = web_helper.get_plan_css()
+    toggle_start = plan_css_full.index("function toggleForceDropdown(")
+    toggle_end = plan_css_full.index("\n    }", toggle_start)
+    toggle_src = plan_css_full[toggle_start:toggle_end]
+    if "if (!dropdown)" not in toggle_src:
+        print("ERROR: expected toggleForceDropdown to null-guard document.getElementById(id) before using it")
+        failed = True
+
     if not failed:
         print("All plan why-reason tests passed")
     return failed

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -5997,6 +5997,16 @@ def get_plan_css():
     function toggleForceDropdown(id) {
         closeDropdowns();
         var dropdown = document.getElementById(id);
+        if (!dropdown) {
+            // dropdownId is assigned by a counter that increments across the whole table render
+            // and gets baked into the cell's onclick string; if that string is now stale relative
+            // to the current DOM (e.g. after a plan refresh reassigned different ids), this would
+            // otherwise throw here and silently abort the click with no visible effect at all -
+            // indistinguishable from the cell just not responding (batpred#4474 follow-up). Log
+            // instead of throwing so a real cause leaves a trace even without DevTools handy.
+            console.warn("toggleForceDropdown: no element found for id", id);
+            return;
+        }
         if (dropdown.style.display === "block") {
             dropdown.style.display = "none";
         } else {
@@ -6493,14 +6503,22 @@ def get_plan_renderer_js():
                     html += `<td id=time bgcolor=#FFFFFF>${timeDisplay}</td>`;
                 }
 
-                // Import rate - formatted bold if in charge window, italic with symbol if estimated
+                // Import rate - formatted bold if in charge window, italic with symbol if estimated.
+                // 'manual' is excluded here when editable: renderRateCell() below already shows its
+                // own override marker (and the only functioning Clear control) for that case, driven
+                // by a separately-computed isOverride check. Baking this marker in too stacks a
+                // second, visually identical glyph from a source the Clear button doesn't know about
+                // - if the two ever disagree, you get a marker with no working Clear behind it
+                // (batpred#4474). Non-'manual' adjust types (offset/future/user/increment/saving)
+                // aren't part of that clickable-override mechanism, so they keep their marker as-is.
                 const importBold = row.state && (row.state === 'Chrg' || row.state === 'HoldChrg' || row.state === 'FrzChrg');
                 let importText = row.import_rate.toFixed(2);
                 if (showDebug && row.import_rate_adjusted !== undefined) {
                     importText += ` (${row.import_rate_adjusted.toFixed(2)})`;
                 }
-                const importAdjust = row.import_rate_adjust_type ? ` ${getAdjustSymbol(row.import_rate_adjust_type)}` : '';
-                if (row.import_rate_adjust_type) {
+                const importAdjustType = (editable && row.import_rate_adjust_type === 'manual') ? null : row.import_rate_adjust_type;
+                const importAdjust = importAdjustType ? ` ${getAdjustSymbol(importAdjustType)}` : '';
+                if (importAdjustType) {
                     importText = `<i>${importText}${importAdjust}</i>`;
                 }
                 if (importBold) {
@@ -6512,13 +6530,15 @@ def get_plan_renderer_js():
                     html += `<td id=import ${cellStyle} bgcolor=${row.rate_color_import || '#FFFFFF'}>${importText}</td>`;
                 }
 
-                // Export rate - italic with symbol if estimated
+                // Export rate - italic with symbol if estimated (see import rate comment above for
+                // why 'manual' is excluded in editable mode)
                 let exportText = row.export_rate.toFixed(2);
                 if (showDebug && row.export_rate_adjusted !== undefined) {
                     exportText += ` (${row.export_rate_adjusted.toFixed(2)})`;
                 }
-                const exportAdjust = row.export_rate_adjust_type ? ` ${getAdjustSymbol(row.export_rate_adjust_type)}` : '';
-                if (row.export_rate_adjust_type) {
+                const exportAdjustType = (editable && row.export_rate_adjust_type === 'manual') ? null : row.export_rate_adjust_type;
+                const exportAdjust = exportAdjustType ? ` ${getAdjustSymbol(exportAdjustType)}` : '';
+                if (exportAdjustType) {
                     exportText = `<i>${exportText}${exportAdjust}</i>`;
                 }
                 if (editable) {


### PR DESCRIPTION
## Summary

Reported as "double F on a doubly-overridden cell, can't clear either" - traced this down against a reporter-supplied debug.yaml/log.

The backend is fine: `manual_select()` (`userinterface.py`) already explicitly removes any existing override for a time slot before adding a new one - confirmed via the reporter's own log, which shows `Removed existing rate override for Mon 14:30 before adding new value` firing correctly, and a subsequent single `Clear` fully removing it. There's no "stacking" at the data level.

The bug is in the editable plan table's rendering (`web_helper.py`). Two independent signals both mark an overridden cell with the same turned-F glyph (`&#8526;`):

1. `row.{import,export}_rate_adjust_type === 'manual'` (server-computed) → rendered via `getAdjustSymbol('manual')`, baked into the cell text before it's handed to `renderRateCell()`.
2. `renderRateCell()`'s own `isOverride` check, matched separately against the `overrides.manual_{import,export}_rates` array by minute.

Both fire for the same single override, stacking two identical markers on one cell. Worse: the Clear link is gated only on signal 2 (`isOverride`) - so if the two signals ever disagree (which the report's "can't clear it" symptom implies they can), you get a marker with no working Clear behind it, and the reporter's only path back to normal was restarting HAOS.

## Fix

Skip the adjust-type marker specifically for `'manual'` when the cell is editable, since `renderRateCell()` already fully owns the marker + Clear UI for that case - `isOverride` becomes the sole source of truth for both, so the two can no longer disagree. Other adjust types (`offset`/`future`/`user`/`increment`/`saving`) aren't part of the clickable-override mechanism and keep their existing marker.

Also hardened `toggleForceDropdown()` with a null guard - `document.getElementById(id)` returning nothing would previously throw silently, indistinguishable from a cell just not responding to clicks. This is a separate symptom also reported alongside the double marker (a cell that won't even open its dropdown) that isn't fully root-caused yet - the guard makes the failure mode loud (`console.warn`) instead of silent, so it's diagnosable next time rather than requiring a restart to move past.

## Test plan

- [x] New regression tests in `test_plan_why_reason.py` (structural JS-source assertions, following that file's existing pattern) covering both the marker de-duplication and the null guard
- [x] `./run_all --test plan_why_reason` passes
- [x] `./run_all --quick` - all tests pass
- [x] `./run_pre_commit` - clean

Fixes #4474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
