### PR TITLE
fix(octopus): defer the joined notification to when the join is actually known

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -884,11 +884,15 @@ class OctopusAPI(ComponentBase):
             # Join the saving sessions
             self.log("OctopusAPI: Joining saving session event {}".format(event_code))
             result = await self.async_graphql_query(octoplus_saving_session_join_mutation.format(account_id=account_id, event_code=event_code), "join-saving-session-event", returns_data=False, use_backend=True)
-            if result is not None:
+            join_info = result.get("joinSavingSessionsEvent") if isinstance(result, dict) else None
+            joined_codes = join_info.get("joinedEventCodes") if isinstance(join_info, dict) else None
+            if joined_codes and event_code in joined_codes:
                 if self.get_arg("set_event_notify"):
                     self.call_notify("Predbat: Joined Octopus saving event {}".format(event_code))
-            else:
+            elif result is None:
                 self.log("Warn: OctopusAPI: Failed to join saving session event {}".format(event_code))
+            else:
+                self.log("Warn: OctopusAPI: Join did not confirm event {} was joined: {}".format(event_code, result))
             # Re-fetch the saving sessions if we have joined any
             self.saving_sessions = await self.async_get_saving_sessions(account_id)
 

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -873,11 +873,22 @@ class OctopusAPI(ComponentBase):
     async def async_join_saving_session_events(self, account_id, event_code):
         """
         Join the saving session events
+
+        The "joined" notification is sent here, not by the caller that triggers this (the
+        select-entity join path in fetch_octopus_sessions()), because this is the only point
+        where the real GraphQL result is known - the select-entity write just queues this call
+        for a later cycle, so notifying at write time would claim success before the join has
+        even been attempted (issue #4593).
         """
         if event_code:
             # Join the saving sessions
             self.log("OctopusAPI: Joining saving session event {}".format(event_code))
-            await self.async_graphql_query(octoplus_saving_session_join_mutation.format(account_id=account_id, event_code=event_code), "join-saving-session-event", returns_data=False, use_backend=True)
+            result = await self.async_graphql_query(octoplus_saving_session_join_mutation.format(account_id=account_id, event_code=event_code), "join-saving-session-event", returns_data=False, use_backend=True)
+            if result is not None:
+                if self.get_arg("set_event_notify"):
+                    self.call_notify("Predbat: Joined Octopus saving event {}".format(event_code))
+            else:
+                self.log("Warn: OctopusAPI: Failed to join saving session event {}".format(event_code))
             # Re-fetch the saving sessions if we have joined any
             self.saving_sessions = await self.async_get_saving_sessions(account_id)
 
@@ -2998,7 +3009,11 @@ class Octopus:
                             entity_id_join = self.get_arg("octopus_saving_session_join", indirect=False)
                             if entity_id_join:
                                 # Join via selector (Octopus Energy Direct, or any other integration wired
-                                # up this way) - unaffected by which Bottle Cap Dave service name is current
+                                # up this way) - unaffected by which Bottle Cap Dave service name is current.
+                                # This only queues the join - OctopusAPI's own select_event() picks up the
+                                # entity write and performs the real join on a later cycle, so the "joined"
+                                # notification is sent there (async_join_saving_session_events()), once the
+                                # actual result is known, not here (issue #4593).
                                 self.call_service_wrapper("select/select_option", entity_id=entity_id_join, option=code)
                             else:
                                 # Join via Bottle Cap Dave's Octopus Energy HA integration. Try the current
@@ -3026,8 +3041,8 @@ class Octopus:
                                 else:
                                     self.log("Note: octopus_energy/join_octoplus_power_down_session_event not available, falling back to the deprecated join_octoplus_saving_session_event service")
                                     self.call_service_wrapper("octopus_energy/join_octoplus_saving_session_event", event_code=code, entity_id=entity_id)
-                            if self.get_arg("set_event_notify"):
-                                self.call_notify("Predbat: Joined Octopus saving event {}-{}, {} p/kWh".format(start_time.strftime("%a %d/%m %H:%M"), end_time.strftime("%H:%M"), saving_rate))
+                                if self.get_arg("set_event_notify"):
+                                    self.call_notify("Predbat: Joined Octopus saving event {}-{}, {} p/kWh".format(start_time.strftime("%a %d/%m %H:%M"), end_time.strftime("%H:%M"), saving_rate))
                             self.octopus_last_joined_try = self.now_utc
 
             # Default saving session rate for when octopoints_per_kwh is not available

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -442,6 +442,45 @@ async def test_octopus_join_saving_session(my_predbat):
         else:
             print("PASS: Multiple events can be joined sequentially")
 
+    # Test 6: A successful join sends the "joined" notification - deferred to here (not the
+    # select-entity caller in fetch_octopus_sessions()) because this is the only point where the
+    # real GraphQL result is known (issue #4593)
+    print("\n*** Test 6: Successful join sends the joined notification ***")
+    ha = my_predbat.ha_interface
+    ha.service_store_enable = True
+    ha.service_store = []
+    api6 = OctopusAPI(my_predbat, key="test-api-key-6", account_id="test-account-6", automatic=False)
+    api6.async_graphql_query = AsyncMock(return_value={"joinSavingSessionsEvent": {"joinedEventCodes": ["OCTOPLUS-SUCCESS"]}})
+    api6.async_get_saving_sessions = AsyncMock(return_value={"events": [], "account": {}})
+    await api6.async_join_saving_session_events("test-account-6", "OCTOPLUS-SUCCESS")
+    notify_calls = [svc for svc in ha.get_service_store() if svc[0] == "notify/notify"]
+    if len(notify_calls) != 1:
+        print(f"ERROR: Expected 1 notification on successful join, got {len(notify_calls)}")
+        failed = True
+    elif "OCTOPLUS-SUCCESS" not in notify_calls[0][1].get("message", ""):
+        print(f"ERROR: Notification message missing event code: {notify_calls[0][1]}")
+        failed = True
+    else:
+        print("PASS: Notification sent on successful join")
+    ha.service_store_enable = False
+
+    # Test 7: A failed join (async_graphql_query returns None, e.g. Octopus rejects the event -
+    # matches the real OE-1305 "event not found" case reported in #4593) sends no notification
+    print("\n*** Test 7: Failed join sends no notification ***")
+    ha.service_store_enable = True
+    ha.service_store = []
+    api7 = OctopusAPI(my_predbat, key="test-api-key-7", account_id="test-account-7", automatic=False)
+    api7.async_graphql_query = AsyncMock(return_value=None)
+    api7.async_get_saving_sessions = AsyncMock(return_value={"events": [], "account": {}})
+    await api7.async_join_saving_session_events("test-account-7", "OCTOPLUS-FAILED")
+    notify_calls = [svc for svc in ha.get_service_store() if svc[0] == "notify/notify"]
+    if len(notify_calls) != 0:
+        print(f"ERROR: Expected no notification on failed join, got {len(notify_calls)}: {notify_calls}")
+        failed = True
+    else:
+        print("PASS: No notification sent on failed join")
+    ha.service_store_enable = False
+
     if failed:
         print("\n**** ❌ Octopus async_join_saving_session_events tests FAILED ****")
         return 1

--- a/apps/predbat/tests/test_saving_session.py
+++ b/apps/predbat/tests/test_saving_session.py
@@ -856,6 +856,76 @@ friendly_name: Predbat Octopus Power Down For Predbat
     return failed
 
 
+def test_saving_session_select_entity_join_defers_notify(my_predbat):
+    """
+    Test that the select-entity join path (octopus_saving_session_join, used by Octopus Energy
+    Direct or similar) writes the select entity but sends no "joined" notification itself - the
+    real join happens asynchronously on a later cycle (OctopusAPI's own select_event() ->
+    process_commands() -> async_join_saving_session_events()), so notifying at write time would
+    claim success before the join has even been attempted. Covers GitHub issue #4593.
+    """
+    print("Test select-entity join defers the joined notification (issue #4593)")
+    ha = my_predbat.ha_interface
+    failed = False
+    date_today = datetime.now().strftime("%Y-%m-%d")
+    tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)
+    tz_offset = f"{tz_offset:02d}"
+
+    session_sensor = f"""
+state: '2025-01-23T12:10:11.108+{tz_offset}:00'
+account_id: A-4DD6C5EE
+available_events:
+    - id: 9999
+      start: '{date_today}T18:30:00+{tz_offset}:00'
+      end: '{date_today}T19:30:00+{tz_offset}:00'
+      duration_in_minutes: 60
+      rewarded_octopoints: null
+      octopoints_per_kwh: 500
+      code: TEST123
+joined_events: []
+friendly_name: Octoplus Saving Session Events
+"""
+
+    saved_args = my_predbat.args.copy()
+    try:
+        ha.dummy_items.clear()
+        ha.dummy_items["event.octopus_energy_test_octoplus_saving_session_event"] = yaml.safe_load(session_sensor)
+        ha.dummy_items["sensor.octopus_free_session"] = {}
+        ha.dummy_items["select.predbat_saving_session_join"] = {"state": "", "attributes": {"options": []}}
+        my_predbat.args["octopus_saving_session"] = "event.octopus_energy_test_octoplus_saving_session_event"
+        my_predbat.args["octopus_saving_session_join"] = "select.predbat_saving_session_join"
+        my_predbat.args["octopus_free_session"] = "sensor.octopus_free_session"
+        if "octopus_free_url" in my_predbat.args:
+            del my_predbat.args["octopus_free_url"]
+        my_predbat.args["octopus_saving_session_octopoints_per_penny"] = 10
+        my_predbat.octopus_last_joined_try = None
+
+        ha.service_store_enable = True
+        ha.service_store = []
+        my_predbat.fetch_octopus_sessions()
+        service_result = ha.get_service_store()
+        ha.service_store_enable = False
+
+        select_calls = [svc for svc in service_result if svc[0] == "select/select_option"]
+        notify_calls = [svc for svc in service_result if svc[0] == "notify/notify"]
+        if len(select_calls) != 1:
+            print(f"ERROR: Expected 1 select_option call to queue the join, got {len(select_calls)}: {service_result}")
+            failed = True
+        elif select_calls[0][1].get("entity_id") != "select.predbat_saving_session_join" or select_calls[0][1].get("option") != "TEST123":
+            print(f"ERROR: select_option call had unexpected args: {select_calls[0][1]}")
+            failed = True
+        elif notify_calls:
+            print(f"ERROR: Expected no notification from the select-entity path (deferred to the real join), got {notify_calls}")
+            failed = True
+        else:
+            print("PASS: select_option queued the join with no premature notification")
+    finally:
+        my_predbat.args = saved_args
+        my_predbat.octopus_last_joined_try = None
+
+    return failed
+
+
 def test_saving_session_default_rate(my_predbat):
     """
     Test that saving sessions with no octopoints_per_kwh use the default rate

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -81,6 +81,7 @@ from tests.test_saving_session import (
     test_saving_session_auto_join_toggle,
     test_saving_session_custom_entity_no_rewrite_match,
     test_saving_session_entity_regex_power_rename,
+    test_saving_session_select_entity_join_defers_notify,
 )
 from tests.test_secrets import run_secrets_tests
 from tests.test_ge_cloud import test_ge_cloud
@@ -465,6 +466,7 @@ def main():
         ("saving_session_auto_join_toggle", test_saving_session_auto_join_toggle, "Saving session auto-join toggle test (issue #4120)", False),
         ("saving_session_custom_entity_no_rewrite_match", test_saving_session_custom_entity_no_rewrite_match, "Saving session custom entity no rewrite match test (issue #4573)", False),
         ("saving_session_entity_regex_power_rename", test_saving_session_entity_regex_power_rename, "Saving/free session entity regex Power Down/Up rename test (issue #4548 point 2)", False),
+        ("saving_session_select_entity_join_defers_notify", test_saving_session_select_entity_join_defers_notify, "Select-entity join defers the joined notification test (issue #4593)", False),
         ("alert_feed", test_alert_feed, "Alert feed tests", False),
         ("fox_api", run_fox_api_tests, "Fox API tests", False),
         ("deye_const", run_deye_const_tests, "DEYE constants tests", False),


### PR DESCRIPTION
## Summary

Addresses #4593's newest comment - a live example on v8.50.0 of the "notify before checking success" pattern, but via a different, previously-unaddressed path than the one #4593's original report and #4595 cover.

The select-entity join path (`octopus_saving_session_join`, used by Octopus Energy Direct) sent the "Joined Octopus saving event" notification immediately after writing the select entity - but that write only *queues* the join. The real GraphQL mutation happens asynchronously, on a later cycle, via `OctopusAPI`'s own `select_event()` -> `process_commands()` -> `async_join_saving_session_events()`. The notification therefore claimed success before the join had even been attempted, let alone completed.

Reported example: a user got a "Joined" notification while the log showed the mutation rejected with `OE-1305: Saving Sessions event not found`.

## Fix

`async_graphql_query()` already returns a reliable `None`-on-failure / data-on-success signal - nothing downstream was using it for this call. `async_join_saving_session_events()` now sends the notification itself, gated on the actual result, at the point where the outcome is genuinely known. The premature notify in `fetch_octopus_sessions()`'s select-entity branch is removed.

The Bottle Cap Dave HA-integration branch (the `else` path, no `octopus_saving_session_join` configured) is untouched - that side is still structurally blocked on the join *service* returning no response at all ([#1823](https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy/issues/1823) upstream), a separate, harder problem this PR doesn't attempt.

## Test plan

- [x] `./run_all --test octopus_misc` - new success/failure cases for `async_join_saving_session_events()`: a successful join sends exactly one notification containing the event code; a failed join (mocked `None` return, matching the real `OE-1305` case) sends none
- [x] `./run_all --test saving_session_select_entity_join_defers_notify` - new end-to-end test confirming the select-entity join path calls `select/select_option` but sends no notification at that point
- [x] Existing `saving_session`/`saving_session_notify`/`saving_session_join_service_fallback` tests unaffected (they all exercise the Bottle Cap Dave branch, not the select-entity one)
- [x] `./run_all --quick` passes
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)