### PR TITLE
fix(sunsynk,deye): own the power sign flags instead of inheriting them

### DIFF
--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -1267,6 +1267,15 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         self.set_arg("soc_percent", [self._sensor_name(sn, "soc") for sn in devices])
         self.set_arg("battery_power", [self._sensor_name(sn, "battery_power") for sn in devices])
         self.set_arg("grid_power", [self._sensor_name(sn, "grid_power") for sn in devices])
+        # Own the sign flags rather than leaving them to whatever else configured this
+        # install. base.args is shared and NOT namespaced per inverter type, so a component
+        # that legitimately inverts its own grid sensor - teslemetry sets grid_power_invert
+        # True, fox does the same - leaves that key set for every inverter index, and a DEYE
+        # inverter that never claims it inherits the flip, turning a correct export into an
+        # apparent import. All three are False because publish_data already emits Predbat's
+        # conventions (see DEYE_TELEMETRY_NEGATE).
+        for flag in ("grid_power_invert", "battery_power_invert", "load_power_invert"):
+            self.set_arg(flag, [False for _ in devices])
         self.set_arg("load_power", [self._sensor_name(sn, "load_power") for sn in devices])
         if not self.automatic_ignore_pv:
             self.set_arg("pv_power", [self._sensor_name(sn, "pv_power") for sn in devices])

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -1518,6 +1518,20 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         self.set_arg_auto("soc_percent", [self._sensor_name(sn, "soc") for sn in devices])
         self.set_arg_auto("battery_power", [self._sensor_name(sn, "battery_power") for sn in devices])
         self.set_arg_auto("grid_power", [self._sensor_name(sn, "grid_power") for sn in devices])
+        # Own the sign flags rather than leaving them to whatever else configured this
+        # install. base.args is shared and NOT namespaced per inverter type, so a component
+        # that legitimately inverts its own grid sensor - teslemetry sets grid_power_invert
+        # True, fox does the same - leaves that key set for every inverter index, and a
+        # Sunsynk inverter that never claims it inherits the flip. The published sensor is
+        # then correct and inverter.py negates it again, so an export reads as an import and
+        # the power-flow arrow points the wrong way.
+        #
+        # All three are False because publish_data already emits Predbat's conventions:
+        # grid negative on import (SUNSYNK_TELEMETRY_NEGATE), battery positive on discharge
+        # and load positive, each confirmed live. Set explicitly, not left to the default,
+        # so the value cannot depend on which components happen to share the install.
+        for flag in ("grid_power_invert", "battery_power_invert", "load_power_invert"):
+            self.set_arg_auto(flag, [False for _ in devices])
         self.set_arg_auto("load_power", [self._sensor_name(sn, "load_power") for sn in devices])
         self.set_arg_auto("battery_temperature", [self._sensor_name(sn, "temperature") for sn in devices])
         if not self.automatic_ignore_pv:

--- a/apps/predbat/tests/test_deye_publish.py
+++ b/apps/predbat/tests/test_deye_publish.py
@@ -239,6 +239,38 @@ def test_automatic_config_maps_all_inverters():
     assert not failed, "test_automatic_config_maps_all_inverters"
 
 
+def test_sign_flags_are_claimed_not_inherited():
+    """DEYE owns the invert flags, so another component cannot flip its sign.
+
+    base.args is shared and NOT namespaced per inverter type. teslemetry and fox both set
+    grid_power_invert True for their own hardware, quite correctly - but that leaves the key
+    set for every inverter index, and a DEYE inverter that never claimed it inherited the
+    flip. inverter.py then negated an already-correct sensor, so an export read as an import
+    and the power-flow arrow pointed the wrong way on any install running both.
+
+    All three are False because publish_data already emits Predbat's conventions: grid
+    negative on import (DEYE_TELEMETRY_NEGATE), battery positive on discharge, load positive.
+    """
+    failed = False
+    d = RecordingDeye()
+    d.device_list = ["INVA", "INVB"]
+    d.device_capacity = {"INVA": 61.44, "INVB": 61.44}
+    d.device_battery_config = {"INVA": {}, "INVB": {}}
+    d.set_args = {}
+    d.set_arg = lambda k, v: d.set_args.__setitem__(k, v)
+    import tests.test_infra as ti
+
+    ti.run_async(d.automatic_config())
+    for flag in ("grid_power_invert", "battery_power_invert", "load_power_invert"):
+        if flag not in d.set_args:
+            print(f"ERROR: {flag} was never set, so it is inherited from whatever else configured the install")
+            failed = True
+        elif d.set_args[flag] != [False, False]:
+            print(f"ERROR: {flag} = {d.set_args[flag]}, expected [False, False] - one entry per inverter")
+            failed = True
+    assert not failed, "test_sign_flags_are_claimed_not_inherited"
+
+
 def test_automatic_config_skips_unavailable_capability_args():
     """With no capacity source, soc_max/battery_min_soc are left unset rather than aimed at missing sensors."""
     failed = False
@@ -588,6 +620,7 @@ def run_deye_publish_tests(my_predbat):
         ("write_button", test_write_button_applies_schedule),
         ("sn_from_entity", test_sn_from_entity_disambiguates_prefix_colliding_serials),
         ("automatic_config", test_automatic_config_maps_all_inverters),
+        ("sign_flags_claimed", test_sign_flags_are_claimed_not_inherited),
         ("automatic_config_skips_capability", test_automatic_config_skips_unavailable_capability_args),
         ("publish_derived_capacity", test_publish_data_publishes_derived_capacity),
         ("automatic_config_ratings", test_automatic_config_maps_ratings),

--- a/apps/predbat/tests/test_sunsynk_config.py
+++ b/apps/predbat/tests/test_sunsynk_config.py
@@ -778,6 +778,34 @@ def test_export_limit_is_auto_mapped_from_the_export_cap():
     assert not failed, "test_export_limit_is_auto_mapped_from_the_export_cap"
 
 
+def test_sign_flags_are_claimed_not_inherited():
+    """Sunsynk owns the invert flags, so another component cannot flip its sign.
+
+    base.args is shared and NOT namespaced per inverter type. teslemetry and fox both set
+    grid_power_invert True for their own hardware, quite correctly - but that leaves the key
+    set for every inverter index, and a Sunsynk inverter that never claimed it inherited the
+    flip. inverter.py then negated an already-correct sensor, so an export read as an import
+    and the power-flow arrow pointed the wrong way on any install running both.
+
+    All three are False because publish_data already emits Predbat's conventions: grid
+    negative on import, battery positive on discharge, load positive.
+    """
+    failed = False
+    s = ConfigSunsynk()
+    s.device_list = ["INV1", "INV2"]
+    s.device_rated_power = {"INV1": 8000.0, "INV2": 8000.0}
+    with patch.object(s, "battery_capacity", return_value=10.0), patch.object(s, "battery_rate_max", return_value=3000.0), patch.object(s, "export_limit", return_value=7000.0):
+        run_async_local(s.automatic_config())
+    for flag in ("grid_power_invert", "battery_power_invert", "load_power_invert"):
+        if flag not in s.args_set:
+            print(f"ERROR: {flag} was never set, so it is inherited from whatever else configured the install")
+            failed = True
+        elif s.args_set[flag] != [False, False]:
+            print(f"ERROR: {flag} = {s.args_set[flag]}, expected [False, False] - one entry per inverter")
+            failed = True
+    assert not failed, "test_sign_flags_are_claimed_not_inherited"
+
+
 def run_sunsynk_config_tests(my_predbat):
     """Run all Sunsynk configuration tests."""
     failed = False
@@ -786,6 +814,7 @@ def run_sunsynk_config_tests(my_predbat):
         ("component_registered", test_component_registered),
         ("apps_schema", test_apps_schema_keys),
         ("automatic_config", test_automatic_config_maps_control_entities),
+        ("sign_flags_claimed", test_sign_flags_are_claimed_not_inherited),
         ("export_limit_mapped", test_export_limit_is_auto_mapped_from_the_export_cap),
         ("partial_capabilities", test_automatic_config_skips_partial_capabilities),
         ("ignore_pv", test_automatic_config_respects_ignore_pv),


### PR DESCRIPTION
## The bug

`base.args` is a single shared dict and is **not namespaced per inverter type**, so whichever component sets `grid_power_invert` sets it for every inverter index on the install.

`teslemetry.py:646` and `fox.py:2235` both set it `True` for their own hardware — quite correctly. Sunsynk and Deye never claimed the key at all, so on an install running either of those alongside them, they inherited the flip:

```
sensor.predbat_sunsynk_<sn>_grid_power  = +506  (exporting, correct)
  → inverter.grid_power                 = +506
  → grid_power_invert, left True by another component → −506
  → Predbat reads negative as importing → power-flow arrow reversed
```

Verified live that the component itself publishes the correct sign — raw `pac` −506 with the day's counters at 0.0 kWh imported against 10.7 kWh exported, published as **+506**, which is Predbat's documented convention (negative import, positive export). So the sensor was right and the flag was flipping it afterwards.

## The fix

Both components now set `grid_power_invert`, `battery_power_invert` and `load_power_invert` explicitly to `False` in `automatic_config`.

Setting them rather than relying on the default is the whole point: a default only applies when nothing else has written the key, which is exactly the case that was failing.

`False` is right for all three because `publish_data` already emits Predbat's conventions — grid negative on import (`SUNSYNK_TELEMETRY_NEGATE` / `DEYE_TELEMETRY_NEGATE`), battery positive on discharge, load positive — each confirmed against live hardware.

## Testing

A regression test per component asserting all three flags are claimed with one entry per inverter, so neither can silently go back to inheriting. Full `--quick` suite green, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
