### PR TITLE
fix(web): floor daily_chart=False chart width at 600px, matching daily_chart=True

### DIFF
--- a/apps/predbat/tests/test_web_charts.py
+++ b/apps/predbat/tests/test_web_charts.py
@@ -116,6 +116,22 @@ def run_web_charts_tests(my_predbat):
         failed += 1
 
     # -------------------------------------------------------------------------
+    # daily_chart=False (Savings, BatteryDegradation, Tariff Comparison) computed width as
+    # window.innerWidth / 3 * 2 with no lower bound - on a phone-width HA Companion App webview
+    # (~400px) that renders a ~270px chart, too narrow to fit a title, dual Y-axis labels and a
+    # verbose legend without everything overlapping (#4561). daily_chart=True already has this
+    # floor; daily_chart=False needs the same one.
+    print("Test: render_chart(daily_chart=False) has the same minimum-width floor as daily_chart=True")
+    html_daily_true = web.render_chart(series_data, "%", "SoC Chart", now_str, tagname="chart_a", daily_chart=True)
+    html_daily_false = web.render_chart(series_data, "%", "Savings Chart", now_str, tagname="chart_b", daily_chart=False)
+    if "if (width < 600)" not in html_daily_true:
+        print("  ERROR: test setup assumption wrong - daily_chart=True no longer has the width floor")
+        failed += 1
+    if "if (width < 600)" not in html_daily_false:
+        print(f"  ERROR: render_chart(daily_chart=False) is missing the width < 600 floor that daily_chart=True has - narrow viewports get an unreadably small chart, got: {html_daily_false}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
     print("Test: render_timeline_chart() targets a percent-unit tagname via getElementById, not a CSS id selector")
     timeline_data = [{"name": "Status", "entity_id": "sensor.x", "data": {"2026-07-23T10:00:00+00:00": "on"}}]
     html = web.render_timeline_chart(timeline_data, "chart_%", 7)

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -1678,6 +1678,10 @@ var height = window.innerHeight;
 width = width / 3 * 2;
 height = height / 3 * 2;
 
+if (width < 600) {
+    width = 600
+}
+
 if (height * 1.68 > width) {
    height = width / 1.68;
 }


### PR DESCRIPTION
## Summary

Fixes #4561 - Charts tab Y-axis/legend labels overlap and render illegibly on narrow (phone-width) viewports, specifically in the HA Companion App on Android.

- `Savings` ("Cost Savings Analysis"), `BatteryDegradation`, and `Tariff Comparison` (both variants) all call `render_chart(..., daily_chart=False, ...)`.
- That path computes `width = window.innerWidth / 3 * 2` with no lower bound. On a phone-width webview (~400px CSS viewport), that's a ~270px chart - too narrow to fit a title, dual Y-axis titles/tick labels (both `Savings` and `BatteryDegradation` pass `extra_yaxis` for a second axis), and a two-line legend (`web.py`'s legend formatter renders `"<value> <unit> <br> <series name>"` per entry) without everything overlapping.
- The `daily_chart=True` path (used by every other chart - Battery SoC Prediction, Home Cost Prediction, Energy Rates, etc.) already has exactly this floor, for exactly this reason. `daily_chart=False` was just missing it.

Trade-off worth being upfront about: this doesn't make the chart shrink-to-fit - ApexCharts renders a fixed-size SVG, so a 600px-wide chart on a narrower screen means a horizontal scroll to see the rest, not true responsive scaling. That's the same trade-off the already-working `daily_chart=True` charts ship with today (no reports of those being cut off, only of these three overlapping), not a new one introduced here.

## Test plan
- [x] New test in `test_web_charts.py` confirming `daily_chart=False` now has the same `width < 600` floor as `daily_chart=True`
- [x] `./run_all --quick` passes
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)