### PR TITLE
fix(inverter): skip the discharge target write on AC Coupled GivTCP inverters

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2523,13 +2523,24 @@ class Inverter:
         if force_export:
             target_soc = int(self.reserve_percent)
             if self.rest_data and self.rest_v3:
-                current = self.rest_readDischargeTarget()
-                if current is None:
-                    self.log("Inverter {} No current discharge target to read, export target not written".format(self.id))
-                elif current != target_soc:
-                    self.rest_setDischargeTarget(target_soc)
+                # AC Coupled inverters don't have a working Discharge_Target_SOC_1 register - GivTCP
+                # still reports a write as successful, but it never persists between cycles, so the
+                # caller sees a permanent mismatch and rewrites indefinitely (#4517). Confirmed
+                # against GivEnergy's own firmware archive (github.com/DJBenson/giv-firmware): "AC
+                # Coupled" is a single product line with exactly two firmware releases ever published
+                # (D212-A212, A214-D214) - not an early/late generational split the way Hybrid has
+                # Gen1/2/3 - so there's no newer AC-coupled variant this would need to keep working for.
+                inverter_model = self.rest_data.get("raw", {}).get("invertor", {}).get("model", "")
+                if inverter_model == "Ac":
+                    self.log("Inverter {} is AC Coupled, discharge target register not supported, export target not written".format(self.id))
                 else:
-                    self.log("Inverter {} Current discharge target is already set to {}".format(self.id, current))
+                    current = self.rest_readDischargeTarget()
+                    if current is None:
+                        self.log("Inverter {} No current discharge target to read, export target not written".format(self.id))
+                    elif current != target_soc:
+                        self.rest_setDischargeTarget(target_soc)
+                    else:
+                        self.log("Inverter {} Current discharge target is already set to {}".format(self.id, current))
             elif "discharge_target_soc" in self.base.args:
                 current = self.base.get_arg("discharge_target_soc", index=self.id, required_unit="%")
                 try:

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1927,6 +1927,66 @@ def test_discharge_target_control_signal(test_name, ha, inv, dummy_rest):
     return failed
 
 
+def test_discharge_target_skipped_for_ac_coupled(test_name, ha, inv, dummy_rest):
+    """
+    Regression test for issue #4517: AC Coupled inverters (raw.invertor.model == "Ac") don't have a
+    working Discharge_Target_SOC_1 register - GivTCP reports a write as successful, but it never
+    persists between cycles, so the caller sees a permanent mismatch and rewrites indefinitely.
+    Confirmed against GivEnergy's own firmware archive: "AC Coupled" is a single product line with
+    only two firmware releases ever published, not an early/late generational split - so there's no
+    newer AC-coupled variant that would need this write to still happen. Skip it outright rather than
+    attempting a write already known to be doomed.
+    """
+    failed = False
+    print("Test: {}".format(test_name))
+
+    saved_rest_data = inv.rest_data
+    saved_rest_api = inv.rest_api
+    saved_rest_v3 = inv.rest_v3
+
+    try:
+        inv.rest_api = "dummy"
+        inv.rest_v3 = True
+        inv.reserve_percent = 20
+
+        start_time = "03:33:00"
+        end_time = "04:44:00"
+        ts = datetime.strptime(start_time, "%H:%M:%S")
+        te = datetime.strptime(end_time, "%H:%M:%S")
+
+        inv.rest_data = {
+            "Control": {"Mode": "Timed Export", "Enable_Discharge_Schedule": "on"},
+            "Timeslots": {"Discharge_start_time_slot_1": start_time, "Discharge_end_time_slot_1": end_time},
+            "raw": {"invertor": {"discharge_target_soc_1": "4", "model": "Ac"}},
+        }
+        dummy_rest.clear_queue()
+        dummy_rest.rest_data = copy.deepcopy(inv.rest_data)
+
+        inv.adjust_force_export(True, ts, te)
+
+        commands = dummy_rest.get_commands()
+        if commands:
+            print("ERROR: {}: AC Coupled should attempt no discharge-target REST commands at all, got {}".format(test_name, commands))
+            failed = True
+
+        # A non-AC-Coupled model (or no model reported at all) must still attempt the write as before.
+        for model in ["Hybrid", ""]:
+            inv.rest_data["raw"]["invertor"]["model"] = model
+            dummy_rest.clear_queue()
+            dummy_rest.rest_data = copy.deepcopy(inv.rest_data)
+            inv.adjust_force_export(True, ts, te)
+            commands = dummy_rest.get_commands()
+            if not any(c[0] == "dummy/setDischargeTarget" for c in commands):
+                print("ERROR: {}: model={!r} should still attempt setDischargeTarget, got {}".format(test_name, model, commands))
+                failed = True
+    finally:
+        inv.rest_data = saved_rest_data
+        inv.rest_api = saved_rest_api
+        inv.rest_v3 = saved_rest_v3
+
+    return failed
+
+
 def test_discharge_target_read_prefers_control(test_name, ha, inv):
     """
     Regression test for issue #4517: a discharge target write kept firing every cycle even when
@@ -3170,6 +3230,12 @@ charge_start_service:
     # Regression test for issue #4421 (follow-up): trust Control.Discharge_Target_SOC_1, GivTCP's
     # synchronous write-time signal, ahead of the much slower raw.invertor background-poll fallback
     failed |= test_discharge_target_control_signal("discharge_target_control_signal", ha, inv, dummy_rest)
+    if failed:
+        return failed
+
+    # Regression test for issue #4517 (follow-up): AC Coupled inverters don't have a working
+    # discharge target register, skip the write entirely rather than retrying it forever
+    failed |= test_discharge_target_skipped_for_ac_coupled("discharge_target_skipped_for_ac_coupled", ha, inv, dummy_rest)
     if failed:
         return failed
 


### PR DESCRIPTION
## Summary

Follow-up to #4517/#4518, for the case #4518 doesn't fix (a REST-v3 inverter where `Control.Discharge_Target_SOC_1` is entirely absent). Supersedes #4542 (closing separately) - that approach (enable `Enable_Charge_Target` before writing) relied on a correlation with a second reporter's data that turned out to predate #4492/#4518 and was confounded by the exact race condition those fixes address, so it was never solid evidence the register works on AC Coupled hardware. Dropped rather than kept alongside this fix.

**Root cause**: AC Coupled inverters don't have a working `Discharge_Target_SOC_1` register. GivTCP still reports each write as successful (`"Setting Discharge Target 1 was a success"` in the reporter's own GivTCP log, repeatedly), but the value never persists between cycles - `adjust_force_export()` sees a permanent mismatch and rewrites it every single cycle, indefinitely.

**Why this is safe to gate on `raw.invertor.model == "Ac"` specifically** (ruled out earlier, for good reason at the time): confirmed against GivEnergy's own firmware archive ([github.com/DJBenson/giv-firmware](https://github.com/DJBenson/giv-firmware)) - "AC Coupled" is a single product line with exactly two firmware releases ever published (`D212-A212`, `A214-D214`), not an early/late generational split the way the Hybrid line has Gen1/2/3/HV/LV variants. Both firmware versions seen across the two reporter samples investigated on this issue match these exact releases - there's no newer AC-coupled variant this gate would need to keep working for, so excluding the whole `model == "Ac"` category is coherent rather than a guess that would need revisiting as more reports come in.

## Test plan
- [x] New regression test, confirmed to fail without the fix (5 REST write attempts) and pass with it (0)
- [x] Existing discharge-target tests (Control-signal trust, settle-delay, read-back) unaffected - none of them set `model`, so the new gate is a no-op for them
- [x] `./run_all --quick` passes
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)