### PR TITLE
perf(load_ml): assemble training features from sliding windows

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -26,6 +26,7 @@ armv
 ASHP
 asyncio
 atfork
+atleast
 authoriser
 autodocstring
 autoflake

--- a/apps/predbat/load_predictor.py
+++ b/apps/predbat/load_predictor.py
@@ -93,7 +93,7 @@ class WindowedFeatures:
     @property
     def dtype(self):
         """Element type of the assembled rows."""
-        return np.float32
+        return np.dtype(np.float32)
 
     def __array__(self, dtype=None, copy=None):
         """Materialise every row, for diagnostics and tests.
@@ -127,8 +127,14 @@ class WindowedFeatures:
             yield self._assemble(self.targets[start : start + block], buffer)
 
     def __getitem__(self, indices):
-        """Return the normalised feature rows for the given sample indices."""
-        target_chunks = self.targets[indices]
+        """Return the normalised feature rows for the given sample indices.
+
+        Accepts anything that indexes the target array. A scalar gives one row back as a
+        1-D array, matching what indexing the matrix this replaces would have returned.
+        """
+        target_chunks = np.atleast_1d(self.targets[indices])
+        scalar = np.ndim(self.targets[indices]) == 0
+
         rows = len(target_chunks)
         if self._scratch is None or len(self._scratch) < rows:
             self._scratch = np.empty((rows, TOTAL_FEATURES), dtype=np.float32)
@@ -136,7 +142,7 @@ class WindowedFeatures:
         if self.mean is not None and self.std is not None:
             batch -= self.mean
             batch /= self.std
-        return batch
+        return batch[0] if scalar else batch
 
 
 def relu(x):

--- a/apps/predbat/load_predictor.py
+++ b/apps/predbat/load_predictor.py
@@ -48,6 +48,97 @@ NUM_EXPORT_RATE_FEATURES = LOOKBACK_STEPS  # Historical export rates
 TOTAL_FEATURES = NUM_LOAD_FEATURES + NUM_PV_FEATURES + NUM_TEMP_FEATURES + NUM_IMPORT_RATE_FEATURES + NUM_EXPORT_RATE_FEATURES + NUM_TIME_FEATURES
 
 
+class WindowedFeatures:
+    """Training features assembled on demand from sliding windows over the source channels.
+
+    A feature row is five LOOKBACK_STEPS windows - load, PV, temperature, import and export -
+    followed by the target chunk's time features. Consecutive rows differ by one step, so a
+    materialised matrix stores every reading about LOOKBACK_STEPS times over: on 90 days of
+    history that is 66MB holding 0.5MB of distinct values.
+
+    Here each channel stays a dense 1-D array and numpy's sliding_window_view supplies the
+    windows as strides over it, costing nothing. Only the rows a batch actually needs are
+    assembled, into a buffer reused across batches. Rows are produced in ascending target
+    order and normalisation is applied as they are gathered, so a batch is identical to the
+    one the materialised path produced.
+    """
+
+    __slots__ = ["channels", "windows", "time_features", "targets", "mean", "std", "_scratch"]
+
+    def __init__(self, channels, time_features, targets):
+        """
+        Build the window views over dense channels.
+
+        :param channels: Dense per-chunk float32 arrays, in feature-block order.
+        :param time_features: Per-chunk time features, shape (chunks, NUM_TIME_FEATURES).
+        :param targets: Chunk indices that can produce a sample, ascending.
+        """
+        self.channels = channels
+        self.windows = [np.lib.stride_tricks.sliding_window_view(channel, LOOKBACK_STEPS) for channel in channels]
+        self.time_features = time_features
+        self.targets = targets
+        self.mean = None
+        self.std = None
+        self._scratch = None
+
+    def __len__(self):
+        """Number of samples available."""
+        return len(self.targets)
+
+    @property
+    def shape(self):
+        """Shape of the feature set, as if it had been materialised."""
+        return (len(self.targets), TOTAL_FEATURES)
+
+    @property
+    def dtype(self):
+        """Element type of the assembled rows."""
+        return np.float32
+
+    def __array__(self, dtype=None, copy=None):
+        """Materialise every row, for diagnostics and tests.
+
+        Training never calls this - the point of the class is that the full matrix is never
+        built - but making the conversion explicit keeps the object usable where a real
+        array is genuinely wanted.
+        """
+        out = np.empty((len(self.targets), TOTAL_FEATURES), dtype=np.float32)
+        self._assemble(self.targets, out)
+        if self.mean is not None and self.std is not None:
+            out -= self.mean
+            out /= self.std
+        return out.astype(dtype) if dtype is not None and dtype != np.float32 else out
+
+    def _assemble(self, target_chunks, out):
+        """Write the feature rows for the given target chunks into out."""
+        rows = len(target_chunks)
+        lookback_start = target_chunks + 1
+        offset = 0
+        for window in self.windows:
+            out[:rows, offset : offset + LOOKBACK_STEPS] = window[lookback_start]
+            offset += LOOKBACK_STEPS
+        out[:rows, offset:] = self.time_features[target_chunks]
+        return out[:rows]
+
+    def blocks(self, block=512):
+        """Yield un-normalised row blocks covering every sample, for fitting statistics."""
+        buffer = np.empty((min(block, len(self.targets)), TOTAL_FEATURES), dtype=np.float32)
+        for start in range(0, len(self.targets), block):
+            yield self._assemble(self.targets[start : start + block], buffer)
+
+    def __getitem__(self, indices):
+        """Return the normalised feature rows for the given sample indices."""
+        target_chunks = self.targets[indices]
+        rows = len(target_chunks)
+        if self._scratch is None or len(self._scratch) < rows:
+            self._scratch = np.empty((rows, TOTAL_FEATURES), dtype=np.float32)
+        batch = self._assemble(target_chunks, self._scratch)
+        if self.mean is not None and self.std is not None:
+            batch -= self.mean
+            batch /= self.std
+        return batch
+
+
 def relu(x):
     """ReLU activation function"""
     return np.maximum(0, x)
@@ -611,97 +702,71 @@ class LoadPredictor:
         # Validation window: most recent chunks (chunk_idx 0 … validation_end_chunk-1)
         validation_end_chunk = validation_holdout_hours * 60 // CHUNK_MINUTES
 
-        # Preallocate the feature matrices and write each sample straight into its row. Holding
-        # a Python list of per-sample arrays and then copying it into np.array() keeps both
-        # alive at once, which for a three week window is an extra 70MB on top of the 66MB
-        # matrix. Rows are sized for the maximum possible sample count and the filled prefix is
-        # returned; samples are only skipped where the history has gaps, so the slack is small.
-        max_train_rows = max(max_chunk_idx - LOOKBACK_STEPS, 0)
-        max_val_rows = max(validation_end_chunk, 0)
-        X_train_all = np.empty((max_train_rows, TOTAL_FEATURES), dtype=np.float32)
-        X_val_all = np.empty((max_val_rows, TOTAL_FEATURES), dtype=np.float32)
-        train_rows = 0
-        val_rows = 0
-        y_train_list = []
-        weight_list = []
-        y_val_list = []
+        # Build dense per-chunk channels and let sliding windows supply the feature rows.
+        # Materialising the matrix stores every reading about LOOKBACK_STEPS times over; the
+        # windows are strides over the channels and cost nothing, so only the rows a batch
+        # needs are ever assembled. Validation is a single small block and stays materialised.
+        n_chunks = max_chunk_idx + 1
+        channel_sources = (chunked_energy, chunked_pv, chunked_temp, chunked_import, chunked_export)
+        channels = []
+        for source_dict in channel_sources:
+            channel = np.zeros(n_chunks, dtype=np.float32)
+            for chunk_idx, value in source_dict.items():
+                if 0 <= chunk_idx < n_chunks:
+                    channel[chunk_idx] = value
+            channels.append(channel)
 
-        def _build_sample(target_chunk_idx, out_row):
-            """Write one sample's features into out_row and return its target, or None on a gap."""
-            lookback_start = target_chunk_idx + 1
-            lookback_values = []
-            pv_lookback_values = []
-            temp_lookback_values = []
-            import_rate_lookback = []
-            export_rate_lookback = []
+        # Time features for every chunk that could be a target
+        time_features = np.zeros((n_chunks, NUM_TIME_FEATURES), dtype=np.float32)
+        for chunk_idx in range(n_chunks):
+            target_time = now_utc - timedelta(minutes=alignment_offset + chunk_idx * CHUNK_MINUTES)
+            time_features[chunk_idx] = self._create_time_features(target_time.hour * 60 + target_time.minute, target_time.weekday(), target_time.timetuple().tm_yday)
 
-            for lb_offset in range(LOOKBACK_STEPS):
-                lb_idx = lookback_start + lb_offset
-                if lb_idx in chunked_energy:
-                    lookback_values.append(chunked_energy[lb_idx])
-                    pv_lookback_values.append(chunked_pv.get(lb_idx, 0.0))
-                    temp_lookback_values.append(chunked_temp.get(lb_idx, 0.0))
-                    import_rate_lookback.append(chunked_import.get(lb_idx, 0.0))
-                    export_rate_lookback.append(chunked_export.get(lb_idx, 0.0))
-                else:
-                    return None  # Gap in data - skip
+        # A sample needs its target chunk and the whole lookback window above it present.
+        # A rolling count over the presence mask finds those without probing each window.
+        present = np.zeros(n_chunks, dtype=bool)
+        for chunk_idx in chunked_energy:
+            if 0 <= chunk_idx < n_chunks:
+                present[chunk_idx] = True
+        counts = np.zeros(n_chunks + 1, dtype=np.int32)
+        np.cumsum(present, out=counts[1:])
 
-            if len(lookback_values) != LOOKBACK_STEPS:
-                return None
-            if target_chunk_idx not in chunked_energy:
-                return None
+        candidates = np.arange(0, max(max_chunk_idx - LOOKBACK_STEPS, 0), dtype=np.int64)
+        if len(candidates):
+            window_full = (counts[candidates + LOOKBACK_STEPS + 1] - counts[candidates + 1]) == LOOKBACK_STEPS
+            train_targets = candidates[window_full & present[candidates]]
+        else:
+            train_targets = candidates
 
-            target_value = chunked_energy[target_chunk_idx]
-
-            # Time features for the TARGET chunk midpoint
-            target_time = now_utc - timedelta(minutes=alignment_offset + target_chunk_idx * CHUNK_MINUTES)
-            minute_of_day = target_time.hour * 60 + target_time.minute
-            day_of_week = target_time.weekday()
-            day_of_year = target_time.timetuple().tm_yday
-            time_features = self._create_time_features(minute_of_day, day_of_week, day_of_year)
-
-            # Assigning the lists straight into row slices converts them in place, avoiding the
-            # five temporary arrays and the concatenated result this used to build per sample
-            offset = 0
-            for values in (lookback_values, pv_lookback_values, temp_lookback_values, import_rate_lookback, export_rate_lookback):
-                out_row[offset : offset + LOOKBACK_STEPS] = values
-                offset += LOOKBACK_STEPS
-            out_row[offset:] = time_features
-            return np.array([target_value], dtype=np.float32)
-
-        # Training samples: all available chunks
-        for target_chunk_idx in range(0, max_chunk_idx - LOOKBACK_STEPS):
-            target = _build_sample(target_chunk_idx, X_train_all[train_rows])
-            if target is None:
-                continue
-
-            train_rows += 1
-            y_train_list.append(target)
-
-            # Time-decay weighting (older samples get lower weight)
-            age_days = (alignment_offset + target_chunk_idx * CHUNK_MINUTES) / (24 * 60)
-            weight_list.append(np.exp(-age_days / time_decay_days))
-
-        # Validation samples: most recent validation_end_chunk chunks
-        for target_chunk_idx in range(0, validation_end_chunk):
-            target = _build_sample(target_chunk_idx, X_val_all[val_rows])
-            if target is None:
-                continue
-            val_rows += 1
-            y_val_list.append(target)
-
-        if not train_rows:
+        if not len(train_targets):
             return None, None, None, None, None
 
-        X_train = X_train_all[:train_rows]
-        y_train = np.array(y_train_list, dtype=np.float32)
-        train_weights = np.array(weight_list, dtype=np.float32)
+        energy = channels[0]
+        y_train = energy[train_targets].reshape(-1, 1).copy()
 
-        # Normalize weights to sum to number of samples
+        # Time-decay weighting (older samples get lower weight)
+        age_days = (alignment_offset + train_targets * CHUNK_MINUTES) / (24.0 * 60.0)
+        train_weights = np.exp(-age_days / time_decay_days).astype(np.float32)
         train_weights = train_weights * len(train_weights) / np.sum(train_weights)
 
-        X_val = X_val_all[:val_rows] if val_rows else None
-        y_val = np.array(y_val_list, dtype=np.float32) if y_val_list else None
+        X_train = WindowedFeatures(channels, time_features, train_targets)
+
+        # Validation: the most recent chunks, small enough to materialise
+        val_candidates = np.arange(0, validation_end_chunk, dtype=np.int64)
+        val_candidates = val_candidates[val_candidates < len(candidates)] if len(candidates) else val_candidates[:0]
+        if len(val_candidates):
+            val_full = (counts[val_candidates + LOOKBACK_STEPS + 1] - counts[val_candidates + 1]) == LOOKBACK_STEPS
+            val_targets = val_candidates[val_full & present[val_candidates]]
+        else:
+            val_targets = val_candidates
+
+        if len(val_targets):
+            X_val = np.empty((len(val_targets), TOTAL_FEATURES), dtype=np.float32)
+            X_train._assemble(val_targets, X_val)
+            y_val = energy[val_targets].reshape(-1, 1).copy()
+        else:
+            X_val = None
+            y_val = None
 
         return X_train, y_train, train_weights, X_val, y_val
 
@@ -850,6 +915,41 @@ class LoadPredictor:
         std = np.sqrt(squares / rows)
 
         return mean.astype(np.float32), std.astype(np.float32)
+
+    def _fit_windowed_normalisation(self, dataset, ema_alpha=0.0):
+        """
+        Fit per-feature normalisation statistics from a WindowedFeatures dataset.
+
+        Walks assembled row blocks rather than a materialised matrix, so the statistics are
+        the ones a full matrix would have produced without ever building one.
+
+        :param dataset: WindowedFeatures supplying the rows.
+        :param ema_alpha: If > 0 and statistics already exist, blend towards the new ones.
+        """
+        rows = len(dataset)
+        total = np.zeros(TOTAL_FEATURES, dtype=np.float64)
+        for block in dataset.blocks():
+            total += block.sum(axis=0, dtype=np.float64)
+        mean = total / rows
+
+        squares = np.zeros(TOTAL_FEATURES, dtype=np.float64)
+        for block in dataset.blocks():
+            deviation = block.astype(np.float64)
+            deviation -= mean
+            squares += np.square(deviation, out=deviation).sum(axis=0)
+        std = np.sqrt(squares / rows)
+
+        new_mean = mean.astype(np.float32)
+        new_std = np.maximum(std.astype(np.float32), self._get_min_std_array(TOTAL_FEATURES))
+
+        if ema_alpha > 0 and self.feature_mean is not None and self.feature_std is not None:
+            self.feature_mean = (ema_alpha * new_mean + (1 - ema_alpha) * self.feature_mean).astype(np.float32)
+            self.feature_std = (ema_alpha * new_std + (1 - ema_alpha) * self.feature_std).astype(np.float32)
+            self._log_normalization_stats(label="ema-update alpha={}".format(ema_alpha))
+        else:
+            self.feature_mean = new_mean
+            self.feature_std = new_std
+            self._log_normalization_stats(label="fit")
 
     def _get_min_std_array(self, n_features):
         """
@@ -1092,13 +1192,19 @@ class LoadPredictor:
         # Normalize features and targets
         # On initial train: fit normalization from scratch
         # On fine-tune: apply EMA update to track distribution drift gradually
+        # Statistics are fitted from assembled blocks and then applied as batches are
+        # gathered, which yields the same per-feature mean and std as normalising a
+        # materialised matrix would have done
         if is_initial or not self.model_initialized:
-            X_train_norm = self._normalize_features(X_train, fit=True, in_place=True)
+            self._fit_windowed_normalisation(X_train)
             y_train_norm = self._normalize_targets(y_train, fit=True)
         else:
-            X_train_norm = self._normalize_features(X_train, fit=False, ema_alpha=norm_ema_alpha, in_place=True)
+            self._fit_windowed_normalisation(X_train, ema_alpha=norm_ema_alpha)
             y_train_norm = self._normalize_targets(y_train, fit=False)
-            self.log("ML Predictor: Applied EMA normalization update (alpha={}) to track feature drift".format(norm_ema_alpha))
+        X_train.mean = self.feature_mean
+        X_train.std = self.feature_std
+        X_train_norm = X_train
+
         X_val_norm = self._normalize_features(X_val, fit=False, in_place=True)
         y_val_norm = self._normalize_targets(y_val, fit=False)
 

--- a/apps/predbat/tests/test_load_ml.py
+++ b/apps/predbat/tests/test_load_ml.py
@@ -449,6 +449,7 @@ def _test_dataset_with_pv():
 
     # Create dataset with PV data
     X_train, y_train, train_weights, X_val, y_val = predictor._create_dataset(load_data, now_utc, pv_minutes=pv_data, time_decay_days=7)
+    X_train = np.asarray(X_train)  # inspecting feature blocks by column needs the assembled rows
 
     # Should have valid samples
     assert X_train is not None, "Training X should not be None"
@@ -490,6 +491,7 @@ def _test_dataset_with_temp():
 
     # Create dataset with temperature data
     X_train, y_train, train_weights, X_val, y_val = predictor._create_dataset(load_data, now_utc, temp_minutes=temp_data, time_decay_days=7)
+    X_train = np.asarray(X_train)  # inspecting feature blocks by column needs the assembled rows
 
     # Should have valid samples
     assert X_train is not None, "Training X should not be None"

--- a/apps/predbat/tests/test_ml_memory.py
+++ b/apps/predbat/tests/test_ml_memory.py
@@ -306,6 +306,59 @@ def test_create_dataset_skips_gaps_in_the_history(my_predbat=None):
     return failed
 
 
+def test_windowed_features_indexes_like_an_array(my_predbat=None):
+    """The dataset must answer the indexing an array would, not just the batch case
+
+    Training only ever gathers with an index array, but the object stands in for the feature
+    matrix everywhere else - diagnostics, tests, anything reaching for a single row - so a
+    scalar index must give one row rather than raising.
+    """
+    print("\n=== Testing WindowedFeatures indexing ===")
+    failed = 0
+
+    load, pv, temp, imp, exp = _synthetic_history(days=5)
+    now = datetime(2026, 8, 17, 12, 0, 0, tzinfo=timezone.utc)
+    predictor = LoadPredictor(learning_rate=0.001)
+    X_train, y_train, weights, X_val, y_val = predictor._create_dataset(load, now, pv_minutes=pv, temp_minutes=temp, import_rates=imp, export_rates=exp, validation_holdout_hours=24)
+
+    if X_train is None:
+        print("ERROR: no dataset built")
+        return failed + 1
+
+    try:
+        row = X_train[0]
+    except Exception as exc:
+        print("ERROR: scalar index raised {}: {}".format(type(exc).__name__, exc))
+        return failed + 1
+
+    if np.shape(row) != (TOTAL_FEATURES,):
+        print("ERROR: scalar index gave shape {}, expected ({},)".format(np.shape(row), TOTAL_FEATURES))
+        failed += 1
+    else:
+        print("✓ scalar index gives a single row")
+
+    batch = X_train[np.array([0, 1])]
+    if not np.array_equal(batch[0], row):
+        print("ERROR: scalar and array indexing disagree on row 0")
+        failed += 1
+    else:
+        print("✓ scalar and array indexing agree")
+
+    if X_train.dtype != np.dtype(np.float32):
+        print("ERROR: dtype is {}, expected a float32 dtype".format(X_train.dtype))
+        failed += 1
+    else:
+        print("✓ dtype reports float32")
+
+    if X_train.shape != (len(X_train), TOTAL_FEATURES):
+        print("ERROR: shape {} disagrees with len {}".format(X_train.shape, len(X_train)))
+        failed += 1
+    else:
+        print("✓ shape agrees with len")
+
+    return failed
+
+
 def run_ml_memory_tests(my_predbat=None):
     """Run all ML training memory tests"""
     print("\n" + "=" * 80)
@@ -319,6 +372,7 @@ def run_ml_memory_tests(my_predbat=None):
     failed += test_create_dataset_output_is_stable(my_predbat)
     failed += test_fitted_statistics_are_accurate_on_large_datasets(my_predbat)
     failed += test_create_dataset_skips_gaps_in_the_history(my_predbat)
+    failed += test_windowed_features_indexes_like_an_array(my_predbat)
 
     print("\n" + "=" * 80)
     if failed == 0:

--- a/apps/predbat/tests/test_ml_memory.py
+++ b/apps/predbat/tests/test_ml_memory.py
@@ -196,7 +196,8 @@ def test_create_dataset_output_is_stable(my_predbat=None):
     # A checksum over the feature matrix catches any change in row content or ordering.
     # Recorded from the list-of-rows construction this replaced; if numpy ever changes its
     # summation this may need re-recording, but it must not move for a refactor.
-    checksum = float(np.sum(X_train.astype(np.float64)))
+    # X_train assembles rows on demand; materialise it explicitly for the checksum
+    checksum = float(np.sum(np.asarray(X_train).astype(np.float64)))
     expected_checksum = 12977609.094096
     if abs(checksum - expected_checksum) > abs(expected_checksum) * 1e-9:
         print("ERROR: feature matrix changed - checksum {:.6f}, expected {:.6f}".format(checksum, expected_checksum))

--- a/apps/predbat/tests/test_ml_training_perf.py
+++ b/apps/predbat/tests/test_ml_training_perf.py
@@ -168,27 +168,31 @@ def test_ml_training_runs_at_production_scale(my_predbat=None):
 
 
 def test_training_does_not_copy_the_dataset_per_epoch(my_predbat=None):
-    """Training must not hold whole extra copies of the feature matrix
+    """Training must not hold the feature matrix it would otherwise materialise
 
-    Drawing a full epoch of samples in one gather materialises a second matrix the size of
-    the dataset, and at the epoch boundary the previous one is still bound, so two live at
-    once. Gathering per batch keeps the working set to a batch. The budget is expressed
-    against the dataset size so it holds whatever history the fixture carries.
+    Every feature row is five sliding windows over five short channels plus time features,
+    so consecutive rows overlap in all but one value and a materialised matrix stores each
+    reading roughly LOOKBACK_STEPS times over. Assembling each batch from window views
+    keeps the working set to a batch. The budget is expressed against the size that matrix
+    would have been, so it holds whatever history the fixture carries.
     """
     print("\n=== Testing training working set ===")
     failed = 0
 
     val_mae, growth, samples, elapsed = measure_training(epochs=2)
     matrix_mb = samples * TOTAL_FEATURES * 4 / 1e6
-    budget = matrix_mb * 2.5
+    # Materialising the matrix costs it once for the dataset and again for the epoch
+    # gather, which put growth above 2x. Assembling per batch leaves the optimiser state
+    # and gradients as the largest items, well under it.
+    budget = matrix_mb * 2.0
 
-    print("dataset ~{:.1f} MB, growth {:.1f} MB ({:.2f}x), {:.1f}s".format(matrix_mb, growth, growth / matrix_mb, elapsed))
+    print("notional matrix ~{:.1f} MB, growth {:.1f} MB ({:.2f}x), {:.1f}s".format(matrix_mb, growth, growth / matrix_mb, elapsed))
 
     if growth > budget:
-        print("ERROR: growth {:.1f} MB exceeds {:.1f} MB ({:.1f}x the dataset) - the dataset is being copied per epoch".format(growth, budget, budget / matrix_mb))
+        print("ERROR: growth {:.1f} MB exceeds {:.1f} MB ({:.1f}x the notional matrix) - the matrix is being materialised".format(growth, budget, budget / matrix_mb))
         failed += 1
     else:
-        print("✓ working set within {:.1f}x the dataset".format(budget / matrix_mb))
+        print("✓ working set within {:.1f}x the notional matrix".format(budget / matrix_mb))
 
     if val_mae is None or not np.isfinite(val_mae):
         print("ERROR: training did not produce a usable result: {}".format(val_mae))


### PR DESCRIPTION
## The observation

A feature row is five `LOOKBACK_STEPS` windows — load, PV, temperature, import, export — plus the target's time features. Consecutive rows differ by **one step**, so a materialised matrix stores every reading ~288 times over:

```
feature matrix       :  65.9 MB   (11,386 x 1,446)
unique source values :   0.23 MB  (5 channels x ~11,674 readings)
redundancy           :  282x
```

## The change

Keep each channel as a dense 1-D array and let `np.lib.stride_tricks.sliding_window_view` supply the windows as **strides over it, costing nothing**. Assemble only the rows a batch needs, into a buffer reused across batches. The matrix is never built.

Three supporting pieces:

- **Sample selection.** A sample needs its target chunk and the whole lookback window above it. Previously found by probing each window per candidate; now a rolling count over a presence mask finds them in one pass. It selects the identical **11,386 targets in the same ascending order** on the fixture.
- **Statistics.** `_fit_windowed_normalisation` walks assembled row blocks rather than a matrix, producing the same **1,446 per-feature** mean/std. No collapse to coarser per-channel statistics, so no model change.
- **Normalisation** is applied as batches are gathered.

## Measured

Against the captured 90-day fixture, `val_mae` **bit-for-bit identical at every epoch count**:

| epochs | before | after | before | after |
|---|---|---|---|---|
| 2 | 162.2 MB | **99.5 MB** | 1.8s | **1.1s** |
| 30 | 169.1 MB | **105.5 MB** | 11.8s | **11.2s** |
| 100 | 165.4 MB | **102.6 MB** | 35.7s | **35.5s** |

**−38% memory and no slowdown.** A spike had predicted ~5% slower from normalising per batch instead of once; that cost is real (+4.6 ms/epoch) but building dense channels vectorised is cheaper than the per-sample row loop it replaces, and the two cancel.

At the new peak the feature matrix does not appear at all. The largest remaining item is `_adam_update`'s live temporaries at **37.9 MB (46%)** — which is where any further work belongs. Worth noting that is *live* memory during one update, distinct from Adam's churn across updates, which was separately measured as costing ~7 MB and is not worth chasing.

## Correctness

- `val_mae` bit-for-bit identical at 2, 30 and 100 epochs
- The `_create_dataset` characterisation test's **feature-matrix checksum is unchanged** (`12977609.094096`), so the assembled rows are bitwise identical to the materialised ones
- Same sample count, same ordering, same per-feature statistics

The dataset object reports `shape` and `dtype` and supports `np.asarray` for diagnostics and for the tests that inspect feature blocks by column. Training never converts it — two `test_load_ml` tests that slice columns now call `np.asarray` explicitly, so materialisation is visible at the call site.

## Testing

- `run_all --test load_ml` — 29/29 pass
- `run_all --test ml_memory` — checksum and sample count unchanged
- `run_all --test ml_training_perf` — working-set budget tightened from 2.5x to 2.0x the notional matrix; verified failing at 2.29x before this change, passing at 1.40x after
- `run_all --quick` — all tests pass, 20/20 random scenarios match baseline across 320 fields
- `run_pre_commit` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)