### PR TITLE
fix(solis): initialise capacity_voltage_warned so publish_entities stops crashing

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.48.4"
+THIS_VERSION = "v8.48.5"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -334,6 +334,7 @@ class SolisAPI(ComponentBase, OAuthMixin):
 
         # Tracking
         self.slots_reset = set()  # Track which inverters had slots reset
+        self.capacity_voltage_warned = set()  # Inverters already warned about an estimated capacity voltage
 
         self.log(f"Solis API: Initialised with inverter_sn={self.configured_inverter_sn}, automatic={automatic}")
 

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -66,7 +66,6 @@ class MockSolisAPI(SolisAPI):
         # Cache structures
         self.cached_values = {}
         self.inverter_details = {}
-        self.storage_modes = {}
         self.parallel_battery_count = {}
         self.max_charge_current = {}
         self.max_discharge_current = {}
@@ -778,6 +777,30 @@ def test_solis_activated_with_api_key():
     return failed
 
 
+def test_initialize_attribute_parity_with_mock():
+    """Every attribute MockSolisAPI stubs must also be set by the real SolisAPI.initialize().
+
+    MockSolisAPI replaces __init__ wholesale, so an attribute added to the mock but forgotten in
+    the real initialize() passes every unit test here and then raises AttributeError against a
+    live inverter — which is exactly how capacity_voltage_warned shipped broken in #4502.
+    """
+    failed = False
+    # Attributes that exist only to drive the test harness and have no production counterpart.
+    test_only = {"_test_now_utc_exact", "log_messages", "dashboard_items", "read_and_write_cid_calls", "set_storage_mode_calls"}
+    component = _init_solis_component({"solis_api_key": "k", "solis_api_secret": "s"})
+    if component is None:
+        print("ERROR: Solis should activate with api_key + api_secret")
+        return True
+    mock_attrs = set(vars(MockSolisAPI()).keys()) - test_only
+    missing = sorted(attr for attr in mock_attrs if not hasattr(component, attr))
+    if missing:
+        print("ERROR: SolisAPI.initialize() does not set attributes stubbed by MockSolisAPI: {}".format(missing))
+        failed = True
+    if not failed:
+        print("PASSED: SolisAPI.initialize() sets every attribute MockSolisAPI stubs")
+    return failed
+
+
 def test_solis_activated_with_oauth_token():
     """Solis activates in OAuth mode when auth_method=oauth + access_token are configured (no api_key)."""
     failed = False
@@ -1018,6 +1041,7 @@ def run_solis_tests(my_predbat):
         failed |= test_solis_not_activated_without_credentials()
         failed |= test_solis_activated_with_api_key()
         failed |= test_solis_activated_with_oauth_token()
+        failed |= test_initialize_attribute_parity_with_mock()
         failed |= asyncio.run(test_oauth_execute_request_refreshes_before_call())
         failed |= asyncio.run(test_oauth_endpoint_namespace_translation())
         failed |= asyncio.run(test_oauth_execute_request_aborts_when_token_missing())


### PR DESCRIPTION
## Problem

Solis users are seeing:

```
Error: SolisAPI: 'SolisAPI' object has no attribute 'capacity_voltage_warned'
```

The update cycle aborts, so **no plan is produced at all** — Predbat keeps trying to calculate and never gets anywhere.

## Root cause

#4502 added a once-per-inverter warning for an estimated battery capacity voltage, guarded by `self.capacity_voltage_warned` (`solis.py:2314-2315`). That set was initialised in `MockSolisAPI.__init__` but **never in `SolisAPI.initialize()`**.

The guard sits on the fallback branch taken when `get_capacity_voltage()` returns `None` — i.e. whenever `solis_nominal_voltage` is not set in `apps.yaml`, which is the case for essentially every existing install. So the first `publish_entities()` run raises `AttributeError` and takes the cycle down with it.

## Why the tests didn't catch it

`MockSolisAPI` overrides `__init__` wholesale rather than calling the real one, so it happily stubbed the attribute the production path was missing. Every Solis test passed against a component that could not survive a single real poll.

## Fix

- `solis.py`: initialise `self.capacity_voltage_warned = set()` alongside the other tracking state in `initialize()`.
- `test_solis.py`: add `test_initialize_attribute_parity_with_mock()`, which builds the **real** component via the existing `_init_solis_component()` helper and asserts it sets every attribute `MockSolisAPI` stubs (minus an explicit test-harness allowlist). This fails CI for the whole class of mock/real divergence, not just this one attribute.
- `test_solis.py`: drop `storage_modes` from the mock — it is referenced nowhere in `solis.py`, so it only existed to be excluded from the new check.
- Version bump `v8.48.4` → `v8.48.5`.

## Verification

The new test was confirmed to fail before the fix for exactly the right reason:

```
ERROR: SolisAPI.initialize() does not set attributes stubbed by MockSolisAPI: ['capacity_voltage_warned', ...]
```

After the fix:

- `./run_all --test solis` — passes
- `./run_all --quick` — all tests pass, 20/20 random scenarios match baseline across 320 compared fields
- `./run_pre_commit` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)