### PR TITLE
fix(octopus): filter saving-session events by target region in Octopus Direct

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -330,6 +330,7 @@ mypy
 nattribute
 ncalls
 nearr
+NESO
 newtok
 njpwerner
 nobat

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -305,6 +305,9 @@ octoplus_saving_session_query = """query {{
 			startAt
 			endAt
       devEvent
+      targetRegion {{
+        regionId
+      }}
 		}}
 		account(accountNumber: "{account_id}") {{
 			hasJoinedCampaign
@@ -314,6 +317,9 @@ octoplus_saving_session_query = """query {{
 				endAt
         rewardGivenInOctoPoints
 			}}
+      signedUpMeterPoint {{
+        regionId
+      }}
 		}}
 	}}
 }}"""
@@ -1000,6 +1006,13 @@ class OctopusAPI(ComponentBase):
             self.log("OctopusAPI: User has not joined Octopus saving sessions campaign")
             available_events = []
 
+        # Some saving sessions are only valid for specific NESO grid regions - Octopus still lists
+        # them as available to every account regardless of region, so joining one the account isn't
+        # eligible for is rejected by the API (matches BottleCapDave/HomeAssistant-OctopusEnergy#1737).
+        # An empty/missing targetRegion means the event is nationwide, not region-restricted.
+        account_region_id = (self.saving_sessions.get("account", {}) or {}).get("signedUpMeterPoint", {}) or {}
+        account_region_id = account_region_id.get("regionId", None)
+
         for event in joined_events:
             event_id = event.get("eventId", None)
             if event_id:
@@ -1016,6 +1029,10 @@ class OctopusAPI(ComponentBase):
             if event_id:
                 event_reward[event_id] = reward
                 event_code[event_id] = code
+            target_regions = [region.get("regionId") for region in (event.get("targetRegion", None) or []) if region]
+            if target_regions and account_region_id not in target_regions:
+                self.log("OctopusAPI: Skipping saving event code {} - not eligible for account region {} (event targets regions {})".format(code, account_region_id, target_regions))
+                continue
             if start and end and event_id not in joined_ids:
                 endDataTime = parse_date_time(end)
                 if endDataTime > self.now_utc_exact:

--- a/apps/predbat/tests/test_octopus_url.py
+++ b/apps/predbat/tests/test_octopus_url.py
@@ -640,6 +640,41 @@ def _test_get_saving_session_data(my_predbat):
             else:
                 print("PASS: All event data fields correctly populated")
 
+    # Test 8: Region-restricted events filtered against the account's own region (issue #4612)
+    print("\n*** Test 8: Region-restricted events filtered against the account's own region ***")
+    api.saving_sessions = {
+        "account": {"hasJoinedCampaign": True, "joinedEvents": [], "signedUpMeterPoint": {"regionId": 10}},
+        "events": [
+            {"id": "in_region", "code": "IN_REGION", "startAt": "2024-06-16T17:00:00+00:00", "endAt": "2024-06-16T18:00:00+00:00", "rewardPerKwhInOctoPoints": 100, "targetRegion": [{"regionId": 10}]},
+            {"id": "out_of_region", "code": "OUT_OF_REGION", "startAt": "2024-06-16T17:00:00+00:00", "endAt": "2024-06-16T18:00:00+00:00", "rewardPerKwhInOctoPoints": 100, "targetRegion": [{"regionId": 3}, {"regionId": 7}]},
+            {"id": "nationwide", "code": "NATIONWIDE", "startAt": "2024-06-16T17:00:00+00:00", "endAt": "2024-06-16T18:00:00+00:00", "rewardPerKwhInOctoPoints": 100, "targetRegion": []},
+        ],
+    }
+
+    with patch.object(type(api), "now_utc_exact", new_callable=lambda: property(lambda self: fixed_time)):
+        available, joined = api.get_saving_session_data()
+
+    available_codes = sorted(event["code"] for event in available)
+    if available_codes != ["IN_REGION", "NATIONWIDE"]:
+        print("ERROR: Expected only IN_REGION and NATIONWIDE events, got: {}".format(available_codes))
+        failed = True
+    else:
+        print("PASS: Out-of-region event excluded, in-region and nationwide events kept")
+
+    # An account with no signedUpMeterPoint (region unknown) can't confirm eligibility for any
+    # region-restricted event, so those are excluded (safer than risking a rejected join) - but
+    # nationwide events (no targetRegion at all) were never restricted, so they still show up.
+    print("\n*** Test 8b: No account region known - region-restricted events excluded, nationwide kept ***")
+    api.saving_sessions["account"]["signedUpMeterPoint"] = None
+    with patch.object(type(api), "now_utc_exact", new_callable=lambda: property(lambda self: fixed_time)):
+        available, joined = api.get_saving_session_data()
+    available_codes = sorted(event["code"] for event in available)
+    if available_codes != ["NATIONWIDE"]:
+        print("ERROR: Expected only NATIONWIDE when account region is unknown, got: {}".format(available_codes))
+        failed = True
+    else:
+        print("PASS: Region-restricted events excluded, nationwide event kept, when account region is unknown")
+
     if not failed:
         print("\n**** All get_saving_session_data tests PASSED ****")
 


### PR DESCRIPTION
## Summary

Fixes #4612. Predbat's own "Octopus Energy Direct" GraphQL client (the direct-to-Octopus connection method, separate from BottleCapDave's HA integration) never requested or filtered on region eligibility for saving sessions, so it would attempt to auto-join events the account's own region doesn't qualify for. Some saving sessions are only valid for specific NESO grid regions - Octopus's API still lists them as "available" to every account regardless of region - so joining one triggers `OE-1308: Account's region is outside of the target regions for this event`.

This is the same root cause BottleCapDave hit and fixed in their integration back in v18.3.0 ([BottlecapDave/HomeAssistant-OctopusEnergy#1737](https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy/issues/1737)) - their fix never reached Predbat's Direct client since it's a fully separate, independent code path.

- Added `targetRegion { regionId }` to the saving-session events query and `signedUpMeterPoint { regionId }` to the account query (both confirmed against Octopus's live GraphQL schema via introspection, not guessed).
- `get_saving_session_data()` now skips any available event whose `targetRegion` is non-empty and doesn't include the account's own region.
- An unknown account region (`signedUpMeterPoint` missing/null) excludes region-restricted events rather than assuming eligibility - a wasted/rejected join attempt is exactly the failure mode this is meant to avoid. Nationwide events (no `targetRegion` at all) are never affected either way.

## Test plan

- [x] `./run_all --test octopus_url` - two new scenarios in the existing `get_saving_session_data` coverage: region-mismatch excluded / matching-region and nationwide kept, and the unknown-account-region edge case (region-restricted events excluded, nationwide kept)
- [x] `./run_all --quick` passes
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)