### PR TITLE
fix(ha): treat a null websocket "success" as False, not None

### DIFF
--- a/apps/predbat/ha.py
+++ b/apps/predbat/ha.py
@@ -631,7 +631,14 @@ class HAInterface(ComponentBase):
                                                     if result_id in self.ws_pending_requests:
                                                         request_info = self.ws_pending_requests.pop(result_id)
                                                         result_holder = request_info["result_holder"]
-                                                        result_holder["success"] = data.get("success", False)
+                                                        # #3460: .get()'s default only covers a *missing* key - some
+                                                        # services (observed for notify.notify) return a "result"
+                                                        # message with "success" explicitly present but null, which
+                                                        # .get("success", False) passes through as None rather than
+                                                        # False. That left success/error both None, indistinguishable
+                                                        # from a genuine 2-minute timeout to the caller and producing
+                                                        # a misleading "failed or timed out" warning immediately.
+                                                        result_holder["success"] = bool(data.get("success"))
                                                         result_holder["response"] = data.get("result", {}).get("response", None)
                                                         result_holder["error"] = None
                                                         # HA's own reported reason when success is False (e.g. {"code": "not_found", "message": "..."})

--- a/apps/predbat/tests/test_hainterface_websocket.py
+++ b/apps/predbat/tests/test_hainterface_websocket.py
@@ -793,6 +793,93 @@ def test_hainterface_socketloop_connection_drop_unblocks_queued_command(my_predb
     return failed
 
 
+def test_hainterface_socketloop_result_null_success(my_predbat=None):
+    """Regression test for #3460 (second bug): a "result" message with "success" explicitly
+    null (observed for notify.notify) must resolve to success=False, not None.
+
+    Before the fix, result_holder["success"] = data.get("success", False) passed a present-but-null
+    "success" straight through as None, since .get()'s default only covers a *missing* key. With
+    success and error both still None, the caller couldn't tell this apart from a genuine 2-minute
+    timeout and logged the misleading "failed or timed out" warning immediately.
+    """
+    print("\n=== Testing #3460: socketLoop result message with success=null ===")
+    failed = 0
+
+    import threading
+
+    mock_base = MockBase()
+    ha_interface = create_ha_interface(mock_base, ha_key="test_key", ha_url="http://localhost:8123")
+
+    mock_ws = MagicMock()
+    mock_ws.send_json = AsyncMock()
+
+    # Queue a notify.notify call before socketLoop gets a chance to send it, same injection
+    # technique as the connection-drop regression test above - it gets sent (assigned sid=1) as
+    # part of auth_ok's own iteration, so the next received message can reply to it by id.
+    queued_event = threading.Event()
+    queued_result = {"response": None, "success": None, "error": None}
+    queued_cmd = ("notify", "notify", {"message": "test"}, False, queued_event, queued_result)
+
+    call_count = [0]
+
+    async def mock_receive():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            with ha_interface.ws_pending_lock:
+                ha_interface.ws_command_queue.append(queued_cmd)
+            return create_mock_websocket_message(WSMsgType.TEXT, {"type": "auth_ok"})
+        if call_count[0] == 2:
+            # Don't hardcode the id: socketLoop's startup sends subscribe_events (x2) and one
+            # fire_event per SERVICE_REGISTER_LIST entry before any queued command, so the
+            # notify/notify command's own sid depends on how many of those there are. Find it
+            # from what was actually sent instead.
+            sent_id = None
+            for call in mock_ws.send_json.call_args_list:
+                payload = call.args[0]
+                if payload.get("type") == "call_service" and payload.get("domain") == "notify":
+                    sent_id = payload.get("id")
+                    break
+            if sent_id is None:
+                raise AssertionError("notify/notify call_service was never sent by socketLoop - test setup is wrong")
+            # "success" present but null is the real-world shape that triggered #3460's second bug.
+            return create_mock_websocket_message(WSMsgType.TEXT, {"type": "result", "id": sent_id, "success": None, "result": {}})
+        ha_interface.api_stop = True
+        return create_mock_websocket_message(WSMsgType.CLOSED, None)
+
+    mock_ws.receive = mock_receive
+
+    async def mock_sleep(delay):
+        ha_interface.api_stop = True
+
+    with patch("ha.ClientSession") as mock_session_class:
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock()
+        mock_session.ws_connect = MagicMock()
+        mock_session.ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_session.ws_connect.return_value.__aexit__ = AsyncMock()
+        mock_session_class.return_value = mock_session
+
+        with patch("ha.asyncio.sleep", new=mock_sleep):
+            run_async(ha_interface.socketLoop())
+
+    if not queued_event.is_set():
+        print("ERROR: threading.Event for the queued command was not set")
+        failed += 1
+    else:
+        print("✓ threading.Event set on receiving the result message")
+
+    # This is the actual regression: must be False, not None, so the caller can distinguish
+    # "got a definitive failure response" from "genuinely still waiting/timed out".
+    if queued_result.get("success") is not False:
+        print(f"ERROR: Expected success=False for a null-success result, got {queued_result.get('success')!r}")
+        failed += 1
+    else:
+        print("✓ result_holder success resolved to False, not None, for a null-success result")
+
+    return failed
+
+
 def test_hainterface_socketloop_service_register(my_predbat=None):
     """Test socketLoop() fires service_registered events"""
     print("\n=== Testing HAInterface socketLoop() service_registered ===")
@@ -873,6 +960,7 @@ def run_hainterface_websocket_tests(my_predbat):
     failed += test_hainterface_socketloop_update_pending(my_predbat)
     failed += test_hainterface_socketloop_service_register(my_predbat)
     failed += test_hainterface_socketloop_connection_drop_unblocks_queued_command(my_predbat)
+    failed += test_hainterface_socketloop_result_null_success(my_predbat)
 
     print("\n" + "=" * 80)
     if failed == 0:


### PR DESCRIPTION
## Summary

Fixes #3460.

PR #3463 already fixed one half of this - moving `call_notify()` to run before the thread pool kill so the notification actually gets sent while the websocket is still alive. That reorder is confirmed working from gcoan's own logs (notify fires, then "Kill current threads", then the websocket closes). But the notification still silently failed after that fix, with the log showing:

```
Warn: Service call notify/notify failed or timed out: result {'response': None, 'success': None, 'error': None}
```

Traced every code path that can call `event.set()` on a pending websocket request (successful result, send failure, the 2-minute periodic timeout sweep, connection-lost cleanup) - every one of them explicitly sets `error` to something truthy or `success` to `False` before signalling, except one:

```python
result_holder["success"] = data.get("success", False)
```

`.get(key, default)` only falls back to the default when the key is **missing** - not when it's present with value `None`. If Home Assistant's websocket "result" message for a call comes back with `"success": null` explicitly (observed for `notify.notify`), this line faithfully stores `None`, and the caller's `success is None and not error` check reports a misleading "failed or timed out" - not a real 2-minute timeout, just a null-success response mislabelled as one.

Fix: `bool(data.get("success"))` - `None`/missing/`False` all correctly resolve to `False`, `True` stays `True`.

## Test plan
- [x] New `test_hainterface_socketloop_result_null_success` in `test_hainterface_websocket.py` - queues a real `notify`/`notify` command through `socketLoop()`, replies with a `"success": null` result message (finding the actual sid from what was sent rather than assuming a fixed id, since startup already consumes several sids for its own subscriptions), and asserts `success` resolves to `False` not `None`. Verified it actually catches the regression - fails without the fix (`got None`), passes with it.
- [x] `./run_all --quick` - full suite passes
- [x] `./run_pre_commit` - clean