### PR TITLE
fix(fox): bump settings cache version to force-refresh fdpwr_max on upgrade

### DIFF
--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -64,7 +64,7 @@ FOX_SETTINGS_DEFAULTS = {
 # range/unit/precision to schedule-derived settings) so a persisted cache from before that
 # change is detected as stale and forces one settings/scheduler refresh regardless of age,
 # instead of being reused as-is - potentially forever, since nothing else would ever correct it.
-FOX_SETTINGS_CACHE_VERSION = 2
+FOX_SETTINGS_CACHE_VERSION = 3
 
 # Storage cache keys for device data persisted between reboots
 FOX_CACHE_KEYS = ["device_list", "device_detail", "battery_charging_time", "device_settings", "device_settings_unavailable", "device_settings_version", "scheduler_state", "device_values", "device_production_month"]


### PR DESCRIPTION
## Summary
- Follow-up to #4527. `battery_rate_max` (`fdpwr_max`) is only recomputed when `get_scheduler()` makes a live API call, gated to once an hour by `FOX_REFRESH_SETTINGS` - otherwise it's restored as-is from the persisted `scheduler_state` cache. That meant a customer upgrading to the #4527 fix kept the old, wrongly-clamped `fdpwr_max` (e.g. 10000W on a 10.5kW inverter) for up to an hour after upgrading, while `inverter_capacity`/`inverter_limit` (recomputed live every publish cycle straight from cached `device_detail`) updated immediately - producing a confusing mismatch between the two ("AC limit 10.5kW" vs "battery rate raw 10000.0W" in the log).
- Bumps `FOX_SETTINGS_CACHE_VERSION`, which triggers the existing self-heal path (added for exactly this kind of derivation change) that forces one scheduler refresh regardless of cache age.

## Test plan
- [x] `./run_all --test fox_api` passes
- [x] `./run_pre_commit` passes (ruff, black, cspell, docstrings, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)