### PR TITLE
fix(octopus): prune Intelligent devices Octopus no longer returns as live

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -759,6 +759,16 @@ class OctopusAPI(ComponentBase):
                     elif device_id not in self.intelligent_devices:
                         # First time seeing this device with no completed dispatches yet
                         self.intelligent_devices[device_id] = device
+
+                # Drop devices that Octopus no longer returns as LIVE. Without this a device that
+                # is deregistered/replaced (e.g. a re-paired charger leaving a stale registration
+                # behind - invisible in the Octopus app but still present via the API at some point
+                # in the past) stays cached and republished forever, permanently occupying a car
+                # slot and holding num_cars up even though only one real device remains.
+                removed = sorted(set(self.intelligent_devices) - set(intelligent_devices))
+                for device_id in removed:
+                    self.log("OctopusAPI: Intelligent device {} no longer live, removing".format(device_id))
+                    del self.intelligent_devices[device_id]
         return self.intelligent_devices
 
     def suffix_to_device_id(self, suffix):

--- a/apps/predbat/tests/test_octopus_intelligent_devices.py
+++ b/apps/predbat/tests/test_octopus_intelligent_devices.py
@@ -29,6 +29,7 @@ async def test_octopus_intelligent_devices(my_predbat):
     - Test 7: Planned dispatch with missing start/end is skipped
     - Test 8: In-progress flex dispatch not promoted to completed but trimmed to remainder (issue #4114)
     - Test 9: Future flex dispatch is left untrimmed in planned
+    - Test 10: async_update_intelligent_devices prunes a device no longer returned as LIVE
     """
     print("**** Running Octopus intelligent devices tests ****")
     failed = 0
@@ -499,6 +500,44 @@ async def test_octopus_intelligent_devices(my_predbat):
             failed += 1
         else:
             print("PASS: Future flex dispatch left untrimmed in planned")
+
+    # ------------------------------------------------------------------
+    # Test 10: async_update_intelligent_devices prunes a device Octopus no longer returns as
+    # LIVE. Regression for a support ticket where a customer with one EV saw two Octopus
+    # Intelligent device IDs in Predbat: a stale/ghost registration (invisible in the Octopus
+    # app) was cached on a prior poll and never dropped once it stopped appearing in the live
+    # devices() response, permanently occupying a car slot and holding num_cars up.
+    # ------------------------------------------------------------------
+    print("\n*** Test 10: Stale device pruned when no longer live ***")
+    api = make_api()
+    api.tariffs = {"import": {"tariffCode": "E-1R-INTELLI-VAR-24-10-29-A", "deviceID": "meter-1"}}
+
+    # Cycle 1: Octopus returns two live devices
+    api.async_get_intelligent_devices = AsyncMock(
+        return_value={
+            "device-real": {"device_id": "device-real", "completed_dispatches": [], "planned_dispatches": []},
+            "device-ghost": {"device_id": "device-ghost", "completed_dispatches": [], "planned_dispatches": []},
+        }
+    )
+    await api.async_update_intelligent_devices("test-account")
+
+    if set(api.intelligent_devices.keys()) != {"device-real", "device-ghost"}:
+        print(f"ERROR: Expected both devices cached after cycle 1, got {list(api.intelligent_devices.keys())}")
+        failed += 1
+    else:
+        # Cycle 2: Octopus now only returns the real device - device-ghost has dropped out of
+        # the live list (re-paired charger, deregistered vehicle, etc.)
+        api.async_get_intelligent_devices = AsyncMock(return_value={"device-real": {"device_id": "device-real", "completed_dispatches": [], "planned_dispatches": []}})
+        await api.async_update_intelligent_devices("test-account")
+
+        if "device-ghost" in api.intelligent_devices:
+            print(f"ERROR: Stale device-ghost was not pruned, still in intelligent_devices: {list(api.intelligent_devices.keys())}")
+            failed += 1
+        elif "device-real" not in api.intelligent_devices:
+            print("ERROR: Real device was incorrectly removed along with the stale one")
+            failed += 1
+        else:
+            print("PASS: Stale device no longer live was pruned, real device retained")
 
     if failed == 0:
         print("\n**** All Octopus intelligent devices tests PASSED ****")


### PR DESCRIPTION
## Summary
- `self.intelligent_devices` only ever grows — once a `device_id` is cached, it stays cached forever, even after Octopus's `devices()` API stops returning it.
- A deregistered/re-paired charger or vehicle (invisible in the Octopus app, but present via the API at some point in the past) then keeps its entities and target-time republished indefinitely, permanently occupying a car slot.
- `async_update_intelligent_devices` now drops any cached `device_id` that's absent from the latest live `devices()` response.

## Root cause (customer report)
A customer with exactly one registered EV saw two Octopus Intelligent device IDs in Predbat (different target times), one of which was invisible in the Octopus app. Live GraphQL logs confirmed Octopus's `get-intelligent-devices` response only ever returns the real device — the ghost ID never appears in any live response, so it was a stale in-memory cache entry, not a `suspended`-but-still-listed device (that case is already handled separately by #4533).

## Changes
- `apps/predbat/octopus.py`: after merging the latest live device data into `self.intelligent_devices`, remove any cached device_id no longer present in the live response.
- `apps/predbat/tests/test_octopus_intelligent_devices.py`: added Test 10 — two devices cached on cycle 1, one drops out of the live response on cycle 2, and the stale one is pruned while the real one is retained.

## Test plan
- [x] `./run_all --test octopus_intelligent_devices` — 10/10 pass
- [x] `./run_all -k octopus_` — full Octopus suite passes, no regressions
- [x] `./run_pre_commit` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)