### PR TITLE
fix: explain and stop wasting work when predbat.* history isn't recorded (#4583)

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -563,9 +563,14 @@ class Fetch:
         else:
             return max(data.get(index + 1, 0) - data.get(index, 0), 0)
 
-    def minute_data_import_export(self, max_days_previous, now_utc, key, scale=1.0, required_unit=None, increment=True, smoothing=True, pad=True):
+    def minute_data_import_export(self, max_days_previous, now_utc, key, scale=1.0, required_unit=None, increment=True, smoothing=True, pad=True, required=True):
         """
         Download one or more entities for import/export data
+
+        :param required: Set False when the data only improves the result rather than being needed for it,
+                         e.g. the rate history the ML load model adds as a training feature. A missing
+                         history is then reported once as information instead of as a fetch failure, as
+                         Home Assistant legitimately has no history for entities its recorder isn't storing.
         """
         if "." not in key:
             entity_ids = self.get_arg(key, indirect=False)
@@ -585,7 +590,7 @@ class Fetch:
                 continue
 
             try:
-                history = self.get_history_wrapper(entity_id=entity_id, days=max_days_previous)
+                history = self.get_history_wrapper(entity_id=entity_id, days=max_days_previous, required=required)
             except (ValueError, TypeError) as exc:
                 self.log("Warn: No history data found for {} : {}".format(entity_id, exc))
                 history = []
@@ -618,7 +623,11 @@ class Fetch:
                     can_modify_history=True,  # history is not accessed after this point, so minute_data can freely modify it
                 )
             else:
-                if history is None:
+                if not required:
+                    # Optional data - Home Assistant simply has no history for this entity, which is
+                    # normal when its recorder isn't configured to store it, so don't cry wolf
+                    self.log("Info: No history available for {}, continuing without it".format(entity_id))
+                elif history is None:
                     # Only record as a failure if it was None (not just empty but failure)
                     self.log("Warn: Failure to fetch history for {}".format(entity_id))
                     self.record_status("Warn: Failure to fetch history from {}".format(entity_id), had_errors=True)

--- a/apps/predbat/load_ml_component.py
+++ b/apps/predbat/load_ml_component.py
@@ -484,8 +484,10 @@ class LoadMLComponent(ComponentBase):
                 )
 
             # try to retrieve import and export rate history to detect rate-based load patterns
-            import_rates_history = self.base.minute_data_import_export(days_to_fetch, self.now_utc, import_entity, scale=1.0, increment=False, smoothing=False, pad=False)
-            export_rates_history = self.base.minute_data_import_export(days_to_fetch, self.now_utc, export_entity, scale=1.0, increment=False, smoothing=False, pad=False)
+            # This is optional - it only adds features to the model, and Home Assistant has no history
+            # for these entities unless its recorder is configured to store them
+            import_rates_history = self.base.minute_data_import_export(days_to_fetch, self.now_utc, import_entity, scale=1.0, increment=False, smoothing=False, pad=False, required=False)
+            export_rates_history = self.base.minute_data_import_export(days_to_fetch, self.now_utc, export_entity, scale=1.0, increment=False, smoothing=False, pad=False, required=False)
 
             # Merge import_rates_history with import_rates_data
             if import_rates_history is None:

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -2949,6 +2949,16 @@ class Output:
                 # Less than an hour old and already updated today
                 return
 
+        # Everything below is anchored on yesterday's recorded cost, so fetch that before doing any of
+        # the expensive work - when Home Assistant isn't recording predbat.cost_today there is nothing
+        # to compute and the step data and rate scans below would only be thrown away again
+        cost_today_data = self.get_history_wrapper(entity_id=self.prefix + ".cost_today", days=2, required=False)
+        if not cost_today_data:
+            self.log("Warn: Calculate yesterday: No history for {}.cost_today, so the savings and plan history can not be computed - check that Home Assistant is recording this entity (see the recorder notes in the FAQ)".format(self.prefix))
+            # Record the attempt so this is retried on the normal hourly cadence rather than every cycle
+            self.savings_last_updated = self.now_utc
+            return
+
         self.log("Calculating data from yesterday for savings calculation")
 
         # step_data_history() only fills in offsets up to self.forecast_minutes + plan_interval_minutes.
@@ -3020,10 +3030,6 @@ class Output:
         self.log("Yesterday basic charge window best: {} charge limit best: {} based on max charge slots {}".format(charge_window_best, charge_limit_best, self.calculate_savings_max_charge_slots))
 
         # Get Cost yesterday
-        cost_today_data = self.get_history_wrapper(entity_id=self.prefix + ".cost_today", days=2, required=False)
-        if not cost_today_data:
-            self.log("Warn: Calculate yesterday: No cost_today data for yesterday")
-            return
         cost_data, _ = minute_data(cost_today_data[0], 2, self.now_utc, "state", "last_updated", backwards=True, clean_increment=False, smoothing=False, divide_by=1.0, scale=1.0)
         cost_data_per_kwh, _ = minute_data(cost_today_data[0], 2, self.now_utc, "p/kWh", "last_updated", attributes=True, backwards=True, clean_increment=False, smoothing=False, divide_by=1.0, scale=1.0)
         cost_yesterday = cost_data.get(minutes_back, 0.0)

--- a/apps/predbat/tests/test_calculate_yesterday.py
+++ b/apps/predbat/tests/test_calculate_yesterday.py
@@ -1191,6 +1191,62 @@ def _test_cross_charging_reconstructed_as_both_windows(my_predbat, failed):
     return failed
 
 
+def _test_missing_cost_today_history(my_predbat, failed):
+    """Test: no recorded history for predbat.cost_today (issue #4583).
+
+    Everything calculate_yesterday computes is anchored on yesterday's recorded cost, so when Home
+    Assistant has no history for predbat.cost_today it must give up *before* the expensive
+    step_data_history()/rate-scan work rather than after it, and must not repeat that work - and its
+    warning - on every 10 minute cycle. The reporter's 30 hour log carried 188 copies of it.
+    """
+    print("calculate_yesterday: Test - missing cost_today history bails out early and throttles")
+    now_utc = _setup_base(my_predbat)
+
+    step_calls = []
+    original_run_pred = my_predbat.run_prediction
+
+    def _counting_step_data(*args, **kwargs):
+        """Record that the yesterday step data was built, which shouldn't happen here."""
+        step_calls.append(args)
+        return {}
+
+    history_calls = []
+
+    def _no_history(entity_id, days=30, required=True, tracked=True):
+        """Mimic Home Assistant recording none of the predbat.* entities."""
+        history_calls.append(entity_id)
+        return None
+
+    my_predbat.step_data_history = _counting_step_data
+    my_predbat.get_history_wrapper = _no_history
+    my_predbat.savings_last_updated = None
+
+    my_predbat.calculate_yesterday()
+
+    if step_calls:
+        print("ERROR: calculate_yesterday built the yesterday step data {} times with no cost_today history to use it with".format(len(step_calls)))
+        failed = True
+
+    if my_predbat.savings_last_updated is None:
+        print("ERROR: calculate_yesterday did not record the attempt, so it will redo this work every cycle")
+        failed = True
+
+    # A second call ten minutes later must early-exit rather than fetching and warning all over again
+    history_calls.clear()
+    my_predbat.now_utc = now_utc + timedelta(minutes=10)
+
+    my_predbat.calculate_yesterday()
+
+    if history_calls:
+        print("ERROR: calculate_yesterday retried within the hour, fetching {}".format(history_calls))
+        failed = True
+
+    my_predbat.now_utc = now_utc
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    return failed
+
+
 def _test_yesterday_slot_is_exporting(my_predbat, failed):
     """Test: yesterday_slot_is_exporting() recognises Cross-charging as export activity.
 
@@ -1241,6 +1297,7 @@ def test_calculate_yesterday(my_predbat):
     failed = _test_reconstruct_car_slots(my_predbat, failed)
     failed = _test_soc_not_mutated_and_override_passed(my_predbat, failed)
     failed = _test_soc_kw_h0_fallback(my_predbat, failed)
+    failed = _test_missing_cost_today_history(my_predbat, failed)
     failed = _test_yesterday_slot_is_exporting(my_predbat, failed)
     failed = _test_cross_charging_reconstructed_as_both_windows(my_predbat, failed)
 

--- a/apps/predbat/tests/test_faq_recorder_config.py
+++ b/apps/predbat/tests/test_faq_recorder_config.py
@@ -97,7 +97,7 @@ def test_faq_recorder_config(my_predbat):
 
     recorder = _load_recorder_example()
     if recorder is None:
-        print("ERROR: no recorder: example found in docs/faq.md")
+        print("ERROR: docs/faq.md no longer contains a recorder filter example to check")
         return True
 
     needed = _entities_read_from_history()

--- a/apps/predbat/tests/test_faq_recorder_config.py
+++ b/apps/predbat/tests/test_faq_recorder_config.py
@@ -1,0 +1,119 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Keep the recorder filter example in docs/faq.md consistent with the entities Predbat reads history
+for (issue #4583).
+
+Users copy that example into configuration.yaml verbatim, so any Predbat entity it stops Home
+Assistant recording is an entity Predbat can no longer read the history of - which silently breaks
+whatever feature needed it. In #4583 the reporter's Plan History and Yesterday Without Predbat
+views were empty and PV calibration was disabled on every cycle, both because the recorder wasn't
+storing the predbat.* entities those features read.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+SOURCE_DIR = os.path.join(REPO_ROOT, "apps", "predbat")
+FAQ_PATH = os.path.join(REPO_ROOT, "docs", "faq.md")
+
+PREFIX = "predbat"
+
+# Entities reached through a local variable rather than written inline at the history call, so the
+# source scan below can't see them - the ML load model builds these two from self.prefix before
+# handing them to minute_data_import_export()
+INDIRECT_HISTORY_ENTITIES = ["{}.rates".format(PREFIX), "{}.rates_export".format(PREFIX)]
+
+# First argument of a get_history_wrapper() call, i.e. the entity being asked for
+HISTORY_CALL_RE = re.compile(r"get_history_wrapper\(\s*(?:entity_id\s*=\s*)?([^,)]+)")
+# Predbat's own entities, written as self.prefix + ".name" / "sensor." + self.prefix + "_name"
+OWN_DOMAIN_RE = re.compile(r'self\.prefix\s*\+\s*"\.([a-z0-9_]+)"')
+OWN_SENSOR_RE = re.compile(r'"sensor\."\s*\+\s*self\.prefix\s*\+\s*"_([a-z0-9_]+)"')
+
+
+def _load_recorder_example():
+    """Return the recorder filter example from the FAQ as a dict, or None if it isn't there."""
+    with open(FAQ_PATH, "r") as handle:
+        text = handle.read()
+    for block in re.findall(r"```yaml\n(.*?)```", text, re.S):
+        parsed = yaml.safe_load(block)
+        if isinstance(parsed, dict) and "recorder" in parsed:
+            return parsed["recorder"] or {}
+    return None
+
+
+def _entities_read_from_history():
+    """Return the set of Predbat owned entities whose history the Predbat source reads."""
+    entities = set(INDIRECT_HISTORY_ENTITIES)
+    for name in sorted(os.listdir(SOURCE_DIR)):
+        if not name.endswith(".py"):
+            continue
+        with open(os.path.join(SOURCE_DIR, name), "r") as handle:
+            source = handle.read()
+        for argument in HISTORY_CALL_RE.findall(source):
+            for match in OWN_DOMAIN_RE.findall(argument):
+                entities.add("{}.{}".format(PREFIX, match))
+            for match in OWN_SENSOR_RE.findall(argument):
+                entities.add("sensor.{}_{}".format(PREFIX, match))
+    return entities
+
+
+def _is_recorded(entity_id, recorder):
+    """Return True if Home Assistant would record this entity under the given filter.
+
+    Mirrors the "exclude domains, include entities" case of Home Assistant's own recorder entity
+    filter: an entity in an excluded domain is recorded only when it is named in include.entities,
+    and an entity in any other domain is recorded unless it is named in exclude.entities. Note that
+    include.entities does *not* rescue an entity that exclude.entities names in a domain which
+    isn't itself excluded.
+    """
+    exclude = recorder.get("exclude", {}) or {}
+    include = recorder.get("include", {}) or {}
+    exclude_domains = exclude.get("domains", []) or []
+    exclude_entities = exclude.get("entities", []) or []
+    include_entities = include.get("entities", []) or []
+
+    domain = entity_id.split(".")[0]
+    if domain in exclude_domains:
+        return entity_id in include_entities
+    return entity_id not in exclude_entities
+
+
+def test_faq_recorder_config(my_predbat):
+    """Check the FAQ's recorder example still records every entity Predbat reads history for."""
+    failed = False
+    print("**** Running FAQ recorder configuration tests ****")
+
+    recorder = _load_recorder_example()
+    if recorder is None:
+        print("ERROR: no recorder: example found in docs/faq.md")
+        return True
+
+    needed = _entities_read_from_history()
+    if not needed:
+        print("ERROR: found no history reads in the Predbat source, the source scan must be broken")
+        return True
+    print("Test: the FAQ recorder example records all {} entities Predbat reads history for".format(len(needed)))
+
+    for entity_id in sorted(needed):
+        if not _is_recorded(entity_id, recorder):
+            print("ERROR: docs/faq.md recorder example stops Home Assistant recording {}, whose history Predbat reads".format(entity_id))
+            failed = True
+
+    if failed:
+        print("ERROR: test_faq_recorder_config FAILED")
+    else:
+        print("test_faq_recorder_config PASSED")
+
+    return failed

--- a/apps/predbat/tests/test_load_ml.py
+++ b/apps/predbat/tests/test_load_ml.py
@@ -2405,6 +2405,28 @@ def _test_component_fetch_load_data():
 
         print("    ✓ Step-size calculation correct (bug #3384 regression test passed)")
 
+    async def test_rate_history_is_optional():
+        """The import/export rate history only adds features to the model, so a missing history
+        must be fetched as optional - Home Assistant has no history for predbat.rates when its
+        recorder isn't storing that entity, and that isn't a Predbat error (issue #4583)."""
+        mock_base = MockBase()
+        load_data, age = create_load_minutes(28)
+        mock_base.minute_data_load = MagicMock(return_value=(load_data, age))
+        mock_base.minute_data_import_export = MagicMock(return_value=None)
+        mock_base.fill_load_from_power = MagicMock(side_effect=lambda x, y: x)
+
+        component = LoadMLComponent(mock_base, load_ml_enable=True)
+        component.ml_max_days_history = 28
+
+        await component._fetch_load_data()
+
+        rate_calls = [call for call in mock_base.minute_data_import_export.call_args_list if str(call.args[2]).endswith((".rates", ".rates_export"))]
+        assert len(rate_calls) == 2, f"Expected the import and export rate history to be fetched, got {rate_calls}"
+        for call in rate_calls:
+            assert call.kwargs.get("required") is False, f"Rate history must be fetched as optional data, got {call}"
+
+        print("    ✓ Rate history is fetched as optional data")
+
     # Run all sub-tests
     print("  Running LoadMLComponent._fetch_load_data tests:")
     run_async(test_basic_fetch())
@@ -2417,6 +2439,7 @@ def _test_component_fetch_load_data():
     run_async(test_temperature_data_fetch())
     run_async(test_temperature_no_data())
     run_async(test_step_size_calculation())
+    run_async(test_rate_history_is_optional())
     print("  All _fetch_load_data tests passed!")
 
 

--- a/apps/predbat/tests/test_minute_data_import_export.py
+++ b/apps/predbat/tests/test_minute_data_import_export.py
@@ -56,7 +56,7 @@ def test_minute_data_import_export(my_predbat):
     # Store original get_history_wrapper for restoration
     original_get_history = my_predbat.get_history_wrapper
 
-    def mock_get_history_wrapper(entity_id, days):
+    def mock_get_history_wrapper(entity_id, days, required=True, tracked=True):
         """Mock get_history_wrapper that returns data from mock_history_store"""
         return mock_history_store.get(entity_id, None)
 
@@ -164,6 +164,62 @@ def test_minute_data_import_export(my_predbat):
     if len(result) == 0:
         print("ERROR: Test 7 failed - no data returned for single string entity")
         failed = True
+
+    # Test 8: Optional fetch of an entity Home Assistant has no recorded history for.
+    # The ML load model asks for the history of predbat.rates/predbat.rates_export purely to
+    # add rate features; when the recorder isn't storing those entities that is not an error
+    # and must not be logged as one, nor flag the run as having errors (issue #4583).
+    print("Test 8: Optional fetch of an entity with no recorded history")
+
+    captured_logs = []
+    status_calls = []
+    original_log = my_predbat.log
+    original_record_status = my_predbat.record_status
+    my_predbat.log = lambda message, **kwargs: captured_logs.append(message)
+    my_predbat.record_status = lambda message, **kwargs: status_calls.append(message)
+
+    def mock_history_no_data(entity_id, days=30, required=True, tracked=True):
+        """Mimic Home Assistant returning no recorded history for the entity."""
+        if required:
+            raise ValueError
+        return None
+
+    my_predbat.get_history_wrapper = mock_history_no_data
+
+    result = my_predbat.minute_data_import_export(max_days_previous=2, now_utc=now, key="predbat.rates", scale=1.0, increment=False, smoothing=False, pad=False, required=False)
+
+    if result:
+        print("ERROR: Test 8 failed - expected no data for an entity with no history, got {}".format(result))
+        failed = True
+    shouty = [message for message in captured_logs if message.startswith("Error") or "Failure to fetch history" in message]
+    if shouty:
+        print("ERROR: Test 8 failed - optional history fetch should not be logged as a failure, got {}".format(shouty))
+        failed = True
+    if status_calls:
+        print("ERROR: Test 8 failed - optional history fetch should not record an error status, got {}".format(status_calls))
+        failed = True
+    if len(captured_logs) != 1:
+        print("ERROR: Test 8 failed - expected a single explanatory log line, got {}".format(captured_logs))
+        failed = True
+    if captured_logs and "predbat.rates" not in captured_logs[0]:
+        print("ERROR: Test 8 failed - the log line should name the entity, got {}".format(captured_logs[0]))
+        failed = True
+
+    # Test 9: A required fetch (the default) still reports the missing history, so a genuinely
+    # misconfigured import/export sensor is still surfaced to the user.
+    print("Test 9: Required fetch of an entity with no recorded history still warns")
+
+    captured_logs.clear()
+    status_calls.clear()
+
+    result = my_predbat.minute_data_import_export(max_days_previous=2, now_utc=now, key="sensor.import_missing", scale=1.0, required_unit="kWh")
+
+    if not any("Unable to fetch history" in message for message in captured_logs):
+        print("ERROR: Test 9 failed - a required entity with no history should still be reported, got {}".format(captured_logs))
+        failed = True
+
+    my_predbat.log = original_log
+    my_predbat.record_status = original_record_status
 
     # Restore original get_history_wrapper
     my_predbat.get_history_wrapper = original_get_history

--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -11,6 +11,7 @@
 import asyncio
 
 from web import WebInterface
+from web_helper import get_plan_renderer_js
 
 
 def make_web(my_predbat):
@@ -184,6 +185,8 @@ def run_web_functions_tests(my_predbat):
     # "Loading chart (please wait)..." messages forever, since nothing will ever load.
     failed += run_compare_empty_state_tests(my_predbat, web)
 
+    failed += run_plan_empty_state_tests(my_predbat, web)
+
     print("**** Web functions tests completed ****")
     return failed
 
@@ -225,6 +228,57 @@ def run_compare_empty_state_tests(my_predbat, web):
     my_predbat.args = original_args
 
     print("**** Compare empty state tests completed ****")
+    return failed
+
+
+def run_plan_empty_state_tests(my_predbat, web):
+    """Unit tests for the Plan page's empty-state messaging (issue #4583).
+
+    The History and Yesterday Without Predbat views are only populated once calculate_yesterday()
+    has run, which it can't do when Home Assistant has no history for predbat.cost_today. Showing
+    'Plan data is loading, please wait...' forever tells the user nothing about why.
+    """
+    failed = 0
+    print("**** Running plan empty state tests ****")
+
+    renderer_js = get_plan_renderer_js()
+
+    # Scope the checks to refreshPlan(), which is what decides what an empty view shows
+    start = renderer_js.index("function refreshPlan(")
+    end = renderer_js.index("function checkStaleness(", start)
+    refresh_plan_src = renderer_js[start:end]
+
+    empty_branch_start = refresh_plan_src.find("if (!data)")
+    if empty_branch_start < 0:
+        print("  ERROR: expected refreshPlan() to handle a view with no data")
+        failed += 1
+    else:
+        # Slice to the branch's own return so the assertions can't be satisfied by later code
+        empty_branch = refresh_plan_src[empty_branch_start : refresh_plan_src.index("return;", empty_branch_start)]
+
+        print("Test: the History / Yesterday views explain themselves instead of loading forever")
+        if "currentView" not in empty_branch:
+            print("  ERROR: the empty-data branch should distinguish the plan view from the yesterday/baseline views")
+            failed += 1
+        if "cost_today" not in empty_branch:
+            print("  ERROR: the empty-data message should name the predbat.cost_today history it needs")
+            failed += 1
+        if "recorder" not in empty_branch:
+            print("  ERROR: the empty-data message should point at the Home Assistant recorder as the thing to check")
+            failed += 1
+
+        print("Test: the plan view itself keeps its genuine loading message")
+        if "Plan data is loading" not in empty_branch:
+            print("  ERROR: the plan view should still show a loading message while it waits for its first plan")
+            failed += 1
+
+    print("Test: the rendered plan page carries the explanation")
+    response = asyncio.run(web.html_plan(None))
+    if "cost_today" not in response.text:
+        print("  ERROR: the plan page should carry the empty-state explanation for the yesterday views")
+        failed += 1
+
+    print("**** Plan empty state tests completed ****")
     return failed
 
 

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -113,6 +113,7 @@ from tests.test_manual_select import run_test_manual_select
 from tests.test_minute_array import test_minute_array
 from tests.test_minute_data import test_minute_data, test_minute_data_load, test_minute_data_no_smoothing_backwards, test_minute_data_no_smoothing_forward
 from tests.test_minute_data_import_export import test_minute_data_import_export
+from tests.test_faq_recorder_config import test_faq_recorder_config
 from tests.test_minute_data_state import test_minute_data_state
 from tests.test_minute_data_copy import run_minute_data_copy_tests
 from tests.test_format_time_ago import test_format_time_ago
@@ -345,6 +346,7 @@ def main():
         ("minute_data", test_minute_data, "Minute data tests", False),
         ("minute_data_load", test_minute_data_load, "Minute data load tests", False),
         ("minute_data_import_export", test_minute_data_import_export, "Minute data import/export tests", False),
+        ("faq_recorder_config", test_faq_recorder_config, "FAQ recorder filter example matches the entities Predbat reads history for", False),
         ("minute_data_no_smoothing_backwards", test_minute_data_no_smoothing_backwards, "Minute data no-smoothing backwards tests", False),
         ("minute_data_no_smoothing_forward", test_minute_data_no_smoothing_forward, "Minute data no-smoothing forward tests", False),
         ("get_now_cumulative", test_get_now_from_cumulative, "Get now from cumulative tests", False),

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -7190,7 +7190,19 @@ def get_plan_renderer_js():
         }
 
         if (!data) {
-            container.innerHTML = '<h2>Plan data is loading, please wait...</h2>';
+            if (currentView === 'plan') {
+                container.innerHTML = '<h2>Plan data is loading, please wait...</h2>';
+            } else {
+                // The yesterday/baseline views are only produced once calculate_yesterday() has run,
+                // which it can't do without the recorded history of predbat.cost_today - say so rather
+                // than sitting on a loading message that will never go away
+                container.innerHTML = '<h2>No data for this view yet</h2>' +
+                    '<p>This view is computed about once an hour from what actually happened yesterday, ' +
+                    'so it stays empty for the first hour after Predbat starts.</p>' +
+                    '<p>If it never fills in, Predbat could not read the history of <b>predbat.cost_today</b> ' +
+                    'from Home Assistant. Check that the Home Assistant recorder is storing the Predbat entities ' +
+                    '(see the recorder notes in the FAQ) and look for <i>Calculate yesterday</i> warnings in the Predbat log.</p>';
+            }
             return;
         }
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -282,12 +282,15 @@ recorder:
 
 ```
 
-Do not trim the list above without checking what reads it - Predbat needs the recorded history of every entity in it,
-and quietly loses a feature for each one it can no longer read. For example `predbat.cost_today` is what the
-Plan tab's *History* and *Yesterday Without Predbat* views are built from, and `sensor.predbat_pv_forecast_h0` and
-`sensor.predbat_pv_today` are what PV calibration and the PV accuracy chart compare against. Note also that an entity
-named under `include` is only recorded if its domain is the one being excluded - listing a `sensor.*` entity under both
-`exclude` and `include` leaves it excluded.
+Two things to be careful of if you adapt the example above:
+
+- Don't drop entries from the `include` list without checking what reads them. Predbat needs the recorded history of
+every entity listed there and quietly loses a feature for each one it can no longer read - `predbat.cost_today`, for
+instance, is what the Plan tab's *History* and *Yesterday Without Predbat* views are built from.
+- Don't add further Predbat sensors to the `exclude` list for the same reason. `sensor.predbat_pv_forecast_h0` and
+`sensor.predbat_pv_today` are deliberately left out of it because PV calibration and the PV accuracy chart compare
+against their history. Adding a `sensor.*` entity to `exclude` and to `include` does not rescue it either - an entry
+under `include` only overrides the exclusion of its whole *domain*, which here is `predbat`, not `sensor`.
 
 When the serialized attributes payload for a Predbat entity state exceeds 16384 bytes, the recorder will not store any attributes for that state (only the state value itself is stored). States whose serialized attributes payload is below this limit are stored normally.
 You can suppress these warnings by adding the following to your `configuration.yaml` file:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -246,13 +246,11 @@ recorder:
       - predheat
     entities:
       - sensor.predbat_load_ml_forecast
-      - sensor.predbat_pv_today
       - sensor.predbat_pv_tomorrow
       - sensor.predbat_pv_forecast_raw
       - sensor.predbat_pv_d2
       - sensor.predbat_pv_d3
       - sensor.predbat_temperature
-      - sensor.predbat_pv_forecast_h0
   include:
     entities: #The history of these entities is used by Predbat
       - predbat.cost_today
@@ -267,6 +265,7 @@ recorder:
       - predbat.load_inday_adjustment
       - predbat.ppkwh_today
       - predbat.ppkwh_hour
+      - predbat.pv_energy_h0
       - predbat.pv_power
       - predbat.rates
       - predbat.rates_export
@@ -282,6 +281,13 @@ recorder:
       - predheat.target_temperature
 
 ```
+
+Do not trim the list above without checking what reads it - Predbat needs the recorded history of every entity in it,
+and quietly loses a feature for each one it can no longer read. For example `predbat.cost_today` is what the
+Plan tab's *History* and *Yesterday Without Predbat* views are built from, and `sensor.predbat_pv_forecast_h0` and
+`sensor.predbat_pv_today` are what PV calibration and the PV accuracy chart compare against. Note also that an entity
+named under `include` is only recorded if its domain is the one being excluded - listing a `sensor.*` entity under both
+`exclude` and `include` leaves it excluded.
 
 When the serialized attributes payload for a Predbat entity state exceeds 16384 bytes, the recorder will not store any attributes for that state (only the state value itself is stored). States whose serialized attributes payload is below this limit are stored normally.
 You can suppress these warnings by adding the following to your `configuration.yaml` file:


### PR DESCRIPTION
Follow-up to #4583.

### What was wrong

The reporter's Plan tab History and Yesterday Without Predbat views were permanently empty, and their log was full of `Error: Failure to fetch history for predbat.rates`. Both come from Home Assistant having no recorder history for the `predbat.*` entities - the REST history API was working fine, fetching 3168 points for a `sensor.*` load sensor in the same second that `predbat.rates` came back empty. That's a recorder configuration problem on their side, but Predbat gave them nothing to go on and made a meal of it. It isn't a v8.48.6/v8.48.7 regression either - their log starts on v8.48.2 with both problems already present.

### Changes

**`calculate_yesterday()` fetches `predbat.cost_today` first** ([output.py](https://github.com/springfall2008/batpred/blob/fix/history-recorder-diagnostics-4583/apps/predbat/output.py)). Everything it computes is anchored on that history, but it was fetched *after* three `step_data_history()` passes over 24h+now, three `history_to_future_rates()` calls and a `rate_scan_window()` - all discarded on the early return. `savings_last_updated` was only set at the end, so with no cost history the whole prologue ran again every 10 minutes: 188 times in the reporter's 30 hour log. It now bails before that work and records the attempt so it retries on the normal hourly cadence.

**The warning is actionable.** It names the entity and points at the recorder rather than saying `No cost_today data for yesterday`.

**The Plan tab explains itself** ([web_helper.py](https://github.com/springfall2008/batpred/blob/fix/history-recorder-diagnostics-4583/apps/predbat/web_helper.py)). `refreshPlan()` showed `Plan data is loading, please wait...` for any view with no data, so the History and Yesterday views claimed to be loading forever. Those two views now say they are computed hourly from yesterday, and what to check if they never fill in. Same treatment the Compare page got in #4334.

**`minute_data_import_export()` takes `required=False`** ([fetch.py](https://github.com/springfall2008/batpred/blob/fix/history-recorder-diagnostics-4583/apps/predbat/fetch.py)). The ML load model asks for `predbat.rates`/`predbat.rates_export` history purely to add rate features to training; it merges whatever it gets and copes fine without. That best-effort fetch was going through the default `required=True` path, which logs `Error: Failure to fetch history`, raises `ValueError`, gets caught, and logs two more warnings - three lines and an exception round trip for a non-event, and the thing that made this look alarming enough to report. It is now a single `Info` line. Required fetches are unchanged, so a genuinely misconfigured import/export sensor is still surfaced.

**The FAQ's recorder example was wrong in three places** ([faq.md](https://github.com/springfall2008/batpred/blob/fix/history-recorder-diagnostics-4583/docs/faq.md)). It told users to exclude `sensor.predbat_pv_forecast_h0` and `sensor.predbat_pv_today`, whose history PV calibration ([solcast.py:896](https://github.com/springfall2008/batpred/blob/fix/history-recorder-diagnostics-4583/apps/predbat/solcast.py#L896)) and the PV accuracy chart read - the reporter's log shows `PV Calibration: Not enough historical data for calibration` on all 64 cycles. It also omitted `predbat.pv_energy_h0` from the include list. Added a note that an entity named under `include` is only rescued when its *domain* is the excluded one, since listing a `sensor.*` entity under both leaves it excluded.

### Tests

All written first and watched fail.

* `test_calculate_yesterday` - no `cost_today` history means no step data is built, and no retry within the hour
* `test_minute_data_import_export` - an optional fetch logs no error and records no error status; a required one still warns
* `test_load_ml` - the rate history is requested as optional
* `test_web_functions` - the empty-data branch distinguishes the views, names `cost_today` and the recorder, and the plan view keeps its genuine loading message
* `test_faq_recorder_config` (new) - scans the source for history reads of Predbat's own entities and checks the FAQ example records every one of them, applying Home Assistant's own exclude-domains/include-entities precedence. It fails on all three doc bugs above before the fix, so the example can't drift out of step with the code again.

Full suite green (including the 4 slow tests) and pre-commit clean.
