### PR TITLE
feat(plan): add morning_cover best_soc_max mode

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -2481,6 +2481,10 @@ class Fetch:
         self.import_export_scaling = self.get_arg("import_export_scaling", 1.0)
         self.best_soc_min = self.get_arg("best_soc_min")
         self.best_soc_max = self.get_arg("best_soc_max")
+        self.best_soc_max_mode = None
+        if self.best_soc_max == "morning_cover":
+            self.best_soc_max_mode = "morning_cover"
+            self.best_soc_max = 0.0
         self.best_soc_keep = self.get_arg("best_soc_keep")
         self.best_soc_keep_weight = self.get_arg("best_soc_keep_weight")
         self.set_soc_minutes = self.plan_interval_minutes

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -86,6 +86,51 @@ class Plan:
     runs to minimise the overall cost metric.
     """
 
+    def update_best_soc_max_morning_cover(self, load_minutes_step, pv_forecast_minute_step):
+        """
+        Dynamically cap best_soc_max to cover load from the charge window end until PV exceeds load.
+        """
+        if getattr(self, "best_soc_max_mode", None) != "morning_cover":
+            return
+
+        morning_deficit = 0.0
+        morning_end = None
+        cover_start = 0
+        active_charge_window = self.in_charge_window(self.charge_window_best, self.minutes_now)
+        if active_charge_window >= 0:
+            cover_start = max(0, self.charge_window_best[active_charge_window]["end"] - self.minutes_now)
+        elif self.charge_window_best:
+            future_charge_windows = [window for window in self.charge_window_best if window["start"] >= self.minutes_now]
+            if future_charge_windows:
+                first_charge_window = min(future_charge_windows, key=lambda window: window["start"])
+                cover_start = max(0, first_charge_window["end"] - self.minutes_now)
+
+        horizon = min(self.forecast_minutes, 24 * 60)
+        for minute in range(cover_start, horizon, PREDICT_STEP):
+            load_step = load_minutes_step.get(minute, 0.0)
+            pv_step = pv_forecast_minute_step.get(minute, 0.0)
+            if pv_step > load_step and pv_step > 0:
+                morning_end = minute
+                break
+            if load_step > pv_step:
+                morning_deficit += load_step - pv_step
+
+        if morning_end is not None:
+            dynamic_best_soc_max = min(self.soc_max, self.reserve + (morning_deficit / max(self.battery_loss_discharge, 0.01)))
+            self.best_soc_max = dp2(dynamic_best_soc_max)
+            self.log(
+                "Dynamic best_soc_max morning_cover: reserve {}kWh + deficit {}kWh from {} until {} = {}kWh".format(
+                    dp2(self.reserve),
+                    dp2(morning_deficit),
+                    self.time_abs_str(self.minutes_now + cover_start),
+                    self.time_abs_str(self.minutes_now + morning_end),
+                    self.best_soc_max,
+                )
+            )
+        else:
+            self.best_soc_max = 0.0
+            self.log("Dynamic best_soc_max morning_cover: no PV>load point found in forecast horizon, leaving uncapped")
+
     def dynamic_load(self):
         """
         Adjust load prediction based on current load
@@ -1306,6 +1351,8 @@ class Plan:
         self.pv_forecast_minute_step = pv_forecast_minute_step
         self.pv_forecast_minute10_step = pv_forecast_minute10_step
         self.pv_forecast_minute90_step = pv_forecast_minute90_step
+
+        self.update_best_soc_max_morning_cover(load_minutes_step, pv_forecast_minute_step)
 
         # Yesterday data
         if recompute and self.calculate_savings and publish:

--- a/apps/predbat/tests/test_morning_cover.py
+++ b/apps/predbat/tests/test_morning_cover.py
@@ -1,0 +1,49 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+
+def _check(cond, message, failures):
+    """Record a failure message if the condition is not met."""
+    if not cond:
+        print("ERROR: {}".format(message))
+        failures.append(message)
+
+
+def run_morning_cover_tests(my_predbat):
+    """Run tests for the dynamic best_soc_max morning_cover mode. Returns True on failure."""
+    print("**** Running morning cover tests ****")
+    failures = []
+
+    my_predbat.best_soc_max_mode = "morning_cover"
+    my_predbat.best_soc_max = 0.0
+    my_predbat.minutes_now = 0
+    my_predbat.forecast_minutes = 24 * 60
+    my_predbat.soc_max = 10.0
+    my_predbat.reserve = 1.0
+    my_predbat.battery_loss_discharge = 0.8
+    my_predbat.charge_window_best = [{"start": 0, "end": 60}]
+
+    load_minutes_step = {60: 1.0, 65: 1.0, 70: 1.0, 75: 1.0}
+    pv_forecast_minute_step = {60: 0.0, 65: 0.5, 70: 1.5, 75: 2.0}
+    my_predbat.update_best_soc_max_morning_cover(load_minutes_step, pv_forecast_minute_step)
+    _check(my_predbat.best_soc_max == 2.88, "morning_cover should cap reserve plus loss-adjusted deficit", failures)
+
+    my_predbat.best_soc_max = 0.0
+    load_minutes_step = {60: 1.0, 65: 1.0}
+    pv_forecast_minute_step = {60: 0.0, 65: 0.0}
+    my_predbat.update_best_soc_max_morning_cover(load_minutes_step, pv_forecast_minute_step)
+    _check(my_predbat.best_soc_max == 0.0, "morning_cover should leave uncapped if PV never exceeds load", failures)
+
+    my_predbat.best_soc_max_mode = None
+    my_predbat.best_soc_max = 4.0
+    my_predbat.update_best_soc_max_morning_cover({0: 1.0}, {0: 2.0})
+    _check(my_predbat.best_soc_max == 4.0, "normal numeric best_soc_max should be unchanged", failures)
+
+    return len(failures) > 0

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -51,6 +51,7 @@ from tests.test_optimise_levels import run_optimise_levels_tests
 from tests.test_trim_export import run_trim_export_tests
 from tests.test_plan_tiebreak import run_plan_tiebreak_tests
 from tests.test_plan_preclip import run_plan_preclip_tests
+from tests.test_morning_cover import run_morning_cover_tests
 from tests.test_export_commitment import run_export_commitment_tests
 from tests.test_energydataservice import run_energydataservice_tests
 from tests.test_iboost import run_iboost_smart_tests
@@ -478,6 +479,7 @@ def main():
         ("trim_export", run_trim_export_tests, "Export trim ordering (buffer from cheapest slot) tests", False),
         ("plan_tiebreak", run_plan_tiebreak_tests, "Plan fragmentation near-tie tie-break tests", False),
         ("plan_preclip", run_plan_preclip_tests, "Plan selection scores the pre-clip plan", True),
+        ("morning_cover", run_morning_cover_tests, "Dynamic best_soc_max morning_cover tests", False),
         ("export_commitment", run_export_commitment_tests, "Forced-export commitment / anti-flapping tests", False),
         ("load_ml", test_load_ml, "ML Load Forecaster tests (MLP, training, persistence, validation)", True),
         # ("optimise_windows", run_optimise_all_windows_tests, "Optimise all windows tests", True),


### PR DESCRIPTION
## Summary

Adds a `best_soc_max: morning_cover` mode that dynamically caps the optimiser's maximum charge target to cover the forecast morning energy gap from the end of the current/next charge window until forecast PV exceeds forecast load.

This avoids needing a fixed `best_soc_max` value that may be too high on sunny days or too low on cloudy days.

## Details

- Allows `best_soc_max: morning_cover` to be used as a special mode.
- Keeps `best_soc_max` numeric internally so existing optimiser comparisons remain safe.
- Uses Predbat's existing stepped load and PV forecast arrays.
- Starts the cover period after the active charge window, or after the next future charge window.
- Sums forecast load minus forecast PV until PV first exceeds load.
- Sets `best_soc_max` to reserve plus the loss-adjusted morning deficit, capped at `soc_max`.
- Leaves `best_soc_max` uncapped if no PV-over-load point is found in the 24h horizon.

## Tests

- `python3 -m py_compile apps/predbat/fetch.py apps/predbat/plan.py apps/predbat/tests/test_morning_cover.py apps/predbat/unit_test.py`
- `unit_test.py --test morning_cover`