### PR TITLE
fix(web): stop the dark-mode page flashing white on load/refresh

### DIFF
--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -422,5 +422,21 @@ def run_web_logo_image_tests(my_predbat):
         print("  ERROR: the page header should reference the local logo route")
         failed += 1
 
+    print("Test: the dark mode background colour is set before any render-blocking external resource (issue #2256)")
+    dark_mode_class_pos = header.find("classList.add('dark-mode')")
+    external_resource_pos = header.find("cdn.jsdelivr.net")
+    background_style_pos = header.find("background-color: #121212")
+    if dark_mode_class_pos < 0 or external_resource_pos < 0 or background_style_pos < 0:
+        print("  ERROR: expected to find the dark-mode class script, an external CDN resource, and a dark background-color rule in the header")
+        failed += 1
+    elif not (dark_mode_class_pos < background_style_pos < external_resource_pos):
+        print(
+            "  ERROR: the dark-mode background colour must be set before the external CDN font/chart resources "
+            "(which block rendering while they load) - otherwise a slow fetch flashes the default white "
+            f"background first. Positions: dark-mode class {dark_mode_class_pos}, background colour rule "
+            f"{background_style_pos}, external CDN resource {external_resource_pos}"
+        )
+        failed += 1
+
     print("**** Web logo image tests completed ****")
     return failed

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -7364,6 +7364,16 @@ if (localStorage.getItem('darkMode') === 'true') {
     });
 }
 </script>
+<style>
+    /* Paint the correct background before the external font/chart resources below (which block
+       rendering while they load) have a chance to delay the full stylesheet - otherwise a slow or
+       uncached CDN fetch leaves the page showing its default white background until they resolve,
+       flashing bright white on every page load/refresh even with dark mode enabled (batpred#2256). */
+    html { background-color: #ffffff; }
+    html.dark-mode { background-color: #121212; }
+    body { background-color: #ffffff; color: #333; }
+    html.dark-mode body { background-color: #121212; color: #e0e0e0; }
+</style>
 <link href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
 <style>


### PR DESCRIPTION
## Summary

Fixes #2256 (follow-up from octoplayer2 after dark mode itself shipped): "every 2-3 minutes the
screen refreshes and the page flashes bright white," described as destroying night vision while
checking overnight battery activity.

## Root cause

The anti-flash-of-white script (`web_helper.py`) correctly adds the `dark-mode` class to `<html>`
synchronously, before the page's `<style>` block - that part was already right. But two
render-blocking external CDN resources sat between that script and the actual background-color
rules:

```html
<link href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css" rel="stylesheet">
<script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
```

Neither is deferred/async, so browsers block further rendering until both are fetched. On a slow
or uncached load, the page paints its default white background and holds it until those resources
resolve, then snaps to dark - a visible flash. Several pages (the Plan page every 5 minutes) also
carry a `<meta http-equiv="refresh">` fallback reload (the primary live-update mechanism is JS/AJAX
polling; this is just a safety net), so every one of those periodic reloads is another chance to
hit it.

## Fix

Moved the critical `background-color`/`color` rules (light default + dark override, for both
`html` and `body`) into a small inline `<style>` block placed *before* the external CDN tags, so
first paint is correct regardless of how long those resources take to load. No behaviour change
for light-mode users - the existing full `<style>` block later in the page still carries the
complete rule set; this just guarantees the essential background/text colours apply first.

## Test plan

New regression test asserts the actual property that matters - that the dark-mode background rule
appears *before* the external CDN resource in the rendered header - rather than just checking the
rule exists somewhere.

- [x] `./run_all --quick` passes (all tests)
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)