### PR TITLE
perf: cut ~23% off planning by removing redundant scans and copies

### DIFF
--- a/apps/predbat/marginal.py
+++ b/apps/predbat/marginal.py
@@ -16,7 +16,6 @@ with extra load injected into different upcoming time windows.
 The matrix covers extra-kWh levels across multiple time windows.
 """
 
-import copy
 from datetime import timedelta
 from const import PREDICT_STEP
 from prediction import Prediction
@@ -70,6 +69,11 @@ class Marginal:
         matrix = {}
         all_costs = []
 
+        # Every cell below builds a Prediction that differs from the others only in its load, so the
+        # kernel context's load-independent arrays - rates, PV, temperature caps, carbon, car slots
+        # over the whole horizon - are built once here and reused instead of 28 times.
+        kernel_static_cache = {}
+
         for extra_kwh in MARGINAL_EXTRA_KWH_LEVELS:
             matrix[extra_kwh] = {}
             # Convert kWh/hour extra load to kWh per 5-minute step
@@ -78,8 +82,9 @@ class Marginal:
             for idx, offset in enumerate(MARGINAL_TIME_OFFSETS):
                 time_label = time_labels[idx]
 
-                # Deep-copy both load forecasts to avoid mutating shared data
-                modified_load = copy.deepcopy(self.load_minutes_step)
+                # Copy the load forecast to avoid mutating shared data - it is a flat minute -> kWh
+                # dict, so a shallow copy is a full copy and deepcopy only walked it more slowly
+                modified_load = dict(self.load_minutes_step)
 
                 # Inject extra load into the 1-hour window starting at `offset` minutes from now
                 for minute in range(offset, offset + 60, PREDICT_STEP):
@@ -88,7 +93,7 @@ class Marginal:
 
                 # Create a fresh Prediction with the modified load.
                 # No need to include 10% extra load as we only run normal simulations.
-                pred = Prediction(self, self.pv_forecast_minute_step, self.pv_forecast_minute_step, modified_load, modified_load)
+                pred = Prediction(self, self.pv_forecast_minute_step, self.pv_forecast_minute_step, modified_load, modified_load, kernel_static_cache=kernel_static_cache)
 
                 # Run prediction against the current best charge/discharge plan, no save to HA
                 (new_metric, *_) = pred.run_prediction(

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -66,6 +66,38 @@ def slots_around(target_slots, slot_lengths):
     return slot_choices
 
 
+def select_window_candidates(entries, price_selected, allow_freeze, accept=None):
+    """
+    Ordered, deduplicated list of (window_n, freeze) that a price threshold makes available.
+
+    entries is a [price, window_n, freeze] list for one side of the search, in the order the
+    optimiser considers them. A window is taken when its price passes price_selected, its freeze
+    flag is allowed by allow_freeze, it has not already been taken, and accept (when given) passes
+    it. Only taken windows count as seen, so a window that accept rejects is offered again if it
+    appears later - which is what the capped scan this replaces did.
+
+    The result is deliberately unbounded: capping at max_slots is the caller slicing the first
+    max_slots off the front. That equivalence holds because the cap in the original scan was
+    monotonic - once reached, nothing further was ever taken - and it is what lets one scan per
+    price threshold serve every slot count the search tries. test_window_selection pins it against
+    a reference implementation of the original capped loop.
+    """
+    chosen = []
+    seen = set()
+    for price, window_n, freeze in entries:
+        if not price_selected(price):
+            continue
+        if freeze and not allow_freeze:
+            continue
+        if window_n in seen:
+            continue
+        if accept is not None and not accept(window_n):
+            continue
+        seen.add(window_n)
+        chosen.append((window_n, freeze))
+    return chosen
+
+
 MASK_64 = (1 << 64) - 1
 
 
@@ -409,6 +441,27 @@ class Plan:
         # depends on charge_mods/best_limits_reset and changes from trial to trial.
         hit_charge_cache = {}
         hit_car_cache = {}  # (start, end) -> does this window hit a car charging slot
+        export_allowed_cache = {}  # window_n -> is this export window usable at all
+
+        def export_window_allowed(window_n):
+            """Whether an export window may be exported at all, ignoring charge window collisions.
+
+            Car charging and iboost collisions depend only on the window's own fixed geometry, so
+            like hit_charge_cache above the answer holds for the life of the call. The charge window
+            collision is deliberately not folded in here - that one depends on charge_mods and so
+            changes from trial to trial.
+            """
+            allowed = export_allowed_cache.get(window_n)
+            if allowed is None:
+                window = export_window[window_n]
+                if not self.car_charging_from_battery and self.hit_car_window(window["start"], window["end"], cache=hit_car_cache):
+                    allowed = False
+                elif not self.iboost_on_export and self.iboost_enable and self.iboost_plan and (self.hit_charge_window(self.iboost_plan, window["start"], window["end"]) >= 0):
+                    allowed = False
+                else:
+                    allowed = True
+                export_allowed_cache[window_n] = allowed
+            return allowed
 
         # Start loop of trials
         for loop_price in all_prices:
@@ -418,6 +471,49 @@ class Plan:
                     if self.debug_enable:
                         self.log("Skipping price {} as level score {} is not within 20% of best {}".format(loop_price, this_level_score, best_level_score))
                     continue
+
+            # Which windows a price threshold makes available depends only on the threshold and the
+            # freeze flag - not on the slot counts swept below, and not on coarse vs fine. So each
+            # side is scanned once per (threshold, freeze) here and every slot count is served by
+            # slicing that one list, rather than rescanning price_set_* inside the four nested slot
+            # loops. That scan was the hottest loop left in planning: ~900 rescans of a few hundred
+            # entries per threshold, for at most a couple of dozen distinct answers.
+            #
+            # Slicing is exactly what capping did - see select_window_candidates - and slot counts at
+            # or above the candidate count all select the same windows, so they collapse onto one
+            # cache entry rather than one per entry in the slot length list.
+            charge_candidates = {}
+            export_candidates = {}
+            charge_selection_cache = {}
+            export_selection_cache = {}
+
+            def charge_selection_for(max_slots, allow_freeze, loop_price=loop_price):
+                """Charge windows this price threshold selects, capped at max_slots"""
+                candidates = charge_candidates.get(allow_freeze)
+                if candidates is None:
+                    candidates = select_window_candidates(price_set_charge, lambda price: loop_price >= price, allow_freeze)
+                    charge_candidates[allow_freeze] = candidates
+                count = min(max_slots, len(candidates))
+                entry = charge_selection_cache.get((count, allow_freeze))
+                if entry is None:
+                    taken = candidates[:count]
+                    entry = ([window_n for window_n, _ in taken], dict(taken))
+                    charge_selection_cache[(count, allow_freeze)] = entry
+                return entry
+
+            def export_selection_for(max_slots, allow_freeze, loop_price=loop_price):
+                """Export windows this price threshold selects, capped at max_slots"""
+                candidates = export_candidates.get(allow_freeze)
+                if candidates is None:
+                    candidates = select_window_candidates(price_set_export, lambda price: loop_price < price, allow_freeze, accept=export_window_allowed)
+                    export_candidates[allow_freeze] = candidates
+                count = min(max_slots, len(candidates))
+                entry = export_selection_cache.get((count, allow_freeze))
+                if entry is None:
+                    taken = candidates[:count]
+                    entry = ([window_n for window_n, _ in taken], dict(taken))
+                    export_selection_cache[(count, allow_freeze)] = entry
+                return entry
 
             for coarse in [True, False] if enable_coarse_fine else [False]:
                 if not enable_coarse_fine:
@@ -434,58 +530,21 @@ class Plan:
                 charge_freeze_options = [True, False] if (self.set_charge_freeze and not coarse) else [False]
                 export_freeze_options = [True, False] if (self.set_export_freeze and not coarse) else [False]
 
-                # Which charge windows the price threshold selects depends only on loop_price (fixed here),
-                # max_charge_slots and try_charge_freeze - not on either of the export loops it is nested
-                # inside, so without this it is rebuilt identically once per (max_export_slots,
-                # try_export_freeze) pair. That scan was the single hottest loop in planning, ~52M
-                # iterations on a heavy scenario. Memoised rather than hoisted so the iteration order, and
-                # with it every tie-break in the search below, is untouched.
-                #
-                # Sharing the cached objects between iterations is safe because neither is mutated after it
-                # is built: all_n is copied into pred_item, and charge_mods is only ever read.
-                charge_selection_cache = {}
-
                 for max_charge_slots in charge_slot_choices:
                     for max_export_slots in export_slot_choices:
                         for try_charge_freeze in charge_freeze_options:
                             for try_export_freeze in export_freeze_options:
-                                all_d = []
-                                count_d = 0
-                                export_mods = {}  # window_n -> freeze flag, for export windows modified from the reset limits
-
-                                charge_selection = charge_selection_cache.get((max_charge_slots, try_charge_freeze))
-                                if charge_selection is None:
-                                    all_n = []
-                                    count_c = 0
-                                    charge_mods = {}  # window_n -> freeze flag, for charge windows modified from the reset limits
-                                    for price, window_n, freeze in price_set_charge:
-                                        if loop_price >= price:
-                                            if not (freeze and not try_charge_freeze) and count_c < max_charge_slots and (window_n not in charge_mods):
-                                                all_n.append(window_n)
-                                                charge_mods[window_n] = freeze
-                                                count_c += 1
-                                    charge_selection_cache[(max_charge_slots, try_charge_freeze)] = (all_n, charge_mods)
-                                else:
-                                    all_n, charge_mods = charge_selection
-
-                                for price, window_n, freeze in price_set_export:
-                                    if loop_price < price:
-                                        # For prices above threshold try export
-                                        if freeze and not try_export_freeze:
-                                            pass
-                                        elif count_d < max_export_slots and (window_n not in export_mods):
-                                            if not self.car_charging_from_battery and self.hit_car_window(export_window[window_n]["start"], export_window[window_n]["end"], cache=hit_car_cache):
-                                                pass
-                                            elif not self.iboost_on_export and self.iboost_enable and self.iboost_plan and (self.hit_charge_window(self.iboost_plan, export_window[window_n]["start"], export_window[window_n]["end"]) >= 0):
-                                                pass
-                                            else:
-                                                all_d.append(window_n)
-                                                export_mods[window_n] = freeze
-                                                count_d += 1
+                                # all_n is copied into pred_item below and charge_mods is only ever read,
+                                # so both cached objects can be shared between trials as they stand. The
+                                # export pair can be pruned just below, so it is copied on write.
+                                all_n, charge_mods = charge_selection_for(max_charge_slots, try_charge_freeze)
+                                all_d, export_mods = export_selection_for(max_export_slots, try_export_freeze)
 
                                 # Remove export hitting charge windows if this is disabled
                                 if not self.calculate_export_oncharge:
-                                    for window_n in all_d[:]:
+                                    pruned_all_d = None
+                                    pruned_export_mods = None
+                                    for window_n in all_d:
                                         hit_charge = hit_charge_cache.get(window_n)
                                         if hit_charge is None:
                                             hit_charge = self.hit_charge_window(self.charge_window_best, export_window[window_n]["start"], export_window[window_n]["end"])
@@ -499,8 +558,14 @@ class Plan:
                                                 # Only remove if it doesn't remove the charge window entirely
                                                 if not (export_window[window_n]["start"] <= self.charge_window_best[hit_charge]["start"] and export_window[window_n]["end"] >= self.charge_window_best[hit_charge]["end"]):
                                                     # Dropping the modification restores the reset value (100.0) for this window
-                                                    export_mods.pop(window_n, None)
-                                                    all_d.remove(window_n)
+                                                    if pruned_all_d is None:
+                                                        pruned_all_d = all_d[:]
+                                                        pruned_export_mods = dict(export_mods)
+                                                    pruned_export_mods.pop(window_n, None)
+                                                    pruned_all_d.remove(window_n)
+                                    if pruned_all_d is not None:
+                                        all_d = pruned_all_d
+                                        export_mods = pruned_export_mods
 
                                 # Skip this one as it's the same as selected already
                                 try_hash = reset_sum

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -2147,7 +2147,12 @@ class Plan:
         best_carbon = 0
         this_export_limit = 100.0
         window = export_window[window_n]
-        try_export_window = copy.deepcopy(export_window)
+        # A shallow copy is enough: nothing here writes to a window dict, and the one write that does
+        # happen downstream - the trial start - is applied copy-on-write by _prepare_export, which
+        # takes its own list and replaces that single window with dict(window, start=start). The list
+        # is still copied so a caller cannot reorder it underneath a batch that has not flushed yet.
+        # Deep-copying every window dict on entry was the largest block of copying in a plan.
+        try_export_window = list(export_window)
         try_export = list(export_limit)
         best_start = window["start"]
         best_size = window["end"] - best_start

--- a/apps/predbat/prediction.py
+++ b/apps/predbat/prediction.py
@@ -57,11 +57,16 @@ class Prediction(PredictionBatch):
     Class to hold prediction input and output data and the run function
     """
 
-    def __init__(self, base=None, pv_forecast_minute_step=None, pv_forecast_minute10_step=None, load_minutes_step=None, load_minutes_step10=None, pv_forecast_minute90_step=None, load_minutes_step90=None, soc_kw=None, soc_max=None):
+    def __init__(
+        self, base=None, pv_forecast_minute_step=None, pv_forecast_minute10_step=None, load_minutes_step=None, load_minutes_step10=None, pv_forecast_minute90_step=None, load_minutes_step90=None, soc_kw=None, soc_max=None, kernel_static_cache=None
+    ):
         """Build a Prediction, optionally copying simulation state from a base PredBat instance.
 
         pv_forecast_minute90_step and load_minutes_step90 fall back to the nominal step arrays when None, so
         every existing call site that never requests the pv90 scenario keeps working unchanged.
+
+        kernel_static_cache is passed straight through to create_kernel_context, for a caller building
+        several Predictions that differ only in their load forecast; see that function for the contract.
         """
         if base:
             self.minutes_now = base.minutes_now
@@ -171,7 +176,7 @@ class Prediction(PredictionBatch):
             self.prediction_kernel_enable = getattr(base, "prediction_kernel_enable", False)
             self.kernel_handle = 0
             if self.prediction_kernel_enable:
-                self.kernel_handle = create_kernel_context(self)
+                self.kernel_handle = create_kernel_context(self, static_cache=kernel_static_cache)
 
         # Outside the `if base:` block on purpose: a Prediction built without a base is still a valid
         # object and its first enqueue_prediction would otherwise raise AttributeError

--- a/apps/predbat/prediction_kernel.py
+++ b/apps/predbat/prediction_kernel.py
@@ -395,11 +395,83 @@ def kernel_context_free(handle):
         KERNEL_LIB.pk_context_free(handle)
 
 
-def create_kernel_context(pred):
+def build_static_context_arrays(pred, n_steps, minutes_now, num_cars):
+    """Build the per-step context arrays that do not depend on the load forecast.
+
+    Split out from create_kernel_context so a caller building several contexts that differ only in
+    their load can compute these once - see the static_cache argument there. Everything here reads
+    rates, PV, temperature, carbon, gas, iboost and car data.
+    """
+    rate_import = []
+    rate_export = []
+    alert_keep = []
+    io_flag = []
+    pv = []
+    pv10 = []
+    pv90 = []
+    temp_charge_cap = []
+    temp_discharge_cap = []
+    carbon = []
+    gas_rate = []
+    iboost_plan_load = []
+    car_load_flat = [0.0] * (num_cars * n_steps)
+    car_rate_flat = [0.0] * (num_cars * n_steps)
+    # The temperature rate caps are a pure function of the temperature at that step, and a forecast
+    # normally holds one value for hours at a time, so the two curve walks are memoised per distinct
+    # temperature instead of repeated for every step. On the benchmark that is 17,856 calls per plan
+    # for a handful of answers.
+    temp_cap_memo = {}
+    for k in range(n_steps):
+        minute = k * PREDICT_STEP
+        minute_absolute = minute + minutes_now
+        rate_import.append(pred.rate_import.get(minute_absolute, 0))
+        rate_export.append(pred.rate_export.get(minute_absolute, 0))
+        alert_keep.append(pred.all_active_keep.get(minute_absolute, 0))
+        io_flag.append(1 if pred.io_adjusted.get(minute_absolute, 0) else 0)
+        pv.append(pred.pv_forecast_minute_step[minute])
+        pv10.append(pred.pv_forecast_minute10_step[minute])
+        pv90.append(pred.pv_forecast_minute90_step[minute])
+        # Pre-compute the temperature rate cap base (before the min against the max rate,
+        # which the kernel applies per lookup) - mirrors utils.py find_battery_temperature_cap
+        battery_temperature = pred.battery_temperature_prediction.get(minute, pred.battery_temperature)
+        caps = temp_cap_memo.get(battery_temperature)
+        if caps is None:
+            caps = (
+                find_battery_temperature_cap(battery_temperature, pred.battery_temperature_charge_curve, pred.soc_max, float("inf")),
+                find_battery_temperature_cap(battery_temperature, pred.battery_temperature_discharge_curve, pred.soc_max, float("inf")),
+            )
+            temp_cap_memo[battery_temperature] = caps
+        temp_charge_cap.append(caps[0])
+        temp_discharge_cap.append(caps[1])
+        carbon.append(pred.carbon_intensity.get(minute, 0) if pred.carbon_intensity else 0)
+        # Gas rate pre-scaled by iboost_gas_scale - mirrors prediction.py:719/725
+        gas_rate.append((pred.rate_gas.get(minute_absolute, 99) * pred.iboost_gas_scale) if pred.rate_gas else 0)
+        iboost_plan_load.append(in_iboost_slot(minute_absolute, pred.iboost_plan) if pred.iboost_plan else 0)
+        if num_cars > 0:
+            car_load, car_rate_slot = in_car_slot(minute_absolute, num_cars, pred.car_charging_slots)
+            for car_n in range(num_cars):
+                car_load_flat[car_n * n_steps + k] = car_load[car_n]
+                car_rate_flat[car_n * n_steps + k] = car_rate_slot[car_n]
+
+    # Raw power curve multipliers by SoC percent - mirrors utils.py get_curve_value
+    charge_curve = [get_curve_value(pred.battery_charge_power_curve, percent, 1.0) for percent in range(101)]
+    discharge_curve = [get_curve_value(pred.battery_discharge_power_curve, percent, 1.0) for percent in range(101)]
+
+    return (rate_import, rate_export, alert_keep, io_flag, pv, pv10, pv90, temp_charge_cap, temp_discharge_cap, carbon, gas_rate, iboost_plan_load, car_load_flat, car_rate_flat, charge_curve, discharge_curve)
+
+
+def create_kernel_context(pred, static_cache=None):
     """Build the per-plan static context for a Prediction object and hand it to the kernel.
 
     Returns the kernel context handle (>0) or 0 when the kernel is unavailable or
     the context could not be built; 0 means the Python engine will be used.
+
+    static_cache is an opt-in dict for a caller building several contexts that differ ONLY in their
+    load forecast - calculate_marginal_costs builds 28 such contexts, one per matrix cell. Passing
+    the same dict to each build computes the load-independent arrays once instead of 28 times, which
+    is nearly all of the work here. The contract is the caller's to keep: anything else that differs
+    between contexts sharing a cache - rates, PV, temperature, carbon, car slots - would be silently
+    taken from the first build. Callers with nothing to share pass nothing and get a full build.
     """
     lib = load_kernel(log=pred.log)
     if not lib:
@@ -413,54 +485,28 @@ def create_kernel_context(pred):
             return 0
         n_steps = forecast_minutes // PREDICT_STEP
 
-        rate_import = []
-        rate_export = []
-        alert_keep = []
-        io_flag = []
-        pv = []
+        # The load arrays are what a static_cache caller varies, so they are always rebuilt here
         load = []
-        pv10 = []
         load10 = []
-        pv90 = []
         load90 = []
-        temp_charge_cap = []
-        temp_discharge_cap = []
-        carbon = []
-        gas_rate = []
-        iboost_plan_load = []
-        car_load_flat = [0.0] * (num_cars * n_steps)
-        car_rate_flat = [0.0] * (num_cars * n_steps)
+        load_step = pred.load_minutes_step
+        load10_step = pred.load_minutes_step10
+        load90_step = pred.load_minutes_step90
         for k in range(n_steps):
             minute = k * PREDICT_STEP
-            minute_absolute = minute + minutes_now
-            rate_import.append(pred.rate_import.get(minute_absolute, 0))
-            rate_export.append(pred.rate_export.get(minute_absolute, 0))
-            alert_keep.append(pred.all_active_keep.get(minute_absolute, 0))
-            io_flag.append(1 if pred.io_adjusted.get(minute_absolute, 0) else 0)
-            pv.append(pred.pv_forecast_minute_step[minute])
-            load.append(pred.load_minutes_step[minute])
-            pv10.append(pred.pv_forecast_minute10_step[minute])
-            load10.append(pred.load_minutes_step10[minute])
-            pv90.append(pred.pv_forecast_minute90_step[minute])
-            load90.append(pred.load_minutes_step90[minute])
-            # Pre-compute the temperature rate cap base (before the min against the max rate,
-            # which the kernel applies per lookup) - mirrors utils.py find_battery_temperature_cap
-            battery_temperature = pred.battery_temperature_prediction.get(minute, pred.battery_temperature)
-            temp_charge_cap.append(find_battery_temperature_cap(battery_temperature, pred.battery_temperature_charge_curve, pred.soc_max, float("inf")))
-            temp_discharge_cap.append(find_battery_temperature_cap(battery_temperature, pred.battery_temperature_discharge_curve, pred.soc_max, float("inf")))
-            carbon.append(pred.carbon_intensity.get(minute, 0) if pred.carbon_intensity else 0)
-            # Gas rate pre-scaled by iboost_gas_scale - mirrors prediction.py:719/725
-            gas_rate.append((pred.rate_gas.get(minute_absolute, 99) * pred.iboost_gas_scale) if pred.rate_gas else 0)
-            iboost_plan_load.append(in_iboost_slot(minute_absolute, pred.iboost_plan) if pred.iboost_plan else 0)
-            if num_cars > 0:
-                car_load, car_rate_slot = in_car_slot(minute_absolute, num_cars, pred.car_charging_slots)
-                for car_n in range(num_cars):
-                    car_load_flat[car_n * n_steps + k] = car_load[car_n]
-                    car_rate_flat[car_n * n_steps + k] = car_rate_slot[car_n]
+            load.append(load_step[minute])
+            load10.append(load10_step[minute])
+            load90.append(load90_step[minute])
 
-        # Raw power curve multipliers by SoC percent - mirrors utils.py get_curve_value
-        charge_curve = [get_curve_value(pred.battery_charge_power_curve, percent, 1.0) for percent in range(101)]
-        discharge_curve = [get_curve_value(pred.battery_discharge_power_curve, percent, 1.0) for percent in range(101)]
+        # Keyed on the shape the arrays were built for, so a cache handed to a differently shaped
+        # Prediction rebuilds rather than returning arrays of the wrong length
+        shape = (n_steps, minutes_now, num_cars)
+        static = static_cache.get("arrays") if static_cache is not None else None
+        if static is None or static[0] != shape:
+            static = (shape, build_static_context_arrays(pred, n_steps, minutes_now, num_cars))
+            if static_cache is not None:
+                static_cache["arrays"] = static
+        (rate_import, rate_export, alert_keep, io_flag, pv, pv10, pv90, temp_charge_cap, temp_discharge_cap, carbon, gas_rate, iboost_plan_load, car_load_flat, car_rate_flat, charge_curve, discharge_curve) = static[1]
 
         ctx = PkContext()
         ctx.rate_import = double_array(rate_import)

--- a/apps/predbat/tests/test_kernel_static_cache.py
+++ b/apps/predbat/tests/test_kernel_static_cache.py
@@ -1,0 +1,135 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+"""Tests for the load-independent context cache shared by the marginal cost matrix.
+
+calculate_marginal_costs builds 28 Predictions that differ only in their load forecast, and each
+one used to rebuild the whole kernel context - 576 steps of rate, PV, carbon, temperature and car
+lookups that are identical every time. create_kernel_context now takes a static_cache the caller
+reuses across those builds.
+
+The cache is only sound while the caller's promise holds: everything except the load arrays is the
+same. The risk it introduces is precisely the opposite - a load array wrongly treated as static,
+so cell two silently answers with cell one's load. These tests build contexts both ways and require
+each cached one to match its own independent build, and require two different loads to still give
+different answers so a leak cannot hide behind coincidentally equal results.
+"""
+from prediction import Prediction
+from prediction_kernel import create_kernel_context, load_kernel
+from tests.test_infra import reset_inverter, reset_rates
+
+
+def run_kernel_static_cache_tests(my_predbat):
+    """Run the kernel static context cache tests"""
+    if not load_kernel():
+        print("**** kernel_static_cache: kernel unavailable, skipping ****")
+        return False
+    failed = False
+    failed |= test_cached_context_matches_an_independent_build(my_predbat)
+    failed |= test_different_loads_still_give_different_answers(my_predbat)
+    return failed
+
+
+def build_environment(my_predbat):
+    """Set up a predbat with a varying battery temperature so the temperature memo is exercised"""
+    reset_inverter(my_predbat)
+    my_predbat.forecast_minutes = 24 * 60
+    my_predbat.prediction_kernel_enable = True
+    my_predbat.battery_temperature = 20
+    my_predbat.soc_max = 10.0
+    my_predbat.soc_kw = 5.0
+    # Real rates, or every prediction costs 0.0 and the two loads compare equal - which would leave
+    # the leak test above unable to fail
+    reset_rates(my_predbat, 10.0, 5.0)
+    # A temperature that changes over the horizon, so a memo keyed on it has to key on the right thing
+    my_predbat.battery_temperature_prediction = {minute: max(20 - minute / (2 * 60.0), -5) for minute in range(0, my_predbat.forecast_minutes, 5)}
+
+    pv_step = {minute: 0.05 for minute in range(0, my_predbat.forecast_minutes, 5)}
+    return pv_step
+
+
+def make_load(my_predbat, base_load):
+    """A flat load profile at base_load kWh per 5 minute step"""
+    return {minute: base_load for minute in range(0, my_predbat.forecast_minutes, 5)}
+
+
+def run_one(my_predbat, pv_step, load_step, static_cache):
+    """Build a Prediction for this load and return its prediction result"""
+    prediction = Prediction(my_predbat, pv_step, pv_step, load_step, load_step)
+    prediction.kernel_handle = create_kernel_context(prediction, static_cache=static_cache)
+    if not prediction.kernel_handle:
+        return None
+    charge_window = [{"start": my_predbat.minutes_now + 60, "end": my_predbat.minutes_now + 120, "average": 10.0}]
+    export_window = [{"start": my_predbat.minutes_now + 180, "end": my_predbat.minutes_now + 240, "average": 15.0}]
+    return prediction.run_prediction([my_predbat.soc_max], charge_window, export_window, [100.0], False, my_predbat.forecast_minutes, save=None, cache=False)
+
+
+def test_cached_context_matches_an_independent_build(my_predbat):
+    """A context built from a shared cache matches one built entirely on its own.
+
+    The second cached build is the one that matters: its cache was primed by a different load, so if
+    the load were treated as static it would answer with the first load's profile.
+    """
+    print("**** test_cached_context_matches_an_independent_build ****")
+    failed = False
+    pv_step = build_environment(my_predbat)
+    low = make_load(my_predbat, 0.02)
+    high = make_load(my_predbat, 0.30)
+
+    fresh_low = run_one(my_predbat, pv_step, low, None)
+    fresh_high = run_one(my_predbat, pv_step, high, None)
+
+    shared = {}
+    cached_low = run_one(my_predbat, pv_step, low, shared)
+    cached_high = run_one(my_predbat, pv_step, high, shared)
+
+    if fresh_low is None or fresh_high is None or cached_low is None or cached_high is None:
+        print("ERROR: kernel context creation failed")
+        return True
+
+    if cached_low[:11] != fresh_low[:11]:
+        print("ERROR: cached low-load context differs from an independent build")
+        print("  cached {}".format(cached_low[:11]))
+        print("  fresh  {}".format(fresh_low[:11]))
+        failed = True
+    if cached_high[:11] != fresh_high[:11]:
+        print("ERROR: cached high-load context differs from an independent build - the cache leaked a load")
+        print("  cached {}".format(cached_high[:11]))
+        print("  fresh  {}".format(fresh_high[:11]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_different_loads_still_give_different_answers(my_predbat):
+    """Two loads sharing a cache must not collapse onto one answer.
+
+    Without this the leak test above could pass on a fixture where both loads happen to cost the
+    same, which would make it unable to fail.
+    """
+    print("**** test_different_loads_still_give_different_answers ****")
+    failed = False
+    pv_step = build_environment(my_predbat)
+    shared = {}
+    cached_low = run_one(my_predbat, pv_step, make_load(my_predbat, 0.02), shared)
+    cached_high = run_one(my_predbat, pv_step, make_load(my_predbat, 0.30), shared)
+
+    if cached_low is None or cached_high is None:
+        print("ERROR: kernel context creation failed")
+        return True
+
+    if cached_low[0] == cached_high[0]:
+        print("ERROR: a 15x load difference produced the same metric ({}), so a leaked load would be invisible here".format(cached_low[0]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed

--- a/apps/predbat/tests/test_minute_data_copy.py
+++ b/apps/predbat/tests/test_minute_data_copy.py
@@ -1,0 +1,145 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+"""Tests for when minute_data copies the history it is given.
+
+minute_data used to deep-copy every history list it was not explicitly allowed to modify, which
+on a plan cycle is ~150k deepcopy calls for the two calculate_yesterday calls alone. The only code
+that writes to history is the glitch filter, and that runs only for clean_increment and backwards,
+so the copy is now taken only when the filter can actually run.
+
+That makes "did it copy?" a behaviour worth pinning in both directions: no copy when nothing can be
+written, and the caller's data still untouched when the filter does run. A dict subclass counts its
+own deep copies so the first of those is observable rather than merely faster.
+"""
+from datetime import datetime
+
+import pytz
+
+from utils import minute_data
+
+UTC = pytz.UTC
+NOW = datetime(2024, 10, 4, 12, 5, 0, tzinfo=UTC)
+
+
+class CountingHistoryItem(dict):
+    """A history entry that records how many times it has been deep-copied"""
+
+    deepcopy_count = 0
+
+    def __deepcopy__(self, memo):
+        """Record the copy and return an independent duplicate"""
+        CountingHistoryItem.deepcopy_count += 1
+        duplicate = CountingHistoryItem(self)
+        memo[id(self)] = duplicate
+        return duplicate
+
+
+def glitch_history():
+    """History whose middle sample is a spike the glitch filter rewrites.
+
+    prev_prev=10, prev=50, value=11 satisfies every arm of the filter's test, so it rewrites the
+    50 sample down to 11 - which is the write the copy exists to keep away from the caller.
+    """
+    return [
+        CountingHistoryItem({"state": "10.0", "last_updated": "2024-10-04T11:00:00+00:00"}),
+        CountingHistoryItem({"state": "50.0", "last_updated": "2024-10-04T11:20:00+00:00"}),
+        CountingHistoryItem({"state": "11.0", "last_updated": "2024-10-04T11:40:00+00:00"}),
+        CountingHistoryItem({"state": "12.0", "last_updated": "2024-10-04T12:00:00+00:00"}),
+    ]
+
+
+def run_minute_data_copy_tests(my_predbat):
+    """Run the minute_data history copying tests"""
+    failed = False
+    failed |= test_no_copy_when_the_glitch_filter_cannot_run()
+    failed |= test_no_copy_when_clean_increment_is_not_backwards()
+    failed |= test_glitch_filter_does_not_write_to_the_callers_history()
+    failed |= test_can_modify_history_writes_through_to_the_caller()
+    return failed
+
+
+def test_no_copy_when_the_glitch_filter_cannot_run():
+    """With clean_increment off nothing can write to history, so it is not copied"""
+    print("**** test_no_copy_when_the_glitch_filter_cannot_run ****")
+    failed = False
+
+    history = glitch_history()
+    CountingHistoryItem.deepcopy_count = 0
+    minute_data(history=history, days=1, now=NOW, state_key="state", last_updated_key="last_updated", backwards=True, smoothing=False, clean_increment=False)
+
+    if CountingHistoryItem.deepcopy_count != 0:
+        print("ERROR: history was deep-copied {} times when the glitch filter could not run".format(CountingHistoryItem.deepcopy_count))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_no_copy_when_clean_increment_is_not_backwards():
+    """The glitch filter needs both clean_increment and backwards, so forward data is not copied"""
+    print("**** test_no_copy_when_clean_increment_is_not_backwards ****")
+    failed = False
+
+    history = glitch_history()
+    CountingHistoryItem.deepcopy_count = 0
+    minute_data(history=history, days=1, now=NOW, state_key="state", last_updated_key="last_updated", backwards=False, smoothing=False, clean_increment=True)
+
+    if CountingHistoryItem.deepcopy_count != 0:
+        print("ERROR: history was deep-copied {} times for a forward clean_increment run".format(CountingHistoryItem.deepcopy_count))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_glitch_filter_does_not_write_to_the_callers_history():
+    """When the filter does run it must rewrite a copy, leaving the caller's samples alone"""
+    print("**** test_glitch_filter_does_not_write_to_the_callers_history ****")
+    failed = False
+
+    history = glitch_history()
+    minute_data(history=history, days=1, now=NOW, state_key="state", last_updated_key="last_updated", backwards=True, smoothing=False, clean_increment=True)
+
+    states = [item["state"] for item in history]
+    expect = ["10.0", "50.0", "11.0", "12.0"]
+    if states != expect:
+        print("ERROR: the caller's history was modified, expected {} but got {}".format(expect, states))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_can_modify_history_writes_through_to_the_caller():
+    """can_modify_history is the caller promising it will not read the data again.
+
+    Pinned so that "always copy" cannot come back as a fix - the callers passing this flag do so to
+    avoid the copy, and the flag silently doing nothing would be invisible otherwise.
+    """
+    print("**** test_can_modify_history_writes_through_to_the_caller ****")
+    failed = False
+
+    history = glitch_history()
+    CountingHistoryItem.deepcopy_count = 0
+    minute_data(history=history, days=1, now=NOW, state_key="state", last_updated_key="last_updated", backwards=True, smoothing=False, clean_increment=True, can_modify_history=True)
+
+    if CountingHistoryItem.deepcopy_count != 0:
+        print("ERROR: history was copied {} times despite can_modify_history".format(CountingHistoryItem.deepcopy_count))
+        failed = True
+    if history[1]["state"] != 11.0:
+        print("ERROR: expected the glitch sample to be rewritten to 11.0 in place, got {}".format(history[1]["state"]))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed

--- a/apps/predbat/tests/test_optimise_export_copy.py
+++ b/apps/predbat/tests/test_optimise_export_copy.py
@@ -1,0 +1,111 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+"""Tests for how optimise_export copies the export window list it is given.
+
+optimise_export took a deepcopy of the whole export window list on entry - every window dict, on
+every call - which on the heaviest benchmark scenario was 2.5 million deepcopy calls and the single
+largest block of copying in a plan.
+
+It does not need one. The trial start is the only thing written, and _prepare_export already applies
+it copy-on-write: it takes its own list and replaces the one window it changes with dict(window,
+start=start). Nothing in optimise_export writes to a window dict at all, so a shallow list copy is
+enough to keep the caller from reordering the list underneath a pending batch.
+
+Both halves are pinned here: that no deep copy is taken, and that the caller's window dicts still
+come back untouched - the guarantee the deepcopy was there to provide.
+"""
+from tests.test_export_commitment import setup_single_export_window
+
+
+class CountingWindow(dict):
+    """An export window that records how many times it has been deep-copied"""
+
+    deepcopy_count = 0
+
+    def __deepcopy__(self, memo):
+        """Record the copy and return an independent duplicate"""
+        CountingWindow.deepcopy_count += 1
+        duplicate = CountingWindow(self)
+        memo[id(self)] = duplicate
+        return duplicate
+
+
+def run_optimise_export_copy_tests(my_predbat):
+    """Run the optimise_export window copying tests"""
+    failed = False
+    failed |= test_optimise_export_does_not_deepcopy_the_windows(my_predbat)
+    failed |= test_optimise_export_leaves_the_callers_windows_untouched(my_predbat)
+    return failed
+
+
+def build_windows(my_predbat):
+    """Set up a single-export-window scenario whose windows count their own deep copies"""
+    export_window_best, record_export_windows, end_record = setup_single_export_window(my_predbat)
+    windows = [CountingWindow(window) for window in export_window_best]
+    return windows, record_export_windows, end_record
+
+
+def test_optimise_export_does_not_deepcopy_the_windows(my_predbat):
+    """The export window list is copied shallowly, so the window dicts are not duplicated"""
+    print("**** test_optimise_export_does_not_deepcopy_the_windows ****")
+    failed = False
+
+    windows, record_export_windows, end_record = build_windows(my_predbat)
+    my_predbat.export_window_best = windows
+    my_predbat.charge_window_best = []
+    my_predbat.charge_limit_best = []
+
+    CountingWindow.deepcopy_count = 0
+    my_predbat.optimise_export(0, record_export_windows, [], [], windows, [0.0], end_record=end_record)
+
+    if CountingWindow.deepcopy_count != 0:
+        print("ERROR: optimise_export deep-copied the export windows {} times".format(CountingWindow.deepcopy_count))
+        failed = True
+
+    my_predbat.export_window_best = []
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_optimise_export_leaves_the_callers_windows_untouched(my_predbat):
+    """The caller's window dicts must come back exactly as they went in.
+
+    This is what the deepcopy was defending. _prepare_export now applies the trial start to its own
+    copy instead, so if that ever reverts to an in-place write this fails rather than silently
+    corrupting every other trial sharing the list.
+    """
+    print("**** test_optimise_export_leaves_the_callers_windows_untouched ****")
+    failed = False
+
+    windows, record_export_windows, end_record = build_windows(my_predbat)
+    my_predbat.export_window_best = windows
+    my_predbat.charge_window_best = []
+    my_predbat.charge_limit_best = []
+
+    before = [dict(window) for window in windows]
+    identities = [id(window) for window in windows]
+
+    my_predbat.optimise_export(0, record_export_windows, [], [], windows, [0.0], end_record=end_record)
+
+    after = [dict(window) for window in windows]
+    if after != before:
+        print("ERROR: optimise_export modified the caller's windows")
+        print("  before {}".format(before))
+        print("  after  {}".format(after))
+        failed = True
+    if [id(window) for window in windows] != identities:
+        print("ERROR: optimise_export replaced entries in the caller's window list")
+        failed = True
+
+    my_predbat.export_window_best = []
+    if not failed:
+        print("PASS")
+    return failed

--- a/apps/predbat/tests/test_window_selection.py
+++ b/apps/predbat/tests/test_window_selection.py
@@ -1,0 +1,187 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+"""Tests for select_window_candidates, the price-threshold window picker in plan.py.
+
+optimise_charge_limit_price_threads picks charge and export windows by walking a price-ordered
+candidate list and taking the first max_slots that qualify. The search tries many slot counts
+against the same threshold, so the picker is memoised on the unbounded selection and sliced per
+slot count. That is only sound because of the prefix property: capping at max_slots takes the
+first max_slots of the unbounded selection and nothing else. test_prefix_property_matches_capped_scan
+pins exactly that against a reference implementation of the original capped loop, so if a future
+change makes the cap interact with the dedup or the accept filter, it fails here rather than
+silently changing plans.
+"""
+from plan import select_window_candidates
+
+
+def run_window_selection_tests(my_predbat):
+    """Run the window selection picker tests"""
+    failed = False
+    failed |= test_takes_windows_passing_the_threshold_in_order()
+    failed |= test_skips_freeze_windows_when_freeze_not_allowed()
+    failed |= test_deduplicates_keeping_the_first_occurrence()
+    failed |= test_rejected_window_is_retried_on_a_later_entry()
+    failed |= test_prefix_property_matches_capped_scan()
+    return failed
+
+
+def capped_reference(entries, price_selected, allow_freeze, max_slots, accept=None):
+    """The original capped selection loop from optimise_charge_limit_price_threads.
+
+    Mirrors the predicate order of the export scan exactly - cap first, then dedup, then the
+    accept filter - so the prefix property is checked against what the optimiser used to do
+    rather than against a restatement of the new implementation.
+    """
+    chosen = []
+    mods = {}
+    count = 0
+    for price, window_n, freeze in entries:
+        if price_selected(price):
+            if freeze and not allow_freeze:
+                pass
+            elif count < max_slots and (window_n not in mods):
+                if accept is not None and not accept(window_n):
+                    pass
+                else:
+                    chosen.append(window_n)
+                    mods[window_n] = freeze
+                    count += 1
+    return chosen, mods
+
+
+def test_takes_windows_passing_the_threshold_in_order():
+    """Windows whose price passes the threshold are taken in candidate-list order"""
+    print("**** test_takes_windows_passing_the_threshold_in_order ****")
+    failed = False
+
+    entries = [[10.0, 0, False], [12.0, 1, False], [8.0, 2, False]]
+    # Charge side semantics: take everything at or below the loop price
+    got = select_window_candidates(entries, lambda price: 10.0 >= price, True)
+    expect = [(0, False), (2, False)]
+    if got != expect:
+        print("ERROR: expected {} but got {}".format(expect, got))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_skips_freeze_windows_when_freeze_not_allowed():
+    """A freeze candidate is only taken when freeze is enabled for this trial"""
+    print("**** test_skips_freeze_windows_when_freeze_not_allowed ****")
+    failed = False
+
+    entries = [[10.0, 0, True], [10.0, 1, False]]
+
+    got = select_window_candidates(entries, lambda price: True, False)
+    if got != [(1, False)]:
+        print("ERROR: freeze disabled should drop window 0, got {}".format(got))
+        failed = True
+
+    got = select_window_candidates(entries, lambda price: True, True)
+    if got != [(0, True), (1, False)]:
+        print("ERROR: freeze enabled should keep both, got {}".format(got))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_deduplicates_keeping_the_first_occurrence():
+    """A window listed twice is taken once, with the freeze flag of its first entry"""
+    print("**** test_deduplicates_keeping_the_first_occurrence ****")
+    failed = False
+
+    entries = [[10.0, 5, False], [11.0, 6, False], [12.0, 5, True]]
+    got = select_window_candidates(entries, lambda price: True, True)
+    expect = [(5, False), (6, False)]
+    if got != expect:
+        print("ERROR: expected {} but got {}".format(expect, got))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_rejected_window_is_retried_on_a_later_entry():
+    """The accept filter runs after the dedup check, so a window it rejects is not marked as seen.
+
+    The original loop only recorded accepted windows, so a rejected window was re-tested when it
+    appeared again. Recording rejects as seen would be a behaviour change, so it is pinned here.
+    """
+    print("**** test_rejected_window_is_retried_on_a_later_entry ****")
+    failed = False
+
+    calls = []
+
+    def accept(window_n):
+        """Reject window 7 the first time it is offered, accept it afterwards"""
+        calls.append(window_n)
+        return not (window_n == 7 and calls.count(7) == 1)
+
+    entries = [[10.0, 7, False], [11.0, 7, False]]
+    got = select_window_candidates(entries, lambda price: True, True, accept=accept)
+    if got != [(7, False)]:
+        print("ERROR: expected the second entry to be retried and taken, got {}".format(got))
+        failed = True
+    if calls != [7, 7]:
+        print("ERROR: expected the accept filter to be offered window 7 twice, got {}".format(calls))
+        failed = True
+
+    if not failed:
+        print("PASS")
+    return failed
+
+
+def test_prefix_property_matches_capped_scan():
+    """Capping at max_slots takes exactly the first max_slots of the unbounded selection.
+
+    This is the invariant the memoisation depends on: the optimiser slices one unbounded list per
+    price threshold instead of rescanning per slot count. Checked against capped_reference across
+    duplicate windows, freeze flags and a rejecting accept filter, since those are the three things
+    that could make the cap interact with the rest of the scan.
+    """
+    print("**** test_prefix_property_matches_capped_scan ****")
+    failed = False
+
+    entries = [
+        [5.0, 0, False],
+        [6.0, 1, True],
+        [7.0, 2, False],
+        [7.0, 0, True],
+        [8.0, 3, False],
+        [9.0, 4, True],
+        [10.0, 5, False],
+        [11.0, 2, False],
+        [12.0, 6, False],
+    ]
+
+    def reject_even(window_n):
+        """Reject window 4 so the accept filter is exercised inside the cap"""
+        return window_n != 4
+
+    for allow_freeze in (True, False):
+        for accept in (None, reject_even):
+            unbounded = select_window_candidates(entries, lambda price: 12.0 >= price, allow_freeze, accept=accept)
+            for max_slots in range(0, 10):
+                expect_chosen, expect_mods = capped_reference(entries, lambda price: 12.0 >= price, allow_freeze, max_slots, accept=accept)
+                sliced = unbounded[:max_slots]
+                got_chosen = [window_n for window_n, _ in sliced]
+                got_mods = dict(sliced)
+                if got_chosen != expect_chosen or got_mods != expect_mods:
+                    print("ERROR: freeze={} accept={} max_slots={} prefix gave {} / {} but capped scan gave {} / {}".format(allow_freeze, accept is not None, max_slots, got_chosen, got_mods, expect_chosen, expect_mods))
+                    failed = True
+
+    if not failed:
+        print("PASS")
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -100,6 +100,7 @@ from tests.test_web_annual import (
 )
 from tests.test_window import run_window_sort_tests, run_intersect_window_tests
 from tests.test_hit_charge_cache import run_hit_charge_cache_tests
+from tests.test_window_selection import run_window_selection_tests
 from tests.test_find_charge_rate import test_find_charge_rate, test_find_charge_rate_pv_overlap, test_find_charge_rate_string_temperature, test_find_charge_rate_string_charge_curve
 from tests.test_manual_api import run_test_manual_api
 from tests.test_manual_soc import run_test_manual_soc
@@ -429,6 +430,7 @@ def main():
         ("car_charging_smart", run_car_charging_smart_tests, "Car charging smart tests", False),
         ("intersect_window", run_intersect_window_tests, "Intersect window tests", False),
         ("hit_charge_cache", run_hit_charge_cache_tests, "Hit charge window cache tests", False),
+        ("window_selection", run_window_selection_tests, "Window selection picker tests", False),
         ("inverter_multi", run_inverter_multi_tests, "Inverter multi tests", False),
         ("octopus_free", test_octopus_free, "Octopus free electricity tests", False),
         ("battery_curve_keys", run_battery_curve_keys_tests, "Battery curve keys tests", False),

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -24,6 +24,7 @@ from tests.test_model import run_model_tests
 from tests.test_predict_pv_power import run_predict_pv_power_tests
 from tests.test_kernel_parity import run_kernel_parity_tests, run_model_kernel_tests
 from tests.test_prediction_batch import run_prediction_batch_tests
+from tests.test_kernel_static_cache import run_kernel_static_cache_tests
 from tests.test_execute import run_execute_tests
 from tests.test_load_car_energy import test_load_car_energy_warns_when_configured_entity_has_no_data
 from tests.test_octopus_slots import run_load_octopus_slots_tests
@@ -433,6 +434,7 @@ def main():
         ("intersect_window", run_intersect_window_tests, "Intersect window tests", False),
         ("hit_charge_cache", run_hit_charge_cache_tests, "Hit charge window cache tests", False),
         ("window_selection", run_window_selection_tests, "Window selection picker tests", False),
+        ("kernel_static_cache", run_kernel_static_cache_tests, "Kernel static context cache tests", False),
         ("inverter_multi", run_inverter_multi_tests, "Inverter multi tests", False),
         ("octopus_free", test_octopus_free, "Octopus free electricity tests", False),
         ("battery_curve_keys", run_battery_curve_keys_tests, "Battery curve keys tests", False),

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -110,6 +110,7 @@ from tests.test_minute_array import test_minute_array
 from tests.test_minute_data import test_minute_data, test_minute_data_load, test_minute_data_no_smoothing_backwards, test_minute_data_no_smoothing_forward
 from tests.test_minute_data_import_export import test_minute_data_import_export
 from tests.test_minute_data_state import test_minute_data_state
+from tests.test_minute_data_copy import run_minute_data_copy_tests
 from tests.test_format_time_ago import test_format_time_ago
 from tests.test_str2time import test_str2time
 from tests.test_override_time import test_get_override_time_from_string
@@ -323,6 +324,7 @@ def main():
         ("prune_today", test_prune_today, "Prune today tests", False),
         ("history_attribute", test_history_attribute, "History attribute tests", False),
         ("minute_data_state", test_minute_data_state, "Minute data state tests", False),
+        ("minute_data_copy", run_minute_data_copy_tests, "Minute data history copying tests", False),
         ("format_time_ago", test_format_time_ago, "Format time ago tests", False),
         ("str2time", test_str2time, "Time string parsing tests", False),
         ("override_time", test_get_override_time_from_string, "Override time from string tests", False),

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -56,6 +56,7 @@ from tests.test_trim_export import run_trim_export_tests
 from tests.test_plan_tiebreak import run_plan_tiebreak_tests
 from tests.test_plan_preclip import run_plan_preclip_tests
 from tests.test_export_commitment import run_export_commitment_tests
+from tests.test_optimise_export_copy import run_optimise_export_copy_tests
 from tests.test_energydataservice import run_energydataservice_tests
 from tests.test_iboost import run_iboost_smart_tests
 from tests.test_alert_feed import test_alert_feed
@@ -435,6 +436,7 @@ def main():
         ("hit_charge_cache", run_hit_charge_cache_tests, "Hit charge window cache tests", False),
         ("window_selection", run_window_selection_tests, "Window selection picker tests", False),
         ("kernel_static_cache", run_kernel_static_cache_tests, "Kernel static context cache tests", False),
+        ("optimise_export_copy", run_optimise_export_copy_tests, "Optimise export window copying tests", False),
         ("inverter_multi", run_inverter_multi_tests, "Inverter multi tests", False),
         ("octopus_free", test_octopus_free, "Octopus free electricity tests", False),
         ("battery_curve_keys", run_battery_curve_keys_tests, "Battery curve keys tests", False),

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -392,7 +392,11 @@ def minute_data(
     if not history:
         return mdata, io_adjusted
 
-    if not can_modify_history:
+    # The glitch filter below is the only code here that writes to history, and it only runs for
+    # backwards incrementing data, so that is the only case worth copying for. Copying regardless
+    # cost ~150k deepcopy calls on a plan cycle for the two calculate_yesterday calls alone, neither
+    # of which asks for the filter. can_modify_history stays the caller's explicit opt-out on top.
+    if clean_increment and backwards and not can_modify_history:
         history = copy.deepcopy(history)  # Copy to avoid modifying original history
 
     # Glitch filter, cleans glitches in the data and removes bad values, only for incrementing data

--- a/coverage/run_random_profile
+++ b/coverage/run_random_profile
@@ -1,2 +1,2 @@
 source setup.csh
-python3 ../apps/predbat/unit_test.py --random-profile --random-template cases/predbat_debug_agile1.yaml --random-scenarios random_scenarios.yaml --random-scenario 0 --random-profile-sort tottime --random-profile-lines 500 2>&1 | tee profile_cprofile.log
+python3 ../apps/predbat/unit_test.py --random-profile --random-template cases/predbat_debug_agile1.yaml --random-scenarios cases/random_scenarios.yaml --random-scenario 0 --random-profile-sort tottime --random-profile-lines 500 2>&1 | tee profile_cprofile.log


### PR DESCRIPTION
Four independent changes to the Python side of planning, which the previous round
([#4540](https://github.com/springfall2008/batpred/pull/4540) / [#4546](https://github.com/springfall2008/batpred/pull/4546)) left as ~88% of plan time. Each was found by profiling, each is
semantics-preserving, and every one is gated on the 20-scenario byte-identical comparison.

**Result: optimisation time over the 20-scenario suite goes from 26.13s to 20.15s, 22.9% faster, with every scenario producing an identical plan.**

## The measurement

`main` (2eb3466d) against this branch, interleaved rather than grouped, best of three, on a
16-core machine with the kernel confirmed active and batch-capable on both sides of every run.

| 20-scenario suite | `main` | this branch | change |
|---|---|---|---|
| Optimisation time (sum of per-scenario) | 26.130s | 20.149s | **22.9% faster** |
| id 6 (heaviest) | 5.741s | 4.036s | 29.7% faster |
| id 15 | 2.311s | 1.481s | 35.9% faster |
| id 2 | 1.530s | 0.889s | 41.9% faster |

**960 fields compared across three rounds of all 20 scenarios** — metric, cost, both PV futures,
final SoC, cycles and carbon — zero mismatches. The heaviest scenarios gain most, which is what
matters: ids 6 and 19 alone were 42% of suite runtime.

## What changed

### 1. Scan window candidates once per price threshold

`optimise_charge_limit_price_threads` sweeps four nested loops of slot counts and freeze flags
against each price threshold. The charge side was already memoised; the export side was not, so it
rescanned the whole `price_set_export` list — a few hundred entries — for every one of the ~900
combinations per threshold, for at most a couple of dozen distinct answers.

Both sides now scan once per `(threshold, freeze)` and every slot count is served by slicing that
one list. That is sound because of the **prefix property**: capping at `max_slots` takes exactly the
first `max_slots` of the unbounded selection, since the original cap was monotonic — once reached,
nothing further was ever taken. Slot counts at or above the candidate count therefore collapse onto
one cache entry instead of one per entry in the slot-length list.

Self time 607ms → 315ms on the profiled scenario.

### 2. Only copy `minute_data`'s history when the glitch filter can write to it

`minute_data` deep-copied every history list it was not explicitly told it could modify. The only
code in it that writes to history is the glitch filter, which runs solely for backwards incrementing
data — so every other caller paid for a copy nothing could use.

Measured on realistic Home Assistant history, the copy was **79-88% of the whole call**, so the
affected calls are now roughly twice as fast (20k entries: 54.8ms → 29.1ms). That lands on the
production fetch path, which the fixture-driven benchmark does not exercise.

### 3. Share the load-independent kernel context across the marginal cost matrix

`calculate_marginal_costs` builds 28 Predictions — four load levels across seven time offsets — that
differ only in their load forecast, and each rebuilt the entire kernel context: 576 steps of rate,
PV, carbon, temperature and car-slot lookups, 27 times for an answer already computed.

Profiling settled the approach: the whole cost is Python array building, and `pk_context_create` does
not register at all, **so no ABI change was needed**. `create_kernel_context` takes an opt-in
`static_cache`; only `calculate_marginal_costs` uses it, where "only the load differs" holds by
construction. The temperature caps are also memoised per distinct temperature, which helps every
context build including the main plan's.

`calculate_marginal_costs` 69ms → 25ms; `find_battery_temperature_cap` 17,856 calls → 3,471.

### 4. Stop deep-copying the export window list in `optimise_export`

`optimise_export` deep-copied the whole export window list on entry, on every one of its ~1000 calls
per plan — 2.5 million deepcopy calls on the heaviest scenario, the largest single block of copying
left in a plan.

It never needed one. Nothing in `optimise_export` writes to a window dict, and the only write on this
path — the trial start — is already applied copy-on-write by `_prepare_export` (since #4540). The
list is still copied, shallowly, so a caller cannot reorder it underneath a batch that has not
flushed.

## Tests

Every new test was verified by deliberately breaking what it guards and confirming the right one
fails:

- Caching the volatile export starts, or dropping the dedup, fails the prefix-property test — which
  is checked against a reference implementation of the original capped loop.
- Removing `minute_data`'s copy fails the test that the glitch filter must not write through to the
  caller. A dict subclass counts its own deep copies, so "no copy when nothing can be written" is a
  behaviour assertion rather than a timing one.
- Caching the load alongside the static kernel arrays — the exact bug that cache could introduce —
  makes cell two answer with cell one's load and fails both new tests.
- Making `_prepare_export` write the start in place corrupts the caller's window from 720 to 835 and
  fails the export-copy guard. That is the defect the copy-on-write was introduced to fix, now pinned
  rather than left to the next reader.

One test earned its keep immediately: a distinctness assertion caught the kernel-cache fixture having
no rates, so every prediction cost 0.0 and the equivalence test would have compared 0.0 against 0.0
and passed regardless of whether the cache leaked.

Alongside that: the full suite of 215 tests, pre-commit clean, and the 20-scenario byte-identical
gate re-run at every step.

## Also fixed

`coverage/run_random_profile` pointed at `random_scenarios.yaml` while `run_random` benchmarks
`cases/random_scenarios.yaml`. Those were **different files**, so every profile was taken against
different scenarios from every benchmark — and since the former was never committed, the script could
not run at all on a fresh clone. Now points at `cases/`.

## Relationship to #4536

[#4536](https://github.com/springfall2008/batpred/pull/4536) overlaps at one line: it changes the same
`optimise_export` deepcopy to `clone_windows`. Its stated rationale — that
`thread_run_prediction_export` writes the start in place — no longer holds on main, since #4540 moved
that to copy-on-write in `_prepare_export`, shared by both the threaded and batch paths. With no dict
mutated, the per-dict copies are unnecessary and a plain `list()` suffices.

#4536's window-bounds cache does not overlap with anything here and remains the stronger answer for
the prediction cache key; a version of that was explored on `perf/cache-key-window-memo` and parked
in its favour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)