### PR TITLE
fix(sigenergy): map Sigenergy ESS max discharge limit to battery rate max

### DIFF
--- a/templates/sigenergy_sigenstor.yaml
+++ b/templates/sigenergy_sigenstor.yaml
@@ -103,7 +103,7 @@ pred_bat:
 
   # Set the maximum charge/discharge rate of the battery
   battery_rate_max:
-    - sensor.sigen_plant_available_max_active_power
+    - sensor.sigen_plant_ess_rated_discharging_power
 
   # Export limit is a software limit set on your inverter that prevents exporting above a given level
   # When enabled Predbat will model this limit


### PR DESCRIPTION
Previously the battery_rate_max value was simply mapped from the plant max power, but this fails to account for the discharge rate limit of the installed batteries (for example, in a single battery system the max battery discharge rate is ~4.8kw).