### PR TITLE
fix(inverter): also skip the discharge target write on Hybrid Gen1/Gen2

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -29,6 +29,13 @@ from utils import calc_percent_limit, compute_window_minutes, dp0, dp1, dp2, dp3
 
 TIME_FORMAT_HMS = "%H:%M:%S"
 
+# GivTCP raw.invertor.model values confirmed not to support the Discharge_Target_SOC_1 register
+# (#4517). "Ac" (AC Coupled) and "Hybrid_gen1" are confirmed live - the latter on two separate
+# reporter inverters, still repeating the write every cycle post-fix until added here.
+# "Hybrid_gen2" is inferred from the same GivEnergy firmware-archive generational split
+# (github.com/DJBenson/giv-firmware), not independently confirmed on real Gen2 hardware yet.
+DISCHARGE_TARGET_UNSUPPORTED_MODELS = ("Ac", "Hybrid_gen1", "Hybrid_gen2")
+
 
 class Inverter:
     """Unified inverter control abstraction for multiple brands.
@@ -2527,16 +2534,13 @@ class Inverter:
         if force_export:
             target_soc = int(self.reserve_percent)
             if self.rest_data and self.rest_v3:
-                # AC Coupled inverters don't have a working Discharge_Target_SOC_1 register - GivTCP
-                # still reports a write as successful, but it never persists between cycles, so the
-                # caller sees a permanent mismatch and rewrites indefinitely (#4517). Confirmed
-                # against GivEnergy's own firmware archive (github.com/DJBenson/giv-firmware): "AC
-                # Coupled" is a single product line with exactly two firmware releases ever published
-                # (D212-A212, A214-D214) - not an early/late generational split the way Hybrid has
-                # Gen1/2/3 - so there's no newer AC-coupled variant this would need to keep working for.
+                # Some GivTCP inverter models don't have a working Discharge_Target_SOC_1 register -
+                # GivTCP still reports a write as successful, but it never persists between cycles, so
+                # the caller sees a permanent mismatch and rewrites indefinitely (#4517). See
+                # DISCHARGE_TARGET_UNSUPPORTED_MODELS above for what's confirmed vs inferred.
                 inverter_model = self.rest_data.get("raw", {}).get("invertor", {}).get("model", "")
-                if inverter_model == "Ac":
-                    self.log("Inverter {} is AC Coupled, discharge target register not supported, export target not written".format(self.id))
+                if inverter_model in DISCHARGE_TARGET_UNSUPPORTED_MODELS:
+                    self.log("Inverter {} is {}, discharge target register not supported, export target not written".format(self.id, inverter_model))
                 else:
                     current = self.rest_readDischargeTarget()
                     if current is None:

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -17,7 +17,7 @@ from utils import calc_percent_limit
 from tests.test_infra import TestHAInterface
 from predbat import PredBat
 from const import MINUTE_WATT, INVERTER_MAX_RETRY_REST
-from inverter import Inverter
+from inverter import Inverter, DISCHARGE_TARGET_UNSUPPORTED_MODELS
 
 
 def dummy_sleep(seconds):
@@ -1929,13 +1929,13 @@ def test_discharge_target_control_signal(test_name, ha, inv, dummy_rest):
 
 def test_discharge_target_skipped_for_ac_coupled(test_name, ha, inv, dummy_rest):
     """
-    Regression test for issue #4517: AC Coupled inverters (raw.invertor.model == "Ac") don't have a
-    working Discharge_Target_SOC_1 register - GivTCP reports a write as successful, but it never
-    persists between cycles, so the caller sees a permanent mismatch and rewrites indefinitely.
-    Confirmed against GivEnergy's own firmware archive: "AC Coupled" is a single product line with
-    only two firmware releases ever published, not an early/late generational split - so there's no
-    newer AC-coupled variant that would need this write to still happen. Skip it outright rather than
-    attempting a write already known to be doomed.
+    Regression test for issue #4517: some GivTCP inverter models (see
+    DISCHARGE_TARGET_UNSUPPORTED_MODELS) don't have a working Discharge_Target_SOC_1 register -
+    GivTCP reports a write as successful, but it never persists between cycles, so the caller sees a
+    permanent mismatch and rewrites indefinitely. "Ac" (AC Coupled) was confirmed first; "Hybrid_gen1"
+    was added after a reporter confirmed live, post-fix, that two of his Gen1 inverters still repeated
+    the write every cycle while a third, genuinely AC Coupled, correctly stopped. Skip outright rather
+    than attempting a write already known to be doomed.
     """
     failed = False
     print("Test: {}".format(test_name))
@@ -1959,18 +1959,22 @@ def test_discharge_target_skipped_for_ac_coupled(test_name, ha, inv, dummy_rest)
             "Timeslots": {"Discharge_start_time_slot_1": start_time, "Discharge_end_time_slot_1": end_time},
             "raw": {"invertor": {"discharge_target_soc_1": "4", "model": "Ac"}},
         }
-        dummy_rest.clear_queue()
-        dummy_rest.rest_data = copy.deepcopy(inv.rest_data)
 
-        inv.adjust_force_export(True, ts, te)
+        # Every model confirmed (or inferred - see the constant's own comment) unsupported must
+        # attempt no discharge-target REST commands at all.
+        for model in DISCHARGE_TARGET_UNSUPPORTED_MODELS:
+            inv.rest_data["raw"]["invertor"]["model"] = model
+            dummy_rest.clear_queue()
+            dummy_rest.rest_data = copy.deepcopy(inv.rest_data)
+            inv.adjust_force_export(True, ts, te)
+            commands = dummy_rest.get_commands()
+            if commands:
+                print("ERROR: {}: model={!r} should attempt no discharge-target REST commands, got {}".format(test_name, model, commands))
+                failed = True
 
-        commands = dummy_rest.get_commands()
-        if commands:
-            print("ERROR: {}: AC Coupled should attempt no discharge-target REST commands at all, got {}".format(test_name, commands))
-            failed = True
-
-        # A non-AC-Coupled model (or no model reported at all) must still attempt the write as before.
-        for model in ["Hybrid", ""]:
+        # A model not on the unsupported list (including a later Hybrid generation, or no model
+        # reported at all) must still attempt the write as before.
+        for model in ["Hybrid", "Hybrid_gen3", ""]:
             inv.rest_data["raw"]["invertor"]["model"] = model
             dummy_rest.clear_queue()
             dummy_rest.rest_data = copy.deepcopy(inv.rest_data)


### PR DESCRIPTION
## Summary

Follow-up to #4543 (merged), per @gcoan's live testing on #4517: his genuinely AC Coupled inverter correctly stopped attempting the discharge-target write after that fix, but two of his Hybrid Gen1 inverters on the same fleet kept repeating it every cycle - the exact original symptom, just on a different model.

Confirmed against the same GivEnergy firmware archive already used for the AC Coupled fix ([github.com/DJBenson/giv-firmware](https://github.com/DJBenson/giv-firmware)): Hybrid Gen1/Gen2/Gen3 are a real, distinct generational split (unlike "AC Coupled", which has no sub-generations) - only Gen3 supports `Discharge_Target_SOC_1`.

`"Hybrid_gen1"` is confirmed live on two separate reporter inverters. `"Hybrid_gen2"` is inferred from the same firmware-archive generational split, not yet independently confirmed on real Gen2 hardware - flagged as such directly in the code comment so it's easy to revisit if that turns out wrong.

## Test plan
- [x] Extended the existing regression test to cover both confirmed and inferred unsupported models, and confirm Hybrid Gen3 (and no model at all) still attempts the write as before
- [x] `./run_all --quick` passes
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)