### PR TITLE
fix: rate_min_base/rate_max_base computed from raw sparse fetch, not the gap-filled curve

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -976,9 +976,7 @@ class Fetch:
         # Replicate and scan import rates
         if import_rates:
             self.rate_scan(import_rates, print=False)
-            self.rate_max_base = self.rate_max  # True peak rate before saving sessions / overrides inflate it
-            self.rate_min_base = self.rate_min  # True off-peak rate before free sessions / overrides deflate it
-            self.rate_import_base, _ = self.rate_replicate(import_rates.copy(), {}, is_import=True)  # True import rates, gap-filled but without IO/saving/override distortion
+            self.rate_import_base, self.rate_min_base, self.rate_max_base = self.rate_base_min_max(import_rates)
             import_rates, self.rate_import_replicated = self.rate_replicate(import_rates, self.io_adjusted, is_import=True)
             self.rate_import_no_io = import_rates.copy()
             for car_n in range(self.num_cars):
@@ -1836,6 +1834,23 @@ class Fetch:
             rate_average /= rate_n
 
         return dp2(rate_min), dp2(rate_max), dp2(rate_average), rate_min_minute, rate_max_minute
+
+    def rate_base_min_max(self, rates):
+        """
+        Gap-fill `rates` into a "base" import curve (replicated, but without IO-slot/saving-session/
+        override distortion) and work out its true min/max.
+
+        Must scan the gap-filled curve, not the raw input: some tariffs (e.g. a fixed day/night
+        product fetched with a short forward window - #4544) only have the currently-active segment
+        in the raw data at fetch time, so a scan taken before replication can miss a cheaper/dearer
+        segment that hasn't started yet and lock in the wrong "true" min/max for the rest of the day.
+        rate_add_io_slots() then stamps IOG/SmartFlex dispatch slots with that stale value instead of
+        the tariff's real off-peak price. Mirrors how rate_export_base is already built downstream of
+        rate_replicate() on the export side.
+        """
+        rate_base, _ = self.rate_replicate(rates.copy(), {}, is_import=True)
+        rate_min_base, rate_max_base, _, _, _ = self.rate_minmax(rate_base)
+        return rate_base, rate_min_base, rate_max_base
 
     def rate_min_forward_calc(self, rates):
         """

--- a/apps/predbat/tests/test_rate_replicate_missing_slots.py
+++ b/apps/predbat/tests/test_rate_replicate_missing_slots.py
@@ -38,6 +38,7 @@ def test_rate_replicate(my_predbat):
         ("import_offset", _test_import_offset, "Import rate offset"),
         ("export_offset", _test_export_offset_negative, "Export rate offset with negative clamping"),
         ("gas_rates", _test_gas_rates, "Gas rates (is_gas=True)"),
+        ("rate_base_min_max", _test_rate_base_min_max, "rate_base_min_max reflects the gap-filled curve, not the raw sparse fetch (#4544)"),
     ]
 
     print("\n" + "="*70)
@@ -696,5 +697,84 @@ def _test_gas_rates(my_predbat):
     my_predbat.minutes_now = int((my_predbat.now_utc - my_predbat.midnight_utc).total_seconds() / 60)
     my_predbat.rate_max = 0
     my_predbat.forecast_minutes = 24*60
+
+    return failed
+
+
+def _test_rate_base_min_max(my_predbat):
+    """
+    Test for rate_base_min_max() reflecting the gap-filled forward curve, not a raw sparse fetch (#4544).
+
+    Reproduces a fixed day/night tariff (e.g. Kraken/E.ON Next Drive Smart) fetched with a short
+    forward window: at fetch time, only the currently-active (expensive, daytime) segment is known
+    forward of "now" - the cheaper night segment a few hours away hasn't been published yet. History
+    has the full repeating day/night pattern, so rate_replicate() can correctly project the true
+    night rate forward from it, but a scan of the raw, not-yet-replicated dict only ever sees the
+    known expensive segment.
+    """
+    failed = 0
+
+    print("*** Test: rate_base_min_max reflects the gap-filled curve, not the raw sparse fetch ***")
+
+    my_predbat.midnight = datetime.strptime("2025-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S")
+    my_predbat.forecast_minutes = 2880
+    my_predbat.minutes_now = 550  # 09:10 - inside the day segment, matching the reported scenario
+    my_predbat.metric_future_rate_offset_import = 0
+    my_predbat.metric_future_rate_offset_export = 0
+    my_predbat.future_energy_rates_import = {}
+    my_predbat.future_energy_rates_export = {}
+    my_predbat.rate_max = 99.0
+
+    day_rate = 31.18
+    night_rate = 8.0
+    day_start, night_start = 300, 1380  # 05:00, 23:00
+
+    rates = {}
+    # Full repeating day/night pattern for yesterday (minutes -1440..-1), so rate_replicate() has a
+    # real forward projection to draw on.
+    for minute in range(-1440, 0):
+        minute_of_day = minute % 1440
+        rates[minute] = night_rate if (minute_of_day >= night_start or minute_of_day < day_start) else day_rate
+
+    # Raw fetch only knows about the current segment (the whole day segment, since the tariff
+    # publishes each segment as a single valid_from/valid_to block) - nothing beyond it is known yet
+    # (mimicking a short forward-fetch window, e.g. Kraken's SmartFlex tariff data).
+    for minute in range(day_start, night_start):
+        rates[minute] = day_rate
+
+    assert night_start not in rates, "Test setup error: tonight's night segment should not be fetched yet"
+
+    # The raw, pre-replicate scan only sees the known expensive segment - this is the bug: taken at
+    # face value, it looks like the tariff never goes below day_rate.
+    raw_min, raw_max, _, _, _ = my_predbat.rate_minmax(rates)
+    if raw_min != day_rate or raw_max != day_rate:
+        print(f"  ✗ ERROR: Test setup error - raw scan should see only {day_rate}, got min={raw_min} max={raw_max}")
+        failed |= 1
+
+    rate_base, rate_min_base, rate_max_base = my_predbat.rate_base_min_max(rates)
+
+    if rate_min_base != night_rate:
+        print(f"  ✗ ERROR: rate_min_base should be {night_rate} (from the gap-filled forward night segment), got {rate_min_base} - this is the #4544 bug")
+        failed |= 1
+    else:
+        print(f"  ✓ rate_min_base correctly reflects the gap-filled night rate: {rate_min_base}")
+
+    if rate_max_base != day_rate:
+        print(f"  ✗ ERROR: rate_max_base should be {day_rate}, got {rate_max_base}")
+        failed |= 1
+    else:
+        print(f"  ✓ rate_max_base correctly reflects the day rate: {rate_max_base}")
+
+    if night_start not in rate_base or rate_base.get(night_start) != night_rate:
+        print(f"  ✗ ERROR: rate_base should have tonight's night segment gap-filled to {night_rate}, got {rate_base.get(night_start)}")
+        failed |= 1
+
+    # Restore context
+    my_predbat.now_utc = datetime.now(my_predbat.local_tz)
+    my_predbat.midnight_utc = my_predbat.now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+    my_predbat.midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    my_predbat.minutes_now = int((my_predbat.now_utc - my_predbat.midnight_utc).total_seconds() / 60)
+    my_predbat.rate_max = 0
+    my_predbat.forecast_minutes = 24 * 60
 
     return failed


### PR DESCRIPTION
## Summary

Fixes #4544 - Predbat charging the car at the "high" import rate instead of the tariff's real off-peak price.

- `rate_min_base`/`rate_max_base` were scanned from the raw import rate dict *before* `rate_replicate()` ran. For a tariff whose raw fetch only exposes the currently-active segment forward of "now" (confirmed via the reporter's debug.yaml: a fixed day/night Kraken/E.ON Next Drive Smart product, `rates_min` genuinely `8.0p` but `rate_min_base` locked at `31.18p`, equal to `rate_max_base`), the scan simply never saw the cheaper segment that hadn't started yet.
- `rate_add_io_slots()`'s `octopus_slot_low_rate=True` path stamps IOG/SmartFlex dispatch slots with `rate_min_base` as the "low" price - so those slots got priced at the tariff's peak rate instead, making the optimiser see no benefit to charging the battery during them.
- New `rate_base_min_max()` helper (`fetch.py`) replicates the raw rates first and scans the result, mirroring how `rate_export_base` is already built downstream of `rate_replicate()` on the export side (the export side never had this bug).

## Test plan

- [x] New `rate_base_min_max` sub-test added to `test_rate_replicate_missing_slots.py`, reproducing the reported tariff's raw-vs-gap-filled scan directly - fails on `main` (well, would, if `rate_base_min_max` existed there) and passes with the fix.
- [x] `./run_all --quick` - full suite green, including the random scenario regression (matches committed baseline across all 320 compared fields).
- [x] `./run_pre_commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)