### PR TITLE
fix(inverter): discharge_start_service sends the planned rate, not always max

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1469,7 +1469,7 @@ class Inverter:
 
         if not quiet:
             self.base.log(
-                "Inverter {} SoC: {}kW {}%, current charge rate {}W, current discharge rate {}W, current battery power {}W, current battery voltage {}V, grid power {}W, load power {}W, PV Power {}W".format(
+                "Inverter {} SoC: {}kWh {}%, current charge rate {}W, current discharge rate {}W, current battery power {}W, current battery voltage {}V, grid power {}W, load power {}W, PV Power {}W".format(
                     self.id,
                     dp2(self.soc_kw),
                     self.soc_percent,
@@ -2858,10 +2858,14 @@ class Inverter:
         service_data_stop = {"device_id": self.base.get_arg("device_id", index=self.id, default="")}
         extra_data = {"discharge_start_time": self.base.get_arg("discharge_start_time", index=self.id, default="00:00:00"), "discharge_end_time": self.base.get_arg("discharge_end_time", index=self.id, default="00:00:00")}
         if target_soc < 100:
+            # Mirrors adjust_charge_immediate()'s charge_start_service payload just above - the
+            # actual (possibly low-power-scaled) rate already set via adjust_discharge_rate(), not
+            # always the inverter's maximum, which produced a full-power discharge_start_service
+            # call even during a planned low-power export (batpred#4619).
             service_data = {
                 "device_id": self.base.get_arg("device_id", index=self.id, default=""),
                 "target_soc": int(target_soc),
-                "power": int(self.battery_rate_max_discharge * MINUTE_WATT),
+                "power": int(self.get_current_discharge_rate()),
             }
 
             # Stop charge

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1308,10 +1308,15 @@ def test_call_adjust_export_immediate(test_name, my_predbat, ha, inv, dummy_item
     else:
         my_predbat.args["discharge_freeze_service"] = None
     my_predbat.args["device_id"] = "DID0"
-    power = int(inv.battery_rate_max_discharge * MINUTE_WATT)
+    my_predbat.args["discharge_rate"] = "number.discharge_rate"
+    if "discharge_rate_percent" in my_predbat.args:
+        del my_predbat.args["discharge_rate_percent"]
 
     dummy_items["select.discharge_start_time"] = discharge_start_time
     dummy_items["select.discharge_end_time"] = discharge_end_time
+    dummy_items["number.discharge_rate"] = 1802
+
+    power = 1802
 
     inv.adjust_export_immediate(soc, freeze=freeze)
     result = ha.get_service_store()


### PR DESCRIPTION
## Summary

Fixes #4619.

`adjust_export_immediate()` hardcoded `discharge_start_service`'s `power` to
`battery_rate_max_discharge` - the inverter's maximum - regardless of whether a lower
rate had already been set via `adjust_discharge_rate()` (e.g. for a planned low-power
export). So the service call always requested full power even while the plan itself
showed a slower discharge (the reporter's log: plan showing a low-power/"snail" export,
`discharge_rate` entity correctly at 3150W, but the actual service call sent `power: 6000`
- the inverter's max).

`adjust_charge_immediate()`'s equivalent `charge_start_service` payload already gets this
right - it reads the actual current rate via `get_current_charge_rate()` rather than
hardcoding a maximum. Discharge had no equivalent despite `get_current_discharge_rate()`
already existing for exactly this purpose, which the reporter (TCWORLD) also pointed out
directly in the issue, suggesting the same fix.

Also fixed a log message typo raised as a side-note in the issue: `Inverter N SoC: X kW`
should read `kWh` (the value itself was already correct, only the unit label was wrong).

## Test plan

`test_call_adjust_export_immediate` previously computed its expected `power` from the
same hardcoded-max formula the production code used, so it could never have caught this
regression. Updated it to configure a specific `discharge_rate` (1802W, deliberately
distinct from the fixture's max rate) and assert the service call uses that value -
mirroring `test_call_adjust_charge_immediate`'s existing pattern for the charge side. All
8 existing `adjust_export_immediate` sub-cases (freeze/start/stop, various target SoCs)
now exercise this.

- [x] `./run_all --quick` passes (all tests)
- [x] `./run_pre_commit` passes

Note: gcoan asked the reporter for their `apps.yaml` and a trace of the SolaX discharge
entity for completeness - this fix addresses the root cause visible directly in the linked
code (confirmed by the reporter's own log excerpt showing `discharge_rate` correctly at
3150W but the service call sent 6000W), independent of that additional info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)