### PR TITLE
fix(sunsynk,deye): make Freeze Export actually reach the inverter

### DIFF
--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -582,8 +582,16 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             if charge_soc > current_soc and charge_soc > reserve:
                 return {"behaviour": "charge", "work_mode": DEYE_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": charge_soc, "power": int(charge.get("power", 0))}
             if charge_soc == reserve:
-                # Zero power IS the freeze: the slot is enabled for grid charge but given no
-                # power, so the battery neither charges nor discharges and simply holds.
+                # A freeze charge holds via the RESERVE, not this rate: Predbat sets the
+                # reserve to soc_percent + 1 for the duration (execute.py) and the slot SoC
+                # follows it, which is what stops the battery discharging below where it
+                # started. Solar charging above that is allowed and expected - a freeze
+                # charge only bars discharge.
+                #
+                # The zero rate is not what makes this a hold. CONFIRMED live on Sunsynk,
+                # the same registers behind a different cloud, that a zero slot rate does
+                # NOT stop the battery charging. What it stops is the battery being SOLD to
+                # the grid - see _freeze_export_state.
                 return {"behaviour": "freeze_charge", "work_mode": DEYE_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": reserve, "power": 0}
             # The battery is already at or above the requested target, so grid charge stays
             # off — the charge is simply not triggered. The slot still carries Predbat's
@@ -658,11 +666,17 @@ class DeyeAPI(ComponentBase, OAuthMixin):
     def _self_use_slot(self, start_time, reserve, self_use_power):
         """Build a self-use TOU slot holding at the reserve SoC.
 
-        self_use_power must NOT be zero. Zero power is how a slot expresses a freeze — the
-        battery neither charges nor discharges — so a zero-power self-use slot would stop
-        the battery serving the house for the whole interval and push the load onto the
-        grid. Self-use slots cover every interval Predbat is not actively charging or
-        exporting, so that would be the battery's default state.
+        self_use_power must NOT be zero. The rate is the battery's power limit for the
+        slot, so a zero-rate self-use slot risks stopping the battery serving the house for
+        the whole interval and pushing the load onto the grid. Self-use slots cover every
+        interval Predbat is not actively charging or exporting, so that would be the
+        battery's default state and not somewhere to take the risk.
+
+        Precisely what a zero rate does is only half known. CONFIRMED live on Sunsynk (the
+        same registers behind a different cloud, 2026-08-20) that it does NOT stop CHARGING,
+        and that it DOES stop the battery being sold to the grid under Selling First - which
+        is what _freeze_export_state relies on. Its effect on discharge to the HOUSE was
+        never measured. This guard stays because that is the untested direction.
         """
         return {TOU_FIELD["time"]: start_time, TOU_FIELD["power"]: int(self_use_power), TOU_FIELD["soc"]: int(reserve), TOU_FIELD["grid_charge"]: False, TOU_FIELD["generate"]: False, TOU_FIELD["sell"]: False}
 

--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -574,9 +574,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         if export.get("enable"):
             export_soc = int(export.get("soc", FREEZE_EXPORT_SOC))
             if export_soc >= FREEZE_EXPORT_SOC:
-                # Zero power IS the freeze: selling-first with no slot power holds the
-                # battery while surplus solar still exports.
-                return {"behaviour": "freeze_export", "work_mode": DEYE_WORKMODE["selling_first"], "grid_charge": False, "solar_sell": True, "slot_soc": FREEZE_EXPORT_SOC, "power": 0}
+                return self._freeze_export_state(reserve)
             return {"behaviour": "export", "work_mode": DEYE_WORKMODE["selling_first"], "grid_charge": False, "solar_sell": True, "slot_soc": export_soc, "power": int(export.get("power", 0))}
 
         if charge.get("enable"):
@@ -593,7 +591,58 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             # mean freeze, which is a different state.
             return {"behaviour": "hold_charge", "work_mode": DEYE_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
 
+        # No window is active, so the only thing left that can distinguish demand from a
+        # freeze export is the charge rate. Predbat expresses Freeze Export - "demand mode,
+        # but with charging disabled" - by turning the forced-export window OFF and calling
+        # adjust_charge_rate(0), because DeyeCloud declares has_timed_pause False and that
+        # is the only lever execute.py has left.
+        #
+        # Without this the freeze never reached the inverter: charge_rate maps to the
+        # per-window battery_schedule_charge_power, which this method only reads inside an
+        # ENABLED charge window - and a freeze export has none. The payload came out
+        # byte-identical to plain Demand. Diagnosed and fixed on sunsynk.py first, which
+        # drives the same registers through a different cloud; see _freeze_export_state.
+        #
+        # The zero is only read as a freeze while the EXPORT rate is non-zero, which makes
+        # the signal "charging disabled, discharging still allowed" rather than just "zero",
+        # and keeps a system whose battery rates were never derived out of a permanent
+        # freeze: all-zero is an absence of a plan, not a plan.
+        if int(charge.get("power", 0)) == 0 and int(export.get("power", 0)) > 0:
+            return self._freeze_export_state(reserve)
+
         return {"behaviour": "idle", "work_mode": DEYE_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
+
+    @staticmethod
+    def _freeze_export_state(reserve):
+        """Return the control state for a freeze export: sell the surplus, keep serving the house.
+
+        Selling First, the slot Sell flag ON, the slot rate at ZERO, and the cap at the
+        RESERVE. The cap is the fix: FREEZE_EXPORT_SOC is Predbat's SENTINEL for "this
+        export window is a freeze" (export_limits_best of 99), not a battery level, and
+        writing it through as the slot SoC told a Selling First inverter to drive the
+        battery to 99% - charging it from the very solar the freeze exists to export.
+
+        Every leg of this was settled on live SUNSYNK hardware (inverter 2405116013,
+        2026-08-20) rather than inferred, and is inherited here on the register-parity rule:
+
+          * Zero-export-to-CT fills the battery from the surplus, so the mode must change -
+            a 99% battery still took 540 W of PV in that mode while the rest exported.
+          * The slot rate is the SELL-RATE cap, and zero is what stops the battery being
+            pushed to the grid. Two runs differing only in that field: at 8000 W with the
+            cap below the SoC the battery drained to the grid at up to 4715 W; at 0 W it
+            held at 1-28 W while the export still tracked PV minus load exactly.
+          * The cap can therefore sit at the reserve, leaving the battery the room it needs
+            to cover the house, because the zero rate is what makes that safe.
+
+        VERIFY@SPIKE on DEYE specifically. The parity argument is stronger than it was for
+        the grid sign - which is a CLOUD presentation choice, and so had to be measured per
+        cloud - because slot-rate and work-mode behaviour is a property of the inverter
+        FIRMWARE, and both clouds drive the same Deye registers. But it is still inherited
+        rather than measured here. The failure mode if DEYE's rate is not the sell-rate cap
+        is that a freeze export drains the battery to the reserve, so one live DEYE run
+        watching battery power against the solar surplus should confirm it.
+        """
+        return {"behaviour": "freeze_export", "work_mode": DEYE_WORKMODE["selling_first"], "grid_charge": False, "solar_sell": True, "slot_soc": int(reserve), "power": 0}
 
     def _self_use_power(self, sn):
         """Return the power to write on self-use slots for one inverter, or 0 when unknown.
@@ -633,12 +682,30 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             TOU_FIELD["sell"]: bool(state.get("solar_sell")),
         }
 
+    def _slot_for(self, start_time, state, reserve, self_use_power):
+        """Build the slot for one derived state: an action slot, or self-use when idle.
+
+        A state that asks for nothing - no grid charge, no sell, no power - is demand, and
+        demand needs the inverter's full rating so the battery can serve the house (see
+        _self_use_slot). Anything else is written verbatim, which is what lets a freeze
+        export, whose only non-default slot field is the sell flag, survive as a zero-rate
+        slot rather than being rewritten as self-use.
+        """
+        if state.get("grid_charge") or state.get("solar_sell") or state.get("power"):
+            return self._action_slot(start_time, state)
+        return self._self_use_slot(start_time, reserve, self_use_power)
+
     def build_tou_slots(self, schedule, current_soc, self_use_power):
         """Build exactly TOU_SLOT_COUNT ordered slots covering 24h from the schedule windows."""
         reserve = int(schedule.get("reserve", 0))
-        # Collect (start_time, state) segment boundaries. Baseline self-use at 00:00.
-        idle = {"behaviour": "idle", "power": 0, "slot_soc": reserve, "grid_charge": False, "solar_sell": False, "work_mode": None}
-        segments = {"00:00": dict(idle)}
+        # Collect (start_time, state) segment boundaries, from a DERIVED baseline at 00:00.
+        # "No window is active" is not always demand - a freeze export is exactly that state
+        # plus a zero charge rate (see derive_control_state) - so every slot the schedule
+        # does not otherwise claim carries the baseline, and a freeze covers the whole
+        # programme instead of being defeated by the first filler that covers the current
+        # time. Predbat never says when a freeze ends, so there is no boundary to write.
+        baseline = self.derive_control_state({"reserve": reserve, "charge": {"enable": False, "power": int(schedule.get("charge", {}).get("power", 0))}, "export": {"enable": False, "power": int(schedule.get("export", {}).get("power", 0))}}, current_soc)
+        segments = {"00:00": dict(baseline)}
         for direction in ("charge", "export"):
             window = schedule.get(direction, {})
             if window.get("enable") and window.get("start") and window.get("end"):
@@ -659,15 +726,12 @@ class DeyeAPI(ComponentBase, OAuthMixin):
                 intent = {"reserve": reserve, "charge": {"enable": False}, "export": {"enable": False}}
                 intent[direction] = {"enable": True, "soc": window.get("soc", 0), "power": window.get("power", 0)}
                 segments[start_time] = self.derive_control_state(intent, current_soc)
-                # After the window, return to self-use at reserve.
-                segments.setdefault(end_time, dict(idle))
+                # After the window, return to the baseline.
+                segments.setdefault(end_time, dict(baseline))
         ordered = sorted(segments.items(), key=lambda kv: kv[0])
         slots = []
         for start_time, state in ordered:
-            if state.get("grid_charge") or state.get("solar_sell") or state.get("power"):
-                slots.append(self._action_slot(start_time, state))
-            else:
-                slots.append(self._self_use_slot(start_time, reserve, self_use_power))
+            slots.append(self._slot_for(start_time, state, reserve, self_use_power))
         # Normalise to exactly TOU_SLOT_COUNT slots, each with a DISTINCT ascending
         # start time (DEYE rejects/mis-applies duplicate slot times). Pad with
         # self-use slots at filler times not already used by a window boundary,
@@ -677,7 +741,7 @@ class DeyeAPI(ComponentBase, OAuthMixin):
             if len(slots) >= TOU_SLOT_COUNT:
                 break
             if filler_time not in used:
-                slots.append(self._self_use_slot(filler_time, reserve, self_use_power))
+                slots.append(self._slot_for(filler_time, baseline, reserve, self_use_power))
                 used.add(filler_time)
         slots = sorted(slots, key=lambda slot: slot[TOU_FIELD["time"]])[:TOU_SLOT_COUNT]
         return slots
@@ -738,7 +802,10 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         reserve = int(schedule.get("reserve", 0))
         charge = schedule.get("charge", {})
         export = schedule.get("export", {})
-        intent = {"reserve": reserve, "charge": {"enable": False}, "export": {"enable": False}}
+        # The rates are carried even when no window is active: with both windows shut a zero
+        # charge rate is Predbat's Freeze Export, and the mode has to follow it rather than
+        # sit in demand (see derive_control_state).
+        intent = {"reserve": reserve, "charge": {"enable": False, "power": int(charge.get("power", 0))}, "export": {"enable": False, "power": int(export.get("power", 0))}}
         if self._window_active(export, now_minutes):
             intent["export"] = {"enable": True, "soc": export.get("soc", 0), "power": export.get("power", 0)}
         elif self._window_active(charge, now_minutes):

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -35,7 +35,7 @@ import hass as hass
 import pytz
 import asyncio
 
-THIS_VERSION = "v8.49.1"
+THIS_VERSION = "v8.49.2"
 
 from download import predbat_update_move, predbat_update_download, check_install, DEFAULT_PREDBAT_REPOSITORY
 from const import MINUTE_WATT

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -649,8 +649,17 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             if charge_soc > current_soc and charge_soc > reserve:
                 return {"behaviour": "charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": charge_soc, "power": int(charge.get("power", 0))}
             if charge_soc == reserve:
-                # Zero power IS the freeze: the slot is enabled for grid charge but given no
-                # power, so the battery neither charges nor discharges and simply holds.
+                # A freeze charge holds via the RESERVE, not this rate: Predbat sets the
+                # reserve to soc_percent + 1 for the duration (execute.py), and cap{n}
+                # follows it, which is what stops the battery discharging below where it
+                # started. Solar charging above that is allowed and expected - a freeze
+                # charge only bars discharge.
+                #
+                # The zero rate is therefore not what makes this a hold, and must not be
+                # read as one: CONFIRMED live 2026-08-20 that a zero slot rate does NOT
+                # stop the battery charging (rate 0 written and read back, battery carried
+                # on at 554 W until it simply reached 100%). What it does stop is the
+                # battery being SOLD to the grid - see _freeze_export_state.
                 return {"behaviour": "freeze_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": True, "solar_sell": False, "slot_soc": reserve, "power": 0}
             # The battery is already at or above the requested target, so grid charge stays
             # OFF - the charge is simply not triggered. The slot still carries Predbat's
@@ -766,10 +775,17 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
     def _self_use_slot(self, start_time, reserve, self_use_power):
         """Build a self-use slot holding at the reserve SOC.
 
-        self_use_power must NOT be zero. Zero power is how Sunsynk expresses a freeze - the
-        battery neither charges nor discharges - so a zero-power self-use slot would stop
-        the battery serving the house for the whole interval and push the load onto the
-        grid. Self-use slots cover most of the day, so this is the default state.
+        self_use_power must NOT be zero. The rate is the battery's power limit for the
+        slot, so a zero-rate self-use slot risks stopping the battery serving the house for
+        the whole interval and pushing the load onto the grid. Self-use slots cover most of
+        the day, so this is the default state and not somewhere to take the risk.
+
+        Precisely what a zero rate does is only half known. CONFIRMED live 2026-08-20 that
+        it does NOT stop CHARGING (rate 0 written and read back, the battery carried on at
+        554 W until it reached 100%), and that it DOES stop the battery being sold to the
+        grid under Selling First - which is what _freeze_export_state relies on. Its effect
+        on discharge to the HOUSE was never measured, because every run was midday sun
+        against a 250 W load. This guard stays because that is the untested direction.
         """
         return {"time": start_time, "power": int(self_use_power), "soc": int(reserve), "grid_charge": False, "sell": False}
 

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -640,12 +640,9 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
 
         if export.get("enable"):
             export_soc = int(export.get("soc", FREEZE_EXPORT_SOC))
-            behaviour = "freeze_export" if export_soc >= FREEZE_EXPORT_SOC else "export"
-            slot_soc = FREEZE_EXPORT_SOC if export_soc >= FREEZE_EXPORT_SOC else export_soc
-            # Zero power IS the freeze: selling-first with no power holds the battery while
-            # surplus solar still exports.
-            power = 0 if behaviour == "freeze_export" else int(export.get("power", 0))
-            return {"behaviour": behaviour, "work_mode": SUNSYNK_WORKMODE["selling_first"], "grid_charge": False, "solar_sell": True, "slot_soc": slot_soc, "power": power}
+            if export_soc >= FREEZE_EXPORT_SOC:
+                return self._freeze_export_state(reserve)
+            return {"behaviour": "export", "work_mode": SUNSYNK_WORKMODE["selling_first"], "grid_charge": False, "solar_sell": True, "slot_soc": export_soc, "power": int(export.get("power", 0))}
 
         if charge.get("enable"):
             charge_soc = int(charge.get("soc", 0))
@@ -662,7 +659,72 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             # different state, and the inverter's full rating would discard Predbat's rate.
             return {"behaviour": "hold_charge", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": int(charge.get("power", 0))}
 
+        # No window is active, so the only thing left that can distinguish demand from a
+        # freeze export is the charge rate. Predbat expresses Freeze Export - "demand mode,
+        # but with charging disabled" - by turning the forced-export window OFF and calling
+        # adjust_charge_rate(0), because SunsynkCloud declares has_timed_pause False and
+        # that is the only lever execute.py has left. A zero charge rate always means "do
+        # not charge the battery" (the same call backs set_freeze_export_during_demand and
+        # the cross-charging guards), so it is honoured here rather than dropped.
+        #
+        # Without this the freeze never reached the inverter at all: charge_rate maps to the
+        # per-window battery_schedule_charge_power, which derive_control_state only reads
+        # inside an ENABLED charge window - and a freeze export has none. Predbat said
+        # Freeze Export, Sunsynk wrote a byte-identical self-use programme to plain Demand,
+        # and surplus PV charged the battery instead of being exported.
+        #
+        # CONFIRMED live end to end (inverter 2405116013, 2026-08-20 11:30). Before the
+        # write the battery was taking 250 W of PV at 99% SoC; after it, battery power sat
+        # at 6, 5, 5, -6, -10 W across five polls while the grid export tracked PV minus
+        # load almost exactly (3620 W PV, 149 W load, 3347 W exported). The battery stopped
+        # charging, was not discharged, and every surplus watt reached the grid. Restoring
+        # the demand payload put it straight back to charging at 535 W.
+        #
+        # A zero charge rate is only read as a freeze while the EXPORT rate is non-zero,
+        # which is what makes the signal "charging disabled, discharging still allowed" -
+        # Freeze Export exactly - rather than just "zero". It also keeps a system whose
+        # battery rates were never derived (both entities still at their published 0, or
+        # battery_rate_max unmappable) out of a permanent freeze: all-zero is not a plan,
+        # it is an absence of one, and demand is the right thing to fall back to.
+        if int(charge.get("power", 0)) == 0 and int(export.get("power", 0)) > 0:
+            return self._freeze_export_state(reserve)
+
         return {"behaviour": "idle", "work_mode": SUNSYNK_WORKMODE["zero_export_ct"], "grid_charge": False, "solar_sell": False, "slot_soc": reserve, "power": 0}
+
+    @staticmethod
+    def _freeze_export_state(reserve):
+        """Return the control state for a freeze export: sell the surplus, keep serving the house.
+
+        Selling First, the per-slot Sell flag ON, the slot rate at ZERO, and the cap at the
+        reserve. Each field earns its place, and all four were settled on live hardware
+        (inverter 2405116013, 2026-08-20) rather than inferred:
+
+          * Selling First is what stops the surplus solar charging the battery. Limited to
+            Home runs PV -> load -> battery -> grid, so the battery fills first: a 99%
+            battery was still taking 540 W of PV in that mode while the rest exported.
+          * The RATE is the sell-rate cap, and zero is what stops the battery being pushed
+            out to the grid. Two runs differing only in this field settle it - at 8000 W
+            with the cap 3% under the SoC the battery drained to the grid at up to 4715 W,
+            and at 0 W with the cap 5% under the SoC it held at 1-28 W across five polls
+            while the export still tracked PV minus load exactly. This is the field the
+            original code had right.
+          * The CAP is the reserve, so the battery keeps the room it needs to cover the
+            house when the load exceeds the solar. The rate is what makes that safe: a cap
+            below the SoC is only dangerous while the sell rate is non-zero.
+
+        The cap must NEVER be FREEZE_EXPORT_SOC. That constant is Predbat's SENTINEL for
+        "this export window is a freeze" (export_limits_best of 99), not a battery level,
+        and writing it through to cap{n} told a Selling First inverter to drive the battery
+        to 99% - charging it from the very solar the freeze exists to export. Conflating the
+        marker with the target is the whole of what made a freeze look like an export, and
+        it is the only field of the four that was ever wrong.
+
+        NOT confirmed live: that the battery still covers the house under this mode. It
+        needs the load to exceed the solar, and every run so far was midday sun against a
+        250 W house. The cap is what should allow it and nothing observed contradicts that,
+        but it is the one leg of this resting on reasoning rather than a measurement.
+        """
+        return {"behaviour": "freeze_export", "work_mode": SUNSYNK_WORKMODE["selling_first"], "grid_charge": False, "solar_sell": True, "slot_soc": int(reserve), "power": 0}
 
     @staticmethod
     def _to_slot_time(value):
@@ -715,6 +777,18 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         """Build a slot realising a derived control state."""
         return {"time": start_time, "power": int(state["power"]), "soc": int(state["slot_soc"]), "grid_charge": bool(state["grid_charge"]), "sell": bool(state.get("solar_sell"))}
 
+    def _slot_for(self, start_time, state, reserve, self_use_power):
+        """Build the slot for one derived state: an action slot, or self-use when idle.
+
+        A state that asks for nothing - no grid charge, no sell, no power - is demand, and
+        demand needs the inverter's full rating so the battery can serve the house (see
+        _self_use_slot). Anything else is written verbatim, which is what lets a freeze,
+        whose only non-default field is the sell flag, survive as a zero-power slot.
+        """
+        if state.get("grid_charge") or state.get("solar_sell") or state.get("power"):
+            return self._action_slot(start_time, state)
+        return self._self_use_slot(start_time, reserve, self_use_power)
+
     def build_tou_slots(self, schedule, current_soc, self_use_power):
         """Build exactly TOU_SLOT_COUNT ordered slots covering 24h from the schedule windows.
 
@@ -723,13 +797,28 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         distinct and ascending. A slot is an interval whatever its grid-charge flag says,
         which is what lets a filler slot terminate the charge window before it.
 
-        Segment boundaries are collected from a 00:00 self-use baseline plus each enabled
-        window's start (its action) and end (back to self-use), then padded with fillers
-        and trimmed to the earliest, most imminent TOU_SLOT_COUNT.
+        Segment boundaries are collected from a 00:00 baseline plus each enabled window's
+        start (its action) and end (back to the baseline), then padded with fillers and
+        trimmed to the earliest, most imminent TOU_SLOT_COUNT.
+
+        The baseline is DERIVED rather than assumed to be self-use, because "no window is
+        active" is not always demand: a freeze export is exactly that state plus a zero
+        charge rate (see derive_control_state). Every slot the schedule does not otherwise
+        claim - the 00:00 start, each window's end, and the fillers - therefore carries the
+        baseline, so a freeze covers the whole programme instead of being defeated by the
+        first filler that happens to cover the current time.
+
+        That coarseness is deliberate. Predbat never tells this component when a freeze
+        ends - it disables the export window rather than describing it - so there is no
+        boundary to write. Pinning the freeze to "now" instead would move every slot time
+        on every tick and turn the applied-payload change detection into a write per cycle.
+        The programme is rebuilt whenever Predbat's plan changes (run() applies each tick
+        for control_active inverters), so it reverts to self-use as soon as the charge rate
+        comes back.
         """
         reserve = int(schedule.get("reserve", 0))
-        idle = {"behaviour": "idle", "power": 0, "slot_soc": reserve, "grid_charge": False, "solar_sell": False, "work_mode": None}
-        segments = {"00:00": dict(idle)}
+        baseline = self.derive_control_state({"reserve": reserve, "charge": {"enable": False, "power": int(schedule.get("charge", {}).get("power", 0))}, "export": {"enable": False, "power": int(schedule.get("export", {}).get("power", 0))}}, current_soc)
+        segments = {"00:00": dict(baseline)}
         for direction in ("charge", "export"):
             window = schedule.get(direction, {})
             if not (window.get("enable") and window.get("start") and window.get("end")):
@@ -748,21 +837,18 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
             intent = {"reserve": reserve, "charge": {"enable": False}, "export": {"enable": False}}
             intent[direction] = {"enable": True, "soc": window.get("soc", 0), "power": window.get("power", 0)}
             segments[start_time] = self.derive_control_state(intent, current_soc)
-            segments.setdefault(end_time, dict(idle))
+            segments.setdefault(end_time, dict(baseline))
 
         slots = []
         for start_time, state in sorted(segments.items(), key=lambda item: item[0]):
-            if state.get("grid_charge") or state.get("solar_sell") or state.get("power"):
-                slots.append(self._action_slot(start_time, state))
-            else:
-                slots.append(self._self_use_slot(start_time, reserve, self_use_power))
+            slots.append(self._slot_for(start_time, state, reserve, self_use_power))
 
         used = {slot["time"] for slot in slots}
         for filler in TOU_FILLER_TIMES:
             if len(slots) >= TOU_SLOT_COUNT:
                 break
             if filler not in used:
-                slots.append(self._self_use_slot(filler, reserve, self_use_power))
+                slots.append(self._slot_for(filler, baseline, reserve, self_use_power))
                 used.add(filler)
         return sorted(slots, key=lambda slot: slot["time"])[:TOU_SLOT_COUNT]
 
@@ -784,7 +870,10 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         reserve = int(schedule.get("reserve", 0))
         charge = schedule.get("charge", {})
         export = schedule.get("export", {})
-        intent = {"reserve": reserve, "charge": {"enable": False}, "export": {"enable": False}}
+        # The charge rate is carried even when no window is active: with both windows shut
+        # a zero rate is Predbat's Freeze Export, and the mode has to follow it rather than
+        # sit in demand (see derive_control_state).
+        intent = {"reserve": reserve, "charge": {"enable": False, "power": int(charge.get("power", 0))}, "export": {"enable": False, "power": int(export.get("power", 0))}}
         if self._window_active(export, now_minutes):
             intent["export"] = {"enable": True, "soc": export.get("soc", 0), "power": export.get("power", 0)}
         elif self._window_active(charge, now_minutes):

--- a/apps/predbat/sunsynk_const.py
+++ b/apps/predbat/sunsynk_const.py
@@ -211,15 +211,22 @@ SUNSYNK_ENERGY = {
 # battery -> house with PV at 0 W while the API reported power +484, so positive already
 # means discharging, matching DEYE and Predbat. No flip.
 #
-# grid_power's FIELD is confirmed - `pac` read 0 W at the same moment the app did, while
-# grid vip[0].power read -418 W and is evidently something else (a CT or per-phase sense,
-# not whole-house flow). Its SIGN is aligned with DEYE on the Deye-parity rule rather than
-# on direct evidence: every sample so far was at night with the grid idle, so 0 negates to
-# 0 and nothing distinguished the two. DEYE reports grid positive when importing and
-# negates to reach Predbat's negative-for-import convention, and Sunsynk is rebadged DEYE
-# hardware, so it is assumed to match. VERIFY@SPIKE - one daytime sample with real import
-# or export confirms or refutes it; if grid power comes back negative while importing,
-# remove "grid_power" here.
+# grid_power CONFIRMED live (inverter 2405116013, 2026-08-20 11:25) and negated, which
+# settles the VERIFY@SPIKE this line used to carry: Sunsynk reports `pac` NEGATIVE when
+# exporting, so it must be flipped to reach Predbat's negative-for-import convention. The
+# DEYE-parity guess was right after all.
+#
+# The sample that settles it, and the trap to avoid repeating: pac -1939 W at a moment when
+# PV 2708 W served a 117 W load and charged the battery at 544 W - a 2047 W surplus, whose
+# magnitude matches - with etodayFrom (import) sitting at 0.0 kWh for the whole day against
+# etodayTo (export) at 2.8 kWh and climbing. Only a sample with real power flowing can show
+# this. Two earlier readings taken near the balance point (pac +19 W and +20 W against a
+# computed surplus of ~0 W) look like the opposite conclusion and are pure noise; do not
+# re-decide this from a sample under a few hundred watts.
+#
+# `pac` is also the right FIELD: it read 0 W at the same moment the app did, while grid
+# vip[0].power read -418 W and is evidently something else (a CT or per-phase sense, not
+# whole-house flow).
 SUNSYNK_TELEMETRY_NEGATE = ("grid_power",)
 
 # Fields used to derive ratings rather than published directly.

--- a/apps/predbat/tests/test_deye_control.py
+++ b/apps/predbat/tests/test_deye_control.py
@@ -15,9 +15,21 @@ from tests.test_deye_api import MockDeye, MOCK_RATED_POWER
 from tests.test_infra import run_async as run_async_local
 
 
-def _state(reserve=10, charge=None, export=None):
-    """Build a schedule dict in the shape ``derive_control_state`` expects."""
-    return {"reserve": reserve, "charge": charge or {"enable": False, "soc": 0, "power": 0}, "export": export or {"enable": False, "soc": 0, "power": 0}}
+def _state(reserve=10, charge=None, export=None, charge_power=3000, export_power=3000):
+    """Build a schedule dict in the shape ``derive_control_state`` expects.
+
+    A DISABLED window still carries a power, because the real control entities do:
+    adjust_charge_rate/adjust_discharge_rate write Predbat's rates every cycle whether or
+    not a window is enabled. That matters because a zero charge rate against a non-zero
+    export rate is precisely how Predbat signals Freeze Export (see derive_control_state),
+    so a fixture leaving both at zero would silently be testing a freeze rather than the
+    demand state it reads as.
+    """
+    return {
+        "reserve": reserve,
+        "charge": charge or {"enable": False, "soc": 0, "power": charge_power},
+        "export": export or {"enable": False, "soc": 0, "power": export_power},
+    }
 
 
 def test_derive_control_state_table():
@@ -30,7 +42,16 @@ def test_derive_control_state_table():
         ("freeze_charge", _state(reserve=50, charge={"enable": True, "soc": 50, "power": 3000}), 50, ("freeze_charge", DEYE_WORKMODE["zero_export_ct"], True, False, 50)),
         ("hold_charge", _state(reserve=50, charge={"enable": True, "soc": 40, "power": 3000}), 50, ("hold_charge", DEYE_WORKMODE["zero_export_ct"], False, False, 50)),
         ("export", _state(reserve=10, export={"enable": True, "soc": 20, "power": 3000}), 80, ("export", DEYE_WORKMODE["selling_first"], False, True, 20)),
-        ("freeze_export", _state(reserve=10, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), 80, ("freeze_export", DEYE_WORKMODE["selling_first"], False, True, FREEZE_EXPORT_SOC)),
+        # The cap is the RESERVE, never the 99 sentinel: 99 marks the window as a freeze,
+        # it is not a battery level, and writing it through told a Selling First inverter to
+        # drive the battery to 99%. The zero sell rate is what makes a cap below the SoC
+        # safe - see _freeze_export_state for the live Sunsynk runs that settled this.
+        ("freeze_export", _state(reserve=10, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), 80, ("freeze_export", DEYE_WORKMODE["selling_first"], False, True, 10)),
+        # The signal Predbat actually sends: both windows off, charge rate zeroed, export
+        # rate left alone. Without this the freeze never reached the inverter at all.
+        ("freeze_export_by_rate", _state(reserve=10, charge_power=0), 80, ("freeze_export", DEYE_WORKMODE["selling_first"], False, True, 10)),
+        # Both rates zero is an absence of a plan, not a freeze.
+        ("no_rates_is_not_a_freeze", _state(reserve=15, charge_power=0, export_power=0), 60, ("idle", DEYE_WORKMODE["zero_export_ct"], False, False, 15)),
         ("idle", _state(reserve=15), 60, ("idle", DEYE_WORKMODE["zero_export_ct"], False, False, 15)),
     ]
     for name, sched, soc, exp in cases:
@@ -86,7 +107,7 @@ def test_build_tou_slots_times_are_distinct():
             print(f"ERROR: slot times not ascending: {times}")
             failed = True
     # An idle schedule (no windows) must also yield 6 distinct times.
-    idle = {"reserve": 15, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    idle = {"reserve": 15, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}}
     idle_times = [s[TOU_FIELD["time"]] for s in d.build_tou_slots(idle, current_soc=50, self_use_power=MOCK_RATED_POWER)]
     if len(set(idle_times)) != TOU_SLOT_COUNT:
         print(f"ERROR: idle schedule produced non-distinct times: {idle_times}")
@@ -419,7 +440,7 @@ def test_repeated_write_button_presses_do_not_resend_an_unchanged_payload():
     d = MockDeye().with_rating("INV1")
     d.device_list = ["INV1"]
     d.device_values = {"INV1": {"soc": 99.0}}
-    d.local_schedule["INV1"] = {"reserve": 14, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000, "start": "16:00", "end": "23:30"}}
+    d.local_schedule["INV1"] = {"reserve": 14, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000, "start": "16:00", "end": "23:30"}}
     posts = []
 
     async def fake_post(endpoint_key, body):
@@ -454,7 +475,7 @@ def test_write_button_still_writes_when_the_schedule_changes():
     d = MockDeye().with_rating("INV1")
     d.device_list = ["INV1"]
     d.device_values = {"INV1": {"soc": 50.0}}
-    d.local_schedule["INV1"] = {"reserve": 14, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    d.local_schedule["INV1"] = {"reserve": 14, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}}
     posts = []
 
     async def fake_post(endpoint_key, body):
@@ -490,7 +511,7 @@ def test_slot_soc_never_goes_below_the_inverter_floor():
     failed = False
     d = MockDeye().with_rating("INV1")
     d.device_battery_config["INV1"] = {"battLowCapacity": 14}
-    idle = {"reserve": 0, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    idle = {"reserve": 0, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}}
     payload = d.build_dynamic_payload("INV1", idle, current_soc=98)
     socs = [s[TOU_FIELD["soc"]] for s in payload["timeUseSettingItems"]]
     if any(s < 14 for s in socs):
@@ -498,7 +519,7 @@ def test_slot_soc_never_goes_below_the_inverter_floor():
         failed = True
 
     # An explicit target above the floor is untouched
-    export = {"reserve": 0, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": True, "soc": 24, "power": 3000, "start": "18:00", "end": "23:30"}}
+    export = {"reserve": 0, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": True, "soc": 24, "power": 3000, "start": "18:00", "end": "23:30"}}
     socs = [s[TOU_FIELD["soc"]] for s in d.build_dynamic_payload("INV1", export, current_soc=98)["timeUseSettingItems"]]
     if 24 not in socs:
         print(f"ERROR: an above-floor target should survive: {socs}")
@@ -668,7 +689,7 @@ def test_zero_length_window_produces_no_action_slot():
     """
     failed = False
     d = MockDeye().with_rating("INV1")
-    idle = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    idle = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}}
     baseline = d.build_tou_slots(idle, current_soc=20, self_use_power=MOCK_RATED_POWER)
     for direction, window in (
         ("charge", {"enable": True, "soc": 95, "power": 3000, "start": "00:00:00", "end": "00:00:00"}),
@@ -704,9 +725,9 @@ def test_solar_sell_is_always_on():
     """
     failed = False
     d = MockDeye().with_rating("INV1")
-    idle = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    idle = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}}
     charge = {"reserve": 10, "charge": {"enable": True, "soc": 95, "power": 3000, "start": "02:00", "end": "05:00"}, "export": {"enable": False, "soc": 0, "power": 0}}
-    export = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": True, "soc": 20, "power": 3000, "start": "16:00", "end": "19:00"}}
+    export = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": True, "soc": 20, "power": 3000, "start": "16:00", "end": "19:00"}}
     for name, sched, now_minutes in (("idle midday", idle, 12 * 60), ("charging 03:00", charge, 3 * 60), ("charge set, midday idle", charge, 12 * 60), ("exporting 17:00", export, 17 * 60)):
         payload = d.build_dynamic_payload("INV1", sched, current_soc=40, now_minutes=now_minutes)
         if payload["solarSellAction"] != "on":
@@ -879,7 +900,7 @@ def test_payload_names_every_day_the_schedule_runs_on():
         failed = True
     # Every payload, not just an active one: the slots are a 24h programme whatever state
     # the top level is in.
-    idle = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    idle = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}}
     if d.build_dynamic_payload("INV1", idle, current_soc=40, now_minutes=12 * 60).get("touDays") != DEYE_TOU_DAYS:
         print("ERROR: an idle payload must still name the days its slots apply on")
         failed = True
@@ -905,9 +926,9 @@ def test_every_slot_carries_the_complete_field_set():
     expected = set(TOU_FIELD.values())
     schedules = [
         {"reserve": 10, "charge": {"enable": True, "soc": 95, "power": 3000, "start": "02:00", "end": "05:00"}, "export": {"enable": False, "soc": 0, "power": 0}},
-        {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": True, "soc": 20, "power": 3000, "start": "16:00", "end": "19:00"}},
+        {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": True, "soc": 20, "power": 3000, "start": "16:00", "end": "19:00"}},
         {"reserve": 20, "charge": {"enable": True, "soc": 20, "power": 3000, "start": "01:00", "end": "02:00"}, "export": {"enable": False, "soc": 0, "power": 0}},
-        {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}},
+        {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}},
     ]
     for index, sched in enumerate(schedules):
         for slot in d.build_dynamic_payload("INV1", sched, current_soc=40, now_minutes=3 * 60)["timeUseSettingItems"]:
@@ -915,6 +936,57 @@ def test_every_slot_carries_the_complete_field_set():
                 print(f"ERROR: schedule {index} produced a slot with fields {sorted(slot)}, expected {sorted(expected)}")
                 failed = True
     assert not failed, "test_every_slot_carries_the_complete_field_set"
+
+
+def test_freeze_export_reaches_the_inverter_from_the_charge_rate():
+    """A Freeze Export written the way execute.py writes it must reach the inverter.
+
+    Predbat expresses Freeze Export by turning the forced-export window OFF and calling
+    adjust_charge_rate(0), because DeyeCloud declares has_timed_pause False. It never writes
+    99 to the export SoC entity, so the export-SoC route into the freeze state could not
+    fire, and charge_rate maps to a per-WINDOW field that a disabled window never reads. The
+    payload came out identical to plain Demand and the inverter carried on charging the
+    battery from the very solar the freeze existed to export.
+
+    Diagnosed and confirmed live on Sunsynk, which drives the same Deye registers through a
+    different cloud - see _freeze_export_state for the runs, and for the VERIFY@SPIKE noting
+    this leg is inherited on DEYE rather than measured.
+    """
+    failed = False
+    d = MockDeye().with_rating("INV1")
+    # Both windows off, charge rate zeroed, export rate untouched.
+    sched = _state(reserve=20, charge_power=0, export_power=1229)
+    payload = d.build_dynamic_payload("INV1", sched, current_soc=95, now_minutes=12 * 60)
+
+    if payload.get("workMode") != DEYE_WORKMODE["selling_first"]:
+        print(f"ERROR: freeze export left the work mode at {payload.get('workMode')!r}, expected selling_first - zero-export-to-CT charges the battery from the surplus")
+        failed = True
+    for slot in payload["timeUseSettingItems"]:
+        # Every slot, not just the one covering now: Predbat never says when a freeze ends,
+        # so a self-use filler left in the programme would defeat it once the clock reached
+        # it. The zero rate is the safety property - a non-zero one exports the battery down
+        # to the cap.
+        if slot[TOU_FIELD["power"]] != 0:
+            print(f"ERROR: freeze export slot {slot[TOU_FIELD['time']]} carries {slot[TOU_FIELD['power']]}W, expected 0")
+            failed = True
+        if slot[TOU_FIELD["soc"]] != 20:
+            print(f"ERROR: freeze export slot {slot[TOU_FIELD['time']]} caps at {slot[TOU_FIELD['soc']]}%, expected the 20% reserve")
+            failed = True
+        if not slot[TOU_FIELD["sell"]]:
+            print(f"ERROR: freeze export slot {slot[TOU_FIELD['time']]} did not arm the sell flag")
+            failed = True
+        if slot[TOU_FIELD["grid_charge"]]:
+            print(f"ERROR: freeze export slot {slot[TOU_FIELD['time']]} enables grid charge, a freeze must not charge")
+            failed = True
+
+    # And the sentinel is never a battery level, whatever the SoC or reserve.
+    for current_soc in (30, 80, 99):
+        for reserve in (5, 20):
+            state = d.derive_control_state(_state(reserve=reserve, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), current_soc)
+            if state["slot_soc"] != reserve:
+                print(f"ERROR: freeze export with reserve {reserve} at {current_soc}% capped at {state['slot_soc']}, expected {reserve}")
+                failed = True
+    assert not failed, "test_freeze_export_reaches_the_inverter_from_the_charge_rate"
 
 
 def test_export_slots_arm_the_sell_flag():
@@ -932,7 +1004,7 @@ def test_export_slots_arm_the_sell_flag():
     failed = False
     d = MockDeye().with_rating("INV1")
     sell = TOU_FIELD["sell"]
-    export = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": True, "soc": 20, "power": 3000, "start": "16:00", "end": "19:00"}}
+    export = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": True, "soc": 20, "power": 3000, "start": "16:00", "end": "19:00"}}
     slots = d.build_dynamic_payload("INV1", export, current_soc=80, now_minutes=17 * 60)["timeUseSettingItems"]
     armed = [slot for slot in slots if slot[sell]]
     if [slot[TOU_FIELD["time"]] for slot in armed] != ["16:00"]:
@@ -943,7 +1015,7 @@ def test_export_slots_arm_the_sell_flag():
         failed = True
 
     # A freeze-export holds the battery but still sells, so it arms too.
-    freeze = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000, "start": "16:00", "end": "19:00"}}
+    freeze = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000, "start": "16:00", "end": "19:00"}}
     frozen = [slot for slot in d.build_dynamic_payload("INV1", freeze, current_soc=80, now_minutes=17 * 60)["timeUseSettingItems"] if slot[sell]]
     if len(frozen) != 1 or frozen[0][TOU_FIELD["power"]] != 0:
         print(f"ERROR: freeze-export should arm one zero-power sell slot: {frozen}")
@@ -951,7 +1023,7 @@ def test_export_slots_arm_the_sell_flag():
 
     # A charge window never sells, and neither does an idle day.
     charge = {"reserve": 10, "charge": {"enable": True, "soc": 95, "power": 3000, "start": "02:00", "end": "05:00"}, "export": {"enable": False, "soc": 0, "power": 0}}
-    idle = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    idle = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}}
     for name, sched in (("charge", charge), ("idle", idle)):
         slots = d.build_dynamic_payload("INV1", sched, current_soc=40, now_minutes=3 * 60)["timeUseSettingItems"]
         if any(slot[sell] for slot in slots):
@@ -998,7 +1070,7 @@ def test_generator_charging_the_owner_configured_is_carried_through():
     generate = TOU_FIELD["generate"]
     # The owner runs the generator on the 2nd and 5th slots of the day.
     d.device_tou_config["INV1"] = [{"time": f"{n * 4:02d}:00", generate: n in (1, 4), "enableGridCharge": False, "power": 5000, "soc": 20} for n in range(6)]
-    sched = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 0}, "export": {"enable": False, "soc": 0, "power": 0}}
+    sched = {"reserve": 10, "charge": {"enable": False, "soc": 0, "power": 3000}, "export": {"enable": False, "soc": 0, "power": 0}}
     slots = d.build_dynamic_payload("INV1", sched, current_soc=40, now_minutes=12 * 60)["timeUseSettingItems"]
     if [slot[generate] for slot in slots] != [False, True, False, False, True, False]:
         print(f"ERROR: the owner's generator slots were not carried through: {[s[generate] for s in slots]}")
@@ -1082,6 +1154,7 @@ def run_deye_control_tests(my_predbat):
         ("non_export_uses_ct", test_non_export_states_measure_at_the_grid_ct),
         ("self_use_slot_power", test_self_use_slots_carry_the_inverter_rating),
         ("freeze_zero_power", test_freeze_states_hold_with_zero_power),
+        ("freeze_export_reaches_inverter", test_freeze_export_reaches_the_inverter_from_the_charge_rate),
         ("no_self_use_power_fails_closed", test_control_write_fails_closed_without_a_self_use_power),
         ("tou_days", test_payload_names_every_day_the_schedule_runs_on),
         ("slot_field_set", test_every_slot_carries_the_complete_field_set),

--- a/apps/predbat/tests/test_sunsynk_api.py
+++ b/apps/predbat/tests/test_sunsynk_api.py
@@ -571,7 +571,7 @@ def test_fetch_device_data_maps_telemetry_and_energy():
         if endpoint_key == "battery":
             return {"soc": 62, "power": -1500, "voltage": 51.2, "temp": 21.5, "capacity": 280, "chargeVolt": 56.8, "maxChargeCurrentLimit": 100, "etodayChg": 7.4, "etodayDischg": 5.1}
         if endpoint_key == "grid":
-            return {"pac": 430, "etodayFrom": 3.2, "etodayTo": 1.1}
+            return {"pac": -430, "etodayFrom": 3.2, "etodayTo": 1.1}
         if endpoint_key == "load":
             return {"totalPower": 900, "dailyUsed": 12.6}
         if endpoint_key == "input":
@@ -581,9 +581,10 @@ def test_fetch_device_data_maps_telemetry_and_energy():
     with patch.object(s, "_get", side_effect=fake_get):
         run_async_local(s.fetch_device_data("INV1"))
     values = s.device_values.get("INV1", {})
-    # grid_power is negated to reach Predbat's negative-for-import convention, matching
-    # deye.py: Sunsynk's pac of +430 (importing) must publish as -430.
-    for leaf, expect in (("soc", 62), ("battery_power", -1500), ("grid_power", -430), ("load_power", 900), ("pv_power", 2100), ("temperature", 21.5)):
+    # grid_power is negated to reach Predbat's negative-for-import convention: Sunsynk
+    # reports pac negative when EXPORTING, so -430 (an export) must publish as +430. See
+    # SUNSYNK_TELEMETRY_NEGATE for the live sample that confirmed it.
+    for leaf, expect in (("soc", 62), ("battery_power", -1500), ("grid_power", 430), ("load_power", 900), ("pv_power", 2100), ("temperature", 21.5)):
         if values.get(leaf) != expect:
             print(f"ERROR: telemetry {leaf} = {values.get(leaf)}, expected {expect}")
             failed = True
@@ -593,6 +594,54 @@ def test_fetch_device_data_maps_telemetry_and_energy():
             print(f"ERROR: energy {leaf} = {energy.get(leaf)}, expected {expect}")
             failed = True
     assert not failed, "test_fetch_device_data_maps_telemetry_and_energy"
+
+
+def test_grid_power_sign_matches_the_live_export_sample():
+    """An exporting site publishes POSITIVE grid power, as Predbat's convention requires.
+
+    Pinned to the live sample from inverter 2405116013 on 2026-08-20 11:25, the only kind
+    that can distinguish the two signs: pac -1939 W while PV 2708 W served a 117 W load and
+    charged the battery at 544 W - a 2047 W surplus whose magnitude matches - with the day's
+    counters reading 0.0 kWh imported against 2.8 kWh exported. Sunsynk reports export as
+    NEGATIVE, Predbat wants it positive (docs/apps-yaml.md), so this must publish +1939.
+
+    Deliberately a high-power sample. Readings taken near the balance point say nothing:
+    the same inverter read pac +19 W and +20 W against a computed surplus of ~0 W earlier
+    the same morning, which points the opposite way and is pure noise.
+    """
+    failed = False
+    s = MockSunsynk()
+
+    async def fake_get(endpoint_key, sn=None, params=None):
+        """Return the live 2026-08-20 11:25 sample for each realtime endpoint."""
+        if endpoint_key == "battery":
+            return {"soc": "98.0", "power": -544, "temp": "22.0", "voltage": "53.9"}
+        if endpoint_key == "grid":
+            return {"pac": -1939, "etodayFrom": "0.0", "etodayTo": "2.8"}
+        if endpoint_key == "load":
+            return {"totalPower": 117, "dailyUsed": 1.9}
+        if endpoint_key == "input":
+            return {"pac": 2708, "etoday": 6.4}
+        return {}
+
+    with patch.object(s, "_get", side_effect=fake_get):
+        run_async_local(s.fetch_device_data("INV1"))
+    values = s.device_values.get("INV1", {})
+    if values.get("grid_power") != 1939.0:
+        print(f"ERROR: exporting site published grid_power {values.get('grid_power')}, expected +1939.0")
+        failed = True
+    # The same sample also pins battery_power: negative while charging, so Predbat's
+    # positive-for-discharge convention needs no flip there either.
+    if values.get("battery_power") != -544.0:
+        print(f"ERROR: charging battery published battery_power {values.get('battery_power')}, expected -544.0")
+        failed = True
+    # Guard the fixture itself: PV must exceed load plus battery charge by roughly the
+    # published grid power, or this has stopped being a test of a real export.
+    surplus = values.get("pv_power", 0) - values.get("load_power", 0) + values.get("battery_power", 0)
+    if surplus < 1000 or abs(surplus - values.get("grid_power", 0)) > 250:
+        print(f"ERROR: the pinned sample no longer reads as a clear export: surplus {surplus} W vs grid {values.get('grid_power')} W")
+        failed = True
+    assert not failed, "test_grid_power_sign_matches_the_live_export_sample"
 
 
 def test_fetch_device_data_absent_fields_are_not_invented():
@@ -1127,6 +1176,7 @@ def run_sunsynk_api_tests(my_predbat):
         ("device_list_paging", test_get_device_list_pages_and_filters),
         ("device_list_unfiltered", test_get_device_list_unfiltered_returns_all),
         ("telemetry_mapping", test_fetch_device_data_maps_telemetry_and_energy),
+        ("grid_power_sign", test_grid_power_sign_matches_the_live_export_sample),
         ("telemetry_absent", test_fetch_device_data_absent_fields_are_not_invented),
         ("nominal_pack_voltage", test_nominal_pack_voltage_variants),
         ("capacity_ah_to_kwh", test_battery_capacity_amp_hours_to_kwh),

--- a/apps/predbat/tests/test_sunsynk_control.py
+++ b/apps/predbat/tests/test_sunsynk_control.py
@@ -26,10 +26,19 @@ from tests.test_sunsynk_api import MockSunsynk
 from tests.test_infra import run_async as run_async_local
 
 
-def _schedule(reserve=10, charge=None, export=None):
-    """Build a schedule dict in the shape the control entities produce."""
-    idle = {"enable": False, "soc": 0, "power": 0, "start": "00:00:00", "end": "00:00:00"}
-    return {"reserve": reserve, "charge": charge or dict(idle), "export": export or dict(idle)}
+def _schedule(reserve=10, charge=None, export=None, charge_power=3000, export_power=3000):
+    """Build a schedule dict in the shape the control entities produce.
+
+    A DISABLED window still carries a power, because the real control entities do:
+    adjust_charge_rate/adjust_discharge_rate write Predbat's rates every cycle whether or
+    not a window is enabled. That matters because a zero charge rate against a non-zero
+    export rate is precisely how Predbat signals Freeze Export (see derive_control_state),
+    so a fixture that left both at zero would silently be testing a freeze instead of the
+    demand state it reads as.
+    """
+    idle_charge = {"enable": False, "soc": 0, "power": charge_power, "start": "00:00:00", "end": "00:00:00"}
+    idle_export = {"enable": False, "soc": 0, "power": export_power, "start": "00:00:00", "end": "00:00:00"}
+    return {"reserve": reserve, "charge": charge or idle_charge, "export": export or idle_export}
 
 
 def test_derive_control_state_table():
@@ -42,7 +51,16 @@ def test_derive_control_state_table():
         ("freeze_charge", _schedule(reserve=50, charge={"enable": True, "soc": 50, "power": 3000}), 50, ("freeze_charge", SUNSYNK_WORKMODE["zero_export_ct"], True, False, 50)),
         ("hold_charge", _schedule(reserve=50, charge={"enable": True, "soc": 40, "power": 3000}), 50, ("hold_charge", SUNSYNK_WORKMODE["zero_export_ct"], False, False, 50)),
         ("export", _schedule(reserve=10, export={"enable": True, "soc": 20, "power": 3000}), 80, ("export", SUNSYNK_WORKMODE["selling_first"], False, True, 20)),
-        ("freeze_export", _schedule(reserve=10, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), 80, ("freeze_export", SUNSYNK_WORKMODE["selling_first"], False, True, FREEZE_EXPORT_SOC)),
+        # A freeze export caps at the RESERVE, not the 99 sentinel: the battery needs that
+        # room to cover the house, and the zero sell rate is what keeps it from being pushed
+        # to the grid instead. Confirmed live - see _freeze_export_state.
+        ("freeze_export", _schedule(reserve=10, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), 80, ("freeze_export", SUNSYNK_WORKMODE["selling_first"], False, True, 10)),
+        # The signal Predbat actually sends: both windows off, charge rate zeroed, export
+        # rate left alone. Without this the freeze never reached the inverter at all.
+        ("freeze_export_by_rate", _schedule(reserve=10, charge_power=0), 80, ("freeze_export", SUNSYNK_WORKMODE["selling_first"], False, True, 10)),
+        # Both rates zero is an absence of a plan, not a freeze - do not strand an
+        # unconfigured system holding its battery all day.
+        ("no_rates_is_not_a_freeze", _schedule(reserve=15, charge_power=0, export_power=0), 60, ("idle", SUNSYNK_WORKMODE["zero_export_ct"], False, False, 15)),
         ("idle", _schedule(reserve=15), 60, ("idle", SUNSYNK_WORKMODE["zero_export_ct"], False, False, 15)),
     ]
     for name, schedule, soc, expect in cases:
@@ -937,6 +955,92 @@ def test_freeze_states_are_expressed_as_zero_power():
     assert not failed, "test_freeze_states_are_expressed_as_zero_power"
 
 
+def test_freeze_export_reaches_the_inverter_from_the_charge_rate():
+    """A Freeze Export written the way execute.py writes it must reach the inverter.
+
+    This is the regression that mattered. Predbat expresses Freeze Export by turning the
+    forced-export window OFF and calling adjust_charge_rate(0), because SunsynkCloud
+    declares has_timed_pause False. It never writes 99 to the export SoC entity, so the
+    export-SoC route into the freeze state could not fire, and charge_rate maps to a
+    per-WINDOW field that a disabled window never reads. The result was a settings object
+    byte-identical to plain Demand, leaving the inverter in self-use charging the battery
+    from the very solar the freeze existed to export - confirmed live 2026-08-20, a 99%
+    battery still taking 540 W of PV.
+
+    So the fixture is the entity state after a freeze export, not a synthetic one, and the
+    expected payload is the one confirmed live: m0 p0 c<reserve> s1.
+    """
+    failed = False
+    s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
+    s.device_settings["INV1"] = {"sn": "INV1", "batteryLowCap": "20"}
+    # Both windows off, charge rate zeroed, export rate untouched.
+    sched = _schedule(reserve=20, charge_power=0, export_power=1229)
+    payload = s.build_settings_payload("INV1", sched, current_soc=95, now_minutes=12 * 60)
+
+    if payload.get(SUNSYNK_WORKMODE_FIELD) != SUNSYNK_WORKMODE["selling_first"]:
+        print(f"ERROR: freeze export left the work mode at {payload.get(SUNSYNK_WORKMODE_FIELD)!r}, expected selling_first - Limited to Home charges the battery from the surplus")
+        failed = True
+    for n in range(1, TOU_SLOT_COUNT + 1):
+        power = int(payload[TOU_FIELD["power"].format(n=n)])
+        soc = int(payload[TOU_FIELD["soc"].format(n=n)])
+        sell = payload[TOU_FIELD["sell"].format(n=n)]
+        grid_charge = payload[TOU_FIELD["grid_charge"].format(n=n)]
+        # Every slot, not just the one covering now: Predbat never says when a freeze ends,
+        # so a self-use filler left in the programme would defeat it the moment the clock
+        # reached it.
+        #
+        # The rate is the safety property. At 8000 W with a cap below the SoC the battery
+        # drained to the grid at 4.7 kW; at 0 W it held. Never relax this to the rating.
+        if power != 0:
+            print(f"ERROR: freeze export slot {n} carries {power}W, expected 0 - a non-zero sell rate exports the battery")
+            failed = True
+        # The cap is the reserve, which is the room the battery needs to cover the house.
+        if soc != 20:
+            print(f"ERROR: freeze export slot {n} caps at {soc}%, expected the 20% reserve")
+            failed = True
+        if sell != "1":
+            print(f"ERROR: freeze export slot {n} sell flag {sell!r}, expected '1'")
+            failed = True
+        if grid_charge != "false":
+            print(f"ERROR: freeze export slot {n} has grid charge {grid_charge!r}, a freeze must not charge")
+            failed = True
+    assert not failed, "test_freeze_export_reaches_the_inverter_from_the_charge_rate"
+
+
+def test_freeze_export_caps_at_the_reserve_never_the_sentinel():
+    """The freeze cap is the reserve, and never FREEZE_EXPORT_SOC whatever the SoC.
+
+    99 is Predbat's MARKER for "this export window is a freeze" (export_limits_best of 99),
+    not a battery level. Writing it through to cap{n} told a Selling First inverter to drive
+    the battery to 99% - charging it from the solar the freeze exists to export, or selling
+    down to 99% from above. That single field is the whole of the original bug; the rest of
+    the mapping was right.
+    """
+    failed = False
+    s = MockSunsynk()
+    s.device_rated_power["INV1"] = 8000.0
+    for current_soc in (30, 55, 80, 95, 99, 100):
+        for reserve in (5, 10, 20):
+            for sched in (_schedule(reserve=reserve, export={"enable": True, "soc": FREEZE_EXPORT_SOC, "power": 3000}), _schedule(reserve=reserve, charge_power=0)):
+                state = s.derive_control_state(sched, current_soc)
+                if state["behaviour"] != "freeze_export":
+                    print(f"ERROR: expected a freeze export at {current_soc}%, got {state['behaviour']}")
+                    failed = True
+                    continue
+                if state["slot_soc"] != reserve:
+                    print(f"ERROR: freeze export with reserve {reserve} capped at {state['slot_soc']}%, expected {reserve}")
+                    failed = True
+                if state["slot_soc"] == FREEZE_EXPORT_SOC and reserve != FREEZE_EXPORT_SOC:
+                    print(f"ERROR: freeze export wrote the {FREEZE_EXPORT_SOC} sentinel as a battery level")
+                    failed = True
+                # The zero rate is what makes a cap below the SoC safe.
+                if state["power"] != 0:
+                    print(f"ERROR: freeze export carries rate {state['power']}, expected 0")
+                    failed = True
+    assert not failed, "test_freeze_export_caps_at_the_reserve_never_the_sentinel"
+
+
 def test_hold_charge_keeps_predbat_rate_without_charging():
     """A charge target at or below current SoC must not trigger a charge, but keeps the rate.
 
@@ -1095,6 +1199,8 @@ def run_sunsynk_control_tests(my_predbat):
         ("tou_slots_shape", test_build_tou_slots_shape),
         ("self_use_never_zero", test_self_use_slots_are_never_zero_power),
         ("freeze_zero_power", test_freeze_states_are_expressed_as_zero_power),
+        ("freeze_export_reaches_inverter", test_freeze_export_reaches_the_inverter_from_the_charge_rate),
+        ("freeze_export_cap", test_freeze_export_caps_at_the_reserve_never_the_sentinel),
         ("hold_charge_rate", test_hold_charge_keeps_predbat_rate_without_charging),
         ("tou_slots_seconds", test_build_tou_slots_seconds_are_dropped),
         ("tou_slots_idle", test_build_tou_slots_idle_is_still_six_distinct),


### PR DESCRIPTION
## The bug

Freeze Export was a silent no-op on both Sunsynk and DEYE. Predbat expresses it by turning the forced-export window **off** and calling `adjust_charge_rate(0)`, because both `SunsynkCloud` and `DeyeCloud` declare `has_timed_pause: False` and that is the only lever `execute.py` has left. But `charge_rate` maps to the per-**window** `battery_schedule_charge_power`, which `derive_control_state` only reads inside an *enabled* charge window — and a freeze export has none. The zero was dropped and the component wrote a settings object byte-identical to plain Demand.

The `freeze_export` branch meant to catch this keyed on the export SoC entity reaching `FREEZE_EXPORT_SOC`, which Predbat never writes: `discharge_target_soc` is only written during a real force export, always as `reserve_percent`. So the branch was unreachable — and had it fired, it wrote the **99 sentinel** as `cap{n}`, telling a Selling First inverter to drive the battery to 99%.

Net effect on a live system: Predbat says "Freeze exporting", the inverter sits in self-use, and surplus PV charges the battery instead of being exported.

## The fix

A freeze export is **Selling First, Sell on, slot rate 0, cap at the RESERVE**. The original code had three of those four right; only the cap was wrong.

- a zero charge rate against a non-zero export rate derives the freeze (the signal Predbat actually sends)
- the cap is the reserve, not the sentinel
- the slot baseline is derived rather than assumed idle, so the fillers carry the freeze too — Predbat never says when a freeze ends, so a self-use filler would otherwise defeat it the moment the clock reached it

## Evidence

Settled on live hardware (Sunsynk inverter 2405116013, 2026-08-20) rather than inferred. The decisive result is a controlled pair differing in **one field**:

| mode | sell | **rate** | cap vs SoC | battery |
|---|---|---|---|---|
| Selling First | 0 | **8000** | 3% below | **drained to grid at 4283–4715 W** |
| Selling First | 1 | **0** | 5% below | **held at 7, 1, 28, 1, 10 W** |

So the slot rate is the **sell-rate cap**, which is what makes a cap below the SoC safe, which is what lets the cap sit at the reserve so the battery keeps the room to cover the house.

Supporting runs:

- Zero-export-to-CT fills the battery from the surplus — a 99% battery still took 540 W of PV while the rest exported. So the mode has to change.
- A zero slot rate does **not** stop charging, so it cannot stand in for the mode swap: rate 0 written and read back, battery carried on at 554 W until it simply reached 100%.
- The production payload (`m0 p0 c20 s1`) was then written live with the cap at the real 20% reserve — 80% of headroom below it — and the battery held at −1/0/3/6/3 W while the export tracked PV minus load (5148 − 257 = 4891 W vs `pac` −4711 W).

Also resolves the `VERIFY@SPIKE` on the Sunsynk `grid_power` sign. **No behaviour change** — it is correct as it was, `pac` is negative when exporting so the negation stands — but it was an unverified DEYE-parity guess and is now pinned to a live sample and a regression test: `pac −1939 W` against a computed 2047 W surplus, with the day's counters at 0.0 kWh imported against 2.8 kWh exported. The comment warns off re-deciding it from a low-power sample, which points the opposite way and is pure noise.

## DEYE

Identical bug in identical code, so the same three changes. Its grid sign needs nothing — already confirmed live by the counter cross-check (`TotalGridPower +25 W` with `DailyGridFeedIn 0.00 kWh`).

Marked `VERIFY@SPIKE` for DEYE specifically. The parity argument is stronger here than it was for the grid sign — a sign convention is a **cloud presentation** choice and so had to be measured per cloud, whereas slot-rate and work-mode behaviour is inverter **firmware**, and both clouds drive the same Deye registers. But it is still inherited rather than measured. If DEYE's rate is not the sell-rate cap, a freeze export would drain the battery to the reserve, so one live DEYE run watching battery power against the solar surplus should confirm it.

## Not verified

- **The discharge half.** That the battery still covers the house under Selling First when the load exceeds the solar. Every run was midday sun against a ~250 W house, so the battery never needed to cover a shortfall. The cap at the reserve is what should allow it and nothing observed contradicts it, but it rests on reasoning — recorded as such in the docstring. An evening run settles it.

## Also

Corrects a stale comment in both files: they asserted "Zero power IS the freeze — the battery neither charges nor discharges", and the charging half is now disproven. They record what is actually known, including that the effect on discharge to the *house* was never measured — which is why the `_self_use_slot` guard stays exactly as it was.

The test fixtures needed a sweep in both components: a disabled window in the real control entities still carries Predbat's rate, so fixtures that left the charge rate at zero were silently describing a freeze rather than the demand state they read as.

## Testing

New regression tests for the freeze-export payload and the sentinel in both components, plus the Sunsynk grid-sign sample. Full `--quick` suite green, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
