### PR TITLE
docs: add Canadian Solar EP Cube inverter setup

### DIFF
--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -39,6 +39,7 @@ Once you get everything working please share the configuration as a GitHub issue
    | [Givenergy with GE Cloud](#givenergy-with-ge-cloud) | [ge_cloud](https://github.com/springfall2008/ge_cloud) | [givenergy_cloud.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/givenergy_cloud.yaml) |
    | [Givenergy with GE Cloud EMS](#givenergy-with-ge-cloud-ems) | [ge_cloud EMS](https://github.com/springfall2008/ge_cloud) | [givenergy_ems.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/givenergy_ems.yaml) |
    | [Givenergy/Octopus No Home Assistant](#givenergy-octopus-cloud-direct---no-home-assistant) | n/a | [ge_cloud_octopus_standalone.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/ge_cloud_octopus_standalone.yaml) |
+   | [Canadian Solar EP Cube](#canadian-solar-ep-cube) | [ha-ep-cube](https://github.com/SkiLtY/ha-ep-cube) | [ep_cube_cloud.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/ep_cube_cloud.yaml) |
    | [DEYE Cloud](#deye-cloud) | Predbat | See [apps.yaml](apps-yaml.md#deye-cloud-api) |
    | [Enphase Cloud](#enphase-cloud) | Predbat | [enphase_cloud.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/enphase_cloud.yaml) |
    | [Fox](#fox) | [Foxess](https://github.com/nathanmarlor/foxess_modbus/) | [fox.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/fox.yaml) |
@@ -192,6 +193,16 @@ This is being worked on by the author of GivTCP, e.g. see [GivTCP issue: unable 
 - Review any other configuration settings
 
 Launch Predbat with hass.py (from the Predbat-addon repository) either via a Docker or just on a Linux/MAC/WSL command line shell.
+
+## Canadian Solar EP Cube
+
+The EP Cube has no local Modbus; the only published control interface is the vendor cloud REST API. The [ha-ep-cube](https://github.com/SkiLtY/ha-ep-cube) custom integration (HACS Default store, MIT-licensed) bridges this to a Predbat-shaped set of entities and services:
+
+- Install via HACS - search "Canadian Solar EP Cube", Download, then restart Home Assistant. Configure the integration with your EP Cube cloud account email + password (captcha is handled automatically).
+- Copy the template [ep_cube_cloud.yaml](https://raw.githubusercontent.com/springfall2008/batpred/main/templates/ep_cube_cloud.yaml) over your `apps.yaml`. No additional helpers or template sensors are needed - entity IDs are stable (no per-account devId substitution).
+- The integration exposes the standard 7 Predbat services (`charge_start`, `charge_stop`, `discharge_start`, `discharge_stop`, `charge_freeze`, `discharge_freeze`, `idle`) and translates each rate + window into a TOU-schedule rewrite on the cube.
+- Writes are idempotent (no cloud call if the requested state is already active) and budgeted to a low number of writes per day. The integration snapshots your normal mode + TOU schedule on the first override and auto-reverts at the slot end.
+- Restart Predbat after saving `apps.yaml` and check its log to confirm it sees the `sensor.ep_cube_*` entities and successfully calls the `ep_cube.*` services.
 
 ## DEYE Cloud
 

--- a/templates/ep_cube_cloud.yaml
+++ b/templates/ep_cube_cloud.yaml
@@ -1,0 +1,421 @@
+# Predbat config for the Canadian Solar EP Cube, via the ha-ep-cube HACS
+# integration (https://github.com/SkiLtY/ha-ep-cube)
+#
+# Copy this over your apps.yaml and:
+#   1. Install the "Canadian Solar EP Cube" integration via HACS (Default
+#      store) and configure it with your EP Cube cloud account email + password.
+#   2. Restart Home Assistant, then Predbat, and check the Predbat log to
+#      confirm it sees the ep_cube_* entities and calls the ep_cube.* services.
+#
+# Entity IDs are stable - the integration always uses the device name
+# "EP Cube", so there's no per-account devId substitution to edit below.
+---
+pred_bat:
+  module: predbat
+  class: PredBat
+
+  # Sets the prefix for all created entities in HA - only change if you want to run more than once instance
+  prefix: predbat
+
+  # Timezone to work in
+  timezone: Europe/London
+
+  # Currency, symbol for main currency second symbol for 1/100s e.g. $ c or £ p or e c
+  currency_symbols:
+    - '£'
+    - 'p'
+
+  # Number of threads to use in plan calculation
+  # Can be auto for automatic, 0 for off or values 1-N for a fixed number
+  threads: auto
+
+  # XXX: This is a configuration template, delete this line once you edit your configuration
+  template: True
+
+  # Sets the maximum period of zero load before the gap is filled, default 30 minutes
+  # To disable set it to 1440
+  load_filter_threshold: 30
+
+  # ─── EP Cube inverter identification ──────────────────────────────────────
+  inverter_type: 'EP_CUBE'
+  num_inverters: 1
+
+  # ─── EP Cube sensor entities (read) ───────────────────────────────────────
+  soc_kw:
+    - sensor.ep_cube_battery_energy
+  soc_max:
+    - sensor.ep_cube_battery_capacity
+  soc_percent:
+    - sensor.ep_cube_battery_soc
+  battery_power:
+    - sensor.ep_cube_battery_power
+  pv_power:
+    - sensor.ep_cube_solar_power
+  load_power:
+    - sensor.ep_cube_load_power
+  grid_power:
+    - sensor.ep_cube_grid_power
+  reserve:
+    - sensor.ep_cube_reserve_soc
+
+  # ─── EP Cube battery physical specs ───────────────────────────────────────
+  # Adjust to match your hardware
+  battery_rate_max_charge: 5.0     # kW
+  battery_rate_max_discharge: 5.0  # kW
+  battery_loss: 0.03               # 3% conversion loss (typical Li-ion + inverter)
+  battery_loss_discharge: 0.03
+  inverter_loss: 0.03
+
+  # ─── EP Cube control surface (write) ──────────────────────────────────────
+  # Predbat calls these services; the integration's shim translates
+  # rate + window into a TOU-schedule rewrite on the cube, and is idempotent
+  # (no cloud write if the requested state is already active).
+  inverter_can_charge_during_export: True
+  inverter_can_force_export: True
+
+  # Each *_service is a dict (Predbat schema) - service: <domain>.<name>.
+  # The shim takes its targets via service_data, not entity_id, so no
+  # entity_id key is needed here.
+  charge_start_service:
+    service: ep_cube.charge_start
+  charge_stop_service:
+    service: ep_cube.charge_stop
+  charge_freeze_service:
+    service: ep_cube.charge_freeze
+  discharge_start_service:
+    service: ep_cube.discharge_start
+  discharge_stop_service:
+    service: ep_cube.discharge_stop
+  discharge_freeze_service:
+    service: ep_cube.discharge_freeze
+  idle_service:
+    service: ep_cube.idle
+
+  # If you have multiple EP Cubes, uncomment and set the device_id explicitly:
+  # service_data:
+  #   device_id: <your-devId>  # the small-int devId from the HA integration config
+  #
+  # Run balance inverters every N seconds (0=disabled) - only for multi-inverter
+  #balance_inverters_seconds: 60
+  #
+
+  # Some inverters don't turn off when the rate is set to 0, still charge or discharge at around 200w
+  # The value can be set here in watts to model this (doesn't change operation)
+  inverter_battery_rate_min:
+    - 200
+
+  # Workaround to limit the maximum reserve setting, some inverters won't allow 100% to be set
+  # Comment out if your inverter allows 100%
+  #inverter_reserve_max : 98
+
+  # Some batteries tail off their charge rate at high soc%
+  # enter the charging curve here as a % of the max charge rate for each soc percentage.
+  # the default is 1.0 (full power). Uncomment and tune once you've observed your
+  # own EP Cube's behaviour - the values below are illustrative only.
+  #battery_charge_power_curve:
+  #  100 : 0.15
+  #  99 : 0.15
+  #  98 : 0.22
+  #  97 : 0.31
+  #  96 : 0.42
+  #  95 : 0.48
+  #  94 : 0.58
+  #  93 : 0.68
+  #  92 : 0.77
+  #  91 : 0.85
+  #  90 : 0.94
+  #battery_discharge_power_curve:
+  #  4: 1.0
+
+    # Inverter clock skew in minutes, e.g. 1 means it's 1 minute fast and -1 is 1 minute slow
+  # Separate start and end options are applied to the start and end time windows, mostly as you want to start late (not early) and finish early (not late)
+  # Separate discharge skew for discharge windows only
+  inverter_clock_skew_start: 0
+  inverter_clock_skew_end: 0
+  inverter_clock_skew_discharge_start: 0
+  inverter_clock_skew_discharge_end: 0
+
+  # Clock skew adjusts the Appdaemon time
+  # This is the time that Predbat takes actions like starting discharge/charging
+  # Only use this for workarounds if your inverter time is correct but Predbat is somehow wrong (AppDaemon issue)
+  # 1 means add 1 minute to AppDaemon time, -1 takes it away
+  clock_skew: 0
+
+  # Solcast cloud interface, set this or the local interface below
+  #solcast_host: 'https://api.solcast.com.au/'
+  #solcast_api_key: 'xxxx'
+  #solcast_poll_hours: 8
+
+  # Set these to match solcast sensor names if not using the cloud interface
+  # The regular expression (re:) makes the solcast bit optional
+  # If these don't match find your own names in Home Assistant
+  pv_forecast_today: re:(sensor.(solcast_|)(pv_forecast_|)forecast_today)
+  pv_forecast_tomorrow: re:(sensor.(solcast_|)(pv_forecast_|)forecast_tomorrow)
+  pv_forecast_d3: re:(sensor.(solcast_|)(pv_forecast_|)forecast_(day_3|d3))
+  pv_forecast_d4: re:(sensor.(solcast_|)(pv_forecast_|)forecast_(day_4|d4))
+
+  # car_charging_energy defines an incrementing sensor which measures the charge added to your car
+  # is used for car_charging_hold feature to filter out car charging from the previous load data
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
+  car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
+
+  # Defines the number of cars modelled by the system, set to 0 for no car
+  num_cars: 1
+
+  # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots
+  # This should not be needed if you use Intelligent Octopus slots which will take priority if enabled
+  # The list of possible values is in car_charging_planned_response
+  # Auto matches Zappi and Wallbox, or change it for your own
+  # One entry per car
+  car_charging_planned:
+    - 're:(sensor.wallbox_portal_status_description|sensor.myenergi_zappi_[0-9a-z]+_plug_status)'
+
+  car_charging_planned_response:
+    - 'yes'
+    - 'on'
+    - 'true'
+    - 'connected'
+    - 'ev connected'
+    - 'charging'
+    - 'paused'
+    - 'waiting for car demand'
+    - 'waiting for ev'
+    - 'scheduled'
+    - 'enabled'
+    - 'latched'
+    - 'locked'
+    - 'plugged in'
+    - 'waiting'
+
+  # In some cases car planning is difficult (e.g. Ohme with Intelligent doesn't report slots)
+  # The car charging now can be set to a sensor to indicate the car is charging and to plan
+  # for it to charge during this 30 minute slot
+  #car_charging_now:
+  #  - off
+
+  # Positive responses for car_charging_now
+  car_charging_now_response:
+    - 'yes'
+    - 'on'
+    - 'true'
+
+  # To make planned car charging more accurate, either using car_charging_planned or the Octopus Energy plugin,
+  # specify your battery size in kwh, charge limit % and current car battery soc % sensors/values.
+  # If you have Intelligent Octopus the battery size and limit will be extracted from the Octopus Energy plugin directly.
+  # Set the car SoC% if you have it to give an accurate forecast of the cars battery levels.
+  # One entry per car if you have multiple cars.
+  #car_charging_battery_size:
+  #  - 75
+  #car_charging_limit:
+  #  - 're:number.tsunami_charge_limit'
+  #car_charging_soc:
+  #  - 're:sensor.tsunami_battery'
+
+  # One per car, when true only one car can charge at once, when False multiple cars can charge at once
+  #car_charging_exclusive:
+  #  - True
+
+  # If you have Octopus Intelligent Go and are not using the Octopus Direct connection method, enable the intelligent slot information to add to pricing
+  # Will automatically disable if not found, or comment out to disable fully
+  # When enabled it overrides the 'car_charging_planned' feature and predict the car charging based on the intelligent plan (unless Octopus intelligent charging is False)
+  # This matches the intelligent slot from the Octopus Energy integration
+  octopus_intelligent_slot: 're:(binary_sensor.octopus_energy([0-9a-z_]+|)_intelligent_dispatching)'
+  octopus_ready_time: 're:((select|time).octopus_energy_([0-9a-z_]+|)_intelligent_target_time)'
+  octopus_charge_limit: 're:(number.octopus_energy([0-9a-z_]+|)_intelligent_charge_target)'
+
+  # Example alternative configuration for Ohme integration release >=v0.6.1
+  #octopus_intelligent_slot: 'binary_sensor.ohme_slot_active'
+  #octopus_ready_time: 'time.ohme_target_time'
+  #octopus_charge_limit: 'number.ohme_target_percent'
+
+  # Set this to False if you use Octopus Intelligent slot for car planning but when on another tariff e.g. Agile
+  #octopus_slot_low_rate: False
+
+  # Carbon Intensity data from National grid
+  # carbon_postcode: 'SW1 5NA'
+  # carbon_automatic: True
+
+  # Octopus saving session points to the saving session Sensor in the Octopus plugin, when enabled saving sessions will be at the assumed
+  # Rate is read automatically from the add-in and converted to pence using the conversion rate below (default is 8)
+  octopus_saving_session: 're:(event.octopus_energy([0-9a-z_]+|)_saving_session_event(s|))'
+  octopus_saving_session_octopoints_per_penny: 8
+
+  # Octopus free session points to the free session Sensor in the Octopus plugin
+  # Note: You must enable this event sensor in the Octopus Integration in Home Assistant for it to work
+  octopus_free_session: 're:(event.octopus_energy_([0-9a-z_]+|)_octoplus_free_electricity_session_events)'
+
+  # Alternative scraper from Octopus web site if the above is not working
+  # octopus_free_url: 'http://octopus.energy/free-electricity'
+
+  # Enter your Axle VPP API key if you have signed up to the Axle service in the UK
+  # axle_api_key: "xxxxxxx"
+
+  # Energy rates
+  # Please set one of these three, if multiple are set then Octopus is used first, second rates_import/rates_export and latest basic metric
+
+  # Set import and export entity to point to the Octopus Energy plugin import and export sensors
+  # automatically matches your meter number assuming you have only one (no need to edit the below)
+  # Will be ignored if you don't have the sensor but will error if you do have one and it's incorrect
+  # Note: To get detailed energy rates you need to go in and manually enable the following events in HA
+  #       event.octopus_energy_electricity_xxxxxxxx_previous_day_rates
+  #       event.octopus_energy_electricity_xxxxxxxx_current_day_rates
+  #       event.octopus_energy_electricity_xxxxxxxx_next_day_rates
+  # and if you have export enable:
+  #       event.octopus_energy_electricity_xxxxxxxx_export_previous_day_rates
+  #       event.octopus_energy_electricity_xxxxxxxx_export_current_day_rates
+  #       event.octopus_energy_electricity_xxxxxxxx_export_next_day_rates
+  # Predbat will automatically find the event. entities from the link below to the sensors
+  metric_octopus_import: 're:(event.octopus_energy_electricity_[0-9a-z_]+(?<!export)_current_day_rates)'
+  # Only uncomment once you actually have an Octopus export tariff (Outgoing, Export SEG, etc).
+  # Predbat 8.40.9+ treats a no-match regex here as a hard validation error rather than a benign disable.
+  #metric_octopus_export: 're:(event.octopus_energy_electricity_[0-9a-z_]+_export_current_day_rates)'
+
+  # Standing charge in pounds, can be set to a sensor or manually entered (e.g. 0.50 is 50p)
+  # The default below will pick up the standing charge from the Octopus Plugin
+  # The standing charge only impacts the cost graphs and doesn't change the way Predbat plans
+  # If you don't want to show the standing charge then just delete this line or set to zero
+  metric_standing_charge: 're:(sensor.(octopus_energy_|)electricity_[0-9a-z]+_[0-9a-z]+_current_standing_charge)'
+
+  # Energy data service (https://github.com/MTrab/energidataservice)
+  #metric_energidataservice_import: 'sensor.energi_data_service_import'
+  #metric_energidataservice_export: 'sensor.energi_data_service_export'
+
+  # Or set your actual rates across time for import and export
+  # If start/end is missing it's assumed to be a fixed rate
+  # Gaps are filled with zero rate
+  #rates_import:
+  #  -  start: "00:30:00"
+  #     end: "04:30:00"
+  #     rate: 7.5
+  #  -  start: "04:30:00"
+  #     end: "00:30:00"
+  #     rate: 40.0
+  #
+  #rates_export:
+  #  -  rate: 4.2
+
+  # Can be used instead of the plugin to get import rates directly online
+  # Overrides metric_octopus_import and rates_import
+  # See the 'energy rates' part of the documentation for instructions on how to find the correct URL for your tariff and DNO region
+  #
+  # rates_import_octopus_url : "https://api.octopus.energy/v1/products/FLUX-IMPORT-23-02-14/electricity-tariffs/E-1R-FLUX-IMPORT-23-02-14-A/standard-unit-rates"
+  # rates_import_octopus_url : "https://api.octopus.energy/v1/products/AGILE-24-10-01/electricity-tariffs/E-1R-AGILE-24-10-01-A/standard-unit-rates"
+
+  # Overrides metric_octopus_export and rates_export
+  # rates_export_octopus_url: "https://api.octopus.energy/v1/products/FLUX-EXPORT-23-02-14/electricity-tariffs/E-1R-FLUX-EXPORT-23-02-14-A/standard-unit-rates"
+  # rates_export_octopus_url: "https://api.octopus.energy/v1/products/AGILE-OUTGOING-19-05-13/electricity-tariffs/E-1R-AGILE-OUTGOING-19-05-13-A/standard-unit-rates/"
+
+  # Import rates can be overridden with rate_import_override
+  # Export rates can be overridden with rate_export_override
+  # Use the same format as above, but a date can be included if it just applies for a set day (e.g. Octopus power ups)
+  # This will override even the Octopus plugin rates if enabled
+  #
+  #rates_import_override:
+  # -  date: '2023-09-10'
+  #    start: '14:00:00'
+  #    end: '14:30:00'
+  #    rate: 112
+  #    load_scaling: 0.8
+
+  # Days previous sets how many days of load history Predbat searches when forecasting your future house load.
+  # By default this uses a weighted-bucket forecast that automatically accounts for day-of-week, holiday mode
+  # and recency (days_previous_auto) - see the documentation for other options, such as picking specific
+  # days/weights instead, or using Load ML.
+  days_previous:
+    - 7
+
+  # Number of hours forward to forecast, best left as-is unless you have specific reason
+  forecast_hours: 48
+
+  # Load ML gives a neural-net 48-hour load forecast trained on your load history, PV generation and outdoor
+  # temperature - recommended once you have a few days of history. See https://springfall2008.github.io/batpred/load-ml/
+  load_ml_enable: true
+  # load_ml_source: true     # enable after comparing sensor.predbat_load_ml_forecast to actuals for a day or two
+  temperature_enable: true   # outdoor temp from zone.home - recommended ML input
+
+  # Specify the devices that notifies are sent to, the default is 'notify' which goes to all
+  #notify_devices:
+  #  - mobile_app_treforsiphone12_2
+
+  # Battery scaling makes the battery smaller (e.g. 0.9) or bigger than its reported
+  # If you have an 80% DoD battery that falsely reports it's kwh then set it to 0.8 to report the real figures
+  # One per inverter
+  battery_scaling:
+    - 1.0
+
+  # Can be used to scale import and export data, used for workarounds
+  import_export_scaling: 1.0
+
+  # Export triggers:
+  # For each trigger give a name, the minutes of export needed and the energy required in that time
+  # Multiple triggers can be set at once so in total you could use too much energy if all run
+  # Creates an entity called 'binary_sensor.predbat_export_trigger_<name>' which will be turned On when the condition is valid
+  # connect this to your automation to start whatever you want to trigger
+  export_triggers:
+     - name: 'large'
+       minutes: 60
+       energy: 1.0
+     - name: 'small'
+       minutes: 15
+       energy: 0.25
+
+  # If you have a sensor that gives the energy consumed by your solar diverter then add it here
+  # this will make the predictions more accurate. It should be an incrementing sensor, it can reset at midnight or not
+  # It's assumed to be in Kwh but scaling can be applied if need be
+  #iboost_energy_today: 'sensor.xxxxx'
+  #iboost_energy_scaling: 1.0
+  # Gas rates for comparison
+  #metric_octopus_gas: 're:(sensor.(octopus_energy_|)gas_[0-9a-z]+_[0-9a-z]+_current_rate)'
+
+  # Nordpool market energy rates
+  #futurerate_url: 'https://dataportal-api.nordpoolgroup.com/api/DayAheadPrices?date=DATE&market=N2EX_DayAhead&deliveryArea=UK&currency=GBP'
+  #futurerate_adjust_import: True
+  #futurerate_adjust_export: False
+  #futurerate_peak_start: "16:00:00"
+  #futurerate_peak_end: "19:00:00"
+  #futurerate_peak_premium_import: 14
+  #futurerate_peak_premium_export: 6.5
+
+  # Tariff comparison feature
+  # Adjust this list to the tariffs you want to compare, include your current tariff also
+  # Octopus region code (https://energy-stats.uk/dno-region-codes-explained/)
+  #octopus_region: "A"
+  #compare_list:
+  #  - id: 'current'
+  #    name: 'Current Tariff'
+  #  - id: 'cap_seg'
+  #    name: 'Price cap import/Seg export'
+  #    rates_import:
+  #       - rate: 24.86
+  #    rates_export:
+  #       - rate: 4.1
+  #  - id: 'agile_fixed'
+  #    name: 'Agile import/Fixed export'
+  #    rates_import_octopus_url: 'https://api.octopus.energy/v1/products/AGILE-24-10-01/electricity-tariffs/E-1R-AGILE-24-10-01-{octopus_region}/standard-unit-rates/'
+  #    rates_export_octopus_url: 'https://api.octopus.energy/v1/products/OUTGOING-VAR-BB-24-10-26/electricity-tariffs/E-1R-OUTGOING-VAR-BB-24-10-26-{octopus_region}/standard-unit-rates/'
+  #  - id: 'agile_agile'
+  #    name: 'Agile import/Agile export'
+  #    rates_import_octopus_url: 'https://api.octopus.energy/v1/products/AGILE-24-10-01/electricity-tariffs/E-1R-AGILE-24-10-01-{octopus_region}/standard-unit-rates/'
+  #    rates_export_octopus_url: 'https://api.octopus.energy/v1/products/AGILE-OUTGOING-BB-23-02-28/electricity-tariffs/E-1R-AGILE-OUTGOING-BB-23-02-28-{octopus_region}/standard-unit-rates/'
+
+  # Alert feeds - customise to your country and the alert types, severity and keep value
+  #alerts:
+  #  url: "https://feeds.meteoalarm.org/feeds/meteoalarm-legacy-atom-united-kingdom"
+  #  event: "(Amber|Yellow|Orange|Red).*(Wind|Snow|Fog|Rain|Thunderstorm|Avalanche|Frost|Heat|Coastal event|Flood|Forestfire|Ice|Low temperature|Storm|Tornado|Tsunami|Volcano|Wildfire)"
+  #  severity: "Moderate|Severe|Extreme"
+  #  certainty: "Possible|Likely|Expected"
+  #  keep: 40
+
+  # Watch list, a list of sensors to watch for changes and then update the plan if they change
+  # This is useful for things like the Octopus Intelligent Slot sensor so that the plan update as soon as you plugin in
+  # Only uncomment the items you actually have set up above in apps.yaml, of course you can add your own as well
+  # Note those using +[] are lists that are appended to this list, whereas {} items are single items only
+  #watch_list:
+  #  - '{octopus_intelligent_slot}'
+  #  - '{octopus_ready_time}'
+  #  - '{octopus_charge_limit}'
+  #  - '{octopus_saving_session}'
+  #  - '+[car_charging_planned]'
+  #  - '+[car_charging_soc]'
+  #  - '{car_charging_now}'


### PR DESCRIPTION
## Summary

- Adds **Canadian Solar EP Cube** to the inverter configuration table in `docs/inverter-setup.md`, with a short setup section
- Adds the `templates/ep_cube_cloud.yaml` apps.yaml template

Per #4069: the EP Cube has no local Modbus, so control goes via the vendor cloud REST API. The [ha-ep-cube](https://github.com/SkiLtY/ha-ep-cube) HA custom integration (now in the HACS Default store, MIT-licensed, 223-test suite) bridges this to a Predbat-shaped set of entities and the standard 7 services, with idempotent writes and snapshot/auto-revert on override. In production against Octopus Agile Import since 2026-05-24.

## Test plan

- [x] `templates/ep_cube_cloud.yaml` parses as valid YAML
- [x] Follows the existing template convention (full standalone `apps.yaml`, same generic boilerplate as `templates/fox_cloud.yaml`/`templates/givenergy_cloud.yaml`, vendor-specific block swapped in)
- [ ] Maintainer review of doc wording/placement

Closes #4069