### PR TITLE
fix(output): set device_class on 9 dashboard sensors missing it

### DIFF
--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -1007,6 +1007,7 @@ class Execute:
                 "friendly_name": "Current PV Power",
                 "state_class": "measurement",
                 "unit_of_measurement": "kW",
+                "device_class": "power",
                 "icon": "mdi:battery",
             },
         )
@@ -1017,6 +1018,7 @@ class Execute:
                 "friendly_name": "Current Grid Power",
                 "state_class": "measurement",
                 "unit_of_measurement": "kW",
+                "device_class": "power",
                 "icon": "mdi:battery",
             },
         )
@@ -1027,6 +1029,7 @@ class Execute:
                 "friendly_name": "Current Load Power",
                 "state_class": "measurement",
                 "unit_of_measurement": "kW",
+                "device_class": "power",
                 "icon": "mdi:battery",
             },
         )
@@ -1037,6 +1040,7 @@ class Execute:
                 "friendly_name": "Current Battery Power",
                 "state_class": "measurement",
                 "unit_of_measurement": "kW",
+                "device_class": "power",
                 "icon": "mdi:battery",
             },
         )

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1432,6 +1432,7 @@ class Fetch:
                 "friendly_name": "Battery temperature",
                 "state_class": "measurement",
                 "unit_of_measurement": "°C",
+                "device_class": "temperature",
                 "icon": "mdi:temperature-celsius",
             },
         )

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -4624,6 +4624,7 @@ class Plan:
                         "friendly_name": "Predicted Battery Power Best",
                         "state_class": "measurement",
                         "unit_of_measurement": "kW",
+                        "device_class": "power",
                         "icon": "mdi:battery",
                     },
                 )
@@ -4648,6 +4649,7 @@ class Plan:
                         "friendly_name": "Predicted PV Power Best",
                         "state_class": "measurement",
                         "unit_of_measurement": "kW",
+                        "device_class": "power",
                         "icon": "mdi:battery",
                     },
                 )
@@ -4660,6 +4662,7 @@ class Plan:
                         "friendly_name": "Predicted Grid Power Best",
                         "state_class": "measurement",
                         "unit_of_measurement": "kW",
+                        "device_class": "power",
                         "icon": "mdi:battery",
                     },
                 )
@@ -4672,6 +4675,7 @@ class Plan:
                         "friendly_name": "Predicted Load Power Best",
                         "state_class": "measurement",
                         "unit_of_measurement": "kW",
+                        "device_class": "power",
                         "icon": "mdi:battery",
                     },
                 )

--- a/apps/predbat/tests/test_dashboard_device_class.py
+++ b/apps/predbat/tests/test_dashboard_device_class.py
@@ -1,0 +1,63 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+from prediction import Prediction
+from tests.test_infra import reset_inverter
+
+
+def test_dashboard_device_class(my_predbat):
+    """
+    #3352 - a batch of dashboard sensors published with the right unit but no device_class, so
+    Home Assistant can't offer them for energy-dashboard style graphing/statistics. Only
+    predbat.temperature (temperature.py) had device_class set; predbat.battery_temperature and the
+    eight power sensors below did not. Regression-tests all nine in one pass.
+    """
+    reset_inverter(my_predbat)
+    failed = False
+
+    print("Test: current power sensors (execute.py) get device_class 'power'")
+    my_predbat.pv_power = 1000
+    my_predbat.grid_power = 500
+    my_predbat.load_power = 800
+    my_predbat.battery_power = 300
+    my_predbat.publish_inverter_data()
+    for entity in ["pv_power", "grid_power", "load_power", "battery_power"]:
+        attrs = my_predbat.ha_interface.dummy_items.get(my_predbat.prefix + "." + entity)
+        if not attrs or attrs.get("device_class") != "power":
+            print("  ERROR: {} missing device_class=power, got {}".format(entity, attrs.get("device_class") if attrs else None))
+            failed = True
+
+    print("Test: battery_temperature (fetch.py) gets device_class 'temperature'")
+    my_predbat.predict_battery_temperature({0: 20}, 30)
+    attrs = my_predbat.ha_interface.dummy_items.get(my_predbat.prefix + ".battery_temperature")
+    if not attrs or attrs.get("device_class") != "temperature":
+        print("  ERROR: battery_temperature missing device_class=temperature, got {}".format(attrs.get("device_class") if attrs else None))
+        failed = True
+
+    print("Test: predicted 'best' power sensors (plan.py) get device_class 'power'")
+    my_predbat.forecast_minutes = 24 * 60
+    my_predbat.end_record = my_predbat.forecast_minutes
+    horizon = my_predbat.forecast_minutes + my_predbat.minutes_now + 10
+    my_predbat.pv_forecast_minute = {m: 0.0 for m in range(0, horizon)}
+    my_predbat.pv_forecast_minute10 = dict(my_predbat.pv_forecast_minute)
+    my_predbat.load_minutes_step = {m: 0.0 for m in range(0, horizon)}
+    my_predbat.load_minutes_step10 = dict(my_predbat.load_minutes_step)
+    pv_step = {m: 0.0 for m in range(0, horizon, 5)}
+    load_step = {m: 0.0 for m in range(0, horizon, 5)}
+    my_predbat.prediction = Prediction(my_predbat, pv_step, pv_step, load_step, load_step)
+    my_predbat.run_prediction([], [], [], [], False, end_record=my_predbat.end_record, save="best")
+
+    for entity in ["pv_power_best", "grid_power_best", "load_power_best", "battery_power_best"]:
+        attrs = my_predbat.ha_interface.dummy_items.get(my_predbat.prefix + "." + entity)
+        if not attrs or attrs.get("device_class") != "power":
+            print("  ERROR: {} missing device_class=power, got {}".format(entity, attrs.get("device_class") if attrs else None))
+            failed = True
+
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -22,6 +22,7 @@ from tests.test_performance_tweaks import run_performance_tweaks_tests
 from tests.test_perf import run_perf_test
 from tests.test_model import run_model_tests
 from tests.test_predict_pv_power import run_predict_pv_power_tests
+from tests.test_dashboard_device_class import test_dashboard_device_class
 from tests.test_kernel_parity import run_kernel_parity_tests, run_model_kernel_tests
 from tests.test_prediction_batch import run_prediction_batch_tests
 from tests.test_kernel_static_cache import run_kernel_static_cache_tests
@@ -336,6 +337,7 @@ def main():
         ("perf", run_perf_test, "Performance tests", False),
         ("model", run_model_tests, "Model tests", False),
         ("predict_pv_power", run_predict_pv_power_tests, "predict_pv_power plan-interval scaling tests", False),
+        ("dashboard_device_class", test_dashboard_device_class, "Dashboard sensor device_class regression tests (#3352)", False),
         ("model_kernel", run_model_kernel_tests, "Model tests run with the C++ prediction kernel enabled", False),
         ("kernel_parity", run_kernel_parity_tests, "C++ prediction kernel vs Python engine parity tests", False),
         ("prediction_batch", run_prediction_batch_tests, "Batched prediction fan-out tests", False),


### PR DESCRIPTION
## Summary

Fixes #3352.

PR #3355 only fixed `predbat.temperature` (`temperature.py`). gcoan's follow-up list in the same issue - 9 more entities with the identical gap - was never actioned. Confirmed all 9 still missing `device_class` on current main, six months later:

- `fetch.py`'s `battery_temperature` → `device_class: temperature`
- `execute.py`'s 4 "current" power sensors (`pv_power`, `grid_power`, `load_power`, `battery_power`) → `device_class: power`
- `plan.py`'s 4 "_best" predicted power sensors (`pv_power_best`, `grid_power_best`, `load_power_best`, `battery_power_best`) → `device_class: power`

Value-preserving only - each is a single added dict key on an existing `dashboard_item()` call, no logic change. `device_class: power` matches the existing convention used elsewhere in the codebase (`enphase.py`) for the same unit (kW).

## Test plan
- [x] New `test_dashboard_device_class.py` - regression-tests all 9 entities in one pass (direct calls to `publish_inverter_data()`, `predict_battery_temperature()`, and a minimal `run_prediction(save="best")`)
- [x] `./run_all --quick` - full suite passes
- [x] `./run_pre_commit` - clean