### PR TITLE
fix(sunsynk): corrections from the first live read-only spike

### DIFF
--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -684,7 +684,11 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
     def build_tou_slots(self, schedule, current_soc):
         """Build exactly TOU_SLOT_COUNT ordered slots covering 24h from the schedule windows.
 
-        Slots are sequential intervals, so every start time must be distinct and ascending.
+        Slots are sequential intervals ("from this start until the next slot's start") and
+        Sunsynk documents that they MUST be set chronologically, so every start is written
+        distinct and ascending. A slot is an interval whatever its grid-charge flag says,
+        which is what lets a filler slot terminate the charge window before it.
+
         Segment boundaries are collected from a 00:00 self-use baseline plus each enabled
         window's start (its action) and end (back to self-use), then padded with fillers
         and trimmed to the earliest, most imminent TOU_SLOT_COUNT.

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -635,14 +635,19 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             export_soc = int(export.get("soc", FREEZE_EXPORT_SOC))
             behaviour = "freeze_export" if export_soc >= FREEZE_EXPORT_SOC else "export"
             slot_soc = FREEZE_EXPORT_SOC if export_soc >= FREEZE_EXPORT_SOC else export_soc
-            return {"behaviour": behaviour, "work_mode": SUNSYNK_WORKMODE["selling_first"], "grid_charge": False, "solar_sell": True, "slot_soc": slot_soc, "power": int(export.get("power", 0))}
+            # Zero power IS the freeze: selling-first with no power holds the battery while
+            # surplus solar still exports.
+            power = 0 if behaviour == "freeze_export" else int(export.get("power", 0))
+            return {"behaviour": behaviour, "work_mode": SUNSYNK_WORKMODE["selling_first"], "grid_charge": False, "solar_sell": True, "slot_soc": slot_soc, "power": power}
 
         if charge.get("enable"):
             charge_soc = int(charge.get("soc", 0))
             if charge_soc > current_soc and charge_soc > reserve:
                 return {"behaviour": "charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": charge_soc, "power": int(charge.get("power", 0))}
             if charge_soc == reserve:
-                return {"behaviour": "freeze_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
+                # Zero power IS the freeze: the slot is enabled for grid charge but given no
+                # power, so the battery neither charges nor discharges and simply holds.
+                return {"behaviour": "freeze_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": reserve, "power": 0}
             return {"behaviour": "hold_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
 
         return {"behaviour": "idle", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
@@ -684,15 +689,21 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             return start <= now_minutes < end
         return now_minutes >= start or now_minutes < end
 
-    def _self_use_slot(self, start_time, reserve):
-        """Build a self-use slot holding at the reserve SOC."""
-        return {"time": start_time, "power": 0, "soc": int(reserve), "grid_charge": False}
+    def _self_use_slot(self, start_time, reserve, self_use_power):
+        """Build a self-use slot holding at the reserve SOC.
+
+        self_use_power must NOT be zero. Zero power is how Sunsynk expresses a freeze - the
+        battery neither charges nor discharges - so a zero-power self-use slot would stop
+        the battery serving the house for the whole interval and push the load onto the
+        grid. Self-use slots cover most of the day, so this is the default state.
+        """
+        return {"time": start_time, "power": int(self_use_power), "soc": int(reserve), "grid_charge": False}
 
     def _action_slot(self, start_time, state):
         """Build a slot realising a derived control state."""
         return {"time": start_time, "power": int(state["power"]), "soc": int(state["slot_soc"]), "grid_charge": bool(state["grid_charge"])}
 
-    def build_tou_slots(self, schedule, current_soc):
+    def build_tou_slots(self, schedule, current_soc, self_use_power):
         """Build exactly TOU_SLOT_COUNT ordered slots covering 24h from the schedule windows.
 
         Slots are sequential intervals ("from this start until the next slot's start") and
@@ -732,14 +743,14 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             if state.get("grid_charge") or state.get("solar_sell") or state.get("power"):
                 slots.append(self._action_slot(start_time, state))
             else:
-                slots.append(self._self_use_slot(start_time, reserve))
+                slots.append(self._self_use_slot(start_time, reserve, self_use_power))
 
         used = {slot["time"] for slot in slots}
         for filler in TOU_FILLER_TIMES:
             if len(slots) >= TOU_SLOT_COUNT:
                 break
             if filler not in used:
-                slots.append(self._self_use_slot(filler, reserve))
+                slots.append(self._self_use_slot(filler, reserve, self_use_power))
                 used.add(filler)
         return sorted(slots, key=lambda slot: slot["time"])[:TOU_SLOT_COUNT]
 
@@ -780,7 +791,15 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         since build_settings_payload rebuilds and re-clamps against the fresh floor as
         soon as a real read does happen - see apply_settings).
         """
-        slots = self.build_tou_slots(schedule, current_soc)
+        # Self-use slots get the inverter's full rating so the battery is free to serve
+        # whatever the house draws. Zero would freeze it (see _self_use_slot); if the rating
+        # is unknown, fall back to the largest slot power already on the inverter rather
+        # than write a freeze by accident.
+        self_use_power = int(self.inverter_limit(sn)) or self._existing_slot_power(sn)
+        if not self_use_power:
+            self.log(f"Warn: Sunsynk {sn} has no inverter rating and no existing slot power, so self-use slots would be written with zero power (a freeze); skipping the write")
+            return {}
+        slots = self.build_tou_slots(schedule, current_soc, self_use_power)
         active = self._active_state(schedule, current_soc, now_minutes)
 
         # Never ask the battery to go below the floor its own installer settings declare.
@@ -846,6 +865,17 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         payload = dict(baseline)
         payload.update(self._owned_payload(sn, schedule, current_soc, now_minutes))
         return payload
+
+    def _existing_slot_power(self, sn):
+        """Return the largest per-slot power already set on the inverter, or 0 if none.
+
+        Used only as a fallback for self-use slots when the inverter rating is unknown -
+        writing zero there would freeze the battery, so reusing whatever the installer
+        already had is strictly better than that.
+        """
+        settings = self.device_settings.get(sn, {})
+        powers = [self._as_float(settings.get(TOU_FIELD["power"].format(n=n))) for n in range(1, TOU_SLOT_COUNT + 1)]
+        return int(max(powers)) if powers and max(powers) > 0 else 0
 
     def payloads_equal(self, a, b):
         """Compare two settings payloads for change detection."""

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -791,7 +791,20 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         # single place that knows which fields Sunsynk wants bare and which quoted, so a
         # field that bypasses it is a field whose encoding cannot be corrected in one place.
         payload = {SUNSYNK_SERIAL_FIELD: sn, SUNSYNK_WORKMODE_FIELD: encode_setting(SUNSYNK_WORKMODE_FIELD, active["work_mode"])}
-        payload[SUNSYNK_SOLAR_SELL_FIELD] = encode_setting(SUNSYNK_SOLAR_SELL_FIELD, "1" if active["solar_sell"] else "0")
+        # Solar Export is always left ON, regardless of what the active state derives.
+        #
+        # solarSell does not govern the BATTERY - it governs whether surplus PV reaches the
+        # grid at all. Predbat plans when the battery charges and exports; it assumes, like
+        # every other inverter it drives, that spare solar exports passively in the
+        # background. Deriving this from the active window (on only inside an export window,
+        # off otherwise) would curtail surplus PV for most daylight hours, silently costing
+        # the user export revenue on a sunny day once the battery is full - and Predbat has
+        # no notion it is doing so, because nothing in its model represents PV curtailment.
+        #
+        # An export window still exports: that is driven by the selling-first work mode and
+        # the slot SoC targets, not by this flag. Turning it off is never useful here, only
+        # harmful, so it is not derived at all.
+        payload[SUNSYNK_SOLAR_SELL_FIELD] = encode_setting(SUNSYNK_SOLAR_SELL_FIELD, "1")
         payload[SUNSYNK_TOU_ENABLE_FIELD] = encode_setting(SUNSYNK_TOU_ENABLE_FIELD, "1")
         for day in SUNSYNK_DAY_FIELDS:
             payload[day] = encode_setting(day, True)

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -44,7 +44,7 @@ from sunsynk_const import (
     SUNSYNK_CAPACITY_AH_FIELD,
     SUNSYNK_CHARGE_VOLT_FIELD,
     SUNSYNK_CHARGE_CURRENT_FIELDS,
-    SUNSYNK_POWER_LIMIT_FIELD,
+    SUNSYNK_EXPORT_LIMIT_FIELD,
     SUNSYNK_RATED_POWER_FIELD,
     SUNSYNK_BATTERY_LOW_CAP_FIELD,
     LIFEPO4_CELL_COUNTS,
@@ -583,15 +583,26 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         return amps * volts
 
     def inverter_limit(self, sn):
-        """Return the inverter's usable AC limit in watts, or 0 when unknown.
+        """Return the inverter's AC power rating in watts, or 0 when unknown.
 
-        The hardware rating (ratePower) is not the whole story: an installer-set power
-        limiter (pvMaxLimit) can cap the inverter below it, and that cap is what actually
-        binds. A real system was seen with ratePower 8000 and pvMaxLimit 7000, so taking the
-        rating alone would have Predbat plan a kilowatt the inverter will never deliver.
-        Whichever is lower wins; if only one is known, that one is used.
+        This is the hardware rating (ratePower) only. It is deliberately NOT reduced by
+        pvMaxLimit: despite that setting's "Inverter Power Limiter" label in the app, Sunsynk
+        documents it as an EXPORT cap, so the inverter can still deliver its full rating to
+        the house. See export_limit.
         """
-        limits = [value for value in (self.device_rated_power.get(sn, 0.0), self._as_float(self.device_settings.get(sn, {}).get(SUNSYNK_POWER_LIMIT_FIELD))) if value > 0]
+        return self.device_rated_power.get(sn, 0.0)
+
+    def export_limit(self, sn):
+        """Return the maximum export power in watts, or 0 when unknown.
+
+        Predbat's inverter.py defaults export_limit to 99999W - effectively unlimited - so
+        leaving this unmapped lets it plan an export the inverter will simply clip. A real
+        system had a 7000W export cap behind an 8000W inverter.
+
+        Bounded by the inverter rating too: whatever the setting nominally allows, the
+        inverter cannot export more AC than it can produce.
+        """
+        limits = [value for value in (self.inverter_limit(sn), self._as_float(self.device_settings.get(sn, {}).get(SUNSYNK_EXPORT_LIMIT_FIELD))) if value > 0]
         return min(limits) if limits else 0.0
 
     def battery_reserve_min(self, sn):
@@ -974,6 +985,9 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             rated_power = self.inverter_limit(sn)
             if rated_power > 0:
                 self.dashboard_item(self._sensor_name(sn, "inverter_limit"), state=rated_power, attributes={"unit_of_measurement": "W", "friendly_name": f"Sunsynk {sn} Inverter Limit"}, app="sunsynk")
+            export_cap = self.export_limit(sn)
+            if export_cap > 0:
+                self.dashboard_item(self._sensor_name(sn, "export_limit"), state=export_cap, attributes={"unit_of_measurement": "W", "friendly_name": f"Sunsynk {sn} Export Limit"}, app="sunsynk")
             floor = self.battery_reserve_min(sn)
             if floor > 0:
                 self.dashboard_item(self._sensor_name(sn, "battery_reserve_min"), state=floor, attributes={"unit_of_measurement": "%", "friendly_name": f"Sunsynk {sn} Battery Reserve Min"}, app="sunsynk")
@@ -1343,20 +1357,15 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             self.set_arg_auto("inverter_limit", [self._sensor_name(sn, "inverter_limit") for sn in devices])
         else:
             self.log("Warn: Sunsynk no ratePower reported, inverter_limit must be set manually in apps.yaml")
-        # export_limit is deliberately NOT auto-mapped. The Sunsynk app has an "Export power
-        # limiter" in Grid Settings which can legitimately sit BELOW the inverter limit -
-        # a G98/G99 site is commonly capped at 3.68kW behind a much larger inverter - but no
-        # settings field could be identified that carries it: on the one system inspected the
-        # app showed 7000 for both the inverter and export limiters while pvMaxLimit was the
-        # only field holding 7000, so the two could not be told apart.
-        #
-        # Guessing it from pvMaxLimit would be worse than leaving it alone, because
-        # set_arg_auto always beats apps.yaml: a user who correctly set export_limit to their
-        # real 3.68kW cap would have it silently replaced by the inverter limit. Left unset,
-        # Predbat keeps its own default and the user's apps.yaml value is honoured.
-        self.log(
-            "Info: Sunsynk cannot identify the inverter's export power limiter from the settings object, so export_limit is left for apps.yaml. If your Export power limiter (app: Grid Settings) is lower than the inverter limit - a G98/G99 export cap, for instance - set export_limit manually."
-        )
+        # Without this Predbat falls back to inverter.py's effectively unlimited 99999W
+        # default and plans exports the inverter simply clips. pvMaxLimit is the export cap
+        # despite its "Inverter Power Limiter" label in the app - a G98/G99 site capped at
+        # 3.68kW behind a much larger inverter is exactly the case this protects.
+        # See SUNSYNK_EXPORT_LIMIT_FIELD.
+        if all(self.export_limit(sn) > 0 for sn in self.device_list):
+            self.set_arg_auto("export_limit", [self._sensor_name(sn, "export_limit") for sn in devices])
+        else:
+            self.log("Warn: Sunsynk no export power limit available, export_limit must be set manually in apps.yaml")
         if all(self.battery_reserve_min(sn) > 0 for sn in self.device_list):
             self.set_arg_auto("battery_min_soc", [self._sensor_name(sn, "battery_reserve_min") for sn in devices])
 

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -43,10 +43,14 @@ from sunsynk_const import (
     SUNSYNK_TELEMETRY_NEGATE,
     SUNSYNK_CAPACITY_AH_FIELD,
     SUNSYNK_CHARGE_VOLT_FIELD,
-    SUNSYNK_MAX_CHARGE_CURRENT_FIELD,
+    SUNSYNK_CHARGE_CURRENT_FIELDS,
+    SUNSYNK_POWER_LIMIT_FIELD,
     SUNSYNK_RATED_POWER_FIELD,
     SUNSYNK_BATTERY_LOW_CAP_FIELD,
-    LIFEPO4_CHARGE_VOLTS_PER_CELL,
+    LIFEPO4_CELL_COUNTS,
+    LIFEPO4_CHARGE_VOLTS_MIN,
+    LIFEPO4_CHARGE_VOLTS_MAX,
+    LIFEPO4_CHARGE_VOLTS_TYPICAL,
     LIFEPO4_NOMINAL_VOLTS_PER_CELL,
     SUNSYNK_WORKMODE,
     SUNSYNK_WORKMODE_FIELD,
@@ -507,7 +511,7 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             values[leaf] = int(value) if float(value).is_integer() and leaf in ("soc",) else value
         # Ratings inputs are kept raw on device_values so the derivations below can read them.
         battery = responses.get("battery") or {}
-        for field in (SUNSYNK_CAPACITY_AH_FIELD, SUNSYNK_CHARGE_VOLT_FIELD, SUNSYNK_MAX_CHARGE_CURRENT_FIELD):
+        for field in (SUNSYNK_CAPACITY_AH_FIELD, SUNSYNK_CHARGE_VOLT_FIELD) + SUNSYNK_CHARGE_CURRENT_FIELDS:
             if field in battery and battery[field] is not None:
                 values[field] = self._as_float(battery[field])
         self.device_values[sn] = values
@@ -544,17 +548,18 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         charge_volts = self._as_float(charge_volts)
         if charge_volts <= 0:
             return 0.0
-        # VERIFY@SPIKE — this rounds to the nearest whole cell assuming every pack charges
-        # to (close enough to) LIFEPO4_CHARGE_VOLTS_PER_CELL. It is exact for a target that
-        # is itself an exact multiple of 3.55V/cell, but a legitimate pack charged to a
-        # different per-cell target - e.g. 24 cells at 3.45V/cell = 82.8V - rounds to 23
-        # cells instead of 24, silently giving a nominal voltage (and therefore capacity and
-        # battery_rate_max) about 4% wrong. See sunsynk_const.py for the full note; no live
-        # hardware has confirmed the real spread of charge targets in use.
-        cells = round(charge_volts / LIFEPO4_CHARGE_VOLTS_PER_CELL)
-        if cells <= 0:
+        # Pick the standard stack size whose implied volts-per-cell falls inside the LiFePO4
+        # charge window, breaking ties toward the typical value. Dividing by one assumed
+        # figure and rounding is wrong at both ends of that window - 3.55 turns a 24-cell
+        # pack charged at 3.65V/cell into 25 cells, and 3.65 turns a 16-cell pack charged at
+        # 3.45V/cell into 15 - and either way the error is silent, ~4%, and lands in soc_max.
+        candidates = [(abs(charge_volts / cells - LIFEPO4_CHARGE_VOLTS_TYPICAL), cells) for cells in LIFEPO4_CELL_COUNTS if LIFEPO4_CHARGE_VOLTS_MIN <= charge_volts / cells <= LIFEPO4_CHARGE_VOLTS_MAX]
+        if not candidates:
+            # A charge target that fits no standard stack is not something to guess at: a
+            # wrong soc_max makes Predbat plan against a battery that does not exist.
+            self.log(f"Warn: Sunsynk cannot infer a LiFePO4 stack size from chargeVolt {charge_volts}; set sunsynk_battery_nominal_voltage in apps.yaml to derive capacity")
             return 0.0
-        return cells * LIFEPO4_NOMINAL_VOLTS_PER_CELL
+        return min(candidates)[1] * LIFEPO4_NOMINAL_VOLTS_PER_CELL
 
     def battery_capacity(self, sn):
         """Return the usable battery capacity in kWh, or 0 when it cannot be derived."""
@@ -568,11 +573,45 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
     def battery_rate_max(self, sn):
         """Return the maximum charge rate in watts, or 0 when it cannot be derived."""
         values = self.device_values.get(sn, {})
-        amps = self._as_float(values.get(SUNSYNK_MAX_CHARGE_CURRENT_FIELD))
+        # First candidate with a positive value wins. A real system was seen reporting
+        # maxChargeCurrentLimit 0.0 alongside chargeCurrentLimit 216.0, which derived a rate
+        # of 0 and made automatic_config skip battery_rate_max entirely.
+        amps = next((amp for amp in (self._as_float(values.get(field)) for field in SUNSYNK_CHARGE_CURRENT_FIELDS) if amp > 0), 0.0)
         volts = self.nominal_pack_voltage(values.get(SUNSYNK_CHARGE_VOLT_FIELD))
         if amps <= 0 or volts <= 0:
             return 0.0
         return amps * volts
+
+    def inverter_limit(self, sn):
+        """Return the inverter's usable AC limit in watts, or 0 when unknown.
+
+        The hardware rating (ratePower) is not the whole story: an installer-set power
+        limiter (pvMaxLimit) can cap the inverter below it, and that cap is what actually
+        binds. A real system was seen with ratePower 8000 and pvMaxLimit 7000, so taking the
+        rating alone would have Predbat plan a kilowatt the inverter will never deliver.
+        Whichever is lower wins; if only one is known, that one is used.
+        """
+        limits = [value for value in (self.device_rated_power.get(sn, 0.0), self._as_float(self.device_settings.get(sn, {}).get(SUNSYNK_POWER_LIMIT_FIELD))) if value > 0]
+        return min(limits) if limits else 0.0
+
+    def export_limit(self, sn):
+        """Return the maximum export power in watts, or 0 when unknown.
+
+        Predbat's inverter.py defaults export_limit to 99999W - effectively unlimited - so
+        leaving this unmapped lets it plan an export the inverter will simply clip. The
+        Sunsynk app exposes an "Export power limiter" in Grid Settings, and a real system
+        had it at 7000W against a 8000W inverter.
+
+        Bounded by inverter_limit as well: the inverter cannot export more AC than it can
+        produce, whichever setting nominally allows it.
+
+        See SUNSYNK_POWER_LIMIT_FIELD - with one sample where the app's "Export power
+        limiter" and "Inverter Power Limiter" both read 7000 against an identical
+        500-16000W range, and pvMaxLimit the only settings field holding 7000, the two
+        cannot yet be told apart and may be one register surfaced twice.
+        """
+        limits = [value for value in (self.inverter_limit(sn), self._as_float(self.device_settings.get(sn, {}).get(SUNSYNK_POWER_LIMIT_FIELD))) if value > 0]
+        return min(limits) if limits else 0.0
 
     def battery_reserve_min(self, sn):
         """Return the inverter's own SOC floor as a percent, or 0 when unknown."""
@@ -951,9 +990,12 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             rate_max = self.battery_rate_max(sn)
             if rate_max > 0:
                 self.dashboard_item(self._sensor_name(sn, "battery_rate_max"), state=round(rate_max), attributes={"unit_of_measurement": "W", "friendly_name": f"Sunsynk {sn} Battery Rate Max"}, app="sunsynk")
-            rated_power = self.device_rated_power.get(sn, 0.0)
+            rated_power = self.inverter_limit(sn)
             if rated_power > 0:
                 self.dashboard_item(self._sensor_name(sn, "inverter_limit"), state=rated_power, attributes={"unit_of_measurement": "W", "friendly_name": f"Sunsynk {sn} Inverter Limit"}, app="sunsynk")
+            export_limit = self.export_limit(sn)
+            if export_limit > 0:
+                self.dashboard_item(self._sensor_name(sn, "export_limit"), state=export_limit, attributes={"unit_of_measurement": "W", "friendly_name": f"Sunsynk {sn} Export Limit"}, app="sunsynk")
             floor = self.battery_reserve_min(sn)
             if floor > 0:
                 self.dashboard_item(self._sensor_name(sn, "battery_reserve_min"), state=floor, attributes={"unit_of_measurement": "%", "friendly_name": f"Sunsynk {sn} Battery Reserve Min"}, app="sunsynk")
@@ -1319,10 +1361,17 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             self.set_arg_auto("battery_rate_max", [self._sensor_name(sn, "battery_rate_max") for sn in devices])
         else:
             self.log("Warn: Sunsynk no battery charge-current limit available, battery_rate_max must be set manually in apps.yaml")
-        if all(self.device_rated_power.get(sn, 0.0) > 0 for sn in self.device_list):
+        if all(self.inverter_limit(sn) > 0 for sn in self.device_list):
             self.set_arg_auto("inverter_limit", [self._sensor_name(sn, "inverter_limit") for sn in devices])
         else:
             self.log("Warn: Sunsynk no ratePower reported, inverter_limit must be set manually in apps.yaml")
+        # Without this Predbat falls back to an effectively unlimited export (inverter.py
+        # defaults export_limit to 99999W), so a system capped at 7kW would be planned as if
+        # it could export 9kW.
+        if all(self.export_limit(sn) > 0 for sn in self.device_list):
+            self.set_arg_auto("export_limit", [self._sensor_name(sn, "export_limit") for sn in devices])
+        else:
+            self.log("Warn: Sunsynk no export power limit available, export_limit must be set manually in apps.yaml")
         if all(self.battery_reserve_min(sn) > 0 for sn in self.device_list):
             self.set_arg_auto("battery_min_soc", [self._sensor_name(sn, "battery_reserve_min") for sn in devices])
 

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -594,25 +594,6 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         limits = [value for value in (self.device_rated_power.get(sn, 0.0), self._as_float(self.device_settings.get(sn, {}).get(SUNSYNK_POWER_LIMIT_FIELD))) if value > 0]
         return min(limits) if limits else 0.0
 
-    def export_limit(self, sn):
-        """Return the maximum export power in watts, or 0 when unknown.
-
-        Predbat's inverter.py defaults export_limit to 99999W - effectively unlimited - so
-        leaving this unmapped lets it plan an export the inverter will simply clip. The
-        Sunsynk app exposes an "Export power limiter" in Grid Settings, and a real system
-        had it at 7000W against a 8000W inverter.
-
-        Bounded by inverter_limit as well: the inverter cannot export more AC than it can
-        produce, whichever setting nominally allows it.
-
-        See SUNSYNK_POWER_LIMIT_FIELD - with one sample where the app's "Export power
-        limiter" and "Inverter Power Limiter" both read 7000 against an identical
-        500-16000W range, and pvMaxLimit the only settings field holding 7000, the two
-        cannot yet be told apart and may be one register surfaced twice.
-        """
-        limits = [value for value in (self.inverter_limit(sn), self._as_float(self.device_settings.get(sn, {}).get(SUNSYNK_POWER_LIMIT_FIELD))) if value > 0]
-        return min(limits) if limits else 0.0
-
     def battery_reserve_min(self, sn):
         """Return the inverter's own SOC floor as a percent, or 0 when unknown."""
         settings = self.device_settings.get(sn, {})
@@ -993,9 +974,6 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             rated_power = self.inverter_limit(sn)
             if rated_power > 0:
                 self.dashboard_item(self._sensor_name(sn, "inverter_limit"), state=rated_power, attributes={"unit_of_measurement": "W", "friendly_name": f"Sunsynk {sn} Inverter Limit"}, app="sunsynk")
-            export_limit = self.export_limit(sn)
-            if export_limit > 0:
-                self.dashboard_item(self._sensor_name(sn, "export_limit"), state=export_limit, attributes={"unit_of_measurement": "W", "friendly_name": f"Sunsynk {sn} Export Limit"}, app="sunsynk")
             floor = self.battery_reserve_min(sn)
             if floor > 0:
                 self.dashboard_item(self._sensor_name(sn, "battery_reserve_min"), state=floor, attributes={"unit_of_measurement": "%", "friendly_name": f"Sunsynk {sn} Battery Reserve Min"}, app="sunsynk")
@@ -1365,13 +1343,20 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             self.set_arg_auto("inverter_limit", [self._sensor_name(sn, "inverter_limit") for sn in devices])
         else:
             self.log("Warn: Sunsynk no ratePower reported, inverter_limit must be set manually in apps.yaml")
-        # Without this Predbat falls back to an effectively unlimited export (inverter.py
-        # defaults export_limit to 99999W), so a system capped at 7kW would be planned as if
-        # it could export 9kW.
-        if all(self.export_limit(sn) > 0 for sn in self.device_list):
-            self.set_arg_auto("export_limit", [self._sensor_name(sn, "export_limit") for sn in devices])
-        else:
-            self.log("Warn: Sunsynk no export power limit available, export_limit must be set manually in apps.yaml")
+        # export_limit is deliberately NOT auto-mapped. The Sunsynk app has an "Export power
+        # limiter" in Grid Settings which can legitimately sit BELOW the inverter limit -
+        # a G98/G99 site is commonly capped at 3.68kW behind a much larger inverter - but no
+        # settings field could be identified that carries it: on the one system inspected the
+        # app showed 7000 for both the inverter and export limiters while pvMaxLimit was the
+        # only field holding 7000, so the two could not be told apart.
+        #
+        # Guessing it from pvMaxLimit would be worse than leaving it alone, because
+        # set_arg_auto always beats apps.yaml: a user who correctly set export_limit to their
+        # real 3.68kW cap would have it silently replaced by the inverter limit. Left unset,
+        # Predbat keeps its own default and the user's apps.yaml value is honoured.
+        self.log(
+            "Info: Sunsynk cannot identify the inverter's export power limiter from the settings object, so export_limit is left for apps.yaml. If your Export power limiter (app: Grid Settings) is lower than the inverter limit - a G98/G99 export cap, for instance - set export_limit manually."
+        )
         if all(self.battery_reserve_min(sn) > 0 for sn in self.device_list):
             self.set_arg_auto("battery_min_soc", [self._sensor_name(sn, "battery_reserve_min") for sn in devices])
 

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -648,13 +648,12 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
                 # Zero power IS the freeze: the slot is enabled for grid charge but given no
                 # power, so the battery neither charges nor discharges and simply holds.
                 return {"behaviour": "freeze_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": reserve, "power": 0}
-            # The battery is already at or above the requested target, so there is nothing
-            # to charge: this behaves exactly like self-use. Reporting zero power here is
-            # what makes build_tou_slots classify it as a self-use slot, which then writes
-            # the inverter's full power - it does NOT emit a zero-power (frozen) slot. A
-            # non-zero power would classify it as an action slot and needlessly constrain
-            # the battery while it is only being asked not to charge.
-            return {"behaviour": "hold_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
+            # The battery is already at or above the requested target, so grid charge stays
+            # OFF - the charge is simply not triggered. The slot still carries Predbat's
+            # charge rate, because that is the rate it has chosen for this window; only the
+            # behaviour differs, not the power. Zero here would mean freeze, which is a
+            # different state, and the inverter's full rating would discard Predbat's rate.
+            return {"behaviour": "hold_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
 
         return {"behaviour": "idle", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
 

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -613,6 +613,17 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
     def derive_control_state(self, schedule, current_soc):
         """Map Predbat's schedule intent to a Sunsynk control state (see the spec's table).
 
+        The work mode governs whether the BATTERY may export, and it is orthogonal to
+        solarSell, which governs whether surplus PV may. Confirmed on a live system that
+        exported 11.1 kWh in a day while sitting in "Limited to Home" with solarSell on, so
+        the mode does not gate solar.
+
+        Non-export states therefore use zero_export_ct ("Limited to Home"): the battery
+        serves the whole house, measured at the grid CT, without exporting. The stricter
+        zero_export_load ("Zero-Export + Limit To Load Only") measures at the inverter's own
+        output instead, so on a CT-clamp install it would stop the battery serving anything
+        not wired to the inverter, and the shortfall would come from the grid.
+
         Semantics are inherited from DEYE — the same registers sit behind both clouds —
         but every wire value comes from SUNSYNK_WORKMODE, never from DEYE's enum.
         """
@@ -629,12 +640,12 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         if charge.get("enable"):
             charge_soc = int(charge.get("soc", 0))
             if charge_soc > current_soc and charge_soc > reserve:
-                return {"behaviour": "charge", "work_mode": SUNSYNK_WORKMODE["zero_export_load"], "grid_charge": True, "solar_sell": False, "slot_soc": charge_soc, "power": int(charge.get("power", 0))}
+                return {"behaviour": "charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": charge_soc, "power": int(charge.get("power", 0))}
             if charge_soc == reserve:
-                return {"behaviour": "freeze_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_load"], "grid_charge": True, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
-            return {"behaviour": "hold_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_load"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
+                return {"behaviour": "freeze_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
+            return {"behaviour": "hold_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
 
-        return {"behaviour": "idle", "work_mode": SUNSYNK_WORKMODE["zero_export_load"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
+        return {"behaviour": "idle", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
 
     @staticmethod
     def _to_slot_time(value):

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -648,7 +648,13 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
                 # Zero power IS the freeze: the slot is enabled for grid charge but given no
                 # power, so the battery neither charges nor discharges and simply holds.
                 return {"behaviour": "freeze_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": reserve, "power": 0}
-            return {"behaviour": "hold_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
+            # The battery is already at or above the requested target, so there is nothing
+            # to charge: this behaves exactly like self-use. Reporting zero power here is
+            # what makes build_tou_slots classify it as a self-use slot, which then writes
+            # the inverter's full power - it does NOT emit a zero-power (frozen) slot. A
+            # non-zero power would classify it as an action slot and needlessly constrain
+            # the battery while it is only being asked not to charge.
+            return {"behaviour": "hold_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
 
         return {"behaviour": "idle", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
 

--- a/apps/predbat/sunsynk_const.py
+++ b/apps/predbat/sunsynk_const.py
@@ -58,10 +58,24 @@ TOU_SLOT_COUNT = 6
 FREEZE_EXPORT_SOC = 99
 
 # Distinct ascending start times used to pad a schedule out to TOU_SLOT_COUNT.
-# Sunsynk's slots are sequential intervals ("from this start until the next slot's
-# start"), so every start must be unique — duplicates create zero-length intervals.
-# Seven options guarantee TOU_SLOT_COUNT distinct times survive even if all four
-# of a schedule's own window boundaries collide with fillers.
+#
+# CONFIRMED by Sunsynk's own documentation ("Avoiding conflicts in the System Mode timer"):
+# the six slots are sequential chronological intervals, each running until the next slot
+# begins, and "Timers MUST be set chronologically from Timer 1 to Timer 6". Timer 6 is the
+# only one permitted to roll over midnight and continue until Timer 1 restarts. So distinct
+# ascending starts are a real requirement, not a Predbat preference.
+#
+# A slot is an interval regardless of its grid-charge flag: the documented factory default
+# runs all six timers as ranges with Grid Charge ticked on only two of them. That is what
+# makes Predbat's padding work - a filler slot with grid charge off still TERMINATES the
+# charge window before it.
+#
+# Note an inverter can nonetheless be found sitting with all six slots at 00:00 (an
+# unconfigured default). The API stores that happily; it is simply not a chronological
+# programme, so no conclusion about valid schedules should be drawn from it.
+#
+# Seven options guarantee TOU_SLOT_COUNT distinct times survive even if all four of a
+# schedule's own window boundaries collide with fillers.
 TOU_FILLER_TIMES = ["00:00", "04:00", "08:00", "12:00", "16:00", "20:00", "23:00"]
 
 # CONFIRMED live (inverter 2405116013, 2026-08-18). The Sunsynk app's System Mode screen

--- a/apps/predbat/sunsynk_const.py
+++ b/apps/predbat/sunsynk_const.py
@@ -64,10 +64,15 @@ FREEZE_EXPORT_SOC = 99
 # of a schedule's own window boundaries collide with fillers.
 TOU_FILLER_TIMES = ["00:00", "04:00", "08:00", "12:00", "16:00", "20:00", "23:00"]
 
-# VERIFY@SPIKE — that Sunsynk has these three modes is a semantic claim inherited
-# from DEYE and is safe. That they are numbered 0/1/2 IN DEYE'S ORDER is an
-# ENCODING claim and is the single highest-cost unknown in this integration:
-# getting it wrong silently swaps export for charge. Confirm before enabling control.
+# CONFIRMED live (inverter 2405116013, 2026-08-18). The Sunsynk app's System Mode screen
+# lists Work Mode as Selling First / Zero-Export + Limit To Load Only / Limited to Home, and
+# with "Limited to Home" selected the settings object reported sysWorkMode '2' - so the
+# numbering follows the app's own order, which is also DEYE's. "Limited to Home" is
+# Sunsynk's name for zero-export-to-CT.
+#
+# The mode does NOT by itself decide whether the system exports: the separate Solar Export
+# toggle (solarSell) does. The same inverter exported 11.1 kWh on the day this was confirmed
+# while sitting in "Limited to Home", because solarSell was '1'.
 SUNSYNK_WORKMODE = {
     "selling_first": "0",
     "zero_export_load": "1",
@@ -134,30 +139,68 @@ SUNSYNK_ENERGY = {
     "battery_discharge_today": ("battery", "etodayDischg"),
 }
 
-# VERIFY@SPIKE — sign convention. DEYE reports battery power positive on discharge;
-# if Sunsynk agrees this stays empty, otherwise add "battery_power" here.
+# Metrics whose sign must be flipped to reach Predbat's convention (battery positive on
+# discharge, grid negative on import).
+#
+# battery_power CONFIRMED live: the app's power-flow diagram showed 478 W flowing
+# battery -> house with PV at 0 W while the API reported power +484, so positive already
+# means discharging, matching DEYE and Predbat. No flip.
+#
+# grid_power is NOT confirmed. `pac` is the right FIELD - the app read 0 W at the same
+# moment the API did, while grid vip[0].power read -418 W and is evidently something else
+# (a CT or per-phase sense, not whole-house flow). The SIGN is untested: the only sample so
+# far was at night with the grid idle. DEYE reports grid positive when importing and so
+# negates; if Sunsynk matches, "grid_power" belongs here. Needs one daytime sample with
+# real import or export to settle.
 SUNSYNK_TELEMETRY_NEGATE = ()
 
 # Fields used to derive ratings rather than published directly.
 SUNSYNK_CAPACITY_AH_FIELD = "capacity"  # battery realtime, amp-hours
 SUNSYNK_CHARGE_VOLT_FIELD = "chargeVolt"  # battery realtime, BMS charge target
-SUNSYNK_MAX_CHARGE_CURRENT_FIELD = "maxChargeCurrentLimit"  # battery realtime, amps
 SUNSYNK_RATED_POWER_FIELD = "ratePower"  # inverter detail, watts
 SUNSYNK_BATTERY_LOW_CAP_FIELD = "batteryLowCap"  # settings, percent floor
 
-# LiFePO4 cell voltages used to infer the pack's nominal voltage from its BMS charge
-# target, so an amp-hour capacity can become kWh. Same derivation deye.py uses.
-LIFEPO4_CHARGE_VOLTS_PER_CELL = 3.55
-LIFEPO4_NOMINAL_VOLTS_PER_CELL = 3.2
+# Output power cap. CONFIRMED live that this can sit BELOW the hardware rating: ratePower
+# 8000 with pvMaxLimit 7000, so using the rating alone would have Predbat plan a kilowatt
+# the inverter will never deliver.
+#
+# VERIFY@SPIKE — which app control this is. The Sunsynk app shows 7000 in TWO places with
+# an identical 500-16000W range: "Inverter Power Limiter" (System Mode) and "Export power
+# limiter" (Grid Settings). With one sample where both read 7000 they cannot be told apart,
+# and pvMaxLimit is the only settings field holding 7000. They may be one register shown
+# twice. Either way 7000 is a real cap on AC output, so it is safe to use for both
+# inverter_limit and export_limit until someone changes one value in the app and re-reads.
+SUNSYNK_POWER_LIMIT_FIELD = "pvMaxLimit"  # settings, watts
 
-# VERIFY@SPIKE — cell-count rounding in SunsynkAPI.nominal_pack_voltage assumes every real
-# pack is charged to (close enough to) 3.55V/cell that round(chargeVolt / 3.55) recovers the
-# true cell count. It is exact for the values tested (56.8, 85.2, 113.6V) because those are
-# exact multiples of 3.55, but a legitimate pack charged to a different per-cell target -
-# e.g. 24 cells at 3.45V/cell = 82.8V - rounds to 23 cells instead of 24, silently giving a
-# nominal voltage, capacity and battery_rate_max about 4% wrong. No live hardware has
-# confirmed the real spread of charge targets in use. The remote tester should compare the
-# derived battery_capacity against the battery's actual rated kWh before trusting it.
+# Grid import cap - "Import power limiter" in the app's Grid Settings. CONFIRMED live:
+# app 10350 W, settings importPower '10350'. Not consumed yet; recorded so the mapping is
+# not lost, since it bounds how fast Predbat can charge from the grid.
+SUNSYNK_IMPORT_LIMIT_FIELD = "importPower"  # settings, watts
+
+# Charge-current limit candidates, in priority order: the FIRST field with a positive value
+# wins. CONFIRMED live that a real system reports maxChargeCurrentLimit 0.0 while
+# chargeCurrentLimit 216.0 carries the actual limit - reading only the max field derived
+# battery_rate_max as 0, so automatic_config skipped it and Predbat ran with no charge-rate
+# limit at all. Both names are kept because it is unknown which other firmware populates.
+SUNSYNK_CHARGE_CURRENT_FIELDS = ("chargeCurrentLimit", "maxChargeCurrentLimit")
+
+# LiFePO4 pack geometry, used to turn an amp-hour capacity into kWh.
+#
+# Cell count is inferred from the BMS charge target. Dividing by one assumed volts-per-cell
+# is wrong at both ends of the legitimate range: 3.55 turns a 24-cell pack charged at
+# 3.65V/cell into 25 cells, and 3.65 turns a 16-cell pack charged at 3.45V/cell into 15.
+# Either error is silent, about 4%, and lands in soc_max. Instead the standard stack sizes
+# are tried and the one whose implied volts-per-cell falls inside the charge window wins,
+# breaking ties toward the typical value - exact for every combination of these stack sizes
+# with a 3.45-3.65V/cell target.
+#
+# CONFIRMED live: chargeVolt 58.4 -> 16 cells at exactly 3.65V/cell -> 51.2V nominal ->
+# 200Ah = 10.24 kWh, matching the pack's rating and its bmsVolt of 52.3V at 42% SoC.
+LIFEPO4_CELL_COUNTS = (8, 15, 16, 24, 32)
+LIFEPO4_CHARGE_VOLTS_MIN = 3.40
+LIFEPO4_CHARGE_VOLTS_MAX = 3.75
+LIFEPO4_CHARGE_VOLTS_TYPICAL = 3.55
+LIFEPO4_NOMINAL_VOLTS_PER_CELL = 3.2
 
 # Refresh cadence per class of state, in minutes. ComponentBase ticks run() every 60
 # seconds; these are the maximum ages a cached tier may reach before it is re-polled.

--- a/apps/predbat/sunsynk_const.py
+++ b/apps/predbat/sunsynk_const.py
@@ -146,13 +146,16 @@ SUNSYNK_ENERGY = {
 # battery -> house with PV at 0 W while the API reported power +484, so positive already
 # means discharging, matching DEYE and Predbat. No flip.
 #
-# grid_power is NOT confirmed. `pac` is the right FIELD - the app read 0 W at the same
-# moment the API did, while grid vip[0].power read -418 W and is evidently something else
-# (a CT or per-phase sense, not whole-house flow). The SIGN is untested: the only sample so
-# far was at night with the grid idle. DEYE reports grid positive when importing and so
-# negates; if Sunsynk matches, "grid_power" belongs here. Needs one daytime sample with
-# real import or export to settle.
-SUNSYNK_TELEMETRY_NEGATE = ()
+# grid_power's FIELD is confirmed - `pac` read 0 W at the same moment the app did, while
+# grid vip[0].power read -418 W and is evidently something else (a CT or per-phase sense,
+# not whole-house flow). Its SIGN is aligned with DEYE on the Deye-parity rule rather than
+# on direct evidence: every sample so far was at night with the grid idle, so 0 negates to
+# 0 and nothing distinguished the two. DEYE reports grid positive when importing and
+# negates to reach Predbat's negative-for-import convention, and Sunsynk is rebadged DEYE
+# hardware, so it is assumed to match. VERIFY@SPIKE - one daytime sample with real import
+# or export confirms or refutes it; if grid power comes back negative while importing,
+# remove "grid_power" here.
+SUNSYNK_TELEMETRY_NEGATE = ("grid_power",)
 
 # Fields used to derive ratings rather than published directly.
 SUNSYNK_CAPACITY_AH_FIELD = "capacity"  # battery realtime, amp-hours
@@ -164,18 +167,24 @@ SUNSYNK_BATTERY_LOW_CAP_FIELD = "batteryLowCap"  # settings, percent floor
 # 8000 with pvMaxLimit 7000, so using the rating alone would have Predbat plan a kilowatt
 # the inverter will never deliver.
 #
-# VERIFY@SPIKE — which app control this is. The Sunsynk app shows 7000 in TWO places with
-# an identical 500-16000W range: "Inverter Power Limiter" (System Mode) and "Export power
-# limiter" (Grid Settings). With one sample where both read 7000 they cannot be told apart,
-# and pvMaxLimit is the only settings field holding 7000. They may be one register shown
-# twice. Either way 7000 is a real cap on AC output, so it is safe to use for both
-# inverter_limit and export_limit until someone changes one value in the app and re-reads.
+# This is the INVERTER limit (confirmed by the system owner). The Sunsynk app surfaces the
+# same 7000 under two labels with an identical 500-16000W range - "Inverter Power Limiter"
+# (System Mode) and "Export power limiter" (Grid Settings) - and pvMaxLimit is the only
+# settings field holding 7000, so one register is evidently shown on both screens. It
+# therefore backs both inverter_limit and export_limit.
+#
+# Not to be confused with solarMaxSellPower (SUNSYNK_MAX_SOLAR_FIELD), a separate setting.
 SUNSYNK_POWER_LIMIT_FIELD = "pvMaxLimit"  # settings, watts
 
 # Grid import cap - "Import power limiter" in the app's Grid Settings. CONFIRMED live:
 # app 10350 W, settings importPower '10350'. Not consumed yet; recorded so the mapping is
 # not lost, since it bounds how fast Predbat can charge from the grid.
 SUNSYNK_IMPORT_LIMIT_FIELD = "importPower"  # settings, watts
+
+# "Max Solar Power" in the app - CONFIRMED live by the system owner: app 9200, settings
+# solarMaxSellPower '9200'. Recorded rather than consumed: it is a PV-side cap, not the AC
+# export cap Predbat's export_limit wants (see automatic_config for why that is left unset).
+SUNSYNK_MAX_SOLAR_FIELD = "solarMaxSellPower"  # settings, watts
 
 # Charge-current limit candidates, in priority order: the FIRST field with a positive value
 # wins. CONFIRMED live that a real system reports maxChargeCurrentLimit 0.0 while

--- a/apps/predbat/sunsynk_const.py
+++ b/apps/predbat/sunsynk_const.py
@@ -167,14 +167,16 @@ SUNSYNK_BATTERY_LOW_CAP_FIELD = "batteryLowCap"  # settings, percent floor
 # 8000 with pvMaxLimit 7000, so using the rating alone would have Predbat plan a kilowatt
 # the inverter will never deliver.
 #
-# This is the INVERTER limit (confirmed by the system owner). The Sunsynk app surfaces the
-# same 7000 under two labels with an identical 500-16000W range - "Inverter Power Limiter"
-# (System Mode) and "Export power limiter" (Grid Settings) - and pvMaxLimit is the only
-# settings field holding 7000, so one register is evidently shown on both screens. It
-# therefore backs both inverter_limit and export_limit.
+# The EXPORT limit. The Sunsynk app shows this same value under two labels with an identical
+# 500-16000W range - "Inverter Power Limiter" (System Mode) and "Export power limiter" (Grid
+# Settings) - which is why pvMaxLimit was the only field holding the 7000 both screens
+# displayed. Per Sunsynk's documentation (confirmed by the system owner) the control despite
+# its System Mode label caps EXPORT, not the inverter's AC output: the inverter can still
+# deliver its full ratePower to the house. So this backs export_limit, and inverter_limit
+# stays on ratePower.
 #
 # Not to be confused with solarMaxSellPower (SUNSYNK_MAX_SOLAR_FIELD), a separate setting.
-SUNSYNK_POWER_LIMIT_FIELD = "pvMaxLimit"  # settings, watts
+SUNSYNK_EXPORT_LIMIT_FIELD = "pvMaxLimit"  # settings, watts
 
 # Grid import cap - "Import power limiter" in the app's Grid Settings. CONFIRMED live:
 # app 10350 W, settings importPower '10350'. Not consumed yet; recorded so the mapping is

--- a/apps/predbat/tests/test_sunsynk_api.py
+++ b/apps/predbat/tests/test_sunsynk_api.py
@@ -1012,6 +1012,119 @@ def test_cli_reports_telemetry_failure_naming_the_serials():
     assert not failed, "test_cli_reports_telemetry_failure_naming_the_serials"
 
 
+def test_battery_rate_max_prefers_a_populated_current_field():
+    """A zero maxChargeCurrentLimit must not mask a populated chargeCurrentLimit.
+
+    Confirmed live on inverter 2405116013: maxChargeCurrentLimit 0.0 alongside
+    chargeCurrentLimit 216.0. Reading only the max field derived a rate of 0, which made
+    automatic_config skip battery_rate_max and left Predbat with no charge-rate limit.
+    """
+    failed = False
+    s = MockSunsynk()
+    # The live shape: max is zero, the real limit is in chargeCurrentLimit.
+    s.device_values["INV1"] = {"chargeCurrentLimit": 216.0, "maxChargeCurrentLimit": 0.0, "chargeVolt": 58.4}
+    rate = s.battery_rate_max("INV1")
+    if abs(rate - 216.0 * 51.2) > 1:
+        print(f"ERROR: expected 216A x 51.2V = 11059W, got {rate}")
+        failed = True
+    # The other way round must still work - unknown which field other firmware populates.
+    s.device_values["INV2"] = {"chargeCurrentLimit": 0.0, "maxChargeCurrentLimit": 100.0, "chargeVolt": 56.8}
+    if abs(s.battery_rate_max("INV2") - 100.0 * 51.2) > 1:
+        print(f"ERROR: fallback to maxChargeCurrentLimit failed, got {s.battery_rate_max('INV2')}")
+        failed = True
+    # Both zero is genuinely unknown and must stay 0 rather than be invented.
+    s.device_values["INV3"] = {"chargeCurrentLimit": 0.0, "maxChargeCurrentLimit": 0.0, "chargeVolt": 58.4}
+    if s.battery_rate_max("INV3") != 0:
+        print(f"ERROR: no current limit should derive 0, got {s.battery_rate_max('INV3')}")
+        failed = True
+    assert not failed, "test_battery_rate_max_prefers_a_populated_current_field"
+
+
+def test_nominal_pack_voltage_across_the_lifepo4_charge_window():
+    """Cell count must come out right for any per-cell charge target in the real range.
+
+    A single assumed volts-per-cell is wrong at both ends: 3.55 turns a 24-cell pack
+    charged at 3.65V/cell into 25 cells, and 3.65 turns a 16-cell pack charged at
+    3.45V/cell into 15. Both errors are silent and land in soc_max.
+    """
+    failed = False
+    s = MockSunsynk()
+    # (charge target, expected cells) across 3.45 / 3.55 / 3.65 V per cell.
+    cases = [(55.2, 16), (56.8, 16), (58.4, 16), (82.8, 24), (85.2, 24), (87.6, 24), (110.4, 32), (113.6, 32), (116.8, 32)]
+    for charge_volts, cells in cases:
+        expect = cells * 3.2
+        got = s.nominal_pack_voltage(charge_volts)
+        if abs(got - expect) > 0.01:
+            print(f"ERROR: chargeVolt {charge_volts} gave {got}V ({got / 3.2:.0f} cells), expected {expect}V ({cells} cells)")
+            failed = True
+    # A target matching no standard stack must refuse rather than guess.
+    if s.nominal_pack_voltage(200.0) != 0:
+        print(f"ERROR: an unmatched charge target should derive 0, got {s.nominal_pack_voltage(200.0)}")
+        failed = True
+    # The explicit override still wins over any inference.
+    s.battery_nominal_voltage = 48.0
+    if s.nominal_pack_voltage(58.4) != 48.0:
+        print("ERROR: sunsynk_battery_nominal_voltage override was ignored")
+        failed = True
+    assert not failed, "test_nominal_pack_voltage_across_the_lifepo4_charge_window"
+
+
+def test_inverter_limit_respects_the_installer_power_limiter():
+    """The installer's Inverter Power Limiter can cap the inverter below its rating.
+
+    Confirmed live: ratePower 8000 with pvMaxLimit 7000. Using the rating alone would have
+    Predbat plan a kilowatt the inverter will never deliver.
+    """
+    failed = False
+    s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
+    s.device_settings["INV1"] = {"pvMaxLimit": "7000"}
+    if s.inverter_limit("INV1") != 7000.0:
+        print(f"ERROR: expected the lower of 8000/7000, got {s.inverter_limit('INV1')}")
+        failed = True
+    # A limiter above the rating must not raise the limit beyond what the hardware can do.
+    s.device_rated_power["INV2"] = 5000.0
+    s.device_settings["INV2"] = {"pvMaxLimit": "16000"}
+    if s.inverter_limit("INV2") != 5000.0:
+        print(f"ERROR: rating must cap the limiter, got {s.inverter_limit('INV2')}")
+        failed = True
+    # Either one alone is still usable.
+    s.device_rated_power["INV3"] = 8000.0
+    s.device_settings["INV3"] = {}
+    if s.inverter_limit("INV3") != 8000.0:
+        print(f"ERROR: rating alone should be used, got {s.inverter_limit('INV3')}")
+        failed = True
+    if s.inverter_limit("UNKNOWN") != 0:
+        print(f"ERROR: an unknown serial should derive 0, got {s.inverter_limit('UNKNOWN')}")
+        failed = True
+    assert not failed, "test_inverter_limit_respects_the_installer_power_limiter"
+
+
+def test_export_limit_is_mapped_and_bounded_by_the_inverter():
+    """Predbat defaults export_limit to 99999W, so leaving it unmapped plans a clipped export.
+
+    Confirmed live: the app's Grid Settings showed an Export power limiter of 7000W on an
+    8000W inverter.
+    """
+    failed = False
+    s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
+    s.device_settings["INV1"] = {"pvMaxLimit": "7000"}
+    if s.export_limit("INV1") != 7000.0:
+        print(f"ERROR: expected the 7000W limiter, got {s.export_limit('INV1')}")
+        failed = True
+    # The inverter cannot export more AC than it can produce, whatever the setting allows.
+    s.device_rated_power["INV2"] = 3600.0
+    s.device_settings["INV2"] = {"pvMaxLimit": "16000"}
+    if s.export_limit("INV2") != 3600.0:
+        print(f"ERROR: export must be bounded by the inverter, got {s.export_limit('INV2')}")
+        failed = True
+    if s.export_limit("UNKNOWN") != 0:
+        print(f"ERROR: an unknown serial should derive 0, got {s.export_limit('UNKNOWN')}")
+        failed = True
+    assert not failed, "test_export_limit_is_mapped_and_bounded_by_the_inverter"
+
+
 def run_sunsynk_api_tests(my_predbat):
     """Run all Sunsynk API tests."""
     failed = False
@@ -1036,6 +1149,10 @@ def run_sunsynk_api_tests(my_predbat):
         ("nominal_pack_voltage", test_nominal_pack_voltage_variants),
         ("capacity_ah_to_kwh", test_battery_capacity_amp_hours_to_kwh),
         ("battery_rate_max", test_battery_rate_max_from_charge_current),
+        ("rate_max_field_priority", test_battery_rate_max_prefers_a_populated_current_field),
+        ("pack_voltage_window", test_nominal_pack_voltage_across_the_lifepo4_charge_window),
+        ("inverter_limit_limiter", test_inverter_limit_respects_the_installer_power_limiter),
+        ("export_limit_mapped", test_export_limit_is_mapped_and_bounded_by_the_inverter),
         ("battery_reserve_min", test_battery_reserve_min_from_settings),
         ("device_list_no_serials_terminates", test_get_device_list_terminates_when_serials_are_missing),
         ("device_list_deduplicates", test_get_device_list_deduplicates_repeated_pages),

--- a/apps/predbat/tests/test_sunsynk_api.py
+++ b/apps/predbat/tests/test_sunsynk_api.py
@@ -581,7 +581,9 @@ def test_fetch_device_data_maps_telemetry_and_energy():
     with patch.object(s, "_get", side_effect=fake_get):
         run_async_local(s.fetch_device_data("INV1"))
     values = s.device_values.get("INV1", {})
-    for leaf, expect in (("soc", 62), ("battery_power", -1500), ("grid_power", 430), ("load_power", 900), ("pv_power", 2100), ("temperature", 21.5)):
+    # grid_power is negated to reach Predbat's negative-for-import convention, matching
+    # deye.py: Sunsynk's pac of +430 (importing) must publish as -430.
+    for leaf, expect in (("soc", 62), ("battery_power", -1500), ("grid_power", -430), ("load_power", 900), ("pv_power", 2100), ("temperature", 21.5)):
         if values.get(leaf) != expect:
             print(f"ERROR: telemetry {leaf} = {values.get(leaf)}, expected {expect}")
             failed = True
@@ -1100,31 +1102,6 @@ def test_inverter_limit_respects_the_installer_power_limiter():
     assert not failed, "test_inverter_limit_respects_the_installer_power_limiter"
 
 
-def test_export_limit_is_mapped_and_bounded_by_the_inverter():
-    """Predbat defaults export_limit to 99999W, so leaving it unmapped plans a clipped export.
-
-    Confirmed live: the app's Grid Settings showed an Export power limiter of 7000W on an
-    8000W inverter.
-    """
-    failed = False
-    s = MockSunsynk()
-    s.device_rated_power["INV1"] = 8000.0
-    s.device_settings["INV1"] = {"pvMaxLimit": "7000"}
-    if s.export_limit("INV1") != 7000.0:
-        print(f"ERROR: expected the 7000W limiter, got {s.export_limit('INV1')}")
-        failed = True
-    # The inverter cannot export more AC than it can produce, whatever the setting allows.
-    s.device_rated_power["INV2"] = 3600.0
-    s.device_settings["INV2"] = {"pvMaxLimit": "16000"}
-    if s.export_limit("INV2") != 3600.0:
-        print(f"ERROR: export must be bounded by the inverter, got {s.export_limit('INV2')}")
-        failed = True
-    if s.export_limit("UNKNOWN") != 0:
-        print(f"ERROR: an unknown serial should derive 0, got {s.export_limit('UNKNOWN')}")
-        failed = True
-    assert not failed, "test_export_limit_is_mapped_and_bounded_by_the_inverter"
-
-
 def run_sunsynk_api_tests(my_predbat):
     """Run all Sunsynk API tests."""
     failed = False
@@ -1152,7 +1129,6 @@ def run_sunsynk_api_tests(my_predbat):
         ("rate_max_field_priority", test_battery_rate_max_prefers_a_populated_current_field),
         ("pack_voltage_window", test_nominal_pack_voltage_across_the_lifepo4_charge_window),
         ("inverter_limit_limiter", test_inverter_limit_respects_the_installer_power_limiter),
-        ("export_limit_mapped", test_export_limit_is_mapped_and_bounded_by_the_inverter),
         ("battery_reserve_min", test_battery_reserve_min_from_settings),
         ("device_list_no_serials_terminates", test_get_device_list_terminates_when_serials_are_missing),
         ("device_list_deduplicates", test_get_device_list_deduplicates_repeated_pages),

--- a/apps/predbat/tests/test_sunsynk_api.py
+++ b/apps/predbat/tests/test_sunsynk_api.py
@@ -1071,35 +1071,40 @@ def test_nominal_pack_voltage_across_the_lifepo4_charge_window():
     assert not failed, "test_nominal_pack_voltage_across_the_lifepo4_charge_window"
 
 
-def test_inverter_limit_respects_the_installer_power_limiter():
-    """The installer's Inverter Power Limiter can cap the inverter below its rating.
+def test_inverter_limit_is_the_rating_and_export_limit_is_the_cap():
+    """pvMaxLimit caps EXPORT, not the inverter's output, despite its app label.
 
-    Confirmed live: ratePower 8000 with pvMaxLimit 7000. Using the rating alone would have
-    Predbat plan a kilowatt the inverter will never deliver.
+    Sunsynk's documentation confirms the "Inverter Power Limiter" control is an export cap,
+    which is why the app shows the same value on both the System Mode and Grid Settings
+    screens. The inverter can still deliver its full ratePower to the house, so reducing
+    inverter_limit by it would under-rate the inverter for self-consumption.
     """
     failed = False
     s = MockSunsynk()
     s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"pvMaxLimit": "7000"}
-    if s.inverter_limit("INV1") != 7000.0:
-        print(f"ERROR: expected the lower of 8000/7000, got {s.inverter_limit('INV1')}")
+    if s.inverter_limit("INV1") != 8000.0:
+        print(f"ERROR: inverter_limit should be the 8000W rating, got {s.inverter_limit('INV1')}")
         failed = True
-    # A limiter above the rating must not raise the limit beyond what the hardware can do.
-    s.device_rated_power["INV2"] = 5000.0
+    if s.export_limit("INV1") != 7000.0:
+        print(f"ERROR: export_limit should be the 7000W cap, got {s.export_limit('INV1')}")
+        failed = True
+    # Export can never exceed what the inverter can produce, whatever the setting allows.
+    s.device_rated_power["INV2"] = 3600.0
     s.device_settings["INV2"] = {"pvMaxLimit": "16000"}
-    if s.inverter_limit("INV2") != 5000.0:
-        print(f"ERROR: rating must cap the limiter, got {s.inverter_limit('INV2')}")
+    if s.export_limit("INV2") != 3600.0:
+        print(f"ERROR: export must be bounded by the rating, got {s.export_limit('INV2')}")
         failed = True
-    # Either one alone is still usable.
+    # A G98 site: a 3.68kW export cap behind a much larger inverter must survive intact.
     s.device_rated_power["INV3"] = 8000.0
-    s.device_settings["INV3"] = {}
-    if s.inverter_limit("INV3") != 8000.0:
-        print(f"ERROR: rating alone should be used, got {s.inverter_limit('INV3')}")
+    s.device_settings["INV3"] = {"pvMaxLimit": "3680"}
+    if s.export_limit("INV3") != 3680.0 or s.inverter_limit("INV3") != 8000.0:
+        print(f"ERROR: G98 case wrong - export {s.export_limit('INV3')}, inverter {s.inverter_limit('INV3')}")
         failed = True
-    if s.inverter_limit("UNKNOWN") != 0:
-        print(f"ERROR: an unknown serial should derive 0, got {s.inverter_limit('UNKNOWN')}")
+    if s.inverter_limit("UNKNOWN") != 0 or s.export_limit("UNKNOWN") != 0:
+        print("ERROR: an unknown serial should derive 0 for both")
         failed = True
-    assert not failed, "test_inverter_limit_respects_the_installer_power_limiter"
+    assert not failed, "test_inverter_limit_is_the_rating_and_export_limit_is_the_cap"
 
 
 def run_sunsynk_api_tests(my_predbat):
@@ -1128,7 +1133,7 @@ def run_sunsynk_api_tests(my_predbat):
         ("battery_rate_max", test_battery_rate_max_from_charge_current),
         ("rate_max_field_priority", test_battery_rate_max_prefers_a_populated_current_field),
         ("pack_voltage_window", test_nominal_pack_voltage_across_the_lifepo4_charge_window),
-        ("inverter_limit_limiter", test_inverter_limit_respects_the_installer_power_limiter),
+        ("inverter_limit_vs_export", test_inverter_limit_is_the_rating_and_export_limit_is_the_cap),
         ("battery_reserve_min", test_battery_reserve_min_from_settings),
         ("device_list_no_serials_terminates", test_get_device_list_terminates_when_serials_are_missing),
         ("device_list_deduplicates", test_get_device_list_deduplicates_repeated_pages),

--- a/apps/predbat/tests/test_sunsynk_config.py
+++ b/apps/predbat/tests/test_sunsynk_config.py
@@ -750,14 +750,12 @@ def test_run_isolates_one_inverters_failure_from_the_rest():
     assert not failed, "test_run_isolates_one_inverters_failure_from_the_rest"
 
 
-def test_export_limit_is_never_auto_mapped():
-    """export_limit must be left to apps.yaml, because we cannot identify the real field.
+def test_export_limit_is_auto_mapped_from_the_export_cap():
+    """export_limit must be mapped, or Predbat plans exports the inverter clips.
 
-    The app's Export power limiter can sit below the inverter limit (a G98/G99 site is
-    commonly capped at 3.68kW behind a much larger inverter), but no settings field carrying
-    it could be identified. Guessing it from pvMaxLimit would be worse than leaving it:
-    set_arg_auto always beats apps.yaml, so a user who correctly set their real export cap
-    would have it silently replaced by the larger inverter limit.
+    inverter.py defaults export_limit to 99999W. pvMaxLimit is the export cap (Sunsynk
+    documents the app's "Inverter Power Limiter" as limiting export), so it is mapped, while
+    inverter_limit stays on the hardware rating.
     """
     failed = False
     s = ConfigSunsynk()
@@ -767,17 +765,17 @@ def test_export_limit_is_never_auto_mapped():
     s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"batteryLowCap": "20", "pvMaxLimit": "7000"}
     run_async_local(s.automatic_config())
-    if "export_limit" in s.args_set:
-        print(f"ERROR: export_limit was auto-mapped to {s.args_set['export_limit']}, which would override the user's apps.yaml value")
+    for arg in ("inverter_limit", "export_limit"):
+        if arg not in s.args_set:
+            print(f"ERROR: {arg} was not mapped")
+            failed = True
+    if s.inverter_limit("INV1") != 8000.0:
+        print(f"ERROR: inverter_limit should be the rating 8000, got {s.inverter_limit('INV1')}")
         failed = True
-    # The inverter limit IS mapped, and reflects the app's power limiter rather than ratePower.
-    if "inverter_limit" not in s.args_set:
-        print("ERROR: inverter_limit should still be mapped")
+    if s.export_limit("INV1") != 7000.0:
+        print(f"ERROR: export_limit should be the cap 7000, got {s.export_limit('INV1')}")
         failed = True
-    if s.inverter_limit("INV1") != 7000.0:
-        print(f"ERROR: inverter_limit should honour pvMaxLimit 7000, got {s.inverter_limit('INV1')}")
-        failed = True
-    assert not failed, "test_export_limit_is_never_auto_mapped"
+    assert not failed, "test_export_limit_is_auto_mapped_from_the_export_cap"
 
 
 def run_sunsynk_config_tests(my_predbat):
@@ -788,7 +786,7 @@ def run_sunsynk_config_tests(my_predbat):
         ("component_registered", test_component_registered),
         ("apps_schema", test_apps_schema_keys),
         ("automatic_config", test_automatic_config_maps_control_entities),
-        ("export_limit_not_mapped", test_export_limit_is_never_auto_mapped),
+        ("export_limit_mapped", test_export_limit_is_auto_mapped_from_the_export_cap),
         ("partial_capabilities", test_automatic_config_skips_partial_capabilities),
         ("ignore_pv", test_automatic_config_respects_ignore_pv),
         ("run_first_cycle", test_run_first_cycle_polls_and_publishes),

--- a/apps/predbat/tests/test_sunsynk_config.py
+++ b/apps/predbat/tests/test_sunsynk_config.py
@@ -750,6 +750,36 @@ def test_run_isolates_one_inverters_failure_from_the_rest():
     assert not failed, "test_run_isolates_one_inverters_failure_from_the_rest"
 
 
+def test_export_limit_is_never_auto_mapped():
+    """export_limit must be left to apps.yaml, because we cannot identify the real field.
+
+    The app's Export power limiter can sit below the inverter limit (a G98/G99 site is
+    commonly capped at 3.68kW behind a much larger inverter), but no settings field carrying
+    it could be identified. Guessing it from pvMaxLimit would be worse than leaving it:
+    set_arg_auto always beats apps.yaml, so a user who correctly set their real export cap
+    would have it silently replaced by the larger inverter limit.
+    """
+    failed = False
+    s = ConfigSunsynk()
+    s.device_list = ["INV1"]
+    s.device_values["INV1"] = {"soc": 50, "capacity": 200, "chargeVolt": 58.4, "chargeCurrentLimit": 216}
+    s.device_energy["INV1"] = {leaf: 1.0 for leaf in ("pv_today", "import_today", "export_today", "load_today", "battery_charge_today", "battery_discharge_today")}
+    s.device_rated_power["INV1"] = 8000.0
+    s.device_settings["INV1"] = {"batteryLowCap": "20", "pvMaxLimit": "7000"}
+    run_async_local(s.automatic_config())
+    if "export_limit" in s.args_set:
+        print(f"ERROR: export_limit was auto-mapped to {s.args_set['export_limit']}, which would override the user's apps.yaml value")
+        failed = True
+    # The inverter limit IS mapped, and reflects the app's power limiter rather than ratePower.
+    if "inverter_limit" not in s.args_set:
+        print("ERROR: inverter_limit should still be mapped")
+        failed = True
+    if s.inverter_limit("INV1") != 7000.0:
+        print(f"ERROR: inverter_limit should honour pvMaxLimit 7000, got {s.inverter_limit('INV1')}")
+        failed = True
+    assert not failed, "test_export_limit_is_never_auto_mapped"
+
+
 def run_sunsynk_config_tests(my_predbat):
     """Run all Sunsynk configuration tests."""
     failed = False
@@ -758,6 +788,7 @@ def run_sunsynk_config_tests(my_predbat):
         ("component_registered", test_component_registered),
         ("apps_schema", test_apps_schema_keys),
         ("automatic_config", test_automatic_config_maps_control_entities),
+        ("export_limit_not_mapped", test_export_limit_is_never_auto_mapped),
         ("partial_capabilities", test_automatic_config_skips_partial_capabilities),
         ("ignore_pv", test_automatic_config_respects_ignore_pv),
         ("run_first_cycle", test_run_first_cycle_polls_and_publishes),

--- a/apps/predbat/tests/test_sunsynk_control.py
+++ b/apps/predbat/tests/test_sunsynk_control.py
@@ -919,13 +919,12 @@ def test_freeze_states_are_expressed_as_zero_power():
     assert not failed, "test_freeze_states_are_expressed_as_zero_power"
 
 
-def test_hold_charge_behaves_as_self_use():
-    """A charge target at or below current SoC must not constrain or freeze the battery.
+def test_hold_charge_keeps_predbat_rate_without_charging():
+    """A charge target at or below current SoC must not trigger a charge, but keeps the rate.
 
-    There is nothing to charge, so the slot should be an ordinary self-use one: no grid
-    charge, and the inverter's full power so the battery keeps serving the house. A
-    zero-power slot would freeze it; an action slot carrying the requested charge power
-    would needlessly cap it.
+    Grid charge stays off - there is nothing to charge - while the slot still carries
+    Predbat's chosen charge rate for that window. Zero would mean freeze, a different
+    state; the inverter's full rating would discard the rate Predbat asked for.
     """
     failed = False
     s = MockSunsynk()
@@ -936,19 +935,27 @@ def test_hold_charge_behaves_as_self_use():
     if state["behaviour"] != "hold_charge":
         print(f"ERROR: expected hold_charge, got {state['behaviour']}")
         failed = True
-    if state["grid_charge"] or state["power"] != 0:
-        print(f"ERROR: hold_charge should not charge and should classify as self-use, got {state}")
+    if state["grid_charge"]:
+        print("ERROR: hold_charge must not enable grid charge - there is nothing to charge")
+        failed = True
+    if state["power"] != 3000:
+        print(f"ERROR: hold_charge should keep Predbat's 3000W rate, got {state['power']}")
         failed = True
     sched = _schedule(reserve=20, charge={"enable": True, "soc": 40, "power": 3000, "start": "03:00:00", "end": "04:00:00"})
     payload = s.build_settings_payload("INV1", sched, current_soc=60, now_minutes=3 * 60 + 30)
-    for n in range(1, TOU_SLOT_COUNT + 1):
+    hold = [n for n in range(1, TOU_SLOT_COUNT + 1) if payload[TOU_FIELD["time"].format(n=n)] == "03:00"]
+    if not hold:
+        print("ERROR: no slot at the window start")
+        failed = True
+    else:
+        n = hold[0]
         if payload[TOU_FIELD["grid_charge"].format(n=n)]:
-            print(f"ERROR: hold_charge produced a grid-charge slot at {payload[TOU_FIELD['time'].format(n=n)]}")
+            print("ERROR: the hold-charge slot enabled grid charge")
             failed = True
-        if int(payload[TOU_FIELD["power"].format(n=n)]) != 8000:
-            print(f"ERROR: slot {n} power {payload[TOU_FIELD['power'].format(n=n)]}, expected the full 8000W rating")
+        if int(payload[TOU_FIELD["power"].format(n=n)]) != 3000:
+            print(f"ERROR: hold-charge slot power {payload[TOU_FIELD['power'].format(n=n)]}, expected Predbat's 3000W")
             failed = True
-    assert not failed, "test_hold_charge_behaves_as_self_use"
+    assert not failed, "test_hold_charge_keeps_predbat_rate_without_charging"
 
 
 def run_sunsynk_control_tests(my_predbat):
@@ -960,7 +967,7 @@ def run_sunsynk_control_tests(my_predbat):
         ("tou_slots_shape", test_build_tou_slots_shape),
         ("self_use_never_zero", test_self_use_slots_are_never_zero_power),
         ("freeze_zero_power", test_freeze_states_are_expressed_as_zero_power),
-        ("hold_charge_self_use", test_hold_charge_behaves_as_self_use),
+        ("hold_charge_rate", test_hold_charge_keeps_predbat_rate_without_charging),
         ("tou_slots_seconds", test_build_tou_slots_seconds_are_dropped),
         ("tou_slots_idle", test_build_tou_slots_idle_is_still_six_distinct),
         ("tou_slots_zero_length_window", test_build_tou_slots_zero_length_window_has_no_effect),

--- a/apps/predbat/tests/test_sunsynk_control.py
+++ b/apps/predbat/tests/test_sunsynk_control.py
@@ -224,8 +224,8 @@ def test_payload_renders_indexed_fields_and_types():
     if payload.get(SUNSYNK_SERIAL_FIELD) != "INV1":
         print(f"ERROR: serial should be echoed back, got {payload.get(SUNSYNK_SERIAL_FIELD)!r}")
         failed = True
-    if payload.get(SUNSYNK_SOLAR_SELL_FIELD) not in ("0", "1"):
-        print(f"ERROR: solarSell should be '0' or '1', got {payload.get(SUNSYNK_SOLAR_SELL_FIELD)!r}")
+    if payload.get(SUNSYNK_SOLAR_SELL_FIELD) != "1":
+        print(f"ERROR: solarSell should always be '1', got {payload.get(SUNSYNK_SOLAR_SELL_FIELD)!r}")
         failed = True
     assert not failed, "test_payload_renders_indexed_fields_and_types"
 
@@ -785,6 +785,34 @@ def test_external_changes_are_logged():
     assert not failed, "test_external_changes_are_logged"
 
 
+def test_solar_export_is_never_disabled():
+    """solarSell must stay on in every state, including idle and charging.
+
+    It governs whether surplus PV reaches the grid at all, not what the battery does.
+    Deriving it from the active window - on only while exporting - would curtail spare
+    solar for most daylight hours once the battery is full, silently costing export
+    revenue, and Predbat has no notion of PV curtailment to notice it. An export window
+    still exports via the selling-first work mode and the slot SoC targets.
+    """
+    failed = False
+    s = MockSunsynk()
+    s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "10"}
+    charge = {"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "05:00:00"}
+    export = {"enable": True, "soc": 20, "power": 3000, "start": "16:00:00", "end": "19:00:00"}
+    cases = [
+        ("idle midday", _schedule(reserve=10), 12 * 60),
+        ("inside the charge window", _schedule(reserve=10, charge=charge), 3 * 60),
+        ("inside the export window", _schedule(reserve=10, export=export), 17 * 60),
+        ("both windows set, neither active", _schedule(reserve=10, charge=charge, export=export), 12 * 60),
+    ]
+    for name, schedule, minutes in cases:
+        payload = s.build_settings_payload("INV1", schedule, current_soc=40, now_minutes=minutes)
+        if payload.get(SUNSYNK_SOLAR_SELL_FIELD) != "1":
+            print(f"ERROR: {name} produced solarSell {payload.get(SUNSYNK_SOLAR_SELL_FIELD)!r}, expected '1'")
+            failed = True
+    assert not failed, "test_solar_export_is_never_disabled"
+
+
 def run_sunsynk_control_tests(my_predbat):
     """Run all Sunsynk control-logic tests."""
     failed = False
@@ -797,6 +825,7 @@ def run_sunsynk_control_tests(my_predbat):
         ("active_window_mode", test_active_window_drives_the_global_mode),
         ("midnight_wrap", test_window_active_handles_midnight_wrap),
         ("payload_field_types", test_payload_renders_indexed_fields_and_types),
+        ("solar_export_never_off", test_solar_export_is_never_disabled),
         ("payload_preserves", test_payload_preserves_unowned_settings),
         ("payload_soc_floor", test_payload_clamps_to_the_inverter_soc_floor),
         ("payload_no_baseline_is_empty", test_build_settings_payload_returns_empty_without_a_baseline),

--- a/apps/predbat/tests/test_sunsynk_control.py
+++ b/apps/predbat/tests/test_sunsynk_control.py
@@ -36,12 +36,12 @@ def test_derive_control_state_table():
     failed = False
     s = MockSunsynk()
     cases = [
-        ("charge", _schedule(reserve=10, charge={"enable": True, "soc": 90, "power": 3000}), 50, ("charge", SUNSYNK_WORKMODE["zero_export_load"], True, False, 90)),
-        ("freeze_charge", _schedule(reserve=50, charge={"enable": True, "soc": 50, "power": 3000}), 50, ("freeze_charge", SUNSYNK_WORKMODE["zero_export_load"], True, False, 50)),
-        ("hold_charge", _schedule(reserve=50, charge={"enable": True, "soc": 40, "power": 3000}), 50, ("hold_charge", SUNSYNK_WORKMODE["zero_export_load"], False, False, 50)),
+        ("charge", _schedule(reserve=10, charge={"enable": True, "soc": 90, "power": 3000}), 50, ("charge", SUNSYNK_WORKMODE["zero_export_ct"], True, False, 90)),
+        ("freeze_charge", _schedule(reserve=50, charge={"enable": True, "soc": 50, "power": 3000}), 50, ("freeze_charge", SUNSYNK_WORKMODE["zero_export_ct"], True, False, 50)),
+        ("hold_charge", _schedule(reserve=50, charge={"enable": True, "soc": 40, "power": 3000}), 50, ("hold_charge", SUNSYNK_WORKMODE["zero_export_ct"], False, False, 50)),
         ("export", _schedule(reserve=10, export={"enable": True, "soc": 20, "power": 3000}), 80, ("export", SUNSYNK_WORKMODE["selling_first"], False, True, 20)),
         ("freeze_export", _schedule(reserve=10, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), 80, ("freeze_export", SUNSYNK_WORKMODE["selling_first"], False, True, FREEZE_EXPORT_SOC)),
-        ("idle", _schedule(reserve=15), 60, ("idle", SUNSYNK_WORKMODE["zero_export_load"], False, False, 15)),
+        ("idle", _schedule(reserve=15), 60, ("idle", SUNSYNK_WORKMODE["zero_export_ct"], False, False, 15)),
     ]
     for name, schedule, soc, expect in cases:
         result = s.derive_control_state(schedule, soc)
@@ -159,7 +159,7 @@ def test_active_window_drives_the_global_mode():
     )
     # 03:00 -> inside the charge window.
     payload = s.build_settings_payload("INV1", schedule, current_soc=40, now_minutes=3 * 60)
-    if payload[SUNSYNK_WORKMODE_FIELD] != SUNSYNK_WORKMODE["zero_export_load"]:
+    if payload[SUNSYNK_WORKMODE_FIELD] != SUNSYNK_WORKMODE["zero_export_ct"]:
         print(f"ERROR: at 03:00 expected zero_export_load, got {payload[SUNSYNK_WORKMODE_FIELD]}")
         failed = True
     # 17:00 -> inside the export window.
@@ -169,7 +169,7 @@ def test_active_window_drives_the_global_mode():
         failed = True
     # 12:00 -> neither window, so self-use.
     payload = s.build_settings_payload("INV1", schedule, current_soc=60, now_minutes=12 * 60)
-    if payload[SUNSYNK_WORKMODE_FIELD] != SUNSYNK_WORKMODE["zero_export_load"]:
+    if payload[SUNSYNK_WORKMODE_FIELD] != SUNSYNK_WORKMODE["zero_export_ct"]:
         print(f"ERROR: at 12:00 expected zero_export_load, got {payload[SUNSYNK_WORKMODE_FIELD]}")
         failed = True
     assert not failed, "test_active_window_drives_the_global_mode"
@@ -813,11 +813,44 @@ def test_solar_export_is_never_disabled():
     assert not failed, "test_solar_export_is_never_disabled"
 
 
+def test_non_export_states_use_limited_to_home():
+    """Every non-export state must use zero_export_ct, and only exporting uses selling_first.
+
+    The work mode gates whether the BATTERY exports; solarSell independently gates PV. A
+    live system exported 11.1 kWh in a day while in "Limited to Home" with solarSell on, so
+    the mode does not block solar. zero_export_load ("Limit To Load Only") measures at the
+    inverter's own output rather than the grid CT, so on a CT-clamp install it would stop
+    the battery serving loads not wired to the inverter and push them onto the grid.
+    """
+    failed = False
+    s = MockSunsynk()
+    charge = {"enable": True, "soc": 95, "power": 3000}
+    cases = [
+        ("charge", _schedule(reserve=10, charge=charge), 50, "zero_export_ct"),
+        ("freeze_charge", _schedule(reserve=50, charge={"enable": True, "soc": 50, "power": 3000}), 50, "zero_export_ct"),
+        ("hold_charge", _schedule(reserve=50, charge={"enable": True, "soc": 40, "power": 3000}), 50, "zero_export_ct"),
+        ("idle", _schedule(reserve=15), 60, "zero_export_ct"),
+        ("export", _schedule(reserve=10, export={"enable": True, "soc": 20, "power": 3000}), 80, "selling_first"),
+        ("freeze_export", _schedule(reserve=10, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), 80, "selling_first"),
+    ]
+    for name, schedule, soc, expect in cases:
+        got = s.derive_control_state(schedule, soc)["work_mode"]
+        if got != SUNSYNK_WORKMODE[expect]:
+            print(f"ERROR: {name} derived work mode {got!r}, expected {expect} ({SUNSYNK_WORKMODE[expect]!r})")
+            failed = True
+    # zero_export_load is never written: it is a real mode, just not one Predbat should pick.
+    if SUNSYNK_WORKMODE["zero_export_load"] in {s.derive_control_state(sched, soc)["work_mode"] for _, sched, soc, _ in cases}:
+        print("ERROR: zero_export_load was derived for some state")
+        failed = True
+    assert not failed, "test_non_export_states_use_limited_to_home"
+
+
 def run_sunsynk_control_tests(my_predbat):
     """Run all Sunsynk control-logic tests."""
     failed = False
     for name, fn in [
         ("derive_state_table", test_derive_control_state_table),
+        ("non_export_mode", test_non_export_states_use_limited_to_home),
         ("tou_slots_shape", test_build_tou_slots_shape),
         ("tou_slots_seconds", test_build_tou_slots_seconds_are_dropped),
         ("tou_slots_idle", test_build_tou_slots_idle_is_still_six_distinct),

--- a/apps/predbat/tests/test_sunsynk_control.py
+++ b/apps/predbat/tests/test_sunsynk_control.py
@@ -919,6 +919,38 @@ def test_freeze_states_are_expressed_as_zero_power():
     assert not failed, "test_freeze_states_are_expressed_as_zero_power"
 
 
+def test_hold_charge_behaves_as_self_use():
+    """A charge target at or below current SoC must not constrain or freeze the battery.
+
+    There is nothing to charge, so the slot should be an ordinary self-use one: no grid
+    charge, and the inverter's full power so the battery keeps serving the house. A
+    zero-power slot would freeze it; an action slot carrying the requested charge power
+    would needlessly cap it.
+    """
+    failed = False
+    s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
+    s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "20"}
+    # Target 40% with the battery already at 60% -> hold_charge.
+    state = s.derive_control_state(_schedule(reserve=20, charge={"enable": True, "soc": 40, "power": 3000}), 60)
+    if state["behaviour"] != "hold_charge":
+        print(f"ERROR: expected hold_charge, got {state['behaviour']}")
+        failed = True
+    if state["grid_charge"] or state["power"] != 0:
+        print(f"ERROR: hold_charge should not charge and should classify as self-use, got {state}")
+        failed = True
+    sched = _schedule(reserve=20, charge={"enable": True, "soc": 40, "power": 3000, "start": "03:00:00", "end": "04:00:00"})
+    payload = s.build_settings_payload("INV1", sched, current_soc=60, now_minutes=3 * 60 + 30)
+    for n in range(1, TOU_SLOT_COUNT + 1):
+        if payload[TOU_FIELD["grid_charge"].format(n=n)]:
+            print(f"ERROR: hold_charge produced a grid-charge slot at {payload[TOU_FIELD['time'].format(n=n)]}")
+            failed = True
+        if int(payload[TOU_FIELD["power"].format(n=n)]) != 8000:
+            print(f"ERROR: slot {n} power {payload[TOU_FIELD['power'].format(n=n)]}, expected the full 8000W rating")
+            failed = True
+    assert not failed, "test_hold_charge_behaves_as_self_use"
+
+
 def run_sunsynk_control_tests(my_predbat):
     """Run all Sunsynk control-logic tests."""
     failed = False
@@ -928,6 +960,7 @@ def run_sunsynk_control_tests(my_predbat):
         ("tou_slots_shape", test_build_tou_slots_shape),
         ("self_use_never_zero", test_self_use_slots_are_never_zero_power),
         ("freeze_zero_power", test_freeze_states_are_expressed_as_zero_power),
+        ("hold_charge_self_use", test_hold_charge_behaves_as_self_use),
         ("tou_slots_seconds", test_build_tou_slots_seconds_are_dropped),
         ("tou_slots_idle", test_build_tou_slots_idle_is_still_six_distinct),
         ("tou_slots_zero_length_window", test_build_tou_slots_zero_length_window_has_no_effect),

--- a/apps/predbat/tests/test_sunsynk_control.py
+++ b/apps/predbat/tests/test_sunsynk_control.py
@@ -35,6 +35,7 @@ def test_derive_control_state_table():
     """Each Predbat intent maps to the work mode and flags the spec's table requires."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     cases = [
         ("charge", _schedule(reserve=10, charge={"enable": True, "soc": 90, "power": 3000}), 50, ("charge", SUNSYNK_WORKMODE["zero_export_ct"], True, False, 90)),
         ("freeze_charge", _schedule(reserve=50, charge={"enable": True, "soc": 50, "power": 3000}), 50, ("freeze_charge", SUNSYNK_WORKMODE["zero_export_ct"], True, False, 50)),
@@ -56,8 +57,9 @@ def test_build_tou_slots_shape():
     """A charge window yields exactly 6 slots with distinct ascending times from 00:00."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     schedule = _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "05:00:00"})
-    slots = s.build_tou_slots(schedule, current_soc=40)
+    slots = s.build_tou_slots(schedule, current_soc=40, self_use_power=8000)
     if len(slots) != TOU_SLOT_COUNT:
         print(f"ERROR: expected {TOU_SLOT_COUNT} slots, got {len(slots)}")
         failed = True
@@ -82,8 +84,9 @@ def test_build_tou_slots_seconds_are_dropped():
     """Entity times carry seconds (HH:MM:SS); slots must be HH:MM."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     schedule = _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "02:30:00", "end": "05:45:00"})
-    times = [slot["time"] for slot in s.build_tou_slots(schedule, current_soc=40)]
+    times = [slot["time"] for slot in s.build_tou_slots(schedule, current_soc=40, self_use_power=8000)]
     for time_text in times:
         if len(time_text) != 5 or time_text.count(":") != 1:
             print(f"ERROR: slot time {time_text!r} is not HH:MM")
@@ -98,7 +101,8 @@ def test_build_tou_slots_idle_is_still_six_distinct():
     """An empty schedule still yields six distinct self-use slots."""
     failed = False
     s = MockSunsynk()
-    slots = s.build_tou_slots(_schedule(reserve=15), current_soc=50)
+    s.device_rated_power["INV1"] = 8000.0
+    slots = s.build_tou_slots(_schedule(reserve=15), current_soc=50, self_use_power=8000)
     times = [slot["time"] for slot in slots]
     if len(set(times)) != TOU_SLOT_COUNT:
         print(f"ERROR: idle schedule produced {len(set(times))} distinct times: {times}")
@@ -125,12 +129,13 @@ def test_build_tou_slots_zero_length_window_has_no_effect():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     cases = [
         _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "00:00:00", "end": "00:00:00"}),
         _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "02:00"}),
     ]
     for schedule in cases:
-        slots = s.build_tou_slots(schedule, current_soc=40)
+        slots = s.build_tou_slots(schedule, current_soc=40, self_use_power=8000)
         if any(slot["grid_charge"] for slot in slots):
             print(f"ERROR: a zero-length window produced a grid-charge slot: {slots}")
             failed = True
@@ -151,6 +156,7 @@ def test_active_window_drives_the_global_mode():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "10"}
     schedule = _schedule(
         reserve=10,
@@ -179,6 +185,7 @@ def test_window_active_handles_midnight_wrap():
     """A window running past midnight is active on both sides of it."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     window = {"enable": True, "start": "23:00", "end": "02:00"}
     for minutes, expect in ((23 * 60 + 30, True), (60, True), (12 * 60, False), (22 * 60, False)):
         got = s._window_active(window, minutes)
@@ -196,6 +203,7 @@ def test_payload_renders_indexed_fields_and_types():
     """Slots become sellTimeN/capN/timeNon with the right wire types."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "10"}
     schedule = _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "05:00:00"})
     payload = s.build_settings_payload("INV1", schedule, current_soc=40, now_minutes=3 * 60)
@@ -234,6 +242,7 @@ def test_payload_preserves_unowned_settings():
     """Read-modify-write leaves every field Predbat does not own exactly as it was."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {
         "sn": "INV1",
         "batteryShutdownCap": "5",
@@ -267,6 +276,7 @@ def test_payload_clamps_to_the_inverter_soc_floor():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"batteryLowCap": "20"}
     # Predbat's control entities start at 0 and only reach real values once written.
     schedule = _schedule(reserve=0, charge={"enable": True, "soc": 5, "power": 3000, "start": "02:00:00", "end": "05:00:00"})
@@ -292,6 +302,7 @@ def test_build_settings_payload_returns_empty_without_a_baseline():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     schedule = _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "05:00:00"})
     payload = s.build_settings_payload("INV1", schedule, current_soc=40, now_minutes=3 * 60)
     if payload != {}:
@@ -304,6 +315,7 @@ def test_payloads_equal_ignores_nothing_material():
     """Change detection sees a real difference and ignores an identical rewrite."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "10"}
     schedule = _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "05:00:00"})
     first = s.build_settings_payload("INV1", schedule, current_soc=40, now_minutes=3 * 60)
@@ -323,6 +335,7 @@ def test_apply_settings_skips_an_unchanged_payload():
     """An unchanged plan does not re-post, so the dongle is not churned every cycle."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     posts = []
 
     async def fake_get(endpoint_key, sn=None, params=None):
@@ -360,6 +373,7 @@ def test_apply_settings_noop_ticks_perform_no_io():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     gets = []
     posts = []
 
@@ -395,6 +409,7 @@ def test_apply_settings_changed_plan_performs_one_get_and_one_post():
     """A genuine change in the plan costs exactly one read and one write, not more."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     gets = []
     posts = []
 
@@ -432,6 +447,7 @@ def test_apply_settings_ignores_a_volatile_unowned_field():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     posts = []
     tick = [0]
 
@@ -459,6 +475,7 @@ def test_apply_settings_fails_closed_without_a_read():
     """If the settings read fails, nothing is written — the write baseline is unknown."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     posts = []
 
     async def fake_get_empty(endpoint_key, sn=None, params=None):
@@ -486,6 +503,7 @@ def test_apply_settings_respects_control_enable():
     """With control disabled, the component derives but never writes."""
     failed = False
     s = MockSunsynk(control_enable=False)
+    s.device_rated_power["INV1"] = 8000.0
     posts = []
 
     async def fake_get(endpoint_key, sn=None, params=None):
@@ -516,6 +534,7 @@ def test_apply_settings_skips_when_the_payload_is_empty():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     posts = []
 
     async def fake_get(endpoint_key, sn=None, params=None):
@@ -548,6 +567,7 @@ def test_apply_settings_reports_a_failed_write():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
 
     async def fake_get(endpoint_key, sn=None, params=None):
         """Return a minimal settings object."""
@@ -593,6 +613,7 @@ def test_note_settle_normalises_wire_types_before_comparing():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "10"}
     schedule = _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "05:00:00"})
     applied = s.build_settings_payload("INV1", schedule, current_soc=40, now_minutes=3 * 60)
@@ -623,6 +644,7 @@ def _settled_baseline():
     it to exercise one field at a time.
     """
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "10"}
     schedule = _schedule(reserve=10, charge={"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "05:00:00"})
     applied = s.build_settings_payload("INV1", schedule, current_soc=40, now_minutes=3 * 60)
@@ -765,6 +787,7 @@ def test_external_changes_are_logged():
     """A setting changed outside Predbat is reported, not silently overwritten."""
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     before = {"sn": "INV1", "batteryLowCap": "10", "zeroExportPower": "20", "cap1": "50"}
     after = {"sn": "INV1", "batteryLowCap": "10", "zeroExportPower": "80", "cap1": "95"}
     s.note_external_change("INV1", before, after)
@@ -796,6 +819,7 @@ def test_solar_export_is_never_disabled():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "10"}
     charge = {"enable": True, "soc": 95, "power": 3000, "start": "02:00:00", "end": "05:00:00"}
     export = {"enable": True, "soc": 20, "power": 3000, "start": "16:00:00", "end": "19:00:00"}
@@ -824,6 +848,7 @@ def test_non_export_states_use_limited_to_home():
     """
     failed = False
     s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
     charge = {"enable": True, "soc": 95, "power": 3000}
     cases = [
         ("charge", _schedule(reserve=10, charge=charge), 50, "zero_export_ct"),
@@ -845,6 +870,55 @@ def test_non_export_states_use_limited_to_home():
     assert not failed, "test_non_export_states_use_limited_to_home"
 
 
+def test_self_use_slots_are_never_zero_power():
+    """A zero-power self-use slot would freeze the battery for most of the day.
+
+    Zero power is how Sunsynk expresses a freeze - the battery neither charges nor
+    discharges. Self-use slots cover every interval Predbat is not actively charging or
+    exporting, so writing zero there would stop the battery serving the house and push the
+    load onto the grid as the DEFAULT state.
+    """
+    failed = False
+    s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
+    s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "20", "pvMaxLimit": "7000"}
+    sched = _schedule(reserve=20, charge={"enable": True, "soc": 90, "power": 3000, "start": "03:00:00", "end": "04:00:00"})
+    payload = s.build_settings_payload("INV1", sched, current_soc=38, now_minutes=22 * 60)
+    for n in range(1, TOU_SLOT_COUNT + 1):
+        power = int(payload[TOU_FIELD["power"].format(n=n)])
+        charging = payload[TOU_FIELD["grid_charge"].format(n=n)]
+        if not charging and power <= 0:
+            print(f"ERROR: self-use slot {n} at {payload[TOU_FIELD['time'].format(n=n)]} has power {power} - that freezes the battery")
+            failed = True
+    # The charge slot carries the requested charge power, not the self-use power.
+    charge_slots = [n for n in range(1, TOU_SLOT_COUNT + 1) if payload[TOU_FIELD["grid_charge"].format(n=n)]]
+    if not charge_slots or int(payload[TOU_FIELD["power"].format(n=charge_slots[0])]) != 3000:
+        print(f"ERROR: charge slot should carry 3000W, got {[payload[TOU_FIELD['power'].format(n=n)] for n in charge_slots]}")
+        failed = True
+    assert not failed, "test_self_use_slots_are_never_zero_power"
+
+
+def test_freeze_states_are_expressed_as_zero_power():
+    """Freeze charge and freeze export are expressed by zero slot power."""
+    failed = False
+    s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
+    freeze_charge = s.derive_control_state(_schedule(reserve=50, charge={"enable": True, "soc": 50, "power": 3000}), 50)
+    if freeze_charge["behaviour"] != "freeze_charge" or freeze_charge["power"] != 0:
+        print(f"ERROR: freeze_charge should have power 0, got {freeze_charge}")
+        failed = True
+    freeze_export = s.derive_control_state(_schedule(reserve=10, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), 80)
+    if freeze_export["behaviour"] != "freeze_export" or freeze_export["power"] != 0:
+        print(f"ERROR: freeze_export should have power 0, got {freeze_export}")
+        failed = True
+    # A real export still carries its requested power.
+    real_export = s.derive_control_state(_schedule(reserve=10, export={"enable": True, "soc": 20, "power": 2500}), 80)
+    if real_export["power"] != 2500:
+        print(f"ERROR: a real export should keep its 2500W, got {real_export['power']}")
+        failed = True
+    assert not failed, "test_freeze_states_are_expressed_as_zero_power"
+
+
 def run_sunsynk_control_tests(my_predbat):
     """Run all Sunsynk control-logic tests."""
     failed = False
@@ -852,6 +926,8 @@ def run_sunsynk_control_tests(my_predbat):
         ("derive_state_table", test_derive_control_state_table),
         ("non_export_mode", test_non_export_states_use_limited_to_home),
         ("tou_slots_shape", test_build_tou_slots_shape),
+        ("self_use_never_zero", test_self_use_slots_are_never_zero_power),
+        ("freeze_zero_power", test_freeze_states_are_expressed_as_zero_power),
         ("tou_slots_seconds", test_build_tou_slots_seconds_are_dropped),
         ("tou_slots_idle", test_build_tou_slots_idle_is_still_six_distinct),
         ("tou_slots_zero_length_window", test_build_tou_slots_zero_length_window_has_no_effect),

--- a/docs/superpowers/specs/2026-08-17-sunsynk-cloud-integration-design.md
+++ b/docs/superpowers/specs/2026-08-17-sunsynk-cloud-integration-design.md
@@ -281,6 +281,22 @@ Sunsynk exposes six time-of-use slots as flat indexed fields. Slots are sequenti
 intervals — each runs from its own start time until the next slot's start — so all six
 start times must be distinct and ascending, the same constraint DEYE has.
 
+Since confirmed by Sunsynk's own documentation, "Avoiding conflicts in the System Mode
+timer": the six slots are sequential chronological intervals, each running until the next
+begins, and "Timers MUST be set chronologically from Timer 1 to Timer 6". Timer 6 is the
+only one permitted to roll over midnight and continue until Timer 1 restarts.
+
+The same article settles a question the API alone could not: a slot is an interval
+regardless of its grid-charge flag — the documented factory default runs all six timers as
+ranges with Grid Charge ticked on only two. That is what makes the filler padding work, since
+a filler slot with grid charge off still terminates the charge window before it. Had the
+opposite been true (only grid-charge-enabled slots being active), a Predbat charge window
+would never have handed over and would have grid-charged for 24 hours.
+
+An inverter can nonetheless be found sitting with all six slots at 00:00, which the API
+stores happily. That is an unconfigured default rather than a valid programme, so no
+conclusion about legal schedules follows from it.
+
 The component derives six ordered slots from Predbat's charge and export windows using
 the same segment-boundary approach as `deye.py`'s `build_tou_slots()`: start from a
 baseline self-use segment at `00:00`, add a segment at each enabled window's start and


### PR DESCRIPTION
First contact between the Sunsynk integration and a real account. Everything here was run through the read-only diagnostics path against one live inverter, and every finding was checked against the Sunsynk app rather than inferred.

**Nothing was written to the inverter.** The client was built with `control_enable=False`, and `run()`'s write branch is separately gated on `control_active`, which is empty on a fresh run — two independent reasons no write could occur.

## Four mapping bugs

| | Was | Now |
|---|---|---|
| `battery_rate_max` | **0 W** — read `maxChargeCurrentLimit`, which the inverter reports as `0.0`, while `chargeCurrentLimit` carries the real 216 A | 11,059 W |
| `export_limit` | **unmapped** → `inverter.py`'s 99999 W default | 7000 W from `pvMaxLimit` |
| `inverter_limit` | `ratePower` only | `ratePower`, explicitly *not* reduced by the export cap |
| cell inference | `round(chargeVolt / 3.55)` | standard stack sizes across the 3.45–3.65 V/cell window |

`battery_rate_max` was the worst of these: deriving 0 made `automatic_config` skip the arg entirely, so Predbat would have run with no charge-rate limit at all.

`export_limit` matters most in the field. Sunsynk's documentation confirms the app's "Inverter Power Limiter" control caps **export** despite its label — which is why the app shows the same value under that name in System Mode and as "Export power limiter" in Grid Settings, and why `pvMaxLimit` was the only settings field holding the 7000 both screens displayed. A G98/G99 site capped at 3.68 kW behind a much larger inverter would otherwise have Predbat plan exports the inverter simply clips.

The cell-count change is not cosmetic: the live pack charges at exactly 3.65 V/cell, and dividing by an assumed 3.55 turns a 24-cell pack into 25 — about 4% wrong capacity, silently, landing in `soc_max`. Picking the standard stack size whose implied volts-per-cell lands in the LiFePO4 charge window is exact across 3.45–3.65 V/cell for 8/15/16/24/32-cell stacks. Derived capacity is unchanged at 10.24 kWh, matching the pack's 200 Ah at 51.2 V and its observed 52.3 V at 42% SoC.

## Two `VERIFY@SPIKE` markers resolved

**`sysWorkMode` enum — confirmed correct.** The app's Work Mode list is Selling First / Zero-Export + Limit To Load Only / Limited to Home, and with "Limited to Home" selected the settings object reported `'2'`. Same order as DEYE. Also worth recording: the mode does not by itself decide whether the system exports — the separate Solar Export toggle (`solarSell`) does. The same inverter exported 11.1 kWh that day while sitting in "Limited to Home".

**Battery power sign — confirmed positive = discharging**, matching DEYE and Predbat's convention. Four independent lines: the app's power-flow arrow (battery → house at 478 W with PV at 0 W), the API reporting `+484` at the same moment, `etodayDischg` advancing 0.20 kWh over 15 minutes while `etodayChg` stayed flat, and SoC falling 42 → 41.

## Field identifications, confirmed by the system owner

```
pvMaxLimit        7000   Inverter Power Limiter (= export cap)  -> export_limit
importPower      10350   Import power limiter                   -> recorded
solarMaxSellPower 9200   Max Solar Power                        -> recorded
batteryLowCap       20   battery floor                          -> battery_min_soc
```

## A finding I retracted

I initially flagged `grid.pac` as broken, because it read 0 while `grid.vip[0].power` read −418 W. The app showed grid at **0 W** at the same moment, so `pac` is correct and `vip[].power` is something else — a CT or per-phase sense, not whole-house flow. Had I "fixed" that I'd have replaced a working mapping with a broken one.

## Still assumption, not evidence

`grid_power` is now negated to match `deye.py` and Predbat's negative-for-import convention. This rests on the DEYE-parity rule, **not** on observation: every sample was at night with the grid idle, so 0 negated to 0 and nothing distinguished the two conventions. It stays marked `VERIFY@SPIKE`, and one daytime sample with real import or export confirms or refutes it.

## Testing

7 Sunsynk suites and the full `--quick` run pass; pre-commit clean. New regression tests cover the charge-current field priority, the cell-count window across 3.45/3.55/3.65 V/cell for every standard stack size, and both limit directions — that the rating is not reduced by the export cap, that the cap is not raised above the rating, and that a 3.68 kW G98 cap behind an 8 kW inverter survives intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)