### PR TITLE
fix: read saving session available_events from configured entity, not rewritten one

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -35,6 +35,10 @@ integration_context_header = "Ha-Integration-Context"
 DATE_STR_FORMAT = "%Y-%m-%d"
 DATE_TIME_STR_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 
+# Sentinel distinguishing "attribute not present on the entity" from a genuinely empty list,
+# since both would otherwise look the same (falsy) to callers.
+_ATTRIBUTE_UNSET = object()
+
 # Night-rate window definitions: start time, end time, whether the window crosses midnight.
 # Keys: "eco7" (Economy 7), "go" (Octopus GO / generic day-night), "iog" (Intelligent GO TOU).
 OCTOPUS_NIGHT_RATE_WINDOWS = {
@@ -2939,18 +2943,22 @@ class Octopus:
             entity_id = self.get_arg("octopus_saving_session", indirect=False)
             if entity_id:
                 state = self.get_arg("octopus_saving_session", False)
-                joined_events = self.get_state_wrapper(entity_id=entity_id, attribute="joined_events")
-                available_events = self.get_state_wrapper(entity_id=entity_id, attribute="available_events")
-                if not joined_events and not available_events:
-                    # Legacy binary_sensor entities carry neither attribute - fall back to the
-                    # newer event entity naming convention, but only adopt it if it actually has data
+                joined_events = self.get_state_wrapper(entity_id=entity_id, attribute="joined_events", default=_ATTRIBUTE_UNSET)
+                available_events = self.get_state_wrapper(entity_id=entity_id, attribute="available_events", default=_ATTRIBUTE_UNSET)
+                if joined_events is _ATTRIBUTE_UNSET and available_events is _ATTRIBUTE_UNSET:
+                    # Legacy binary_sensor entities carry neither attribute at all - fall back to the
+                    # newer event entity naming convention, but only adopt it if it actually has data.
+                    # A configured entity that has the attributes but with no events right now (empty
+                    # lists) is a valid state and must not trigger this fallback.
                     fallback_entity_id = entity_id.replace("binary_sensor.", "event.").replace("_sessions", "_session_events")
-                    fallback_joined_events = self.get_state_wrapper(entity_id=fallback_entity_id, attribute="joined_events")
-                    fallback_available_events = self.get_state_wrapper(entity_id=fallback_entity_id, attribute="available_events")
-                    if fallback_joined_events or fallback_available_events:
+                    fallback_joined_events = self.get_state_wrapper(entity_id=fallback_entity_id, attribute="joined_events", default=_ATTRIBUTE_UNSET)
+                    fallback_available_events = self.get_state_wrapper(entity_id=fallback_entity_id, attribute="available_events", default=_ATTRIBUTE_UNSET)
+                    if fallback_joined_events is not _ATTRIBUTE_UNSET or fallback_available_events is not _ATTRIBUTE_UNSET:
                         entity_id = fallback_entity_id
                         joined_events = fallback_joined_events
                         available_events = fallback_available_events
+                joined_events = [] if joined_events is _ATTRIBUTE_UNSET else joined_events
+                available_events = [] if available_events is _ATTRIBUTE_UNSET else available_events
 
             if available_events and not self.get_arg("octopus_saving_auto_join", True):
                 self.log("Octopus: Saving session auto-join is disabled, not joining available events")

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2940,11 +2940,17 @@ class Octopus:
             if entity_id:
                 state = self.get_arg("octopus_saving_session", False)
                 joined_events = self.get_state_wrapper(entity_id=entity_id, attribute="joined_events")
-                if not joined_events:
-                    entity_id = entity_id.replace("binary_sensor.", "event.").replace("_sessions", "_session_events")
-                    joined_events = self.get_state_wrapper(entity_id=entity_id, attribute="joined_events")
-
                 available_events = self.get_state_wrapper(entity_id=entity_id, attribute="available_events")
+                if not joined_events and not available_events:
+                    # Legacy binary_sensor entities carry neither attribute - fall back to the
+                    # newer event entity naming convention, but only adopt it if it actually has data
+                    fallback_entity_id = entity_id.replace("binary_sensor.", "event.").replace("_sessions", "_session_events")
+                    fallback_joined_events = self.get_state_wrapper(entity_id=fallback_entity_id, attribute="joined_events")
+                    fallback_available_events = self.get_state_wrapper(entity_id=fallback_entity_id, attribute="available_events")
+                    if fallback_joined_events or fallback_available_events:
+                        entity_id = fallback_entity_id
+                        joined_events = fallback_joined_events
+                        available_events = fallback_available_events
 
             if available_events and not self.get_arg("octopus_saving_auto_join", True):
                 self.log("Octopus: Saving session auto-join is disabled, not joining available events")

--- a/apps/predbat/tests/test_saving_session.py
+++ b/apps/predbat/tests/test_saving_session.py
@@ -592,6 +592,76 @@ friendly_name: Octoplus Saving Session Events
     return failed
 
 
+def test_saving_session_custom_entity_no_rewrite_match(my_predbat):
+    """
+    Test that available_events is read from the configured entity even when its name
+    does not match the binary_sensor -> event rewrite pattern (no '_sessions' substring),
+    and no rewritten entity exists at all.
+    Covers GitHub issue #4573
+    """
+    print("Test saving session with custom entity name that does not match the rewrite pattern (issue #4573)")
+    ha = my_predbat.ha_interface
+    failed = False
+    date_today = datetime.now().strftime("%Y-%m-%d")
+    tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)
+    tz_offset = f"{tz_offset:02d}"
+
+    # Custom entity name bridging a saving session event. It has no '_sessions' substring
+    # so the legacy binary_sensor -> event rewrite would point at a non-existent entity if
+    # it were ever applied. joined_events is empty (nothing joined yet) but available_events
+    # is populated - this is exactly the state auto-join needs to act on.
+    session_binary = f"""
+state: off
+available_events:
+    - id: 9999
+      start: '{date_today}T18:00:00+{tz_offset}:00'
+      end: '{date_today}T19:00:00+{tz_offset}:00'
+      duration_in_minutes: 60
+      rewarded_octopoints: null
+      octopoints_per_kwh: 505
+      code: EVENT_TEST
+joined_events: []
+friendly_name: Predbat Octopus Power Down For Predbat
+"""
+
+    ha.dummy_items.clear()
+    ha.dummy_items["binary_sensor.predbat_octopus_power_down_for_predbat"] = yaml.safe_load(session_binary)
+    ha.dummy_items["sensor.octopus_free_session"] = {}
+    my_predbat.args["octopus_saving_session"] = "binary_sensor.predbat_octopus_power_down_for_predbat"
+    my_predbat.args["octopus_free_session"] = "sensor.octopus_free_session"
+    if "octopus_free_url" in my_predbat.args:
+        del my_predbat.args["octopus_free_url"]
+    if "octopus_saving_session_join" in my_predbat.args:
+        del my_predbat.args["octopus_saving_session_join"]
+    my_predbat.args["octopus_saving_session_octopoints_per_penny"] = 10
+    # Reset throttle so a join is attempted
+    my_predbat.octopus_last_joined_try = None
+
+    ha.service_store_enable = True
+    ha.service_store = []
+    my_predbat.fetch_octopus_sessions()
+    service_result = ha.get_service_store()
+    ha.service_store_enable = False
+
+    join_calls = [svc for svc in service_result if "join" in svc[0]]
+    if len(join_calls) != 1:
+        print(f"ERROR: Expected 1 join call reading available_events from the configured entity, got {len(join_calls)}: {service_result}")
+        failed = True
+    elif join_calls[0][1].get("entity_id") != "binary_sensor.predbat_octopus_power_down_for_predbat":
+        print(f"ERROR: Expected join call to use the configured entity, got {join_calls[0][1]}")
+        failed = True
+    else:
+        print("  PASS: available_events read from the configured entity despite no rewrite match")
+
+    if not failed:
+        print("PASS: Custom entity name (no rewrite match) auto-join test passed")
+
+    # Restore default throttle state so we do not leak it to other tests
+    my_predbat.octopus_last_joined_try = None
+
+    return failed
+
+
 def test_saving_session_default_rate(my_predbat):
     """
     Test that saving sessions with no octopoints_per_kwh use the default rate

--- a/apps/predbat/tests/test_saving_session.py
+++ b/apps/predbat/tests/test_saving_session.py
@@ -624,40 +624,43 @@ joined_events: []
 friendly_name: Predbat Octopus Power Down For Predbat
 """
 
-    ha.dummy_items.clear()
-    ha.dummy_items["binary_sensor.predbat_octopus_power_down_for_predbat"] = yaml.safe_load(session_binary)
-    ha.dummy_items["sensor.octopus_free_session"] = {}
-    my_predbat.args["octopus_saving_session"] = "binary_sensor.predbat_octopus_power_down_for_predbat"
-    my_predbat.args["octopus_free_session"] = "sensor.octopus_free_session"
-    if "octopus_free_url" in my_predbat.args:
-        del my_predbat.args["octopus_free_url"]
-    if "octopus_saving_session_join" in my_predbat.args:
-        del my_predbat.args["octopus_saving_session_join"]
-    my_predbat.args["octopus_saving_session_octopoints_per_penny"] = 10
-    # Reset throttle so a join is attempted
-    my_predbat.octopus_last_joined_try = None
+    saved_args = my_predbat.args.copy()
+    try:
+        ha.dummy_items.clear()
+        ha.dummy_items["binary_sensor.predbat_octopus_power_down_for_predbat"] = yaml.safe_load(session_binary)
+        ha.dummy_items["sensor.octopus_free_session"] = {}
+        my_predbat.args["octopus_saving_session"] = "binary_sensor.predbat_octopus_power_down_for_predbat"
+        my_predbat.args["octopus_free_session"] = "sensor.octopus_free_session"
+        if "octopus_free_url" in my_predbat.args:
+            del my_predbat.args["octopus_free_url"]
+        if "octopus_saving_session_join" in my_predbat.args:
+            del my_predbat.args["octopus_saving_session_join"]
+        my_predbat.args["octopus_saving_session_octopoints_per_penny"] = 10
+        # Reset throttle so a join is attempted
+        my_predbat.octopus_last_joined_try = None
 
-    ha.service_store_enable = True
-    ha.service_store = []
-    my_predbat.fetch_octopus_sessions()
-    service_result = ha.get_service_store()
-    ha.service_store_enable = False
+        ha.service_store_enable = True
+        ha.service_store = []
+        my_predbat.fetch_octopus_sessions()
+        service_result = ha.get_service_store()
+        ha.service_store_enable = False
 
-    join_calls = [svc for svc in service_result if "join" in svc[0]]
-    if len(join_calls) != 1:
-        print(f"ERROR: Expected 1 join call reading available_events from the configured entity, got {len(join_calls)}: {service_result}")
-        failed = True
-    elif join_calls[0][1].get("entity_id") != "binary_sensor.predbat_octopus_power_down_for_predbat":
-        print(f"ERROR: Expected join call to use the configured entity, got {join_calls[0][1]}")
-        failed = True
-    else:
-        print("  PASS: available_events read from the configured entity despite no rewrite match")
+        join_calls = [svc for svc in service_result if "join" in svc[0]]
+        if len(join_calls) != 1:
+            print(f"ERROR: Expected 1 join call reading available_events from the configured entity, got {len(join_calls)}: {service_result}")
+            failed = True
+        elif join_calls[0][1].get("entity_id") != "binary_sensor.predbat_octopus_power_down_for_predbat":
+            print(f"ERROR: Expected join call to use the configured entity, got {join_calls[0][1]}")
+            failed = True
+        else:
+            print("  PASS: available_events read from the configured entity despite no rewrite match")
 
-    if not failed:
-        print("PASS: Custom entity name (no rewrite match) auto-join test passed")
-
-    # Restore default throttle state so we do not leak it to other tests
-    my_predbat.octopus_last_joined_try = None
+        if not failed:
+            print("PASS: Custom entity name (no rewrite match) auto-join test passed")
+    finally:
+        my_predbat.args = saved_args
+        # Restore default throttle state so we do not leak it to other tests
+        my_predbat.octopus_last_joined_try = None
 
     return failed
 

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -64,7 +64,15 @@ from tests.test_alert_feed import test_alert_feed
 from tests.test_solax import run_solax_tests
 from tests.test_sigenergy import run_sigenergy_tests
 from tests.test_single_debug import run_single_debug
-from tests.test_saving_session import test_saving_session, test_saving_session_null_octopoints, test_saving_session_notify_config, test_saving_session_default_rate, test_saving_session_axle_conflict, test_saving_session_auto_join_toggle
+from tests.test_saving_session import (
+    test_saving_session,
+    test_saving_session_null_octopoints,
+    test_saving_session_notify_config,
+    test_saving_session_default_rate,
+    test_saving_session_axle_conflict,
+    test_saving_session_auto_join_toggle,
+    test_saving_session_custom_entity_no_rewrite_match,
+)
 from tests.test_secrets import run_secrets_tests
 from tests.test_ge_cloud import test_ge_cloud
 from tests.test_teslemetry import test_teslemetry
@@ -436,6 +444,7 @@ def main():
         ("saving_session_default_rate", test_saving_session_default_rate, "Saving session default rate injection test", False),
         ("saving_session_axle_conflict", test_saving_session_axle_conflict, "Saving session Axle conflict avoidance test (issue #4120)", False),
         ("saving_session_auto_join_toggle", test_saving_session_auto_join_toggle, "Saving session auto-join toggle test (issue #4120)", False),
+        ("saving_session_custom_entity_no_rewrite_match", test_saving_session_custom_entity_no_rewrite_match, "Saving session custom entity no rewrite match test (issue #4573)", False),
         ("alert_feed", test_alert_feed, "Alert feed tests", False),
         ("fox_api", run_fox_api_tests, "Fox API tests", False),
         ("deye_const", run_deye_const_tests, "DEYE constants tests", False),


### PR DESCRIPTION
## Summary

Fixes #4573.

The `octopus_saving_session` binary_sensor -> event entity rewrite (a fallback for legacy configs) rebound `entity_id` unconditionally whenever `joined_events` was empty on the configured entity. The following `available_events` read then used the rewritten entity name instead of the one the user configured. If the rewritten entity didn't exist (e.g. custom entity names with no `_sessions` substring, or the newer flexibility API naming), `available_events` came back empty and saving-session auto-join silently stopped working - with nothing logged, since the "auto-join is disabled" message also requires `available_events` to be truthy.

## Fix

`available_events` and `joined_events` are now both read from the configured entity first. The rewrite to the `event.*` entity is only attempted - and only adopted - when the configured entity has **neither** attribute and the rewritten entity actually returns data. This preserves the legacy binary_sensor path (where `entity_id` genuinely needs to be rebound so a later join-service call targets the correct entity) while fixing the case where the configured entity already has the data needed.

## Test plan

- [x] Added `test_saving_session_custom_entity_no_rewrite_match`, reproducing the issue's scenario (custom entity name, empty `joined_events`, populated `available_events`, no matching rewritten entity). Confirmed it fails on the pre-fix code (0 join calls) and passes with the fix.
- [x] All existing saving-session tests still pass (`saving_session`, `saving_session_null`, `saving_session_notify`, `saving_session_default_rate`, `saving_session_axle_conflict`, `saving_session_auto_join_toggle`).
- [x] Full `./run_all --quick` suite passes.
- [x] `pre-commit` (ruff, black, cspell) passes on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)