### PR TITLE
fix(rates): manual API rate overrides no longer mark the whole day

### DIFF
--- a/apps/predbat/annual_tariff.py
+++ b/apps/predbat/annual_tariff.py
@@ -472,7 +472,7 @@ class AnnualTariff:
             usable.append(entry)
         if ignored:
             self.log("Warn: Annual: {} contains {} day_of_week/date entries, which are anchored to today's date rather than the sampled historical date and cannot be honoured during an annual replay; ignoring them".format(name, ignored))
-        table = self.predbat.basic_rates(usable, name)
+        table = self.predbat.basic_rates(usable, name, include_manual_api=False)
         setattr(self, cache_attr, table)
         return table
 

--- a/apps/predbat/compare.py
+++ b/apps/predbat/compare.py
@@ -97,7 +97,7 @@ class Compare:
             else:
                 self.log("Warn: Compare tariff {} bad Strømligning entity ids".format(tariff.get("id", "")))
         elif "rates_import" in tariff:
-            pb.rate_import = pb.basic_rates(tariff["rates_import"], "rates_import")
+            pb.rate_import = pb.basic_rates(tariff["rates_import"], "rates_import", include_manual_api=False)
         else:
             self.log("Using existing rate import data")
 
@@ -127,7 +127,7 @@ class Compare:
             else:
                 self.log("Warn: Compare tariff {} bad Strømligning entity ids".format(tariff.get("id", "")))
         elif "rates_export" in tariff:
-            pb.rate_export = pb.basic_rates(tariff["rates_export"], "rates_export")
+            pb.rate_export = pb.basic_rates(tariff["rates_export"], "rates_export", include_manual_api=False)
         else:
             self.log("Using existing rate export data")
 
@@ -135,7 +135,7 @@ class Compare:
             pb.rate_scan(pb.rate_import, print=False)
             pb.rate_import, pb.rate_import_replicated = pb.rate_replicate(pb.rate_import, pb.io_adjusted, is_import=True)
             if "rates_import_override" in tariff:
-                pb.rate_import = pb.basic_rates(tariff["rates_import_override"], "rates_import_override", pb.rate_import, pb.rate_import_replicated)
+                pb.rate_import = pb.basic_rates(tariff["rates_import_override"], "rates_import_override", pb.rate_import, pb.rate_import_replicated, include_manual_api=False)
             pb.rate_scan(pb.rate_import, print=True)
 
         # Replicate and scan export rates
@@ -143,7 +143,7 @@ class Compare:
             pb.rate_scan_export(pb.rate_export, print=False)
             pb.rate_export, pb.rate_export_replicated = pb.rate_replicate(pb.rate_export, is_import=False)
             if "rates_export_override" in tariff:
-                pb.rate_export = pb.basic_rates(tariff["rates_export_override"], "rates_export_override", pb.rate_export, pb.rate_export_replicated)
+                pb.rate_export = pb.basic_rates(tariff["rates_export_override"], "rates_export_override", pb.rate_export, pb.rate_export_replicated, include_manual_api=False)
             pb.rate_scan_export(pb.rate_export, print=True)
 
         # Set rate thresholds

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1780,10 +1780,14 @@ class Fetch:
 
         return rates
 
-    def basic_rates(self, info, rtype, prev=None, rate_replicate=None):
+    def basic_rates(self, info, rtype, prev=None, rate_replicate=None, include_manual_api=True):
         """
         Work out the energy rates based on user supplied time periods
         works on a 24-hour period only and then gets replicated later for future days
+
+        include_manual_api should be False for callers (e.g. tariff comparison, annual replay)
+        that simulate a tariff other than the live one - the live system's manual API overrides
+        apply to the actual running plan and must not leak into those simulations.
         """
         rates = {}
         if rate_replicate is None:
@@ -1810,10 +1814,15 @@ class Fetch:
         # manual API overrides into its own return value) this would duplicate an override already
         # present in `info`. Avoid double-applying, as incremental overrides would otherwise stack.
         manual_items = []
-        for item in self.get_manual_api(rtype):
-            if isinstance(item, dict) and isinstance(item.get("value"), dict):
-                if item["value"] not in info:
-                    manual_items.append(item["value"])
+        if include_manual_api:
+            for item in self.get_manual_api(rtype):
+                value = item.get("value")
+                if not isinstance(value, dict):
+                    self.log("Warn: Manual API override for {} must use the '?start=...&end=...&rate=...' form, got {}".format(rtype, value))
+                    self.record_status("Warn: Manual API override for {} must use the '?start=...&end=...&rate=...' form".format(rtype), had_errors=True)
+                    continue
+                if value not in info:
+                    manual_items.append(value)
         if manual_items:
             self.log("Basic rate API override items for {} are {}".format(rtype, manual_items))
 
@@ -1882,9 +1891,9 @@ class Fetch:
                     rate_increment = True
 
                 # Resolve any sensor links
-                if isinstance(rate, str) and rate[0].isalpha():
+                if isinstance(rate, str) and rate and rate[0].isalpha():
                     rate = self.resolve_arg("rate", rate, 0.0)
-                if isinstance(load_scaling, str) and load_scaling[0].isalpha():
+                if isinstance(load_scaling, str) and load_scaling and load_scaling[0].isalpha():
                     load_scaling = self.resolve_arg("load_scaling", load_scaling, 1.0)
 
                 # Ensure the end result is a float

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1807,10 +1807,13 @@ class Fetch:
         # rate value) - silently marking every minute of the day as overridden in rate_replicate
         # (and hence in the plan display) even for the narrowest override window (batpred#2578).
         # For most callers (anything sourced via get_arg(..., default=[]), which already merges
-        # manual API overrides into its own return value) this duplicates an override that's already
-        # present in `info` - harmless once correctly shaped, since re-applying the same window with
-        # the same rate is idempotent.
-        manual_items = [item["value"] for item in self.get_manual_api(rtype) if isinstance(item, dict) and isinstance(item.get("value"), dict)]
+        # manual API overrides into its own return value) this would duplicate an override already
+        # present in `info`. Avoid double-applying, as incremental overrides would otherwise stack.
+        manual_items = []
+        for item in self.get_manual_api(rtype):
+            if isinstance(item, dict) and isinstance(item.get("value"), dict):
+                if item["value"] not in info:
+                    manual_items.append(item["value"])
         if manual_items:
             self.log("Basic rate API override items for {} are {}".format(rtype, manual_items))
 

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1799,7 +1799,18 @@ class Fetch:
                 rates[minute] = 0
             max_minute = 48 * 60
 
-        manual_items = self.get_manual_api(rtype)
+        # get_manual_api() returns each override wrapped as {"index": ..., "value": {...}}, not the
+        # flat {"start": ..., "end": ..., "rate": ...} shape this loop expects below - unwrap it here.
+        # Before this fix, an unwrapped entry's this_rate.get("start")/get("rate") always missed,
+        # falling through to the "00:00:00" start/end default (which, since end<=start, wraps to a
+        # full 24-hour range) and the rate=0/rate_increment=True default (a genuine no-op on the
+        # rate value) - silently marking every minute of the day as overridden in rate_replicate
+        # (and hence in the plan display) even for the narrowest override window (batpred#2578).
+        # For most callers (anything sourced via get_arg(..., default=[]), which already merges
+        # manual API overrides into its own return value) this duplicates an override that's already
+        # present in `info` - harmless once correctly shaped, since re-applying the same window with
+        # the same rate is idempotent.
+        manual_items = [item["value"] for item in self.get_manual_api(rtype) if isinstance(item, dict) and isinstance(item.get("value"), dict)]
         if manual_items:
             self.log("Basic rate API override items for {} are {}".format(rtype, manual_items))
 

--- a/apps/predbat/tests/test_annual_tariff.py
+++ b/apps/predbat/tests/test_annual_tariff.py
@@ -342,12 +342,14 @@ def test_annual_tariff(my_predbat):
 
     print("Test: basic rates are computed once and cached, not recomputed on every rates_for call")
     basic_rates_calls = []
+    basic_rates_include_manual_api = []
     original_basic_rates = my_predbat.basic_rates
 
-    def counting_basic_rates(info, rtype, prev=None, rate_replicate=None):
+    def counting_basic_rates(info, rtype, prev=None, rate_replicate=None, include_manual_api=True):
         """Wrap basic_rates to count how many times it is actually invoked, then delegate to the real implementation."""
         basic_rates_calls.append(rtype)
-        return original_basic_rates(info, rtype, prev=prev, rate_replicate=rate_replicate)
+        basic_rates_include_manual_api.append(include_manual_api)
+        return original_basic_rates(info, rtype, prev=prev, rate_replicate=rate_replicate, include_manual_api=include_manual_api)
 
     my_predbat.basic_rates = counting_basic_rates
     try:
@@ -360,6 +362,9 @@ def test_annual_tariff(my_predbat):
         my_predbat.basic_rates = original_basic_rates
     if basic_rates_calls.count("rates_import") != 1 or basic_rates_calls.count("rates_export") != 1:
         print("  ERROR: expected basic_rates called exactly once per rate type across three rates_for calls, got {}".format(basic_rates_calls))
+        failed = True
+    if any(basic_rates_include_manual_api):
+        print("  ERROR: expected annual replay to call basic_rates with include_manual_api=False, so a live manual API override never leaks into a historical replay, got {}".format(basic_rates_include_manual_api))
         failed = True
 
     print("Test: standing charge is carried through from config")

--- a/apps/predbat/tests/test_basic_rates.py
+++ b/apps/predbat/tests/test_basic_rates.py
@@ -150,4 +150,42 @@ def test_basic_rates(my_predbat):
 
     my_predbat.minutes_now = old_minutes_now
     my_predbat.midnight = old_midnight
+
+    # Test 8: predbat_manual_api rate override only marks the actually-overridden window in
+    # rate_replicate, not the whole day (issue #2578). get_manual_api() returns each override
+    # wrapped as {"index": ..., "value": {...}} - before the fix, basic_rates() used that wrapper
+    # directly as if it were the flat {"start", "end", "rate"} shape, so every lookup missed,
+    # falling through to the "00:00:00" start/end default (which wraps to a full 24-hour range
+    # since end<=start) and rate_increment=True/rate=0 (a real no-op on the rate value, but not on
+    # the marker) - silently flagging every minute of the day as overridden.
+    print("*** Running test: Manual API rate override marker scoping (issue #2578)")
+    old_manual_api = my_predbat.manual_api
+    my_predbat.manual_api = ["rates_import_override?start=17:00:00&end=19:00:00&rate=0"]
+    try:
+        info = my_predbat.get_arg("rates_import_override", [], indirect=False)
+        base_rates = {minute: 25.0 for minute in range(-24 * 60, 48 * 60)}
+        rate_replicate = {}
+        results = my_predbat.basic_rates(info, "rates_import_override", base_rates, rate_replicate)
+
+        if results.get(17 * 60 + 30) != 0.0:
+            print(f"ERROR: Expected the overridden rate at 17:30 to be 0.0, got {results.get(17 * 60 + 30)}")
+            failed = 1
+        if results.get(10 * 60) != 25.0:
+            print(f"ERROR: Expected the unaffected rate at 10:00 to stay 25.0, got {results.get(10 * 60)}")
+            failed = 1
+        if 10 * 60 in rate_replicate:
+            print(f"ERROR: Expected minute 10:00 to NOT be marked as overridden, got {rate_replicate.get(10 * 60)!r}")
+            failed = 1
+        if 17 * 60 + 30 not in rate_replicate:
+            print("ERROR: Expected minute 17:30 to be marked as overridden")
+            failed = 1
+        # Every 24-hour period the override recurs in should mark exactly its own 120-minute
+        # window (17:00-19:00), never the whole day either side of it
+        for minute in (0, 6 * 60, 16 * 60 + 59, 19 * 60, 20 * 60, 23 * 60 + 59):
+            if minute in rate_replicate:
+                print(f"ERROR: Minute {minute} outside the override window should not be marked, got {rate_replicate.get(minute)!r}")
+                failed = 1
+    finally:
+        my_predbat.manual_api = old_manual_api
+
     return failed

--- a/apps/predbat/tests/test_basic_rates.py
+++ b/apps/predbat/tests/test_basic_rates.py
@@ -188,4 +188,84 @@ def test_basic_rates(my_predbat):
     finally:
         my_predbat.manual_api = old_manual_api
 
+    # Test 9: manual API override is actually applied when it isn't already present in `info`
+    # (e.g. rates_import, which - unlike rates_import_override - get_arg() never pre-merges).
+    # This is the append branch of basic_rates()'s manual_items dedup loop.
+    print("*** Running test: Manual API override applied when not pre-merged into info")
+    old_manual_api = my_predbat.manual_api
+    my_predbat.manual_api = ["rates_import?start=17:00:00&end=19:00:00&rate=3.5"]
+    try:
+        base_rates = {minute: 25.0 for minute in range(-24 * 60, 48 * 60)}
+        rate_replicate = {}
+        results = my_predbat.basic_rates([], "rates_import", base_rates, rate_replicate)
+
+        if results.get(17 * 60 + 30) != 3.5:
+            print(f"ERROR: Expected manual API override rate 3.5 at 17:30, got {results.get(17 * 60 + 30)}")
+            failed = 1
+        if results.get(10 * 60) != 25.0:
+            print(f"ERROR: Expected the unaffected rate at 10:00 to stay 25.0, got {results.get(10 * 60)}")
+            failed = 1
+    finally:
+        my_predbat.manual_api = old_manual_api
+
+    # Test 10: a manual API override with an empty rate value (e.g. "...&rate=" with nothing after
+    # the "=") must not crash basic_rates() - it should be treated as a bad rate and skipped.
+    print("*** Running test: Manual API override with empty rate value does not crash")
+    old_manual_api = my_predbat.manual_api
+    my_predbat.manual_api = ["rates_import?start=17:00:00&end=19:00:00&rate="]
+    try:
+        base_rates = {minute: 25.0 for minute in range(-24 * 60, 48 * 60)}
+        rate_replicate = {}
+        try:
+            results = my_predbat.basic_rates([], "rates_import", base_rates, rate_replicate)
+        except IndexError as e:
+            print(f"ERROR: basic_rates() raised IndexError on an empty manual API rate value: {e}")
+            failed = 1
+        else:
+            if results.get(17 * 60 + 30) != 25.0:
+                print(f"ERROR: Expected the bad override to be skipped, leaving 25.0 at 17:30, got {results.get(17 * 60 + 30)}")
+                failed = 1
+    finally:
+        my_predbat.manual_api = old_manual_api
+
+    # Test 11: include_manual_api=False (used by tariff comparison and annual replay, which
+    # simulate a tariff other than the live one) must keep the live system's manual API overrides
+    # out of the simulated result, even though `info` doesn't already contain them.
+    print("*** Running test: include_manual_api=False keeps live overrides out of simulated tariffs")
+    old_manual_api = my_predbat.manual_api
+    my_predbat.manual_api = ["rates_import_override?start=17:00:00&end=19:00:00&rate=0"]
+    try:
+        base_rates = {minute: 25.0 for minute in range(-24 * 60, 48 * 60)}
+        rate_replicate = {}
+        results = my_predbat.basic_rates([], "rates_import_override", base_rates, rate_replicate, include_manual_api=False)
+
+        if results.get(17 * 60 + 30) != 25.0:
+            print(f"ERROR: Live manual API override leaked into a simulated tariff at 17:30, got {results.get(17 * 60 + 30)}")
+            failed = 1
+    finally:
+        my_predbat.manual_api = old_manual_api
+
+    # Test 12: a manual API override in the flat "command=value" shorthand form (rather than the
+    # documented "command?start=...&end=...&rate=..." form) is not a usable rate override - it
+    # must be reported via record_status(had_errors=True), not silently dropped.
+    print("*** Running test: Manual API override in unsupported shorthand form is reported, not silently dropped")
+    old_manual_api = my_predbat.manual_api
+    old_had_errors = my_predbat.had_errors
+    my_predbat.manual_api = ["rates_import=5"]
+    my_predbat.had_errors = False
+    try:
+        base_rates = {minute: 25.0 for minute in range(-24 * 60, 48 * 60)}
+        rate_replicate = {}
+        results = my_predbat.basic_rates([], "rates_import", base_rates, rate_replicate)
+
+        if not my_predbat.had_errors:
+            print("ERROR: Expected had_errors to be set when a shorthand-form manual API rate override is ignored")
+            failed = 1
+        if results.get(10 * 60) != 25.0:
+            print(f"ERROR: Expected the unusable override to be ignored, leaving 25.0 at 10:00, got {results.get(10 * 60)}")
+            failed = 1
+    finally:
+        my_predbat.manual_api = old_manual_api
+        my_predbat.had_errors = old_had_errors
+
     return failed


### PR DESCRIPTION
## Summary

Fixes #2578.

`basic_rates()` merged `get_manual_api()`'s return value directly into its per-entry loop
(`for this_rate in info + manual_items:`), but `get_manual_api()` wraps each override as
`{"index": ..., "value": {...}}` - not the flat `{"start", "end", "rate"}` shape the loop expects.
So every `this_rate.get("start")`/`get("rate")` lookup on the wrapper missed, falling through to
the defaults: `start`/`end` both default to `"00:00:00"`, which (since `end <= start`) wraps to a
full 24-hour range, and `rate`/`rate_increment` default to `rate=0, rate_increment=True` - a
genuine no-op on the price, but not on the marker.

Net effect: a narrow manual API override (e.g. a 2-hour Octopus Power Up event override set via
`rates_import_override?start=...&end=...&rate=0`) silently flagged **every minute of the day** as
"overridden" in the plan display's +/- marker, while every other price stayed correct and
untouched - exactly what gcoan reported and screenshotted.

## Fix

Unwrap each override's `"value"` dict before using it, so the start/end/rate lookups actually find
their fields. This is harmless where it duplicates an override already merged in by `get_arg()`'s
own list-default manual-API handling (the actual mechanism that applies the real price change, used
by every production call site for `rates_import_override`/`rates_export_override`) - re-applying the
same correctly-shaped window with the same rate is idempotent.

Verified directly against gcoan's own `debug.yaml` from the issue: before the fix,
`rate_import_replicated` is marked `"increment"` for essentially every minute in the capture; after
the fix it's scoped to only the minutes the override's own window actually covers.

## Test plan

New sub-case in `test_basic_rates.py` covers the manual API path specifically - no prior test
exercised `get_manual_api()`'s actual output shape at all, which is how this went unnoticed.

- [x] `./run_all --quick` passes (all tests)
- [x] `./run_pre_commit` passes
- [x] Reproduced the exact reported symptom against the reporter's own debug.yaml, confirmed fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)