### PR TITLE
fix(octopus): split a slot around a fully-contained overlap instead of losing its remainder

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2565,19 +2565,40 @@ class Octopus:
                 kwh = remaining_minutes * self.car_charging_rate[car_n] / 60.0
                 start_minutes = self.minutes_now  # align span with the synthesised kwh so downstream rate calculations are consistent
             if kwh > 0:
-                # Don't add overlapping slots, bug in Octopus API means that sometimes slots overlap
+                # Don't add overlapping slots, bug in Octopus API means that sometimes slots overlap.
+                # Subtract every already-decoded slot's span from this slot's remaining segments -
+                # a slot can be trimmed at the start, trimmed at the end, removed entirely (it's
+                # fully covered by an existing slot), or - the case that was previously missing
+                # here (issue #4497) - it can fully CONTAIN an existing slot, which must split it
+                # into up to two remaining segments rather than just trimming one edge, or the
+                # whole future remainder silently disappears. This matters because fetch.py merges
+                # the HA Octopus Energy integration's completed_dispatches ahead of
+                # planned_dispatches: a short completed historical interval commonly sits inside a
+                # much longer still-active planned interval.
+                original_span = end_minutes - start_minutes
+                segments = [(start_minutes, end_minutes)]
                 for current_slot in slots_decoded:
                     current_start, current_end, current_kwh, current_source, current_location = current_slot
-                    if (start_minutes < current_end) and (end_minutes > current_start):
-                        if start_minutes < current_start:
-                            end_minutes = current_start
-                        elif end_minutes > current_end:
-                            start_minutes = current_end
+                    remaining = []
+                    for seg_start, seg_end in segments:
+                        if seg_start < current_end and seg_end > current_start:
+                            if seg_start < current_start:
+                                remaining.append((seg_start, current_start))
+                            if seg_end > current_end:
+                                remaining.append((current_end, seg_end))
                         else:
-                            start_minutes = end_minutes  # Remove slot
-                # Only add the slot if it has a non-zero duration
-                if start_minutes != end_minutes:
-                    slots_decoded.append((start_minutes, end_minutes, kwh, source, location))
+                            remaining.append((seg_start, seg_end))
+                    segments = remaining
+                # A single remaining segment (the common case: no overlap, or the previously-existing
+                # single-edge-trim behaviour) keeps its original full kwh unchanged. Only when the
+                # slot was actually split into multiple pieces is kwh scaled by each piece's share of
+                # the original span, so a genuine split never duplicates energy across the pieces.
+                split = len(segments) > 1
+                for seg_start, seg_end in segments:
+                    if seg_start == seg_end:
+                        continue
+                    seg_kwh = kwh * (seg_end - seg_start) / original_span if (split and original_span > 0) else kwh
+                    slots_decoded.append((seg_start, seg_end, seg_kwh, source, location))
 
         # Sort slots by start time
         slots_sorted = sorted(slots_decoded, key=lambda x: x[0])

--- a/apps/predbat/tests/test_octopus_slots.py
+++ b/apps/predbat/tests/test_octopus_slots.py
@@ -194,6 +194,54 @@ def run_load_octopus_slots_tests(my_predbat):
     slot_future_zero = [{"start": future_start.strftime(TIME_FORMAT), "end": future_end.strftime(TIME_FORMAT), "charge_in_kwh": 0, "source": "null", "location": "AT_HOME"}]
     failed |= run_load_octopus_slot_test("zero_kwh_future", my_predbat, slot_future_zero, [], False, 0.0, 0.0, 1.0)
 
+    # --- containment overlap: completed dispatch inside a longer planned dispatch (#4497) ---
+    # The HA Octopus Energy integration's completed_dispatches are merged ahead of
+    # planned_dispatches (fetch.py). A short completed historical interval sitting inside a much
+    # longer still-active planned interval must not truncate away the planned interval's future
+    # remainder - the overlap dedup previously only ever trimmed one edge of a slot, never split
+    # it around a fully-contained earlier slot.
+    print("**** Checking containment overlap (completed dispatch inside planned dispatch) ****")
+    saved_minutes_now = my_predbat.minutes_now
+    containment_now = midnight_utc + timedelta(hours=10, minutes=37)
+    my_predbat.minutes_now = int((containment_now - midnight_utc).total_seconds() / 60)
+
+    containment_slots = [
+        # completed_dispatches (merged first, per fetch.py)
+        {"start": (midnight_utc + timedelta(hours=8)).strftime(TIME_FORMAT), "end": (midnight_utc + timedelta(hours=8, minutes=30)).strftime(TIME_FORMAT), "charge_in_kwh": 5.45, "source": "null", "location": "AT_HOME"},
+        {"start": (midnight_utc + timedelta(hours=8, minutes=30)).strftime(TIME_FORMAT), "end": (midnight_utc + timedelta(hours=9)).strftime(TIME_FORMAT), "charge_in_kwh": 5.66, "source": "null", "location": "AT_HOME"},
+        # planned_dispatches (merged second) - the first one fully contains both completed slots above
+        {"start": (midnight_utc + timedelta(hours=7, minutes=59)).strftime(TIME_FORMAT), "end": (midnight_utc + timedelta(hours=16)).strftime(TIME_FORMAT), "charge_in_kwh": 40.0, "source": "SMART", "location": "AT_HOME"},
+        {"start": (midnight_utc + timedelta(hours=17, minutes=30)).strftime(TIME_FORMAT), "end": (midnight_utc + timedelta(hours=18)).strftime(TIME_FORMAT), "charge_in_kwh": 2.5, "source": "SMART", "location": "AT_HOME"},
+    ]
+
+    my_predbat.car_charging_soc[0] = 0.0
+    my_predbat.car_charging_limit[0] = 0.0
+    my_predbat.car_charging_loss = 1.0
+    result = my_predbat.load_octopus_slots(0, containment_slots, False)
+
+    # The 09:00-16:00 (540-960) future remainder of the contained planned dispatch must survive
+    if not result or result[0]["end"] != 960:
+        print("ERROR: Future remainder of contained planned dispatch was lost - expected the earliest surviving slot to end at 960 (16:00), got {}\nSlots: {}".format(result[0]["end"] if result else None, result))
+        failed = True
+    else:
+        # kwh for that remainder is the 40.0kWh original scaled by its 420-of-481-minute share
+        # (479-960 minus the 480-540 carved out by the two completed slots) - must not have been
+        # lost (the reported bug) nor duplicated across the split pieces
+        expected_kwh = 40.0 * (960 - 540) / (960 - 479)
+        if abs(result[0]["kwh"] - expected_kwh) > 0.01:
+            print("ERROR: Future remainder kwh should be {:.2f}, got {}\nSlots: {}".format(expected_kwh, result[0]["kwh"], result))
+            failed = True
+
+    # The second planned dispatch (17:30-18:00), which never overlapped anything, is untouched
+    if len(result) < 2 or result[1]["start"] != 1050 or result[1]["end"] != 1080 or result[1]["kwh"] != 2.5:
+        print("ERROR: Non-overlapping planned dispatch should be unchanged (1050-1080, 2.5kWh), got {}\nSlots: {}".format(result[1] if len(result) > 1 else None, result))
+        failed = True
+
+    my_predbat.minutes_now = saved_minutes_now
+
+    if failed:
+        return failed
+
     print("**** Checking car_charge_slot_kwh ****")
     my_predbat.car_charging_slots[0] = expected_slots5
     my_predbat.num_cars = 1


### PR DESCRIPTION
## Summary

Fixes #4497 - `fetch.py` merges the HA Octopus Energy integration's `completed_dispatches` ahead of `planned_dispatches` unconditionally. `load_octopus_slots()`'s overlap dedup loop processes slots in that order, but could only ever trim one edge of a slot against an already-decoded slot, or drop it entirely if it was fully contained *within* an already-decoded one - it had no path for the reverse case, where a new slot fully **contains** an already-decoded one.

A short completed historical interval sitting inside a much longer still-active planned interval therefore truncated the planned interval down to whatever sliver preceded the completed interval, silently discarding its entire future remainder. Example from the report: a planned 07:59-16:00 dispatch containing a 08:00-09:00 completed interval collapsed to 07:59-08:00 - already in the past by the time it's evaluated, so the car plan lost its whole future charging window despite a valid ready-by time and SoC gap.

Reported by @cparmar with an exact repro payload and precise code line references - I traced it through the actual code before touching anything and it checks out exactly as described (see verification note below).

## The fix

The overlap resolution now subtracts each already-decoded slot's span from the new slot's remaining segments, which can produce zero, one, or two pieces - the two-piece case is the one that was missing:

- Zero pieces: the slot is fully covered by an existing slot (unchanged from before - fully removed)
- One piece: a simple edge overlap (unchanged from before - single trim, same kwh)
- Two pieces (new): the slot fully contains an existing one - now correctly split into a before-piece and after-piece instead of losing everything after the first overlap check

`kwh` is only rescaled proportionally when a slot is actually split into multiple pieces, mirroring the proportional scaling `decode_octopus_slot()` already does a few lines above for forecast-window capping. The pre-existing single-edge-trim behaviour (and its energy value) is left exactly as before, so the existing hard-coded regression expectations in `test_octopus_slots.py`'s `sample_bad` test are unaffected.

## Verification

Hand-traced the reporter's exact example against the pre-fix code and reproduced the failure precisely (planned slot's end trimmed to the completed interval's start, future remainder never restored). Added a regression test reproducing it exactly; confirmed it fails without the fix (`got 1080` - only the unrelated later dispatch survived, the contained one's future remainder was gone) and passes with it.

## Test plan
- [x] New test in `test_octopus_slots.py`: completed dispatches fully contained within a planned dispatch - future remainder survives with correctly-scaled kwh, non-overlapping dispatches untouched
- [x] Verified the new test fails without the fix and passes with it (temporarily reverted `octopus.py` only, re-ran)
- [x] Existing `test_octopus_slots`, `multi_car_iog`, `add_now_to_octopus_slot`, `octopus_slots_change` tests pass unchanged
- [x] `./run_all --quick` passes
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)