### PR TITLE
fix(plan): split low-power charge windows at dawn, not window end

### DIFF
--- a/apps/predbat/const.py
+++ b/apps/predbat/const.py
@@ -52,6 +52,16 @@ MINUTE_WATT = 60 * 1000
 # which increases the cost of the plan over the full rate charge the planner costed the window at.
 LOW_POWER_PV_THRESHOLD = 0.1
 
+# Fraction of the peak forecast PV power above which a plan_interval_minutes bucket is classed as
+# "light" rather than "dark" when deciding where to split a charge window (calc_dawn). A charge window
+# otherwise built from a single long cheap-rate period spanning sunrise would apply LOW_POWER_PV_THRESHOLD
+# across the whole thing and abandon low power charging even for the still-dark hours before the sun is
+# up (#4557) - splitting at dawn keeps the dark portion as its own window, genuinely PV-free, so it stays
+# throttled. A fraction of that forecast's own peak, rather than a fixed Watts figure, scales with the
+# site - a fixed threshold picked for a typical system would be noise-level for a large array and
+# unreachable for a small one.
+LOW_POWER_PV_LIGHT_FRACTION = 0.1
+
 INVERTER_TEST = False  # Run inverter control self test
 
 # Create an array of times in the day in 5-minute intervals

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1617,7 +1617,7 @@ class Fetch:
         pv_light_dark = {pv_minute: bucket_light[pv_minute // interval] for pv_minute in self.pv_forecast_minute}
         return pv_light_dark
 
-    def find_charge_window(self, rates, minute, threshold_rate, find_high, alt_rates={}, pv_light_dark={}):
+    def find_charge_window(self, rates, minute, threshold_rate, find_high, alt_rates=None, pv_light_dark=None):
         """
         Find the charging windows based on the low rate threshold (percent below average)
 
@@ -1628,6 +1628,8 @@ class Fetch:
         light windows - see #4557, where low power charging was defeated for the whole window,
         including the still-dark hours, just because the window's tail overlapped PV later on.
         """
+        alt_rates = alt_rates or {}
+        pv_light_dark = pv_light_dark or {}
         rate_low_start = -1
         rate_low_end = -1
         rate_low_average = 0
@@ -1975,10 +1977,12 @@ class Fetch:
 
         return rate_min_forward
 
-    def rate_scan_window(self, rates, rate_low_min_window, threshold_rate, find_high, return_raw=False, alt_rates={}, pv_light_dark={}):
+    def rate_scan_window(self, rates, rate_low_min_window, threshold_rate, find_high, return_raw=False, alt_rates=None, pv_light_dark=None):
         """
         Scan for the next high/low rate window
         """
+        alt_rates = alt_rates or {}
+        pv_light_dark = pv_light_dark or {}
         minute = 0
         found_rates = []
         lowest = 99

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -20,7 +20,19 @@ dictionaries for use by the prediction engine.
 
 from datetime import datetime, timedelta
 from utils import minutes_to_time, str2time, dp1, dp2, dp3, dp4, time_string_to_stamp, minute_data, get_now_from_cumulative, MinuteArray
-from const import MINUTE_WATT, PREDICT_STEP, TIME_FORMAT, PREDBAT_MODE_OPTIONS, PREDBAT_MODE_CONTROL_SOC, PREDBAT_MODE_CONTROL_CHARGEDISCHARGE, PREDBAT_MODE_CONTROL_CHARGE, PREDBAT_MODE_MONITOR, LOAD_FORECAST_HISTORY_MAX_DAYS, PREDBAT_MAX_CARS
+from const import (
+    MINUTE_WATT,
+    PREDICT_STEP,
+    TIME_FORMAT,
+    PREDBAT_MODE_OPTIONS,
+    PREDBAT_MODE_CONTROL_SOC,
+    PREDBAT_MODE_CONTROL_CHARGEDISCHARGE,
+    PREDBAT_MODE_CONTROL_CHARGE,
+    PREDBAT_MODE_MONITOR,
+    LOAD_FORECAST_HISTORY_MAX_DAYS,
+    PREDBAT_MAX_CARS,
+    LOW_POWER_PV_LIGHT_FRACTION,
+)
 from predbat_metrics import metrics
 from futurerate import FutureRate
 from axle import fetch_axle_sessions, load_axle_slot, fetch_axle_active
@@ -1028,8 +1040,10 @@ class Fetch:
 
         # Find charging windows
         if self.rate_import:
+            pv_light_dark = self.calc_dawn() if self.set_charge_low_power else {}
+
             # Find charging window
-            self.low_rates, lowest, highest = self.rate_scan_window(self.rate_import, 5, self.rate_import_cost_threshold, False, alt_rates=self.rate_export)
+            self.low_rates, lowest, highest = self.rate_scan_window(self.rate_import, 5, self.rate_import_cost_threshold, False, alt_rates=self.rate_export, pv_light_dark=pv_light_dark)
             self.log("Low Import rate found rates in range {}{} to {}{}".format(lowest, curr, highest, curr))
             # Update threshold automatically
             if self.rate_low_threshold == 0 and highest >= self.rate_min:
@@ -1539,9 +1553,80 @@ class Fetch:
 
         return rates, replicated_rates
 
-    def find_charge_window(self, rates, minute, threshold_rate, find_high, alt_rates={}):
+    def calc_dawn(self):
+        """
+        Find dawn in self.pv_forecast_minute and return a pv_light_dark dict classifying each minute
+        as light (1, at/after dawn) or dark (0, before it). Used by find_charge_window to split a
+        charge window at the light/dark boundary rather than abandoning low power charging for a whole
+        window just because its tail overlaps the sun - see #4557.
+
+        Classified per plan_interval_minutes bucket (averaged), not per raw minute - a threshold
+        compared minute to minute would let ordinary forecast noise near the cutoff (e.g. a patchy dawn
+        hovering around the threshold) retrigger the split repeatedly and chop the window into several
+        small pieces. Bucketing makes the classification a step function that can change at most once
+        per bucket boundary, at the same granularity the plan already displays.
+
+        Within each calendar day, light is a one-way latch: the first bucket that crosses the threshold
+        confirms dawn, and every later bucket that day stays light too, even if PV genuinely dips back
+        under the threshold later (a cloud passing). This is a dawn detector, not a tracker of every
+        rise and fall - it only cares about finding the first dawn each day, so an intermittently
+        cloudy morning can't chop the window into several flip-flopping pieces. The latch resets at
+        each day boundary so the next day's dawn is found independently rather than one early crossing
+        holding "light" for the rest of the multi-day forecast horizon - this also makes a polar-night
+        day correctly stay all-dark (dawn never crosses) and a polar-day day correctly stay all-light
+        (crossed from the very first bucket).
+
+        The threshold itself is LOW_POWER_PV_LIGHT_FRACTION of the peak PV forecast anywhere in
+        self.pv_forecast_minute, not a fixed Watts figure, so it scales with the site rather than being
+        picked for a "typical" system size.
+
+        Built from whatever PV forecast is already in self.pv_forecast_minute, which at the point this
+        is called from fetch_sensor_data is up to one cycle stale (refreshed later this same loop by
+        fetch_pv_forecast()) - fine for a forecast that doesn't meaningfully change minute to minute.
+        """
+        pv_light_dark = {}
+        if not self.pv_forecast_minute:
+            return pv_light_dark
+
+        peak_pv = max(self.pv_forecast_minute.values())
+        if peak_pv <= 0:
+            return {pv_minute: 0 for pv_minute in self.pv_forecast_minute}
+
+        light_threshold = peak_pv * LOW_POWER_PV_LIGHT_FRACTION
+        interval = self.plan_interval_minutes
+        bucket_sums = {}
+        bucket_counts = {}
+        for pv_minute, pv in self.pv_forecast_minute.items():
+            bucket = pv_minute // interval
+            bucket_sums[bucket] = bucket_sums.get(bucket, 0.0) + pv
+            bucket_counts[bucket] = bucket_counts.get(bucket, 0) + 1
+        bucket_crossed = {bucket: (1 if (bucket_sums[bucket] / bucket_counts[bucket]) >= light_threshold else 0) for bucket in bucket_sums}
+
+        bucket_light = {}
+        after_dawn = False
+        current_day = None
+        for bucket in sorted(bucket_crossed):
+            bucket_day = (bucket * interval) // (24 * 60)
+            if bucket_day != current_day:
+                after_dawn = False
+                current_day = bucket_day
+            if bucket_crossed[bucket]:
+                after_dawn = True
+            bucket_light[bucket] = 1 if after_dawn else 0
+
+        pv_light_dark = {pv_minute: bucket_light[pv_minute // interval] for pv_minute in self.pv_forecast_minute}
+        return pv_light_dark
+
+    def find_charge_window(self, rates, minute, threshold_rate, find_high, alt_rates={}, pv_light_dark={}):
         """
         Find the charging windows based on the low rate threshold (percent below average)
+
+        pv_light_dark, when scanning for charge (not find_high) windows, is a minute-indexed dict of 0/1
+        marking whether PV forecast is at/after dawn ("light") or not ("dark") - see calc_dawn.
+        A transition between the two forces a window split, so a charge window that would otherwise
+        span sunrise (e.g. a single long cheap-rate period) is instead built as separate dark and
+        light windows - see #4557, where low power charging was defeated for the whole window,
+        including the still-dark hours, just because the window's tail overlapped PV later on.
         """
         rate_low_start = -1
         rate_low_end = -1
@@ -1550,6 +1635,8 @@ class Fetch:
         rate_low_count = 0
         alternate_rate_boundary = False
         alt_rate_last = None
+        pv_boundary = False
+        pv_light_dark_last = None
 
         # Work out alternate rate threshold
         alt_rate_max = max(alt_rates.values()) if alt_rates else 0
@@ -1563,6 +1650,13 @@ class Fetch:
             if (alt_rate is not None) and (alt_rate_last is not None) and (abs(alt_rate - alt_rate_last) >= alt_rate_threshold):
                 # Create alternate rate boundary if the rate is different
                 alternate_rate_boundary = True
+            pv_state = pv_light_dark.get(minute, None)
+            if (rate_low_start >= 0) and (pv_state is not None) and (pv_light_dark_last is not None) and (pv_state != pv_light_dark_last):
+                # Create a PV boundary when the light/dark classification changes since the window
+                # started. Gated on rate_low_start so a transition crossed only during the pre-window
+                # search phase (e.g. scanning past last night's sunset before this window is even
+                # found) doesn't leave a stale boundary that breaks the window the moment it starts.
+                pv_boundary = True
             if minute in rates:
                 rate = rates[minute]
                 if ((not find_high) and (rate <= threshold_rate)) or (find_high and (rate >= threshold_rate) and (rate > 0)) or (minute in self.manual_all_times) or (rate_low_start in self.manual_all_times):
@@ -1587,6 +1681,10 @@ class Fetch:
                         # Export slot can never be bigger than 4 hours
                         rate_low_end = minute
                         break
+                    if (not find_high) and (rate_low_start >= 0) and ((minute - rate_low_start) >= self.plan_interval_minutes) and pv_boundary:
+                        # Split a charge window where PV forecast crosses the light/dark threshold
+                        rate_low_end = minute
+                        break
                     if rate_low_start < 0:
                         rate_low_start = minute
                         rate_low_end = stop_at
@@ -1606,6 +1704,7 @@ class Fetch:
                     break
             minute += 5
             alt_rate_last = alt_rate
+            pv_light_dark_last = pv_state
 
         if rate_low_count:
             rate_low_average = dp2(rate_low_average / rate_low_count)
@@ -1876,7 +1975,7 @@ class Fetch:
 
         return rate_min_forward
 
-    def rate_scan_window(self, rates, rate_low_min_window, threshold_rate, find_high, return_raw=False, alt_rates={}):
+    def rate_scan_window(self, rates, rate_low_min_window, threshold_rate, find_high, return_raw=False, alt_rates={}, pv_light_dark={}):
         """
         Scan for the next high/low rate window
         """
@@ -1887,7 +1986,7 @@ class Fetch:
         upcoming_period = self.minutes_now + 4 * 60
 
         while True:
-            rate_low_start, rate_low_end, rate_low_average = self.find_charge_window(rates, minute, threshold_rate, find_high, alt_rates=alt_rates)
+            rate_low_start, rate_low_end, rate_low_average = self.find_charge_window(rates, minute, threshold_rate, find_high, alt_rates=alt_rates, pv_light_dark=pv_light_dark)
             window = {}
             window["start"] = rate_low_start
             window["end"] = rate_low_end

--- a/apps/predbat/tests/test_find_charge_window.py
+++ b/apps/predbat/tests/test_find_charge_window.py
@@ -34,6 +34,7 @@ def test_find_charge_window(my_predbat):
       Path D - manual_all_times slot split at plan_interval_minutes
       Path E - alt_rates alternate_rate_boundary terminates export window;
                also 24-hour export cap
+      Path J - pv_light_dark boundary splits a charge window (#4557)
       Path F - window start (rate_low_start set for first time)
       Path G - window continuation and correct average calculation
       Path H - rate outside threshold while window in progress → closes window
@@ -212,6 +213,42 @@ def test_find_charge_window(my_predbat):
     failed |= _assert_window("path E alt rate boundary", s, e, _, 0, 30)
 
     # -----------------------------------------------------------------------
+    # Test: Path J — pv_light_dark boundary splits a charge window at the light/dark
+    # transition (regression test for #4557: a single long cheap-rate period
+    # spanning sunrise was built as one charge window, which made low power
+    # charging get abandoned for the whole thing - including the still-dark
+    # hours - just because the tail overlapped PV later on).
+    # find_high=False; pv_light_dark goes dark (0) -> light (1) at minute 30;
+    # cheap import rate throughout; combine_charge_slots left True so only
+    # the pv_light_dark boundary - not charge_slot_split - is under test.
+    # -----------------------------------------------------------------------
+    print("Test find_charge_window: pv_light_dark boundary splits charge window (Path J)")
+    my_predbat.plan_interval_minutes = 30
+    my_predbat.combine_charge_slots = True
+    pv_light_dark_j = {}
+    for m in range(0, 30, 5):
+        pv_light_dark_j[m] = 0  # dark
+    for m in range(30, scan_end, 5):
+        pv_light_dark_j[m] = 1  # light
+
+    rates_j = {m: low_rate for m in range(0, scan_end, 5)}  # cheap throughout
+
+    s, e, _ = my_predbat.find_charge_window(rates_j, 0, thresh_lo, find_high=False, pv_light_dark=pv_light_dark_j)
+    failed |= _assert_window("path J pv boundary (dark window)", s, e, _, 0, 30)
+
+    # Scanning onward from the split should then pick up the light portion as its own window
+    s2, e2, _ = my_predbat.find_charge_window(rates_j, 30, thresh_lo, find_high=False, pv_light_dark=pv_light_dark_j)
+    if s2 != 30:
+        print("ERROR: path J pv boundary (light window): expected start=30, got start={}".format(s2))
+        failed = 1
+
+    # No pv_light_dark supplied at all → behaves exactly as before, one uninterrupted window
+    s3, e3, _ = my_predbat.find_charge_window(rates_j, 0, thresh_lo, find_high=False)
+    if e3 != scan_end:
+        print("ERROR: path J no pv_light_dark: expected window to run uninterrupted to {}, got end={}".format(scan_end, e3))
+        failed = 1
+
+    # -----------------------------------------------------------------------
     # Test: 24-hour export cap (Path E first condition)
     # find_high=True with high rates spanning >24h; window must cap at 24*60
     # -----------------------------------------------------------------------
@@ -315,4 +352,141 @@ def test_find_charge_window(my_predbat):
     my_predbat.charge_slot_split = old_charge_slot_split
     my_predbat.export_slot_split = old_export_slot_split
     my_predbat.plan_interval_minutes = old_plan_interval
+
+    failed |= test_calc_dawn(my_predbat)
+    return failed
+
+
+def test_calc_dawn(my_predbat):
+    """
+    Tests for calc_dawn (#4557): classifies pv_forecast_minute into light/dark buckets of
+    plan_interval_minutes, used to split a charge window at the light/dark boundary. Dawn is the first
+    bucket that crosses LOW_POWER_PV_LIGHT_FRACTION of the peak PV forecast anywhere in the dict.
+
+      - no PV forecast at all -> empty dict
+      - no PV output at all (every value zero) -> all dark, no divide-by-zero on a zero peak
+      - noise straddling the threshold within a single bucket does not flip that bucket's
+        classification (regression: a raw per-minute threshold would chop the window into several
+        small pieces on a noisy forecast)
+      - a clean dawn confirms immediately on the first bucket that crosses the threshold
+      - once confirmed, a later cloud dip (dark again) does not revert the latch - a dawn detector,
+        not a rise/fall tracker
+      - the latch resets at each calendar day boundary so the next day's dawn is found independently
+      - the same absolute PV value classifies differently depending on the peak elsewhere in the
+        forecast - the threshold is a fraction of that peak, not an absolute figure
+    """
+    failed = 0
+    old_pv_forecast_minute = my_predbat.pv_forecast_minute
+    old_plan_interval = my_predbat.plan_interval_minutes
+    old_low_power = my_predbat.set_charge_low_power
+    my_predbat.plan_interval_minutes = 30
+    my_predbat.set_charge_low_power = True
+
+    def set_buckets(bucket_values):
+        """Fill pv_forecast_minute with one value per plan_interval_minutes bucket, from minute 0."""
+        interval = my_predbat.plan_interval_minutes
+        my_predbat.pv_forecast_minute = {}
+        for bucket_index, value in enumerate(bucket_values):
+            for m in range(bucket_index * interval, bucket_index * interval + interval, 5):
+                my_predbat.pv_forecast_minute[m] = value
+
+    peak = 1.0  # an arbitrary "midday" peak somewhere in the forecast - threshold is 10% of this
+    light = peak * 0.15  # above the 10% threshold
+    dark = peak * 0.05  # below it
+    dawn_bucket_index = 2  # bucket where dawn happens in most scenarios below; peak sits after it
+
+    print("Test calc_dawn: no PV forecast")
+    my_predbat.pv_forecast_minute = {}
+    result = my_predbat.calc_dawn()
+    if result != {}:
+        print("ERROR: calc_dawn: expected empty dict for no PV forecast, got {}".format(result))
+        failed = 1
+
+    print("Test calc_dawn: no PV output at all classifies everything dark, no divide-by-zero")
+    set_buckets([0.0, 0.0, 0.0])
+    result = my_predbat.calc_dawn()
+    if any(v != 0 for v in result.values()):
+        print("ERROR: calc_dawn: an all-zero forecast should classify everything dark, got {}".format(result))
+        failed = 1
+
+    print("Test calc_dawn: noise straddling the threshold within one bucket stays stable")
+    my_predbat.pv_forecast_minute = {}
+    # Average across the bucket is just below threshold, but individual minutes swing both sides of
+    # it - a raw per-minute comparison would flip-flop within this single bucket. A late peak bucket
+    # establishes what "threshold" means without affecting the noisy bucket's own average.
+    noisy_values = [dark * 1.3, dark * 0.6, dark * 1.2, dark * 0.5, dark * 0.9, dark * 0.7]
+    for i, m in enumerate(range(0, 30, 5)):
+        my_predbat.pv_forecast_minute[m] = noisy_values[i]
+    my_predbat.pv_forecast_minute[30] = peak
+    result = my_predbat.calc_dawn()
+    classifications = {result[m] for m in range(0, 30, 5)}
+    if len(classifications) != 1:
+        print("ERROR: calc_dawn: noisy bucket should have a single stable classification, got {}".format({m: result[m] for m in range(0, 30, 5)}))
+        failed = 1
+
+    print("Test calc_dawn: clean dawn confirms immediately on the first crossed bucket")
+    set_buckets([dark, dark, light, peak])
+    result = my_predbat.calc_dawn()
+    if result.get(0) != 0 or result.get(30) != 0:
+        print("ERROR: calc_dawn: dark buckets before dawn should classify 0, got {}".format({m: result.get(m) for m in (0, 30)}))
+        failed = 1
+    if result.get(dawn_bucket_index * 30) != 1:
+        print("ERROR: calc_dawn: first crossed bucket should confirm dawn immediately, got {}".format(result.get(dawn_bucket_index * 30)))
+        failed = 1
+
+    print("Test calc_dawn: a later cloud dip after confirmed dawn stays latched light")
+    set_buckets([dark, dark, light, dark, light, peak])
+    result = my_predbat.calc_dawn()
+    if result.get(60) != 1:
+        print("ERROR: calc_dawn: dawn should be confirmed at minute 60, got {}".format(result.get(60)))
+        failed = 1
+    if result.get(90) != 1:
+        print("ERROR: calc_dawn: bucket after a cloud dip should stay latched at 1, got {}".format(result.get(90)))
+        failed = 1
+    if result.get(120) != 1:
+        print("ERROR: calc_dawn: bucket after the dip should classify 1, got {}".format(result.get(120)))
+        failed = 1
+
+    print("Test calc_dawn: latch resets at the next calendar day boundary")
+    my_predbat.pv_forecast_minute = {}
+    day_minutes = 24 * 60
+    # Day 1: dawn at minute 60, light for the rest of the day.
+    for m in range(0, day_minutes, 5):
+        my_predbat.pv_forecast_minute[m] = light if m >= 60 else dark
+    my_predbat.pv_forecast_minute[day_minutes - 30] = peak
+    # Day 2: dark again until its own dawn at minute 90 into the day.
+    for m in range(day_minutes, day_minutes + 150, 5):
+        my_predbat.pv_forecast_minute[m] = light if (m - day_minutes) >= 90 else dark
+    result = my_predbat.calc_dawn()
+    if result.get(day_minutes - 5) != 1:
+        print("ERROR: calc_dawn: end of day 1 should still be latched light, got {}".format(result.get(day_minutes - 5)))
+        failed = 1
+    if result.get(day_minutes) != 0:
+        print("ERROR: calc_dawn: start of day 2 should reset to dark, got {}".format(result.get(day_minutes)))
+        failed = 1
+    if result.get(day_minutes + 60) != 0:
+        print("ERROR: calc_dawn: day 2 should stay dark before its own dawn, got {}".format(result.get(day_minutes + 60)))
+        failed = 1
+    if result.get(day_minutes + 90) != 1:
+        print("ERROR: calc_dawn: day 2 should reach its own dawn at minute 90, got {}".format(result.get(day_minutes + 90)))
+        failed = 1
+
+    print("Test calc_dawn: threshold scales with the forecast's own peak, not an absolute figure")
+    fixed_pv_value = 0.5
+    # Against a high peak, fixed_pv_value is well under 10% and should stay dark.
+    set_buckets([fixed_pv_value, 10.0])
+    result = my_predbat.calc_dawn()
+    if result.get(0) != 0:
+        print("ERROR: calc_dawn: {}kWh/min should be dark against a peak of 10.0, got {}".format(fixed_pv_value, result.get(0)))
+        failed = 1
+    # Against a low peak, the same fixed_pv_value comfortably exceeds 10% and should be light.
+    set_buckets([fixed_pv_value, 1.0])
+    result = my_predbat.calc_dawn()
+    if result.get(0) != 1:
+        print("ERROR: calc_dawn: {}kWh/min should be light against a peak of 1.0, got {}".format(fixed_pv_value, result.get(0)))
+        failed = 1
+
+    my_predbat.pv_forecast_minute = old_pv_forecast_minute
+    my_predbat.plan_interval_minutes = old_plan_interval
+    my_predbat.set_charge_low_power = old_low_power
     return failed


### PR DESCRIPTION
## Summary

Fixes #4557: a charge window built from a single long cheap-rate period spanning sunrise (e.g. 03:00-10:00) was treated as one window by `find_charge_rate`'s PV-overlap check (#4373), which abandons low power charging for the *whole* window the moment any PV is forecast in it - including the still-dark hours before sunrise.

- Adds `calc_dawn` (`fetch.py`): classifies each `plan_interval_minutes` bucket as PV-light or PV-dark, and `find_charge_window` now splits charge windows at that boundary (new `pv_light_dark` param), reusing the same mechanism already used for export windows' `alternate_rate_boundary`. The dark portion now stays low power throughout; the light portion keeps today's existing behaviour.
- Dawn is the first bucket that crosses `LOW_POWER_PV_LIGHT_FRACTION` (10%) of the peak PV forecast anywhere in the horizon - a fraction of the forecast's own peak rather than a fixed Watts figure, so the same threshold is meaningful whether the system is 2kWp or 15kWp.
- Within a calendar day it's a one-way latch: once crossed, later buckets stay light even if PV genuinely dips back under the threshold (a cloud passing), so an intermittently cloudy morning can't chop the window into several flip-flopping pieces. The latch resets at each day boundary, which also makes it behave correctly at extreme latitudes - a polar-night day never crosses (stays all-dark) and a polar-day day crosses from the first bucket (stays all-light).
- No dusk-side equivalent needed: the PV-overlap check is a forward sum from "now" to window end, recomputed every loop, so it already self-corrects once a light patch is behind it - the false-trigger-then-never-corrects failure mode this fix addresses only exists in the dawn direction.

Verified throughout against the #4557 reporter's own debug.yaml - the real 03:00-10:00 window splits cleanly at the actual crossing point, using that household's own forecast peak.

## Test plan

- [x] New `test_calc_dawn` covering: no forecast, all-zero forecast, within-bucket noise stability, first-crossing confirmation, cloud-dip latching, day-boundary reset, and threshold scaling with the forecast's own peak
- [x] New `find_charge_window` regression test (Path J) covering the light/dark boundary split
- [x] Full quick suite (`./run_all --quick`) passes
- [x] `./run_pre_commit` clean
- [x] Replayed against the #4557 reporter's actual `debug.yaml` before and after - confirms the real 03:00-10:00 window now splits cleanly at the dawn crossing point

🤖 Generated with [Claude Code](https://claude.com/claude-code)