### PR TITLE
feat(web): add live apps.yaml download from in-memory settings

### DIFF
--- a/apps/predbat/tests/test_web_if.py
+++ b/apps/predbat/tests/test_web_if.py
@@ -47,6 +47,9 @@ def run_test_web_if(my_predbat):
         my_predbat.components.start("web")
         ha = my_predbat.ha_interface
 
+        # Inject a fake credential so we can verify live apps.yaml masking below
+        my_predbat.args["octopus_api_key"] = "test_secret_value"
+
         # Define all registered endpoints from web.py
         # Format: (method, path)
         all_endpoints = [
@@ -70,6 +73,7 @@ def run_test_web_if(my_predbat):
             ("GET", "/debug_yaml"),
             ("GET", "/debug_log"),
             ("GET", "/debug_apps"),
+            ("GET", "/debug_apps_live"),
             ("GET", "/debug_plan"),
             ("GET", "/compare"),
             ("POST", "/compare"),
@@ -317,6 +321,17 @@ def run_test_web_if(my_predbat):
 
         if result != "on":
             print("ERROR: Compare tariffs not triggered - expected {} got {}".format("on", result))
+            failed = 1
+
+        print("\n**** Verifying live apps.yaml masking ****")
+        res = requests.get("http://127.0.0.1:5052/debug_apps_live")
+        if res.status_code != 200 or "test_secret_value" not in res.text:
+            print("ERROR: Unmasked /debug_apps_live did not contain the expected credential value")
+            failed = 1
+
+        res = requests.get("http://127.0.0.1:5052/debug_apps_live", params={"masked": "1"})
+        if res.status_code != 200 or "test_secret_value" in res.text or "xxx" not in res.text:
+            print("ERROR: Masked /debug_apps_live did not redact the expected credential value")
             failed = 1
 
         # Check endpoint coverage

--- a/apps/predbat/tests/test_web_if.py
+++ b/apps/predbat/tests/test_web_if.py
@@ -324,9 +324,16 @@ def run_test_web_if(my_predbat):
             failed = 1
 
         print("\n**** Verifying live apps.yaml masking ****")
+        # A bare request (no masked param) must default to masked - a direct/copied URL
+        # should never leak credentials without an explicit opt-in.
         res = requests.get("http://127.0.0.1:5052/debug_apps_live")
+        if res.status_code != 200 or "test_secret_value" in res.text or "xxx" not in res.text:
+            print("ERROR: Default /debug_apps_live request was not masked")
+            failed = 1
+
+        res = requests.get("http://127.0.0.1:5052/debug_apps_live", params={"masked": "0"})
         if res.status_code != 200 or "test_secret_value" not in res.text:
-            print("ERROR: Unmasked /debug_apps_live did not contain the expected credential value")
+            print("ERROR: Unmasked /debug_apps_live (masked=0) did not contain the expected credential value")
             failed = 1
 
         res = requests.get("http://127.0.0.1:5052/debug_apps_live", params={"masked": "1"})

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -19,7 +19,7 @@ service calls) to the appropriate handlers.
 
 import os
 from datetime import timedelta
-from utils import get_override_time_from_string
+from utils import get_override_time_from_string, mask_secret_args
 import json
 import yaml
 import re
@@ -774,11 +774,7 @@ class UserInterface:
                     pass
                 else:
                     if key == "args":
-                        # Remove keys from args
-                        debug[key] = copy.deepcopy(self.__dict__[key])
-                        for sub_key in debug[key]:
-                            if ("_key" in sub_key.lower()) or ("password" in sub_key.lower()):
-                                debug[key][sub_key] = "xxx"
+                        debug[key] = mask_secret_args(self.__dict__[key])
                     else:
                         debug[key] = self.__dict__[key]
         inverters_debug = []

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -83,6 +83,17 @@ class MinuteArray:
         return new
 
 
+def mask_secret_args(args):
+    """
+    Return a deep copy of an apps.yaml-style args dict with credential-like keys redacted.
+    """
+    masked = copy.deepcopy(args)
+    for key in masked:
+        if ("_key" in key.lower()) or ("password" in key.lower()):
+            masked[key] = "xxx"
+    return masked
+
+
 # Helper to make dict hashable for caching
 def charge_curve_to_tuple(d):
     """Convert dict to tuple for use as cache key"""

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -69,7 +69,7 @@ from web_helper import (
     get_dashboard_collapsible_js,
 )
 
-from utils import calc_percent_limit, str2time, dp0, dp2, dp4, format_time_ago, get_override_time_from_string, history_attribute, prune_today
+from utils import calc_percent_limit, str2time, dp0, dp2, dp4, format_time_ago, get_override_time_from_string, history_attribute, prune_today, mask_secret_args
 from const import TIME_FORMAT, TIME_FORMAT_DAILY, TIME_FORMAT_HA
 from predbat import THIS_VERSION
 from component_base import ComponentBase
@@ -2808,14 +2808,12 @@ chart.render();
         """
         Return an apps.yaml reconstructed from the live in-memory settings (self.args).
 
-        Pass ?masked=1 to redact credential-like keys, matching create_debug_yaml's masking rule.
+        Defaults to masking credential-like keys (see mask_secret_args) so a direct or
+        copied request never leaks secrets without an explicit opt-in; pass ?masked=0
+        to download the full unmasked file.
         """
-        masked = request.query.get("masked", "0") == "1"
-        args_copy = copy.deepcopy(self.args)
-        if masked:
-            for key in args_copy:
-                if ("_key" in key.lower()) or ("password" in key.lower()):
-                    args_copy[key] = "xxx"
+        masked = request.query.get("masked", "1") != "0"
+        args_copy = mask_secret_args(self.args) if masked else copy.deepcopy(self.args)
         yaml = YAML()
         buf = StringIO()
         yaml.dump({ROOT_YAML_KEY: args_copy}, buf)

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -454,6 +454,7 @@ class WebInterface(ComponentBase):
         app.router.add_get("/debug_yaml", self.html_debug_yaml)
         app.router.add_get("/debug_log", self.html_debug_log)
         app.router.add_get("/debug_apps", self.html_debug_apps)
+        app.router.add_get("/debug_apps_live", self.html_debug_apps_live)
         app.router.add_get("/debug_plan", self.html_debug_plan)
         app.router.add_get("/compare", self.html_compare)
         app.router.add_post("/compare", self.html_compare_post)
@@ -872,7 +873,7 @@ class WebInterface(ComponentBase):
         text += '<div style="flex: 1;">\n'
         text += "<h2>Debug</h2>\n"
         text += "<table>\n"
-        text += "<tr><td>Download</td><td><a href='./debug_apps'>apps.yaml</a></td></tr>\n"
+        text += "<tr><td>Download</td><td><a href='javascript:void(0)' onclick='downloadLiveApps()'>apps.yaml (live)</a> | <a href='./debug_apps'>apps.yaml (file)</a></td></tr>\n"
         text += "<tr><td>Create</td><td><a href='./debug_yaml'>predbat_debug.yaml</a></td></tr>\n"
         text += "<tr><td>Download</td><td><a href='./debug_log'>predbat.log</a></td></tr>\n"
         text += "<tr><td>Download</td><td><a href='./debug_plan'>predbat_plan.html</a></td></tr>\n"
@@ -2802,6 +2803,24 @@ chart.render();
 
     async def html_debug_apps(self, request):
         return await self.html_file_load("apps.yaml", as_file="apps.yaml.txt")
+
+    async def html_debug_apps_live(self, request):
+        """
+        Return an apps.yaml reconstructed from the live in-memory settings (self.args).
+
+        Pass ?masked=1 to redact credential-like keys, matching create_debug_yaml's masking rule.
+        """
+        masked = request.query.get("masked", "0") == "1"
+        args_copy = copy.deepcopy(self.args)
+        if masked:
+            for key in args_copy:
+                if ("_key" in key.lower()) or ("password" in key.lower()):
+                    args_copy[key] = "xxx"
+        yaml = YAML()
+        buf = StringIO()
+        yaml.dump({ROOT_YAML_KEY: args_copy}, buf)
+        filename = "apps_live_masked.yaml.txt" if masked else "apps_live.yaml.txt"
+        return await self.html_file(filename, buf.getvalue())
 
     async def html_debug_plan(self, request):
         html_plan = self.get_state_wrapper(entity_id=self.prefix + ".plan_html", attribute="html", default="<p>No plan available</p>")

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -7734,7 +7734,7 @@ function restartPredbat() {
 }
 
 function downloadLiveApps() {
-    if (confirm('Download apps.yaml with real credentials?\n\nOK = full unmasked file\nCancel = masked file (credentials redacted)')) {
+    if (confirm(`Download apps.yaml with real credentials?\\n\\nOK = full unmasked file\\nCancel = masked file (credentials redacted)`)) {
         window.location.href = './debug_apps_live?masked=0';
     } else {
         window.location.href = './debug_apps_live?masked=1';

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -7733,6 +7733,14 @@ function restartPredbat() {
     }
 }
 
+function downloadLiveApps() {
+    if (confirm('Download apps.yaml with real credentials?\n\nOK = full unmasked file\nCancel = masked file (credentials redacted)')) {
+        window.location.href = './debug_apps_live?masked=0';
+    } else {
+        window.location.href = './debug_apps_live?masked=1';
+    }
+}
+
 function toggleSwitch(element, fieldName) {
     // Toggle the active class
     element.classList.toggle('active');


### PR DESCRIPTION
## Summary
- Adds a second "apps.yaml (live)" download link on the dashboard's Debug table, alongside the existing file-based "apps.yaml (file)" download
- The live download reconstructs `apps.yaml` from the running Predbat's in-memory `self.args`, rather than reading the file off disk — useful for seeing/exporting the effective config including any changes made via the UI/API that haven't been saved to disk
- Clicking the link prompts (via a `confirm()` dialog) whether to download the full unmasked file or a masked copy with credential-like keys (`_key`, `password`) redacted to `xxx`, matching the existing `create_debug_yaml` masking rule

## Test plan
- [x] Added `("GET", "/debug_apps_live")` to the endpoint coverage list in `test_web_if.py`
- [x] Added a dedicated test block that injects a fake `octopus_api_key` into `self.args`, then verifies the unmasked download contains it and the `?masked=1` download redacts it to `xxx`
- [x] `./run_all --test web_if` passes
- [x] Scoped pre-commit hooks (ruff, black, cspell, whitespace) pass on changed files
- [x] Verified `random` scenario test failure in the quick suite is pre-existing on `main`, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)