### PR TITLE
fix(load-ml): stop a training run that crosses midnight inflating the…

### DIFF
--- a/apps/predbat/load_ml_component.py
+++ b/apps/predbat/load_ml_component.py
@@ -108,6 +108,10 @@ class LoadMLComponent(ComponentBase):
         self.data_lock = asyncio.Lock()
         self.last_data_fetch = None
         self.load_ml_calculating = False
+        # Cumulative load since local midnight, captured at fetch time along with the timestamp
+        # it refers to so a stale snapshot can be detected if publishing is delayed across midnight
+        self.load_minutes_now = 0
+        self.load_minutes_now_time = None
 
         # Model state
         self.predictor = None
@@ -589,8 +593,26 @@ class LoadMLComponent(ComponentBase):
         self.export_rates_data = self._merge_channel(self.export_rates_data, export_rates_data) if export_rates_data else self.export_rates_data
         self._recompute_age_days()
         self.load_minutes_now = load_minutes_now
+        self.load_minutes_now_time = self.now_utc
         self.last_data_fetch = self.now_utc
         self.data_ready = True
+
+    async def _do_fetch(self):
+        """
+        Shift the in-memory data to 'now', fetch fresh sensor history and merge the two.
+
+        Re-anchors every channel plus the load_minutes_now baseline to the current time,
+        so anything computed afterwards (predictions, published entity) uses data that
+        belongs to the same moment as self.minutes_now.
+        """
+        async with self.data_lock:
+            self._shift_fetch_data()
+            load_data, age_days, load_minutes_now, pv_data, temperature_data, import_rates_data, export_rates_data = await self._fetch_load_data()
+            if load_data:
+                self._merge_fetch_data(load_data, age_days, load_minutes_now, pv_data, temperature_data, import_rates_data, export_rates_data)
+            else:
+                self.log("Warn: ML Component: Failed to fetch load data, no data was returned.")
+        self.log("ML Component: Data fetch completed, load data age {:.1f} days, {} data points".format(self.load_data_age_days, len(self.load_data) if self.load_data else 0))
 
     def get_current_prediction(self):
         """
@@ -702,14 +724,7 @@ class LoadMLComponent(ComponentBase):
 
         if should_fetch:
             # Shift existing data to keep it anchored to 'minutes ago from now' before fetching new data, so that we can merge them and preserve historical depth even if the fetch returns limited history
-            async with self.data_lock:
-                self._shift_fetch_data()
-                load_data, age_days, load_minutes_now, pv_data, temperature_data, import_rates_data, export_rates_data = await self._fetch_load_data()
-                if load_data:
-                    self._merge_fetch_data(load_data, age_days, load_minutes_now, pv_data, temperature_data, import_rates_data, export_rates_data)
-                else:
-                    self.log("Warn: ML Component: Failed to fetch load data, no data was returned.")
-            self.log("ML Component: Data fetch completed, load data age {:.1f} days, {} data points".format(self.load_data_age_days, len(self.load_data) if self.load_data else 0))
+            await self._do_fetch()
 
         # Check if we have data
         if not self.data_ready:
@@ -748,6 +763,17 @@ class LoadMLComponent(ComponentBase):
                 if should_train:
                     self.log("ML Component: Doing training...")
                     await self._do_training(is_initial)
+
+                    # Training can run for many minutes, during which the data fetched above
+                    # goes stale - both the lookback window feeding the prediction and the
+                    # load_minutes_now baseline still refer to the pre-training time. Re-fetch
+                    # so everything is anchored to the current time again. Without this a
+                    # training run that straddles midnight publishes yesterday's daily total
+                    # as today's baseline, inflating the forecast by a whole day of load.
+                    stale_minutes = (self.now_utc - self.last_data_fetch).total_seconds() / 60.0 if self.last_data_fetch else 0
+                    if stale_minutes >= PREDICT_STEP:
+                        self.log("ML Component: Data is {:.0f} minutes stale after training, re-fetching before prediction".format(stale_minutes))
+                        await self._do_fetch()
 
                 # Update model validity status
                 self._update_model_status()
@@ -1005,6 +1031,31 @@ class LoadMLComponent(ComponentBase):
             self.model_valid = False
             self.model_status = "fallback_" + reason
 
+    def _load_baseline_now(self):
+        """
+        Return the cumulative load since local midnight to use as the forecast baseline.
+
+        Normally this is the snapshot captured during the last data fetch. If that snapshot
+        was taken on a previous day then the daily counter has since reset, and carrying it
+        forward would add a whole day of load on top of every forecast point, so in that case
+        it is re-derived from the per-step load history instead.
+
+        Returns:
+            Cumulative load in kWh since local midnight
+        """
+        if self.load_minutes_now_time is None or self.load_minutes_now_time.date() == self.now_utc.date():
+            return self.load_minutes_now
+
+        derived_baseline = 0.0
+        if self.load_data:
+            for minute in range(0, self.minutes_now, PREDICT_STEP):
+                derived_baseline += self.load_data.get(minute, 0.0)
+        derived_baseline = dp4(derived_baseline)
+        self.log(
+            "Warn: ML Component: Load baseline of {} kWh was captured on {} which is a previous day, re-derived load so far today as {} kWh".format(dp2(self.load_minutes_now), self.load_minutes_now_time.strftime("%Y-%m-%d %H:%M"), dp2(derived_baseline))
+        )
+        return derived_baseline
+
     def _publish_entity(self):
         """Publish the load_forecast_ml entity with current predictions."""
         # Convert predictions to timestamp format for entity
@@ -1016,6 +1067,7 @@ class LoadMLComponent(ComponentBase):
         power_today_now = 0
         power_today_h1 = 0
         power_today_h8 = 0
+        load_minutes_now = self._load_baseline_now()
         # Future predictions
         if self.current_predictions:
             prev_value = 0
@@ -1024,8 +1076,8 @@ class LoadMLComponent(ComponentBase):
                 timestamp_str = timestamp.strftime(TIME_FORMAT)
                 # Reset at midnight
                 if minute > 0 and ((minute + self.minutes_now) % (24 * 60) == 0):
-                    reset_amount = value + self.load_minutes_now
-                output_value = round(value - reset_amount + self.load_minutes_now, 4)
+                    reset_amount = value + load_minutes_now
+                output_value = round(value - reset_amount + load_minutes_now, 4)
                 results[timestamp_str] = output_value
                 delta_value = (value - prev_value) / PREDICT_STEP * 60.0
                 if minute == 0:
@@ -1058,7 +1110,7 @@ class LoadMLComponent(ComponentBase):
             "sensor." + self.prefix + "_load_ml_stats",
             state=round(total_kwh, 2),
             attributes={
-                "load_today": dp2(self.load_minutes_now),
+                "load_today": dp2(load_minutes_now),
                 "load_today_h1": dp2(load_today_h1),
                 "load_today_h8": dp2(load_today_h8),
                 "load_total": dp2(total_kwh),

--- a/apps/predbat/tests/test_load_ml.py
+++ b/apps/predbat/tests/test_load_ml.py
@@ -59,6 +59,7 @@ def test_load_ml(my_predbat=None):
         ("prediction_with_temp", _test_prediction_with_temp, "Prediction with temperature forecast data"),
         ("component_fetch_load_data", _test_component_fetch_load_data, "LoadMLComponent _fetch_load_data method"),
         ("component_publish_entity", _test_component_publish_entity, "LoadMLComponent _publish_entity method"),
+        ("component_stale_midnight_baseline", _test_component_stale_midnight_baseline, "LoadMLComponent baseline handling when publishing crosses midnight"),
         ("car_subtraction_direct", _test_car_subtraction_direct, "Direct car_subtraction method with interpolation and smoothing"),
         ("component_run_data_merge", _test_component_run_data_merge, "LoadMLComponent run() data fetch, save and merge across two runs"),
         ("component_init_predictor_last_train_time", _test_component_init_predictor_sets_last_train_time, "LoadMLComponent _init_predictor sets last_train_time from embedded training_timestamp"),
@@ -2605,6 +2606,169 @@ def _test_component_publish_entity():
     print("    ✓ Empty predictions handled correctly")
 
     print("  All _publish_entity tests passed!")
+
+
+def _test_component_stale_midnight_baseline():
+    """Test that a load baseline captured on a previous day is not carried into today's forecast.
+
+    Reproduces the case where a long training run starts before local midnight and finishes
+    after it: load_minutes_now still holds yesterday's full daily total while minutes_now has
+    already reset, which used to add a whole day of load on top of every published value.
+    """
+    import asyncio
+    from datetime import datetime, timezone
+    from load_ml_component import LoadMLComponent
+    from unittest.mock import MagicMock
+    from const import PREDICT_STEP
+
+    def run_async(coro):
+        """Run a coroutine on the current or a fresh event loop."""
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return loop.run_until_complete(coro)
+
+    class MockBase:
+        """Minimal PredBat stand-in positioned at 00:15, just after local midnight."""
+
+        def __init__(self):
+            """Set up the mock at 2026-01-02 00:15, 15 minutes into the new day."""
+            self.prefix = "predbat"
+            self.config_root = None
+            self.now_utc = datetime(2026, 1, 2, 0, 15, 0, tzinfo=timezone.utc)
+            self.midnight_utc = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+            self.minutes_now = 15
+            self.local_tz = timezone.utc
+            self.args = {}
+            self.log_messages = []
+            self.dashboard_calls = []
+
+        def log(self, msg):
+            """Record a log message."""
+            self.log_messages.append(msg)
+
+        def get_arg(self, key, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
+            """Return canned config values for the keys the component reads."""
+            return {
+                "load_today": ["sensor.load_today"],
+                "load_power": None,
+                "car_charging_energy": None,
+                "load_scaling": 1.0,
+                "car_charging_energy_scale": 1.0,
+            }.get(key, default)
+
+    mock_base = MockBase()
+    component = LoadMLComponent(mock_base, load_ml_enable=True)
+
+    def mock_dashboard_item(entity_id, state, attributes, app):
+        """Capture published entities."""
+        mock_base.dashboard_calls.append({"entity_id": entity_id, "state": state, "attributes": attributes, "app": app})
+
+    component.dashboard_item = mock_dashboard_item
+
+    # Baseline snapshot taken at 23:50 the previous day, holding that whole day's total
+    component.load_minutes_now = 24.9
+    component.load_minutes_now_time = datetime(2026, 1, 1, 23, 50, 0, tzinfo=timezone.utc)
+    # Per-step load history for the 15 minutes since midnight (0.05 kWh per 5 min = 0.15 kWh)
+    component.load_data = {0: 0.05, 5: 0.05, 10: 0.05, 15: 0.05, 20: 0.05}
+
+    component.current_predictions = {0: 0.05, 60: 0.6, 480: 5.0}
+    component.predictor.validation_mae = 0.5
+    component.predictor.get_model_age_hours = MagicMock(return_value=0.5)
+    component.last_train_time = mock_base.now_utc
+    component.load_data_age_days = 7.0
+    component.model_status = "active"
+
+    component._publish_entity()
+
+    attrs2 = mock_base.dashboard_calls[1]["attributes"]
+
+    # Baseline must be re-derived from the 15 minutes of load since midnight, not 24.9 kWh
+    assert abs(attrs2["load_today"] - 0.15) < 0.01, f"Expected load_today 0.15 re-derived since midnight, got {attrs2['load_today']}"
+    assert abs(attrs2["load_today_h1"] - 0.75) < 0.01, f"Expected load_today_h1 0.75 (0.6 + 0.15), got {attrs2['load_today_h1']}"
+    assert abs(attrs2["load_today_h8"] - 5.15) < 0.01, f"Expected load_today_h8 5.15 (5.0 + 0.15), got {attrs2['load_today_h8']}"
+    assert any("previous day" in msg for msg in mock_base.log_messages), "Stale baseline should be logged as a warning"
+
+    print("    ✓ Stale pre-midnight baseline re-derived from load history")
+
+    # Same-day snapshot must be used verbatim, no re-derivation
+    mock_base.dashboard_calls = []
+    component.load_minutes_now = 0.4
+    component.load_minutes_now_time = datetime(2026, 1, 2, 0, 10, 0, tzinfo=timezone.utc)
+
+    component._publish_entity()
+
+    attrs2 = mock_base.dashboard_calls[1]["attributes"]
+    assert abs(attrs2["load_today"] - 0.4) < 0.01, f"Expected load_today 0.4 from the snapshot, got {attrs2['load_today']}"
+    assert abs(attrs2["load_today_h1"] - 1.0) < 0.01, f"Expected load_today_h1 1.0 (0.6 + 0.4), got {attrs2['load_today_h1']}"
+
+    print("    ✓ Same-day baseline snapshot used unchanged")
+
+    # A missing snapshot timestamp (e.g. loaded from an older state) keeps the old behaviour
+    mock_base.dashboard_calls = []
+    component.load_minutes_now_time = None
+
+    component._publish_entity()
+
+    attrs2 = mock_base.dashboard_calls[1]["attributes"]
+    assert abs(attrs2["load_today"] - 0.4) < 0.01, f"Expected load_today 0.4 when no snapshot time is known, got {attrs2['load_today']}"
+
+    print("    ✓ Missing snapshot timestamp falls back to the stored baseline")
+
+    # Re-fetch after a long training run must re-anchor the baseline before predicting
+    async def run_stale_refetch():
+        """Drive run() through a training cycle that leaves the fetched data stale."""
+        fetch_times = []
+
+        async def mock_fetch_load_data():
+            """Return canned data and record when the fetch happened."""
+            fetch_times.append(mock_base.now_utc)
+            load_now = 24.9 if mock_base.now_utc.day == 1 else 0.15
+            return {0: 0.05, 5: 0.05}, 7.0, load_now, {}, {}, {}, {}
+
+        async def mock_do_training(is_initial):
+            """Simulate a training run that takes 25 minutes and crosses midnight."""
+            mock_base.now_utc = datetime(2026, 1, 2, 0, 15, 0, tzinfo=timezone.utc)
+            mock_base.midnight_utc = datetime(2026, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+            mock_base.minutes_now = 15
+
+        component._fetch_load_data = mock_fetch_load_data
+        component._do_training = mock_do_training
+        component._update_model_status = MagicMock()
+        component.base.prediction_started = False
+        component.load_ml_database_days = 0
+        component.ml_min_days = 0
+        component.initial_training_done = True
+        component.model_valid = True
+        component.data_ready = True
+        component.last_train_time = datetime(2026, 1, 1, 21, 50, 0, tzinfo=timezone.utc)
+        component.predictor.predict = MagicMock(return_value={0: 0.05, 60: 0.6, 480: 5.0})
+
+        # Start the cycle at 23:50 the previous day, before training moves the clock
+        mock_base.now_utc = datetime(2026, 1, 1, 23, 50, 0, tzinfo=timezone.utc)
+        mock_base.midnight_utc = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        mock_base.minutes_now = 1430
+        mock_base.dashboard_calls = []
+
+        await component.run(0, False)
+
+        assert len(fetch_times) == 2, f"Expected a second fetch after training, got {len(fetch_times)} fetches"
+        assert fetch_times[1].day == 2, f"Second fetch should happen after midnight, got {fetch_times[1]}"
+        assert component.load_minutes_now_time == mock_base.now_utc, "Baseline timestamp should be re-anchored to the post-training time"
+        assert abs(component.load_minutes_now - 0.15) < 0.01, f"Expected re-fetched baseline 0.15, got {component.load_minutes_now}"
+
+        attrs = mock_base.dashboard_calls[1]["attributes"]
+        assert abs(attrs["load_today_h8"] - 5.15) < 0.01, f"Expected load_today_h8 5.15 after re-fetch, got {attrs['load_today_h8']}"
+
+    run_async(run_stale_refetch())
+
+    print("    ✓ Stale data re-fetched after training before predicting")
+
+    assert PREDICT_STEP == 5, "Test assumes a 5 minute prediction step"
+
+    print("  All midnight baseline tests passed!")
 
 
 def _test_car_subtraction_direct():


### PR DESCRIPTION
… forecast

The load baseline (load_minutes_now, cumulative load since local midnight) is captured during the data fetch, while minutes_now is read live from the base at publish time. Training runs for many minutes, so when a fine-tune starts before midnight and finishes after it the two disagree: minutes_now has reset to the new day but the baseline still holds yesterday's full daily total, which then gets added on top of every published forecast point.

Seen in the wild as a single-sample spike in the ML load chart - a fetch at 23:50 followed by training that completed at 00:15 published load_today_h1 of ~25 kWh and load_today_h8 of ~30 kWh against an actual daily total of 25 kWh. The next cycle re-fetched and the values returned to normal.

Re-fetch after training whenever the data has gone stale, which re-anchors both the baseline and the lookback window feeding the prediction to the current time. As a second line of defence, detect a baseline snapshot belonging to a previous day at publish time and re-derive it from the per-step load history instead.

# PR note: ML load forecast spikes when a training run crosses midnight

Working note for a later PR. Branch: `fix/load-ml-midnight-stale-baseline`, commit `e58fd256`
(rebased onto main at v8.48.3). Not intended to be committed — delete before opening the PR.

## Symptom

Occasional single-sample spikes in the LoadML chart, where the `Forecast (+1h)` and
`Forecast (+8h)` series jump to a value above the household's entire daily consumption
and then return to normal on the next cycle.

Reported by a user on a ~25 kWh/day install: `Forecast (+1h)` spiked to ~26 kWh just
after midnight and `Forecast (+8h)` to ~30 kWh, against an actual daily total of 25 kWh.
The `Load (Actual)` series was unaffected apart from the same single sample.

Because the chart series carry a `+1h` / `+8h` plotting offset
(`web.py`, `prune_today(..., offset_minutes=...)`), the spikes appear on the chart one and
eight hours *after* the cycle that produced them, which makes them look unrelated to
midnight at first glance.

## Root cause

`load_ml_component.py` mixes two different notions of "now" when publishing:

- `self.load_minutes_now` — cumulative load since local midnight, a **snapshot taken during
  the data fetch** (`_fetch_load_data` → `_merge_fetch_data`).
- `self.minutes_now` — read **live** from the base object via the `ComponentBase` property.

`_publish_entity()` uses both together:

```python
if minute > 0 and ((minute + self.minutes_now) % (24 * 60) == 0):
    reset_amount = value + self.load_minutes_now
output_value = round(value - reset_amount + self.load_minutes_now, 4)
```

Normally the fetch and the publish are seconds apart and the two agree. But training runs
between them, and a fine-tune on a large history takes tens of minutes. When a training run
starts before local midnight and finishes after it:

- `self.minutes_now` has reset to the new day, so the midnight-reset branch does not fire
  until minute `1440 - minutes_now`, which is now late in the forecast.
- `self.load_minutes_now` still holds the *previous* day's full total.

Every forecast point before that reset therefore gets a whole day of load added to it.
`load_today_h1` (minute 60) and `load_today_h8` (minute 480) are both in that range, so both
published stats are inflated by roughly one day of consumption.

Secondary effect, present regardless of midnight: the prediction itself is generated from the
pre-training lookback window, so after a 25-minute training run the model is fed data that is
25 minutes out of date.

## Evidence

From the reporter's log (local time, Europe/Copenhagen):

```
2026-08-07 23:50:35  ML Component: Fetching 28 days of load history from [...]
2026-08-07 23:50:36  ML Component: Starting fine-tune training (2h interval), model age is 2.017 hours
2026-08-07 23:50:36  ML Component: Doing training...
2026-08-08 00:15:27  ML Predictor: Curriculum training complete, final val_mae=0.0059 kWh
2026-08-08 00:15:28  ML Component: Generated 576 predictions (total 48.68 kWh over 48h)
2026-08-08 00:15:28  ML Component: Prediction cycle completed        <- publishes with minutes_now = 15
2026-08-08 00:25:29  ML Component: Fetching 28 days of load history  <- next cycle, back to normal
```

The fetch at 23:50 captured `load_minutes_now` ≈ 25 kWh (`minutes_now` was 1430). The publish
at 00:15 used `minutes_now` = 15. Predicted values for that cycle were normal — the totals in
`Generated 576 predictions` are in the usual 43–48 kWh range throughout the log — so the error
is entirely in the published baseline, not in the model.

## Scope

- Affects the `sensor.<prefix>_load_ml_stats` attributes and the `results` attribute of
  `sensor.<prefix>_load_ml_forecast`, i.e. the LoadML/LoadMLPower charts.
- With `load_ml_source` enabled, the bad cycle also feeds the planner via
  `fetch_ml_load_forecast()`, which reads the `results` attribute back. The reporter had
  `load_ml_source` off, so for them it was display-only.
- Every version from v8.47.3 through current main is affected identically. `load_predictor.py`
  is byte-identical across that range; `load_ml_component.py` changed once, at v8.48.0, where
  #4462 (PV90) made `fetch_pv_forecast()` return three values — a single line at the call site,
  nowhere near the baseline handling.

## Fix

Two layers:

1. **Root cause.** The fetch block in `run()` is factored out into `_do_fetch()`, and after
   `_do_training()` the data is re-fetched when it has gone stale (>= `PREDICT_STEP` minutes).
   This re-anchors both the baseline and the lookback window feeding the prediction to the
   current time, which also fixes the "predicting from 25-minute-old data" problem.

2. **Defence in depth.** `load_minutes_now_time` is stored alongside the baseline, and
   `_load_baseline_now()` detects a snapshot belonging to a previous local day and re-derives
   the value from the per-step `load_data` history instead, logging a warning.

New log lines to look for:

```
ML Component: Data is 25 minutes stale after training, re-fetching before prediction
Warn: ML Component: Load baseline of 24.9 kWh was captured on 2026-01-01 23:50 which is a
      previous day, re-derived load so far today as 0.15 kWh
```

## Tests

New sub-test `component_stale_midnight_baseline` in `tests/test_load_ml.py`, covering:

- a stale pre-midnight baseline is re-derived from the load history;
- a same-day snapshot is used unchanged;
- a missing snapshot timestamp falls back to the previous behaviour;
- a full `run()` cycle where training moves the clock from 23:50 to 00:15 triggers a second
  fetch and publishes the corrected values.

Without the fix the test fails with
`Expected load_today 0.15 re-derived since midnight, got 24.9`.

Verification performed:

- `--test load_ml`: 29/29 pass (28/29 without the fix).
- `pre-commit` (ruff, black, cspell) on both changed files: clean.
- All other non-slow tests pass.

## Field verification

The fix has run on a live install since 2026-08-08. The bug scenario occurred once in that
window, on the night of 12-13 August, and was handled correctly:

```
2026-08-12 23:40:42  ML Component: Doing training...
2026-08-13 00:06:09  ML Component: Training successful, val_mae=0.0065 kWh
2026-08-13 00:06:09  ML Component: Data is 25 minutes stale after training, re-fetching before prediction
2026-08-13 00:06:12  ML Component: Generated 576 predictions (total 43.25 kWh over 48h)
```

Training started 19 minutes before local midnight and finished 6 minutes after it. The
published forecast is continuous across the boundary — 41.52 kWh at 23:28, 43.25 kWh at the
crossing, 43.26 kWh at 00:24 — where before the fix the baseline would have carried the
previous day's ~25 kWh total into every point.

Over 11-15 August: 48 training runs, 1 midnight crossing, 244 prediction cycles all within
37.6-58.86 kWh. No inflation anywhere.

The layer-2 backstop (`_load_baseline_now` re-deriving the baseline) has never fired on the
live install — the re-fetch in layer 1 catches the condition first, which is the intended
order. It is covered by unit tests only.

## Unrelated issues noticed while verifying

Worth separate PRs, not addressed here:

- `test_fox_api.py::test_run_midnight_reset` is flaky. The final assertion
  `fox.start_time_today > initial_start_time` races against clock resolution and fails on
  roughly 4 out of 5 runs on Windows. It aborts `run_all --quick` before the rest of the suite.
- `ge_cloud` and `annual_load_octopus` fail on Windows with
  `RuntimeError: aiodns needs a SelectorEventLoop on Windows`. Environment limitation,
  reproduces on a clean tree.

## Open question, not part of this fix

The reporter's `Forecast (+8h)` series sits systematically *below* actual load through the day
(~20 kWh predicted vs ~25 kWh actual at 18:00), which is why they run with `load_ml_source`
disabled. This is not the midnight bug — the model's own diagnostics are strong
(`ar_mae` ≈ 0.003–0.006 kWh per 5-min chunk, bias near zero, teacher-forced drift ~0.0002 kWh).
A plausible candidate is the historical-pattern blending in `load_predictor.py:1553-1560`
(`blend_floor = 0.5`), which pulls the forecast toward the day-of-week mean as the horizon
grows. Needs its own investigation before anything is claimed.


<img width="1389" height="855" alt="Skærmbillede 2026-08-08 141059" src="https://github.com/user-attachments/assets/44208dc0-44db-4562-b381-10ea73ee86e4" />
[predbat (20).log](https://github.com/user-attachments/files/31106771/predbat.20.log)
