### PR TITLE
fix(config): a missing get_arg value is the default, not an error

### DIFF
--- a/apps/predbat/tests/test_get_arg_missing_index.py
+++ b/apps/predbat/tests/test_get_arg_missing_index.py
@@ -1,0 +1,126 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""Tests for get_arg()'s numeric coercion when the resolved value is missing (None) rather than
+malformed.
+
+Per-inverter args are lists indexed by inverter id, but nothing guarantees the list is as long as
+num_inverters. set_arg(arg, value, index=i) grows the list only to i+1, so an arg first written by
+inverter 0 - e.g. inverter.py's battery_scaling_auto caching a measured soc_max - leaves a
+single-element list that inverter 1 then reads out of range. resolve_arg() correctly returns None
+there (and logs "Out of range index ..."), which is precisely what the caller's default is for.
+
+Coercing that None used to raise TypeError and be reported via record_status(had_errors=True),
+pinning "Warn: Return bad float value None from soc_max" on the status sensor and ending every
+5-minute run as "Read-Only with Errors" - for a gap the caller already handles (inverter.py falls
+back to the 8 kWh default). A value that is present but unparseable ("unavailable", "abc") is a
+genuine fault and must still be reported.
+"""
+
+
+def test_get_arg_missing_index_uses_default_quietly(my_predbat):
+    """A too-short per-inverter list returns the default without flagging an error, while a
+    present-but-unparseable value still warns and sets had_errors."""
+    failed = False
+    print("**** Testing get_arg numeric coercion for missing vs malformed values ****")
+
+    # my_predbat is a shared fixture across the whole test run - save everything this test touches
+    # so it can be restored afterward regardless of outcome, or later tests get a poisoned instance.
+    had_soc_max_arg = "soc_max" in my_predbat.args
+    original_soc_max = my_predbat.args.get("soc_max")
+    had_scaling_arg = "battery_scaling_last_known" in my_predbat.args
+    original_scaling = my_predbat.args.get("battery_scaling_last_known")
+    original_had_errors = my_predbat.had_errors
+    original_status = my_predbat.current_status
+
+    try:
+        print("Test: float arg, index past the end of the list - returns the default, stays silent")
+        my_predbat.args["soc_max"] = [25.68]
+        my_predbat.had_errors = False
+        my_predbat.current_status = ""
+        value = my_predbat.get_arg("soc_max", default=0.0, index=1)
+        if value != 0.0:
+            print("  ERROR: expected the default 0.0 for an out-of-range index, got {!r}".format(value))
+            failed = True
+        if my_predbat.had_errors:
+            print("  ERROR: a missing per-inverter value must not set had_errors - it is what the default is for")
+            failed = True
+        if my_predbat.current_status != "":
+            print("  ERROR: a missing per-inverter value must not pin the status sensor, got {!r}".format(my_predbat.current_status))
+            failed = True
+
+        print("Test: float arg, index within the list - returns the configured value")
+        my_predbat.had_errors = False
+        my_predbat.current_status = ""
+        value = my_predbat.get_arg("soc_max", default=0.0, index=0)
+        if value != 25.68:
+            print("  ERROR: expected the configured 25.68 for index 0, got {!r}".format(value))
+            failed = True
+        if my_predbat.had_errors:
+            print("  ERROR: a valid value must not set had_errors")
+            failed = True
+
+        print("Test: float arg, present but unparseable - still warns and flags an error")
+        my_predbat.args["soc_max"] = [25.68, "unavailable"]
+        my_predbat.had_errors = False
+        my_predbat.current_status = ""
+        value = my_predbat.get_arg("soc_max", default=0.0, index=1)
+        if value != 0.0:
+            print("  ERROR: expected the default 0.0 for an unparseable value, got {!r}".format(value))
+            failed = True
+        if not my_predbat.had_errors:
+            print("  ERROR: expected had_errors to be set for a present-but-unparseable value")
+            failed = True
+        if "soc_max" not in my_predbat.current_status:
+            print("  ERROR: expected the warning to be recorded to current_status, got {!r}".format(my_predbat.current_status))
+            failed = True
+
+        print("Test: int arg, index past the end of the list - returns the default, stays silent")
+        my_predbat.args["battery_scaling_last_known"] = [1]
+        my_predbat.had_errors = False
+        my_predbat.current_status = ""
+        value = my_predbat.get_arg("battery_scaling_last_known", default=2, index=1)
+        if value != 2:
+            print("  ERROR: expected the int default 2 for an out-of-range index, got {!r}".format(value))
+            failed = True
+        if my_predbat.had_errors:
+            print("  ERROR: a missing per-inverter int value must not set had_errors")
+            failed = True
+        if my_predbat.current_status != "":
+            print("  ERROR: a missing per-inverter int value must not pin the status sensor, got {!r}".format(my_predbat.current_status))
+            failed = True
+
+        print("Test: int arg, present but unparseable - still warns and flags an error")
+        my_predbat.args["battery_scaling_last_known"] = [1, "unavailable"]
+        my_predbat.had_errors = False
+        my_predbat.current_status = ""
+        value = my_predbat.get_arg("battery_scaling_last_known", default=2, index=1)
+        if value != 2:
+            print("  ERROR: expected the int default 2 for an unparseable value, got {!r}".format(value))
+            failed = True
+        if not my_predbat.had_errors:
+            print("  ERROR: expected had_errors to be set for a present-but-unparseable int value")
+            failed = True
+
+    finally:
+        if had_soc_max_arg:
+            my_predbat.args["soc_max"] = original_soc_max
+        else:
+            my_predbat.args.pop("soc_max", None)
+        if had_scaling_arg:
+            my_predbat.args["battery_scaling_last_known"] = original_scaling
+        else:
+            my_predbat.args.pop("battery_scaling_last_known", None)
+        my_predbat.had_errors = original_had_errors
+        my_predbat.current_status = original_status
+
+    if not failed:
+        print("**** get_arg missing-index tests PASSED ****")
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -206,6 +206,7 @@ from tests.test_integer_config import (
 )
 from tests.test_predbat_metrics_data_age import test_data_age_metrics_round_trip
 from tests.test_validate_config import test_validate_config, test_validate_config_retry
+from tests.test_get_arg_missing_index import test_get_arg_missing_index_uses_default_quietly
 from tests.test_plan_json_rate_adjust import run_test_plan_json_rate_adjust
 from tests.test_plan_why_reason import run_test_plan_why_reason
 from tests.test_rate_replicate_missing_slots import test_rate_replicate
@@ -510,6 +511,7 @@ def main():
         ("teslemetry", test_teslemetry, "Teslemetry Tesla Powerwall component tests (data path, control, tariff)", False),
         ("integer_config", test_integer_config_entities, "Integer config entities tests", False),
         ("validate_config", test_validate_config, "APPS_SCHEMA validator tests (string types, sensor boolean states)", False),
+        ("get_arg_missing_index", test_get_arg_missing_index_uses_default_quietly, "get_arg missing (out-of-range index) vs malformed numeric coercion tests", False),
         ("validate_config_retry", test_validate_config_retry, "Config validation retry-after-failure tests (#4379)", False),
         ("expose_config_integer", test_expose_config_preserves_integer, "Expose config preserves integer tests", False),
         ("config_item_range_clamp", test_config_item_range_clamp, "Config item min/max range clamp tests", False),

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -254,20 +254,33 @@ class UserInterface:
 
         if isinstance(default, float):
             # Convert to float?
-            try:
-                value = float(value)
-            except (ValueError, TypeError):
-                self.log("Warn: Return bad float value {} from {} using default {}".format(value, arg, default))
-                self.record_status("Warn: Return bad float value {} from {}".format(value, arg), had_errors=True)
+            if value is None:
+                # Nothing resolved - not configured, or an out-of-range index on a per-inverter list
+                # (resolve_arg has already logged "Out of range index ..."). That is exactly what the
+                # caller's default is for, so apply it quietly rather than reporting an error: flagging
+                # it pins the warning on the status sensor and ends every run as "Read-Only with Errors"
+                # for a gap the caller already handles. A value that is present but unparseable is a
+                # genuine fault and is still reported below.
                 value = default
+            else:
+                try:
+                    value = float(value)
+                except (ValueError, TypeError):
+                    self.log("Warn: Return bad float value {} from {} using default {}".format(value, arg, default))
+                    self.record_status("Warn: Return bad float value {} from {}".format(value, arg), had_errors=True)
+                    value = default
         elif isinstance(default, int) and not isinstance(default, bool):
             # Convert to int?
-            try:
-                value = int(float(value))
-            except (ValueError, TypeError):
-                self.log("Warn: Return bad int value {} from {} using default {}".format(value, arg, default))
-                self.record_status("Warn: Return bad int value {} from {}".format(value, arg), had_errors=True)
+            if value is None:
+                # See the float case above - a missing value is what the default is for, not an error
                 value = default
+            else:
+                try:
+                    value = int(float(value))
+                except (ValueError, TypeError):
+                    self.log("Warn: Return bad int value {} from {} using default {}".format(value, arg, default))
+                    self.record_status("Warn: Return bad int value {} from {}".format(value, arg), had_errors=True)
+                    value = default
         elif isinstance(default, bool) and isinstance(value, str):
             # Convert to Boolean
             if value.lower() in ["on", "true", "yes", "enabled", "enable", "connected"]:


### PR DESCRIPTION
## Problem

Per-inverter args are lists indexed by inverter id, but nothing guarantees the list is as long as `num_inverters`. `set_arg(arg, value, index=i)` grows the list only to `i+1`, so an arg first written by inverter 0 leaves a single-element list that inverter 1 then reads out of range.

`resolve_arg()` handles that correctly — it logs `Out of range index ...` and returns `None`, which is exactly what the caller's `default` is for. But `get_arg()`'s numeric coercion then ran `float(None)` / `int(None)`, caught the resulting `TypeError` in the same `except` as a genuine parse failure, and reported both via `record_status(had_errors=True)`.

### Seen in the field

A two-inverter SolisCloud site. Solis deliberately doesn't bind `soc_max` (the capacity sensor is voltage-estimated and drifts), so the only writer is inverter 0's own `battery_scaling_auto` branch in `inverter.py`, caching its measured size with `set_arg("soc_max", 25.68, index=0)` → `soc_max = [25.68]`.

Inverter 1 then reads index 1, and every 5-minute cycle logs:

```
Warn: Out of range index 1 within item soc_max value [25.68]
Warn: Return bad float value None from soc_max using default 0.0
Warn: record_status Warn: Return bad float value None from soc_max
Warn: Unable to determine battery size for inverter 1, using 8 kWh default for this cycle ...
Error: Completed run status Read-Only with Errors reported (check log)
```

So the status sensor is pinned to `Warn: Return bad float value None from soc_max` and every run ends "Read-Only with Errors" — for a gap `inverter.py` already handles deliberately, by falling back to its 8 kWh default (with a comment explaining why it must *not* persist that fallback).

The same site also hits it through `battery_scaling_last_known = [1.0]`, and `car_charging_planned = ['on']` produces the same out-of-range read on other sites (harmless there — it's a string arg, so no coercion and no error status).

## Fix

Apply the caller's default quietly when nothing resolved. A value that is *present but unparseable* (`"unavailable"`, `"abc"`) is a real fault and is still logged and flagged exactly as before, and `resolve_arg`'s `Out of range index` warning still records the diagnostic — so nothing is silently swallowed.

## Testing

New `tests/test_get_arg_missing_index.py` (registered as `get_arg_missing_index`), covering float and int defaults for both the missing and the malformed case. It fails on `main` with the exact log lines above and passes with the fix.

Full suite: `python3 ../apps/predbat/unit_test.py --quick` — 243 tests. Before: 2 failures (the new test, plus `data_age_metrics`). After: 1 failure (`data_age_metrics` only). `data_age_metrics` fails identically on unmodified `main` (`Expected data_age_days=8, got 0`) and is unrelated to this change.

`black --check` clean.