### PR TITLE
Detect inverter settings changed outside Predbat

### DIFF
--- a/apps/predbat/control_ledger.py
+++ b/apps/predbat/control_ledger.py
@@ -1,0 +1,518 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# Control ownership ledger - detect settings changed outside Predbat
+# -----------------------------------------------------------------------------
+
+"""Remember which control values Predbat has PROVED it set, so a later change can be
+attributed.
+
+The distinction that makes this safe is ownership. Predbat writing a value proves
+nothing - the write may never have reached the inverter. Predbat writing a value and
+reading it back proves the inverter accepted it, and only then does a later difference
+mean somebody else changed it. Without that step there is no way to separate "a third
+party changed this" from "our write silently failed", which is exactly the ambiguity
+that makes naive settings-diffing untrustworthy.
+
+The owned value stored here is the value READ BACK at confirmation, never the value
+passed to the write. Both sides of every later comparison are then reads of the same
+entity, so units, rounding and time formatting match by construction rather than by
+re-implementing the write path's comparison rules.
+
+This module has no engine dependencies so it can be tested standalone.
+"""
+
+import re
+from datetime import datetime
+
+# Verdicts returned by observe().
+OWNED = "owned"  # reads back as we set it - the normal case
+UNOWNED = "unowned"  # we never proved we set this, so nothing can have been taken
+STALE = "stale"  # the read is not newer than our confirmation
+IMPLAUSIBLE = "implausible"  # the inverter returned something that cannot be a real value
+SETTLING = "settling"  # exception-path guard: a write was noted that never resolved (see observe())
+EXTERNAL = "external"  # everything else ruled out - somebody else changed it
+UNAVAILABLE = "unavailable"  # the entity is not reporting - a non-reading cannot contradict anything
+
+# The rolling window the customer-facing entity reports over.
+DEFAULT_WINDOW_S = 86400
+
+# How far into the future an event's timestamp may sit and still be judged. Clocks jitter
+# between the write and the publish, so a few seconds forward is ordinary; anything beyond
+# this is a clock that has not synchronised or an attribute that has been corrupted.
+CLOCK_JITTER_S = 60
+
+# Controls whose value must parse as a single wall-clock time. An inverter returning "00:80"
+# is a corrupt read; treating it as evidence would manufacture accusations.
+TIME_CONTROLS = frozenset(
+    {
+        "charge_start_time",
+        "charge_end_time",
+        "discharge_start_time",
+        "discharge_end_time",
+        "idle_start_time",
+        "idle_end_time",
+        "pause_start_time",
+        "pause_end_time",
+    }
+)
+
+# Controls that hold a time RANGE rather than a single time. Inverters using
+# inv_charge_time_format "H:M-H:M" (Solis, Solax) write one entity holding both ends -
+# adjust_charge_window() builds "01:30-05:00", and the disable path writes "00:00-00:00".
+# Validating those against a single-time regex made them permanently implausible, which
+# silently blinded the whole H:M-H:M family. Each side is validated separately and a range
+# is the ONLY accepted shape here, so a truncated read of half a range stays implausible
+# rather than being reported as somebody shortening the window.
+#
+# Deliberately DISJOINT from TIME_CONTROLS: is_plausible() tests this set first and returns,
+# so listing a name in both made the TIME_CONTROLS membership unreachable and implied a
+# single-time shape was also accepted, which is exactly what this set exists to refuse.
+TIME_RANGE_CONTROLS = frozenset(
+    {
+        "charge_time",
+        "discharge_time",
+    }
+)
+
+# Controls holding the hour or minute component of a charge/export window. adjust_charge_window()
+# writes these alongside the *_time entity whenever inv_charge_time_format is "H M", so they carry
+# exactly the semantics TIME_CONTROLS validates, split in two. Left unvalidated, a Modbus or GivTCP
+# glitch returning 255 or -1 walked every suppression rung and became a customer-facing accusation.
+HOUR_CONTROLS = frozenset(
+    {
+        "charge_start_hour",
+        "charge_end_hour",
+        "discharge_start_hour",
+        "discharge_end_hour",
+    }
+)
+MINUTE_CONTROLS = frozenset(
+    {
+        "charge_start_minute",
+        "charge_end_minute",
+        "discharge_start_minute",
+        "discharge_end_minute",
+    }
+)
+
+# Controls expressed as a percentage of capacity or rate.
+PERCENT_CONTROLS = frozenset(
+    {
+        "charge_limit",
+        "reserve",
+        "discharge_target_soc",
+        "charge_rate_percent",
+        "discharge_rate_percent",
+    }
+)
+
+_TIME_RE = re.compile(r"^(\d{1,2}):(\d{2})(?::(\d{2}))?$")
+
+
+def _is_wall_clock(value):
+    """Return True when the value parses as a single wall-clock time."""
+    match = _TIME_RE.match(str(value).strip())
+    if not match:
+        return False
+    hour, minute = int(match.group(1)), int(match.group(2))
+    second = int(match.group(3)) if match.group(3) else 0
+    return hour <= 23 and minute <= 59 and second <= 59
+
+
+def _is_clock_component(value, maximum, owned=None):
+    """Return True when the value is a valid hour or minute component for this control.
+
+    Two shapes are legitimate for the same control NAME, decided by the entity rather than the
+    name: adjust_charge_window() writes the integer component to a `number.`/`select.` hour or
+    minute entity, but writes the WHOLE time string to both the hour and the minute entity when
+    they are `time.` ones (GivEnergy FB00 firmware, inverter.py:3071-3080).
+
+    Which shape is legitimate is therefore decided by the shape Predbat OWNS. An entity we
+    confirmed holding 30 has no business reading "01:30" - that is a corrupt read, not a change.
+    An entity we confirmed holding "23:30:00" legitimately reads wall-clock. With no ownership
+    context (a direct call) both are accepted, because permissive here means fewer accusations.
+
+    255 and -1 are refused in every case, which is the point.
+    """
+    if owned is not None and _is_wall_clock(owned):
+        # A `time.` entity. It holds whole times, so a bare component is a truncated read.
+        return _is_wall_clock(value)
+    if _is_wall_clock(value):
+        # No ownership context: both shapes stay acceptable, because permissive here means fewer
+        # accusations. An integer entity (owned is a number) falls through to the range check.
+        return owned is None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return False
+    return 0 <= number <= maximum
+
+
+def values_match(a, b, fuzzy=0):
+    """Return True when a read is not meaningfully different from the owned value.
+
+    Numeric comparison honours a tolerance because the write path itself does: a charge
+    rate written as 3000 W and reading back 2950 W is accepted there, so reporting it
+    here would contradict the engine's own definition of a successful write.
+    """
+    try:
+        return abs(float(a) - float(b)) <= float(fuzzy)
+    except (TypeError, ValueError):
+        return str(a) == str(b)
+
+
+def is_plausible(control, value, owned=None):
+    """Return False when the value cannot be a real setting for this control.
+
+    `owned` is the value Predbat confirmed for this entity, where there is one. Only the
+    hour/minute family uses it, to tell an integer entity from a `time.` one - see
+    _is_clock_component(). Defaults to True for controls with no rule: an unvalidated control
+    must not be silently undetectable, only unvalidated.
+    """
+    if control in TIME_RANGE_CONTROLS:
+        parts = str(value).split("-")
+        if len(parts) != 2:
+            return False
+        return _is_wall_clock(parts[0]) and _is_wall_clock(parts[1])
+    if control in TIME_CONTROLS:
+        return _is_wall_clock(value)
+    if control in HOUR_CONTROLS:
+        return _is_clock_component(value, 23, owned)
+    if control in MINUTE_CONTROLS:
+        return _is_clock_component(value, 59, owned)
+    if control in PERCENT_CONTROLS:
+        try:
+            return 0 <= float(value) <= 100
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
+# Values Home Assistant uses for an entity that is not currently reporting. None of these
+# are readings, so none of them can confirm or contradict an owned value.
+NON_READINGS = frozenset({"", "none", "unavailable", "unknown", "nan", "null"})
+
+
+def is_reading(value):
+    """Return False when the value means "this entity is not reporting right now".
+
+    An entity that has dropped out fails an equality check against every owned value, and
+    for any control without a plausibility rule that would otherwise fall straight through
+    to EXTERNAL - reporting a dropout as somebody else changing the inverter.
+    """
+    if value is None:
+        return False
+    return str(value).strip().lower() not in NON_READINGS
+
+
+def _event_time(event):
+    """Return an event's "at" as a float, or None when it cannot be read as one.
+
+    THE single definition of "unusable timestamp". A restored event can carry anything
+    after a round trip through Home Assistant - restore() deliberately does not filter a bad
+    "at", so a non-dict or a nonsense string reaches here - and both the sort key and the
+    window filter have to survive that rather than taking out the whole plan run. Duplicating
+    the parse with narrower exception handling is how a non-dict event previously raised
+    AttributeError out of recent_events() while sorting perfectly happily.
+    """
+    try:
+        return float(event.get("at", 0))
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+def _event_sort_key(event):
+    """Order events by time, sorting an unusable "at" to the front.
+
+    Harmless because recent_events() drops those from every window anyway - they just need a
+    deterministic place to sit so sorted() has a total order to work with.
+    """
+    at = _event_time(event)
+    return 0.0 if at is None else at
+
+
+def generation_from_state(raw):
+    """Extract an observation generation (a float timestamp) from a raw HA state record.
+
+    "last_changed" is read first because that is the key the engine actually produces:
+    ha.py's update_state_item() is the only writer of the state table a raw read returns,
+    and it stores the timestamp as "last_changed". Reading only "last_updated" made this
+    return None on every production call, so the freshness gate below never fired and the
+    cycle counter was the sole defence against a vendor cloud serving a cached read of the
+    pre-write value. "last_changed" is also the better semantic - Home Assistant moves it
+    exactly when the value changes, which is the event this ordering is about.
+
+    "last_updated" is still honoured as a fallback: the raw records straight off the HA
+    API carry that key instead, and ha.py itself falls back to it when populating
+    last_changed.
+
+    Returns None when the record is missing, malformed, or carries no usable timing
+    metadata - the ledger then falls back to its cycle counter, which is weaker but
+    never wrong in the unsafe direction.
+    """
+    if not isinstance(raw, dict):
+        return None
+    stamp = raw.get("last_changed")
+    if stamp is None:
+        stamp = raw.get("last_updated")
+    if stamp is None:
+        return None
+    try:
+        return float(stamp)
+    except (TypeError, ValueError):
+        pass
+    try:
+        return datetime.fromisoformat(str(stamp).replace("Z", "+00:00")).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+class ControlLedger:
+    """Ownership state for every control entity Predbat writes.
+
+    Keyed on the resolved ENTITY ID, never on (inverter index, control name): a GivEnergy
+    EMS assigns the same entity to every inverter index, so index-keyed state would let
+    inverter 1's write be reported as tampering against inverter 0's record.
+
+    Deliberately not persisted. After a restart nothing is owned, so nothing is reported
+    until Predbat has set and confirmed a value again - which is correct, because after a
+    restart we genuinely do not know who set what.
+    """
+
+    def __init__(self):
+        self.records = {}
+        self.events = []
+        # The subset of self.events this process detected, as opposed to restored from the
+        # published attribute. Held by identity so newest_events() can protect them from the
+        # publish cap - see there.
+        self.session_events = []
+        self.cycle = 0
+
+    def begin_cycle(self):
+        """Advance the cycle counter. Called once per plan run."""
+        self.cycle += 1
+
+    def owned_value(self, entity_id):
+        """Return the value Predbat has proved it set for this entity, or None if it owns none.
+
+        Exists so a caller can log what the ledger believed WITHOUT reaching into records -
+        observe() pops the record when it reports, so a caller that read it afterwards would
+        always find nothing.
+        """
+        record = self.records.get(entity_id)
+        return record["owned_value"] if record else None
+
+    def record_write(self, entity_id, control, read_back, fuzzy=0, now=0.0, generation=None):
+        """Record a VERIFIED read-back, conferring ownership.
+
+        Only ever called with a read-back the write helper has already checked against the
+        value it asked for. A write that failed, or one that returned success without ever
+        polling (ignore_fail), proves nothing - those call clear(entity_id) instead, which
+        says what is meant rather than passing a value this would then discard.
+
+        A read-back that is itself a non-reading (the inverter answered "unavailable" to the
+        poll) is worthless in the same way - "we confirmed it holds unavailable" cannot mean
+        anything, so it drops ownership rather than being stored as an owned value.
+        """
+        if not is_reading(read_back):
+            self.records.pop(entity_id, None)
+            return
+        self.records[entity_id] = {
+            "control": control,
+            "owned_value": read_back,
+            "fuzzy": fuzzy,
+            "confirmed_cycle": self.cycle,
+            "confirmed_at": now,
+            "confirmed_generation": generation,
+            "wrote_cycle": self.cycle,
+        }
+
+    def note_write_attempt(self, entity_id):
+        """Mark that Predbat wrote this control, so divergence is treated as settling."""
+        record = self.records.get(entity_id)
+        if record:
+            record["wrote_cycle"] = self.cycle
+
+    def clear(self, entity_id=None):
+        """Drop ownership. Called when Predbat stops controlling (read-only, calibration)."""
+        if entity_id is None:
+            self.records.clear()
+        else:
+            self.records.pop(entity_id, None)
+
+    def observe(self, entity_id, control, value, now=0.0, generation=None):
+        """Classify a freshly read control value. Returns one of the verdict constants.
+
+        The ladder is biased toward silence: every innocent explanation is eliminated
+        before EXTERNAL is returned.
+        """
+        record = self.records.get(entity_id)
+        if not record:
+            return UNOWNED
+
+        if not is_reading(value):
+            return UNAVAILABLE
+
+        if values_match(value, record["owned_value"], record["fuzzy"]):
+            return OWNED
+
+        # The read must be newer than the confirmation, by cycle and - where the entity
+        # exposes it - by generation. GivEnergy serves bulk settings reads from cache, so
+        # a read taken before our write propagated shows the old value and looks exactly
+        # like a reversion.
+        if self.cycle <= record["confirmed_cycle"]:
+            return STALE
+        if generation is not None and record["confirmed_generation"] is not None and generation <= record["confirmed_generation"]:
+            return STALE
+
+        if not is_plausible(control, value, record["owned_value"]):
+            return IMPLAUSIBLE
+
+        # An exception-path guard, NOT the ordinary in-flight case. Every note_write_attempt()
+        # is followed, in the same helper call, by a record_write() that re-confirms (making
+        # wrote_cycle == confirmed_cycle) or a clear() that pops the record entirely - so on
+        # any path that returns normally this rung cannot be reached, and the cycle gate above
+        # is what actually suppresses our own change propagating. It stays because a helper
+        # that raises between the two leaves wrote_cycle ahead, and next cycle that state must
+        # not be read as somebody else's change.
+        if record["wrote_cycle"] > record["confirmed_cycle"]:
+            return SETTLING
+
+        event = {
+            "at": now,
+            "control": control,
+            "entity_id": entity_id,
+            "we_set": record["owned_value"],
+            "now_reads": value,
+            "confirmed_at": record["confirmed_at"],
+        }
+        self.events.append(event)
+        self.session_events.append(event)
+        # Ownership is cleared so one externally-set value counts once. Predbat rewrites
+        # and re-confirms next cycle, which re-arms detection naturally.
+        self.records.pop(entity_id, None)
+        return EXTERNAL
+
+    def _in_window(self, now, window_s, drop_future):
+        """The one place the window rules live, oldest first.
+
+        Two callers want almost the same filter, and the difference is the whole point:
+
+        - recent_events() (READ) wants `drop_future=True`. Testing only `(now - at) <= window_s`
+          is satisfied by any negative age, so an event stamped in the future counted for ever.
+          CLOCK_JITTER_S of ordinary forward drift still counts; anything further ahead cannot be
+          judged against a window that runs backwards from now.
+        - prune() (WRITE) wants `drop_future=False`, because it maintains the durable store and a
+          future "at" may simply be a clock that has not caught up yet.
+
+        An "at" that cannot be read as a number is dropped for both: no clock correction makes it
+        parseable.
+        """
+        kept = []
+        for event in self.events:
+            at = _event_time(event)
+            if at is None:
+                continue
+            age = now - at
+            if age > window_s:
+                continue
+            if drop_future and age < -CLOCK_JITTER_S:
+                continue
+            kept.append(event)
+        return kept
+
+    def recent_events(self, now, window_s=DEFAULT_WINDOW_S):
+        """READ path: events that can be judged right now, oldest first.
+
+        Excludes future-dated events, which prune() deliberately keeps - see both.
+        """
+        return self._in_window(now, window_s, drop_future=True)
+
+    def newest_events(self, limit):
+        """Return at most `limit` events to publish, oldest first, never losing one we just detected.
+
+        The published attribute IS the durable store, so whatever this drops is gone for good.
+        Sorting by time is NOT sufficient, and neither is the tail of the list: restore() already
+        leaves the store sorted, so the two are the same thing. On a pod whose clock is behind,
+        this run's real event is stamped with a small "at" and is therefore genuinely the OLDEST
+        by timestamp - so any by-time cap discards precisely the event just detected, which is the
+        one thing here that cannot be recovered from anywhere else.
+
+        Events detected by THIS process are therefore kept ahead of restored history, whatever
+        their timestamp says, and the remaining room goes to the newest history by time.
+        """
+        if len(self.events) <= limit:
+            return sorted(self.events, key=_event_sort_key)
+        detected = {id(event) for event in self.session_events}
+        mine = [event for event in self.events if id(event) in detected]
+        if len(mine) >= limit:
+            return self.session_events[-limit:]
+        history = sorted((event for event in self.events if id(event) not in detected), key=_event_sort_key)
+        return sorted(history[len(history) - (limit - len(mine)) :] + mine, key=_event_sort_key)
+
+    def sustained_controls(self, events, threshold=3):
+        """Return control names hit repeatedly, from an ALREADY-WINDOWED list of events.
+
+        A single event has too many exotic explanations to put in front of a customer.
+        Repeated events on the same control mean Predbat sets it, something changes it
+        back, repeatedly - which is the state actually worth reporting.
+
+        Takes the windowed list rather than a `now`/`window_s` pair so there is exactly one
+        place the window is applied - a signature accepting both silently ignored one of them.
+        """
+        counts = {}
+        for event in events:
+            # restore() does not require "control" to be present, so a restored event can carry
+            # control=None or a non-name. The result is written straight into a customer-facing
+            # attribute and interpolated into a log line, so an event with no usable control
+            # name is dropped here rather than counted - it can only ever name nothing.
+            control = event.get("control") if isinstance(event, dict) else None
+            if not isinstance(control, str) or not control.strip():
+                continue
+            counts[control] = counts.get(control, 0) + 1
+        return sorted(control for control, count in counts.items() if count >= threshold)
+
+    def prune(self, now, window_s=DEFAULT_WINDOW_S):
+        """WRITE path: drop only what has genuinely aged out, so the list cannot grow unbounded.
+
+        Deliberately keeps future-dated events, which recent_events() excludes. This list is the
+        durable store - the publisher writes it back to the entity attribute restore() reads - so
+        anything dropped here is gone for good, and a pod that starts before NTP sync with a slow
+        clock makes every restored event look future-dated. Pruning on that basis would delete a
+        real 24 hours of history irrecoverably on the very next publish. The clock corrects; the
+        events have to still be there when it does.
+        """
+        self.events = self._in_window(now, window_s, drop_future=False)
+        # Keep the protected set in step, or it grows for the life of the process and can protect
+        # events that have already aged out of the store.
+        surviving = {id(event) for event in self.events}
+        self.session_events = [event for event in self.session_events if id(event) in surviving]
+
+    def restore(self, events):
+        """Rehydrate the event list from the entity's own last published attributes.
+
+        The rolling window needs timestamps, so seeding a bare count is not enough. Reading
+        back what we published is the cheapest durable store available and needs no new
+        table. Anything malformed is dropped rather than trusted - except a bad "at" is
+        deliberately NOT filtered out here: it is recent_events()/prune() that treat it as
+        unusable, so a restore-time bug can't silently masquerade as "no events".
+
+        The attribute round-trips through Home Assistant, so it is not guaranteed to still
+        be a list - it may be missing, None, or (on a corrupt read) a non-iterable value.
+        Anything that is not a list is treated the same as no history, not as a crash.
+
+        The whole list is re-sorted afterwards because restore() runs AFTER execute_plan()
+        has already appended this cycle's events, so appending history to the end leaves the
+        newest event FIRST. Sorting makes the list genuinely oldest-first, as recent_events()
+        already documents it to be, so anything reading the store in order sees history in order.
+        The publisher does not rely on that ordering - see newest_events() for why.
+        """
+        if not isinstance(events, list):
+            return
+        for event in events:
+            if isinstance(event, dict) and "at" in event:
+                self.events.append(event)
+        self.events.sort(key=_event_sort_key)

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -106,15 +106,13 @@ class Execute:
     """
 
     def clear_control_ledger(self):
-        """Drop every control ownership record, if the ledger is present.
+        """Drop every control ownership record, if the ledger is configured.
 
         Called wherever PredBat stops controlling the inverter - read-only mode and
-        calibration. Reached defensively because execute_plan() runs against test harnesses
-        that construct the engine without a ledger.
+        calibration.
         """
-        ledger = getattr(self, "control_ledger", None)
-        if ledger is not None:
-            ledger.clear()
+        if self.control_ledger is not None:
+            self.control_ledger.clear()
 
     def execute_plan(self):
         # Per-inverter detail segments, assembled into the status text after the headline status is

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -105,6 +105,17 @@ class Execute:
     adjustment, and multi-inverter balancing.
     """
 
+    def clear_control_ledger(self):
+        """Drop every control ownership record, if the ledger is present.
+
+        Called wherever PredBat stops controlling the inverter - read-only mode and
+        calibration. Reached defensively because execute_plan() runs against test harnesses
+        that construct the engine without a ledger.
+        """
+        ledger = getattr(self, "control_ledger", None)
+        if ledger is not None:
+            ledger.clear()
+
     def execute_plan(self):
         # Per-inverter detail segments, assembled into the status text after the headline status is
         # resolved - see build_status_extra() for why they can't be concatenated inline.
@@ -129,6 +140,13 @@ class Execute:
         if self.inverter_needs_reset:
             self.reset_inverter()
 
+        # Belt and braces: the read-only branch below runs before anything that could confer
+        # ownership - but ownership from BEFORE read-only was enabled would survive, and
+        # PredBat is no longer controlling anything, so it is not ours to claim. set_read_only
+        # is a global flag, so this is decided once rather than re-decided per inverter.
+        if self.set_read_only:
+            self.clear_control_ledger()
+
         isCharging = False
         isExporting = False
         for inverter in self.inverters:
@@ -151,6 +169,11 @@ class Execute:
                     inverter.adjust_discharge_rate(inverter.battery_rate_max_discharge * MINUTE_WATT)
                     inverter.adjust_battery_target(100.0, False)
                     inverter.adjust_reserve(0)
+                # Those writes go through the ordinary helpers, so they CONFER ownership - in
+                # exactly the mode where the inverter's own firmware is driving its settings.
+                # A value found moved next cycle is the inverter calibrating, not a third
+                # party, so ownership is dropped after the writes rather than before them.
+                self.clear_control_ledger()
                 break
 
             resetDischarge = self.set_charge_window or self.set_export_window

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -25,9 +25,11 @@ import requests
 from datetime import datetime, timedelta
 from config import INVERTER_DEF, SOLAX_SOLIS_MODES_NEW, SOLAX_SOLIS_MODES
 from const import MINUTE_WATT, TIME_FORMAT, TIME_FORMAT_OCTOPUS, INVERTER_TEST, TIME_FORMAT_SECONDS, INVERTER_MAX_RETRY, INVERTER_MAX_RETRY_REST, INVERTER_REST_TIMEOUT, EXPORT_LIMIT_IDLE
+from control_ledger import generation_from_state, OWNED, UNOWNED
 from utils import calc_percent_limit, compute_window_minutes, dp0, dp1, dp2, dp3, dp4, time_string_to_stamp, minute_data, minute_data_state, window2minutes
 
 TIME_FORMAT_HMS = "%H:%M:%S"
+
 
 # GivTCP raw.invertor.model values confirmed not to support the Discharge_Target_SOC_1 register
 # (#4517). "Ac" (AC Coupled) and "Hybrid_gen1" are confirmed live - the latter on two separate
@@ -1990,6 +1992,36 @@ class Inverter:
             else:
                 self.mimic_target_soc(0)
 
+    def _ledger_generation(self, entity_id):
+        """Return the entity's observation generation, or None if it exposes no timing metadata.
+
+        The ledger requires a divergent read to be NEWER than the confirmation, not merely
+        from a later cycle - GivEnergy serves bulk settings reads from cache, so a read taken
+        before our write propagated shows the old value and is indistinguishable from a
+        reversion. Where an entity exposes no timing metadata the ledger falls back to the
+        cycle counter alone, which is weaker but never wrong in the unsafe direction.
+        """
+        try:
+            return generation_from_state(self.base.get_state_wrapper(entity_id, raw=True))
+        except Exception:
+            return None
+
+    def _ledger_observe(self, ledger, name, entity_id, value):
+        """Classify a control read and log every verdict that is not a plain owned/unowned.
+
+        observe()'s verdict is otherwise discarded at all three call sites, which makes the
+        whole suppression ladder invisible. When a customer reports interference and the
+        entity reads 0 there is then no way to tell whether the ledger owned nothing,
+        suppressed on the freshness gate, refused the read as implausible, saw a dropout, or
+        had been wiped by a service template - four completely different problems that look
+        identical from outside. This line is the feature's only diagnostic.
+        """
+        owned = ledger.owned_value(entity_id)
+        verdict = ledger.observe(entity_id, name, value, now=time.time(), generation=self._ledger_generation(entity_id))
+        if verdict not in (OWNED, UNOWNED):
+            self.base.log("Inverter {} control ledger: {} ({}) verdict {} - Predbat set {}, inverter now reads {}".format(self.id, name, entity_id, verdict, owned, value))
+        return verdict
+
     def write_and_poll_switch(self, name, entity_id, new_value):
         """
         GivTCP Workaround, keep writing until correct
@@ -2002,8 +2034,19 @@ class Inverter:
         domain, entity_name = entity_id.split(".")
 
         current_state = self.base.get_state_wrapper(entity_id=entity_id)
+        # The ledger is shown the RAW read, taken before the boolean coercion below. That
+        # coercion maps "unavailable" to False, which is a perfectly valid switch position -
+        # a routine integration dropout would otherwise pass every suppression rung and be
+        # reported to the customer as somebody else turning their charging off.
+        raw_state = current_state
         if isinstance(current_state, str):
             current_state = current_state.lower() in ["on", "enable", "true"]
+
+        ledger = getattr(self.base, "control_ledger", None)
+        if ledger is not None:
+            self._ledger_observe(ledger, name, entity_id, raw_state)
+            if current_state != new_value:
+                ledger.note_write_attempt(entity_id)
 
         if current_state == new_value:
             self.base.log("Inverter {} write_and_poll_switch: No write needed for {} as {} == {}".format(self.id, name, new_value, current_state))
@@ -2024,6 +2067,7 @@ class Inverter:
 
             self.sleep(self.inv_write_and_poll_sleep)
             current_state = self.base.get_state_wrapper(entity_id=entity_id, refresh=domain != "sensor")
+            raw_state = current_state
             if isinstance(current_state, str):
                 current_state = current_state.lower() in ["on", "enable", "true"]
 
@@ -2031,10 +2075,20 @@ class Inverter:
             self.base.log("Inverter {} Wrote {} to {} successfully and got {}".format(self.id, name, new_value, self.base.get_state_wrapper(entity_id=entity_id)))
             if domain != "sensor":
                 self.count_register_writes += 1
+            # The owned value must be the same SHAPE as the reads it will later be compared
+            # against, so record_write gets the raw read too. Storing the coerced bool while
+            # observing the raw string would make every subsequent read ("on" vs True) look
+            # like a change - PredBat accusing somebody else of its own successful write.
+            if ledger is not None:
+                ledger.record_write(entity_id, name, raw_state, now=time.time(), generation=self._ledger_generation(entity_id))
             return True
         else:
             self.base.log("Warn: Inverter {} Trying to write {} to {} didn't complete got {}".format(self.id, name, new_value, self.base.get_state_wrapper(entity_id=entity_id)))
             self.base.record_status("Warn: Inverter {} write to {} failed".format(self.id, name), had_errors=True)
+            # The write never verified, so we cannot claim this value - and holding the PREVIOUS
+            # confirmation would report the next read of a control we have just failed to set.
+            if ledger is not None:
+                ledger.clear(entity_id)
             return False
 
     def write_and_poll_value(self, name, entity_id, new_value, fuzzy=0, ignore_fail=False, required_unit=None):
@@ -2047,6 +2101,12 @@ class Inverter:
         domain, entity_name = entity_id.split(".")
         current_state = self.base.get_state_wrapper(entity_id, required_unit=required_unit)
 
+        # The ledger is shown the RAW read, taken before the float coercion below. That
+        # coercion turns a failed read - "unavailable", "unknown", a missing entity - into
+        # 0.0, which is a real-looking number that passes every suppression rung. Reported
+        # to a customer that reads as "a third party set your charge rate to 0 W", produced
+        # by nothing more than a routine integration dropout.
+        raw_state = current_state
         if isinstance(new_value, str):
             matched = current_state == new_value
         else:
@@ -2056,6 +2116,12 @@ class Inverter:
                 self.log("Warn: Inverter {} write_and_poll_value: Current state for {} is {}".format(self.id, name, current_state))
                 current_state = 0.0
             matched = abs(current_state - new_value) <= fuzzy
+
+        ledger = getattr(self.base, "control_ledger", None)
+        if ledger is not None:
+            self._ledger_observe(ledger, name, entity_id, raw_state)
+            if not matched:
+                ledger.note_write_attempt(entity_id)
 
         retry = 0
         while (not matched) and (retry < INVERTER_MAX_RETRY):
@@ -2069,10 +2135,15 @@ class Inverter:
                 self.base.call_service_wrapper(service, value=new_value_conv, entity_id=entity_id)
 
             if ignore_fail:
+                # Returns success without ever polling, so nothing has been proved about what
+                # the inverter now holds - drop ownership rather than claim it.
+                if ledger is not None:
+                    ledger.clear(entity_id)
                 return True
 
             self.sleep(self.inv_write_and_poll_sleep)
             current_state = self.base.get_state_wrapper(entity_id, refresh=domain != "sensor", required_unit=required_unit)
+            raw_state = current_state
             if isinstance(new_value, str):
                 matched = current_state == new_value
             else:
@@ -2089,10 +2160,17 @@ class Inverter:
             self.base.log(f"Inverter {self.id} write_and_poll_value: Wrote {new_value} to {name}, successfully now {current_state}")
             if domain != "sensor":
                 self.count_register_writes += 1
+            # Raw again, for the same reason as observe() above: both sides of every later
+            # comparison must be reads of the same entity in the same shape, and a coerced
+            # 0.0 read-back would otherwise be stored as a confirmed owned value.
+            if ledger is not None:
+                ledger.record_write(entity_id, name, raw_state, fuzzy=fuzzy, now=time.time(), generation=self._ledger_generation(entity_id))
             return True
         else:
             self.base.log(f"Warn: Inverter {self.id} Trying to write {new_value} to {name} didn't complete got {current_state}")
             self.base.record_status(f"Warn: Inverter {self.id} write to {name} failed", had_errors=True)
+            if ledger is not None:
+                ledger.clear(entity_id)
             return False
 
     def write_and_poll_option(self, name, entity_id, new_value, ignore_fail=False):
@@ -2118,6 +2196,12 @@ class Inverter:
         if old_value and (":" in old_value) and (":" in new_value) and (len(old_value) == 5) and (len(new_value) == 8):
             new_value = new_value[:5]
 
+        ledger = getattr(self.base, "control_ledger", None)
+        if ledger is not None:
+            self._ledger_observe(ledger, name, entity_id, old_value)
+            if old_value != new_value:
+                ledger.note_write_attempt(entity_id)
+
         for retry in range(INVERTER_MAX_RETRY):
             if entity_base == "time":
                 service = entity_base + "/set_value"
@@ -2129,15 +2213,22 @@ class Inverter:
                 service = entity_base + "/select_option"
                 self.base.call_service_wrapper(service, option=new_value, entity_id=entity_id)
             if ignore_fail:
+                # Same as write_and_poll_value: success without a poll proves nothing.
+                if ledger is not None:
+                    ledger.clear(entity_id)
                 return True
             self.sleep(self.inv_write_and_poll_sleep)
             old_value = self.base.get_state_wrapper(entity_id, refresh=True)
             if old_value == new_value:
                 self.base.log("Inverter {} Wrote {} to {} successfully".format(self.id, name, new_value))
                 self.count_register_writes += 1
+                if ledger is not None:
+                    ledger.record_write(entity_id, name, old_value, now=time.time(), generation=self._ledger_generation(entity_id))
                 return True
         self.base.log("Warn: Inverter {} Trying to write {} to {} didn't complete got {}".format(self.id, name, new_value, self.base.get_state_wrapper(entity_id, refresh=True)))
         self.base.record_status("Warn: Inverter {} write to {} failed".format(self.id, name), had_errors=True)
+        if ledger is not None:
+            ledger.clear(entity_id)
         return False
 
     def adjust_pause_mode(self, pause_charge=False, pause_discharge=False):
@@ -2727,6 +2818,8 @@ class Inverter:
         """
         if self.inv_has_mqtt_api:
             self.base.call_service_wrapper("mqtt/publish", qos=1, retain=True, topic=(self.inv_mqtt_topic + "/" + topic), payload=payload)
+            # No ledger call: this publishes to a broker topic and maps to no Home Assistant
+            # entity, so there is nothing here to record against one.
 
     def enable_charge_discharge_with_time_current(self, direction, enable):
         """

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2042,7 +2042,7 @@ class Inverter:
         if isinstance(current_state, str):
             current_state = current_state.lower() in ["on", "enable", "true"]
 
-        ledger = getattr(self.base, "control_ledger", None)
+        ledger = self.base.control_ledger
         if ledger is not None:
             self._ledger_observe(ledger, name, entity_id, raw_state)
             if current_state != new_value:
@@ -2117,7 +2117,7 @@ class Inverter:
                 current_state = 0.0
             matched = abs(current_state - new_value) <= fuzzy
 
-        ledger = getattr(self.base, "control_ledger", None)
+        ledger = self.base.control_ledger
         if ledger is not None:
             self._ledger_observe(ledger, name, entity_id, raw_state)
             if not matched:
@@ -2196,7 +2196,7 @@ class Inverter:
         if old_value and (":" in old_value) and (":" in new_value) and (len(old_value) == 5) and (len(new_value) == 8):
             new_value = new_value[:5]
 
-        ledger = getattr(self.base, "control_ledger", None)
+        ledger = self.base.control_ledger
         if ledger is not None:
             self._ledger_observe(ledger, name, entity_id, old_value)
             if old_value != new_value:

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -674,6 +674,14 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         if self.had_errors:
             m.errors_total.labels(type="general").inc()
 
+        # Control ownership ledger
+        conflict_events = self.control_ledger.recent_events(time.time())
+        m.control_conflicts_24h.set(len(conflict_events))
+        sustained = self.control_ledger.sustained_controls(conflict_events)
+        m.control_conflicts_sustained_total.set(len(sustained))
+        m.control_conflicts_events = self.control_ledger.newest_events(20)
+        m.control_conflicts_sustained_controls = sustained
+
     def save_plan(self):
         """Save the current best plan via the storage component so it can be restored on next startup."""
         storage = self.components.get_component("storage") if self.components else None

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -84,6 +84,7 @@ from compare import Compare
 from plugin_system import PluginSystem
 from github import GitHub
 from ha import run_async
+from control_ledger import ControlLedger
 
 
 class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, Marginal, Execute, Output, UserInterface, GitHub):
@@ -300,6 +301,8 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.currency_symbols = self.args.get("currency_symbols", "£p")
         self.watch_list = []
         self.restart_active = False
+        self.control_ledger = ControlLedger()
+        self.control_ledger_restored = False
         self.inverter_needs_reset = False
         self.inverter_needs_reset_force = ""
         self.inverters = []
@@ -836,6 +839,13 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
             self.log("Sensor changes require a replan, will recompute the plan")
             recompute = True
 
+        # Open the control-ledger cycle BEFORE the first inverter read. fetch_inverter_data()
+        # runs update_status(), which writes scheduled_charge_enable through write_and_poll_switch
+        # and so CONFIRMS ownership - stamping those with the previous cycle number made the next
+        # observe() of them hit the STALE rung whenever execute_plan() had written the entity in
+        # the prior run. Every write in a run must share that run's cycle number.
+        self.control_ledger.begin_cycle()
+
         # Fetch inverter data
         if not self.fetch_inverter_data():
             self.log("Error: Failed to fetch inverter data, not able to compute a plan")
@@ -949,6 +959,42 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
             },
         )
         self.log("Total inverter register writes now {}".format(previous_inverter_writes))
+
+        # Control interference detection. Restored once per process from the entity's own
+        # attributes so the 24h window survives a pod restart - without this "3 in 24h"
+        # silently means "3 since the last restart".
+        now_ts = time.time()
+        if not self.control_ledger_restored:
+            self.control_ledger.restore(self.load_previous_value_from_ha(self.prefix + ".control_conflicts", attribute="events"))
+            self.control_ledger_restored = True
+        # prune() and recent_events() are NOT the same filter and neither can stand in for the
+        # other. prune() maintains the durable store, dropping only what has genuinely aged out;
+        # a future-dated event (a clock behind NTP) stays, because the clock corrects and the
+        # history must survive until it does. recent_events() is what can be JUDGED right now, so
+        # it is what the count and the sustained list are built from. The "events" attribute
+        # publishes the stored list, because that attribute IS the store restore() reads back -
+        # publishing only the events it can judge would delete the rest on the next run.
+        self.control_ledger.prune(now_ts)
+        conflict_events = self.control_ledger.recent_events(now_ts)
+        sustained = self.control_ledger.sustained_controls(conflict_events)
+        self.dashboard_item(
+            self.prefix + ".control_conflicts",
+            state=len(conflict_events),
+            attributes={
+                "friendly_name": "Settings changed outside Predbat (24h)",
+                "state_class": "measurement",
+                "unit_of_measurement": "changes",
+                "icon": "mdi:account-alert",
+                # Newest 20 BY TIME. The stored list is sorted by restore(), so on a pod whose clock
+                # is behind, this run's real event carries a small "at", sorts to index 0, and a
+                # plain [-20:] tail discarded the very event just detected - from the attribute that
+                # IS the durable store.
+                "events": self.control_ledger.newest_events(20),
+                "sustained": sustained,
+            },
+        )
+        if conflict_events:
+            self.log("Control interference: {} change(s) in the last 24h, sustained on {}".format(len(conflict_events), sustained or "nothing"))
 
         if self.calculate_savings:
             # Get current totals

--- a/apps/predbat/predbat_metrics.py
+++ b/apps/predbat/predbat_metrics.py
@@ -133,6 +133,14 @@ class PredbatMetrics:
         self.pv_scaling_best = _gauge("predbat_pv_scaling_best", "PV calibration best-day scaling factor")
         self.pv_scaling_total = _gauge("predbat_pv_scaling_total", "PV calibration total adjustment factor")
 
+        # -- Control ownership ledger -------------------------------------------
+        self.control_conflicts_24h = _gauge("predbat_control_conflicts_24h", "Control values changed outside Predbat in the last 24h")
+        self.control_conflicts_sustained_total = _gauge("predbat_control_conflicts_sustained_total", "Number of controls with repeated (sustained) external interference")
+        # Plain data, not a Prometheus metric - the dashboard needs the actual events and control
+        # names, not just a count, and Prometheus gauges cannot carry that shape.
+        self.control_conflicts_events = []
+        self.control_conflicts_sustained_controls = []
+
 
     def to_dict(self):
         """Return current metric values as a plain dict for the dashboard."""
@@ -230,6 +238,11 @@ class PredbatMetrics:
             "pv_scaling_worst": _val(self.pv_scaling_worst),
             "pv_scaling_best": _val(self.pv_scaling_best),
             "pv_scaling_total": _val(self.pv_scaling_total),
+            # Control ownership ledger
+            "control_conflicts_24h": _val(self.control_conflicts_24h),
+            "control_conflicts_sustained_total": _val(self.control_conflicts_sustained_total),
+            "control_conflicts_events": self.control_conflicts_events,
+            "control_conflicts_sustained_controls": self.control_conflicts_sustained_controls,
         }
 
 

--- a/apps/predbat/tests/test_control_ledger.py
+++ b/apps/predbat/tests/test_control_ledger.py
@@ -1,0 +1,1646 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# Test control ownership ledger
+# -----------------------------------------------------------------------------
+
+"""Tests for the control ownership ledger.
+
+Most of these assert SILENCE. The expensive failure for this feature is telling a
+customer that someone else changed their inverter when in fact our own write failed,
+the read was stale, or the inverter returned garbage.
+"""
+
+from control_ledger import (
+    ControlLedger,
+    values_match,
+    is_plausible,
+    generation_from_state,
+    OWNED,
+    UNOWNED,
+    STALE,
+    IMPLAUSIBLE,
+    SETTLING,
+    EXTERNAL,
+    UNAVAILABLE,
+)
+from const import INVERTER_MAX_RETRY
+
+
+def test_values_match_uses_fuzzy_for_numerics():
+    """A read inside the write path's tolerance is a match, not a change."""
+    failed = False
+    if not values_match(2950, 3000, fuzzy=130):
+        print("ERROR: 2950 vs 3000 within fuzzy 130 should match")
+        failed = True
+    if values_match(2000, 3000, fuzzy=130):
+        print("ERROR: 2000 vs 3000 outside fuzzy 130 should not match")
+        failed = True
+    if not values_match("23:30", "23:30"):
+        print("ERROR: identical strings should match")
+        failed = True
+    if values_match("19:42", "23:30"):
+        print("ERROR: different times should not match")
+        failed = True
+    assert not failed, "test_values_match_uses_fuzzy_for_numerics"
+
+
+def test_is_plausible_rejects_impossible_times():
+    """00:80 and 00:60 are not times - the inverter returned garbage, not a change."""
+    failed = False
+    for bad in ("00:80", "00:60", "25:00", "not-a-time"):
+        if is_plausible("charge_start_time", bad):
+            print(f"ERROR: {bad} accepted as a plausible time")
+            failed = True
+    for good in ("23:30", "07:00", "00:00", "23:30:00"):
+        if not is_plausible("charge_start_time", good):
+            print(f"ERROR: {good} rejected as implausible")
+            failed = True
+    if is_plausible("charge_limit", 150):
+        print("ERROR: 150 accepted as a plausible percentage")
+        failed = True
+    if not is_plausible("charge_limit", 90):
+        print("ERROR: 90 rejected as a percentage")
+        failed = True
+    if not is_plausible("some_unknown_control", "anything"):
+        print("ERROR: unvalidated controls must default to plausible")
+        failed = True
+    assert not failed, "test_is_plausible_rejects_impossible_times"
+
+
+def test_generation_from_state():
+    """Timing metadata is parsed where present and refused where not."""
+    failed = False
+    if generation_from_state({"state": "23:30", "last_updated": 1234.5}) != 1234.5:
+        print("ERROR: a float last_updated was not returned")
+        failed = True
+    if generation_from_state({"state": "23:30", "last_updated": "2026-08-21T07:07:00+00:00"}) is None:
+        print("ERROR: an ISO last_updated was not parsed")
+        failed = True
+    if generation_from_state({"state": "23:30", "last_updated": "2026-08-21T07:07:00Z"}) is None:
+        print("ERROR: a Z-suffixed ISO last_updated was not parsed")
+        failed = True
+    for bad in (None, "not a dict", {}, {"state": "23:30"}, {"last_updated": "gibberish"}):
+        if generation_from_state(bad) is not None:
+            print(f"ERROR: {bad!r} should yield None")
+            failed = True
+    assert not failed, "test_generation_from_state"
+
+
+def test_generation_from_state_reads_engine_record_shape():
+    """The record the ENGINE produces must yield a generation, not just a fabricated one.
+
+    ha.py's update_state_item() is the only writer of the state table a raw read returns, and
+    it stores {"state", "attributes", "last_changed"} - there is no "last_updated" key. Reading
+    only "last_updated" made this return None on every production call, so confirmed_generation
+    was always None and the freshness gate never fired, leaving the cycle counter as the sole
+    defence against a vendor cloud serving a cached read of the pre-write value. Fabricated
+    {"last_updated": ...} records assert the key the code wants rather than the one it will be
+    handed, so this test uses the real shape and keeps a last_updated case for the raw HA API
+    records that genuinely carry that key instead.
+    """
+    failed = False
+    engine_record = {"state": "23:30", "attributes": {}, "last_changed": "2026-08-21T07:00:00+00:00"}
+    generation = generation_from_state(engine_record)
+    if not isinstance(generation, float):
+        print(f"ERROR: the engine's own record shape yielded {generation!r}, not a usable float")
+        failed = True
+    if generation_from_state({"state": "23:30", "attributes": {}, "last_changed": 1234.5}) != 1234.5:
+        print("ERROR: a float last_changed was not returned")
+        failed = True
+    # ha.py falls back to last_updated when HA supplied only that, and stores the result as
+    # last_changed=None; the raw HA API records at ha.py's own fetch layer use last_updated.
+    if generation_from_state({"state": "23:30", "last_updated": 1234.5}) != 1234.5:
+        print("ERROR: the last_updated fallback was not honoured")
+        failed = True
+    if generation_from_state({"state": "23:30", "last_changed": None, "last_updated": 1234.5}) != 1234.5:
+        print("ERROR: a null last_changed did not fall back to last_updated")
+        failed = True
+    if generation_from_state({"state": "23:30", "attributes": {}, "last_changed": None}) is not None:
+        print("ERROR: a record with no usable timing metadata should yield None")
+        failed = True
+    assert not failed, "test_generation_from_state_reads_engine_record_shape"
+
+
+def test_is_plausible_accepts_time_ranges():
+    """charge_time/discharge_time hold a RANGE, not a single time.
+
+    Inverters using inv_charge_time_format "H:M-H:M" (Solis, Solax) write one entity holding
+    both ends - "01:30-05:00" from adjust_charge_window(), "00:00-00:00" to disable. Validating
+    those against the single-time regex made them permanently implausible, so every real
+    external change to that whole family was swallowed.
+    """
+    failed = False
+    for control in ("charge_time", "discharge_time"):
+        for good in ("01:30-05:00", "00:00-00:00", "23:30-07:00", "01:30:00-05:00:00"):
+            if not is_plausible(control, good):
+                print(f"ERROR: {control} rejected the valid range {good}")
+                failed = True
+        # A range is only as good as both halves, and a truncated read of half a range is a
+        # corrupt read - not somebody shortening the window - so it must stay implausible.
+        for bad in ("01:30-99:99", "99:99-05:00", "noon-05:00", "01:30", "01:30-05:00-09:00", "", "unavailable"):
+            if is_plausible(control, bad):
+                print(f"ERROR: {control} accepted the invalid value {bad!r}")
+                failed = True
+    # The single-time controls keep the stricter single-time rule.
+    if not is_plausible("charge_start_time", "23:30"):
+        print("ERROR: a single time was rejected for charge_start_time")
+        failed = True
+    if is_plausible("charge_start_time", "01:30-05:00"):
+        print("ERROR: charge_start_time accepted a range, which it never holds")
+        failed = True
+    assert not failed, "test_is_plausible_accepts_time_ranges"
+
+
+def test_unowned_never_reports():
+    """A value we never confirmed is not ours to claim was taken."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    if ledger.observe("select.charge_start", "charge_start_time", "19:42") != UNOWNED:
+        print("ERROR: an unconfirmed control reported something other than UNOWNED")
+        failed = True
+    if ledger.events:
+        print(f"ERROR: an unconfirmed control produced events: {ledger.events}")
+        failed = True
+    assert not failed, "test_unowned_never_reports"
+
+
+def test_confirmed_then_changed_is_external():
+    """The core case: we set it, proved it landed, and next cycle it is something else."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+    ledger.begin_cycle()
+    verdict = ledger.observe("select.charge_start", "charge_start_time", "19:42", now=400.0, generation=400.0)
+    if verdict != EXTERNAL:
+        print(f"ERROR: expected EXTERNAL, got {verdict}")
+        failed = True
+    if len(ledger.events) != 1:
+        print(f"ERROR: expected exactly one event, got {ledger.events}")
+        failed = True
+    else:
+        event = ledger.events[0]
+        if event["we_set"] != "23:30" or event["now_reads"] != "19:42":
+            print(f"ERROR: event did not carry both values: {event}")
+            failed = True
+    assert not failed, "test_confirmed_then_changed_is_external"
+
+
+def test_matching_read_stays_owned():
+    """Reading back what we set is the normal case and must be silent."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+    ledger.begin_cycle()
+    if ledger.observe("select.charge_start", "charge_start_time", "23:30", now=400.0, generation=400.0) != OWNED:
+        print("ERROR: an unchanged value was not reported as OWNED")
+        failed = True
+    if ledger.events:
+        print(f"ERROR: an unchanged value produced events: {ledger.events}")
+        failed = True
+    assert not failed, "test_matching_read_stays_owned"
+
+
+def test_failed_write_never_owns():
+    """A write that did not verify cannot make us the owner of anything."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.clear("select.charge_start")
+    ledger.begin_cycle()
+    if ledger.observe("select.charge_start", "charge_start_time", "19:42", now=400.0, generation=400.0) != UNOWNED:
+        print("ERROR: a failed write conferred ownership")
+        failed = True
+    assert not failed, "test_failed_write_never_owns"
+
+
+def test_ignore_fail_write_never_owns():
+    """ignore_fail returns success without ever polling, so the helper clears rather than records."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.clear("select.pause_start")
+    ledger.begin_cycle()
+    if ledger.observe("select.pause_start", "pause_start_time", "05:00", now=400.0, generation=400.0) != UNOWNED:
+        print("ERROR: an ignore_fail write conferred ownership")
+        failed = True
+    assert not failed, "test_ignore_fail_write_never_owns"
+
+
+def test_same_cycle_read_is_stale():
+    """A read taken in the same cycle as the confirmation proves nothing new."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+    if ledger.observe("select.charge_start", "charge_start_time", "19:42", now=110.0, generation=110.0) != STALE:
+        print("ERROR: a same-cycle divergence was not treated as stale")
+        failed = True
+    assert not failed, "test_same_cycle_read_is_stale"
+
+
+def test_older_generation_is_stale():
+    """GE serves settings reads from cache, so a read older than our confirmation is not evidence."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=500.0, generation=500.0)
+    ledger.begin_cycle()
+    if ledger.observe("select.charge_start", "charge_start_time", "19:42", now=800.0, generation=400.0) != STALE:
+        print("ERROR: a read generation older than the confirmation was not treated as stale")
+        failed = True
+    if ledger.events:
+        print("ERROR: a stale read produced an event")
+        failed = True
+    assert not failed, "test_older_generation_is_stale"
+
+
+def test_implausible_read_is_suppressed():
+    """00:80 is a corrupt read, not a third party."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.discharge_start", "discharge_start_time", "00:00", now=100.0, generation=100.0)
+    ledger.begin_cycle()
+    if ledger.observe("select.discharge_start", "discharge_start_time", "00:80", now=400.0, generation=400.0) != IMPLAUSIBLE:
+        print("ERROR: an impossible time was not suppressed")
+        failed = True
+    if ledger.events:
+        print("ERROR: an impossible time produced an event")
+        failed = True
+    assert not failed, "test_implausible_read_is_suppressed"
+
+
+def test_write_in_flight_is_settling():
+    """If we wrote since the confirmation, divergence is our own change propagating."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("number.charge_limit", "charge_limit", 90, now=100.0, generation=100.0)
+    ledger.begin_cycle()
+    ledger.note_write_attempt("number.charge_limit")
+    if ledger.observe("number.charge_limit", "charge_limit", 50, now=400.0, generation=400.0) != SETTLING:
+        print("ERROR: an in-flight write was not treated as settling")
+        failed = True
+    assert not failed, "test_write_in_flight_is_settling"
+
+
+def test_event_clears_ownership_so_it_counts_once():
+    """One externally-set value must be one event, not one per cycle forever."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+    for n in range(1, 6):
+        ledger.begin_cycle()
+        ledger.observe("select.charge_start", "charge_start_time", "19:42", now=100.0 + 300 * n, generation=100.0 + 300 * n)
+    if len(ledger.events) != 1:
+        print(f"ERROR: a persistent external value produced {len(ledger.events)} events, expected 1")
+        failed = True
+    assert not failed, "test_event_clears_ownership_so_it_counts_once"
+
+
+def test_second_event_requires_reconfirmation():
+    """PredBat must regain the control before losing it can count again."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+    ledger.begin_cycle()
+    ledger.observe("select.charge_start", "charge_start_time", "19:42", now=400.0, generation=400.0)
+    ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=420.0, generation=420.0)
+    ledger.begin_cycle()
+    ledger.observe("select.charge_start", "charge_start_time", "19:42", now=700.0, generation=700.0)
+    if len(ledger.events) != 2:
+        print(f"ERROR: expected 2 events after a re-confirmation, got {len(ledger.events)}")
+        failed = True
+    assert not failed, "test_second_event_requires_reconfirmation"
+
+
+def test_clear_drops_ownership():
+    """Read-only or calibration means we stopped controlling; later changes are not ours to claim."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+    ledger.clear("select.charge_start")
+    ledger.begin_cycle()
+    if ledger.observe("select.charge_start", "charge_start_time", "19:42", now=400.0, generation=400.0) != UNOWNED:
+        print("ERROR: ownership survived an explicit clear")
+        failed = True
+    assert not failed, "test_clear_drops_ownership"
+
+
+def test_echo_component_never_fires():
+    """Deye/Fox/Enphase republish our own write, so the read always matches - silent, not wrong."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.deye_charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+    for n in range(1, 11):
+        ledger.begin_cycle()
+        ledger.observe("select.deye_charge_start", "charge_start_time", "23:30", now=100.0 + 300 * n, generation=100.0 + 300 * n)
+    if ledger.events:
+        print(f"ERROR: an echoing component produced events: {ledger.events}")
+        failed = True
+    assert not failed, "test_echo_component_never_fires"
+
+
+def test_shared_ems_entity_is_one_record():
+    """A GE EMS assigns one entity to every inverter index; our own write must not look external."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    # Inverter 0 and inverter 1 both drive the same entity id.
+    ledger.record_write("select.ems_charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+    ledger.record_write("select.ems_charge_start", "charge_start_time", "01:00", now=110.0, generation=110.0)
+    ledger.begin_cycle()
+    if ledger.observe("select.ems_charge_start", "charge_start_time", "01:00", now=400.0, generation=400.0) != OWNED:
+        print("ERROR: the second inverter's own write was not recognised as ours")
+        failed = True
+    if ledger.events:
+        print("ERROR: PredBat's own write on a shared EMS entity was reported as external")
+        failed = True
+    assert not failed, "test_shared_ems_entity_is_one_record"
+
+
+def test_unavailable_read_is_suppressed():
+    """An entity that dropped out is not a third party changing the setting.
+
+    inverter_mode has no plausibility rule, so without an explicit rung this falls all the
+    way through to EXTERNAL and accuses somebody of an outage.
+    """
+    failed = False
+    for dropout in (None, "unavailable", "unknown", "", "None"):
+        ledger = ControlLedger()
+        ledger.begin_cycle()
+        ledger.record_write("select.inverter_mode", "inverter_mode", "Eco", now=100.0, generation=100.0)
+        ledger.begin_cycle()
+        verdict = ledger.observe("select.inverter_mode", "inverter_mode", dropout, now=400.0, generation=400.0)
+        if verdict != UNAVAILABLE:
+            print(f"ERROR: a read of {dropout!r} gave {verdict}, expected UNAVAILABLE")
+            failed = True
+        if ledger.events:
+            print(f"ERROR: a read of {dropout!r} produced an event: {ledger.events}")
+            failed = True
+    assert not failed, "test_unavailable_read_is_suppressed"
+
+
+def test_unavailable_readback_never_owns():
+    """Confirming that the inverter holds "unavailable" is meaningless, so it cannot own."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("select.inverter_mode", "inverter_mode", "unavailable", now=100.0, generation=100.0)
+    ledger.begin_cycle()
+    if ledger.observe("select.inverter_mode", "inverter_mode", "Eco", now=400.0, generation=400.0) != UNOWNED:
+        print("ERROR: an unavailable read-back conferred ownership")
+        failed = True
+    assert not failed, "test_unavailable_readback_never_owns"
+
+
+def test_ledger_generation_reads_last_updated():
+    """The generation helper pulls timing metadata off the raw HA state record."""
+    failed = False
+    from inverter import Inverter
+
+    class _Base:
+        def __init__(self, entities):
+            self.entities = entities
+
+        def get_state_wrapper(self, entity_id, raw=False, **kwargs):
+            record = self.entities.get(entity_id)
+            return record if raw else (record.get("state") if record else None)
+
+    class _Stub:
+        def __init__(self, entities):
+            self.base = _Base(entities)
+
+    stub = _Stub({"select.charge_start": {"state": "23:30", "last_updated": 1234.5}})
+    if Inverter._ledger_generation(stub, "select.charge_start") != 1234.5:
+        print("ERROR: last_updated was not returned")
+        failed = True
+    if Inverter._ledger_generation(stub, "select.missing") is not None:
+        print("ERROR: a missing entity should yield None")
+        failed = True
+
+    class _Raiser:
+        base = type("B", (), {"get_state_wrapper": lambda self, *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))})()
+
+    if Inverter._ledger_generation(_Raiser(), "select.charge_start") is not None:
+        print("ERROR: a raising state read should yield None, not propagate")
+        failed = True
+    assert not failed, "test_ledger_generation_reads_last_updated"
+
+
+class _RecordingLedger:
+    """Records the ledger calls a write helper makes, so the wiring itself can be asserted.
+
+    The manufacturer suites all run with control_ledger unset, so they only ever exercise the
+    `ledger is None` no-op branches - they would pass identically against wiring that called
+    observe()/record_write() with swapped arguments, the wrong value, or not at all. This fake
+    is what actually watches the hooks fire.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def owned_value(self, entity_id):
+        return None
+
+    def observe(self, entity_id, control, value, now=0.0, generation=None):
+        self.calls.append(("observe", entity_id, control, value))
+        return UNOWNED
+
+    def note_write_attempt(self, entity_id):
+        self.calls.append(("note_write_attempt", entity_id))
+
+    def record_write(self, entity_id, control, read_back, fuzzy=0, now=0.0, generation=None):
+        self.calls.append(("record_write", entity_id, control, read_back))
+
+    def clear(self, entity_id=None):
+        self.calls.append(("clear", entity_id))
+
+
+class _ScriptedBase:
+    """Minimal stand-in for the predbat instance a write helper reaches through self.base.
+
+    raw=True calls (from _ledger_generation) get a record in the shape ha.py's
+    update_state_item() actually stores - state, attributes and last_changed - rather than an
+    invented one, so a helper driven through this fake exercises the same generation-parsing
+    path production does. `generation` is per-instance so a test can run one phase of a
+    scenario, then a later phase with a NEWER generation; leaving it fixed would let the
+    ledger's freshness gate suppress everything and make a dropout test pass for the wrong
+    reason. Plain calls pop through a scripted sequence of state reads and then repeat the
+    last one, so a test only has to script the values it cares about and a retry loop can run
+    to exhaustion without running out of script. non_raw_reads counts every non-raw call, so a
+    test can pin the exact number of live state fetches a helper makes - the only way to catch
+    a superfluous extra fetch when the fake would otherwise return the same repeated value
+    either way.
+    """
+
+    def __init__(self, state_sequence, ledger=None, generation=1000.0):
+        self._state_sequence = list(state_sequence)
+        self.control_ledger = ledger
+        self.generation = generation
+        self.non_raw_reads = 0
+        # call_service_template() reaches for these on self.base.
+        self.args = {}
+        self.last_service_hash = {}
+        # Control name -> entity id, for helpers that resolve a control by name.
+        self.arg_entities = {}
+        self.logs = []
+
+    def get_state_wrapper(self, entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False):
+        if raw:
+            return {"state": self._state_sequence[0], "attributes": {}, "last_changed": self.generation}
+        self.non_raw_reads += 1
+        if len(self._state_sequence) > 1:
+            return self._state_sequence.pop(0)
+        return self._state_sequence[0]
+
+    def log(self, msg):
+        self.logs.append(msg)
+
+    def get_arg(self, name, indirect=True, index=None, default=None, **kwargs):
+        return self.arg_entities.get(name, default)
+
+    def record_status(self, msg, had_errors=False):
+        pass
+
+    def set_state_wrapper(self, entity_id=None, state=None, attributes=None, required_unit=None):
+        pass
+
+    def call_service_wrapper(self, service, **kwargs):
+        pass
+
+    def unit_conversion(self, entity_id, state, units, required_unit, going_to=False):
+        return state
+
+    def resolve_arg(self, template, value, indirect=True, index=None, default="", extra_args=None):
+        return value
+
+
+def _stub_inverter(state_sequence, ledger=None, generation=1000.0):
+    """Build a real (uninitialised) Inverter instance wired to a scripted base.
+
+    Using Inverter.__new__ rather than a duck-typed class means self._ledger_generation(...)
+    inside the helpers resolves to the real bound method, not a hand-copied stand-in - the same
+    reasoning that ruled out copying _ledger_generation into a test fake applies to the helpers
+    that call it internally.
+    """
+    from inverter import Inverter
+
+    stub = Inverter.__new__(Inverter)
+    stub.base = _ScriptedBase(state_sequence, ledger=ledger, generation=generation)
+    stub.log = stub.base.log
+    stub.id = 0
+    stub.count_register_writes = 0
+    stub.created_attributes = {}
+    stub.inv_write_and_poll_sleep = 0
+    stub.sleep = lambda seconds: None
+    stub.inv_has_mqtt_api = False
+    stub.inv_mqtt_topic = "test"
+    return stub
+
+
+def test_wiring_no_write_needed_skips_note_and_record():
+    """A read that already matches must not be treated as a write attempt.
+
+    This is the property that matters most: if note_write_attempt fired here with no matching
+    record_write, the control would be stuck reporting SETTLING forever (correction 2 in the
+    task brief). write_and_poll_option has no such fast path - it always issues at least one
+    write regardless of whether old_value already equals new_value - so this property does not
+    apply to it.
+    """
+    failed = False
+    ledger = _RecordingLedger()
+    stub = _stub_inverter([True], ledger=ledger)
+    if not stub.write_and_poll_switch("enable", "switch.charge_enable", True):
+        print("ERROR: write_and_poll_switch should report success with nothing to do")
+        failed = True
+    if ledger.calls != [("observe", "switch.charge_enable", "enable", True)]:
+        print(f"ERROR: write_and_poll_switch no-write-needed call list was {ledger.calls}")
+        failed = True
+
+    ledger = _RecordingLedger()
+    stub = _stub_inverter([50.0], ledger=ledger)
+    if not stub.write_and_poll_value("charge_limit", "number.charge_limit", 50.0, fuzzy=0):
+        print("ERROR: write_and_poll_value should report success with nothing to do")
+        failed = True
+    if ledger.calls != [("observe", "number.charge_limit", "charge_limit", 50.0)]:
+        print(f"ERROR: write_and_poll_value no-write-needed call list was {ledger.calls}")
+        failed = True
+
+    assert not failed, "test_wiring_no_write_needed_skips_note_and_record"
+
+
+def test_wiring_successful_write_records_actual_read_back():
+    """record_write must carry the value actually read back, not the value requested.
+
+    write_and_poll_value's fuzzy tolerance is the only one of the three helpers where a
+    successful write can read back something other than new_value - switch and option only
+    ever succeed on an exact match, so their read_back is structurally equal to new_value at
+    that point and cannot be distinguished from it there. Their assertions below still confirm
+    record_write fires with the correct value, just not that it differs from new_value.
+
+    write_and_poll_switch records the RAW read ("on"), not the coerced bool it compares
+    against new_value. The owned value has to be the same shape as the reads it will later be
+    compared with: storing True and then observing "on" makes every subsequent healthy read
+    look like a change, which is PredBat reporting its own successful write as a third party.
+    """
+    failed = False
+    ledger = _RecordingLedger()
+    stub = _stub_inverter([2000.0, 2950.0], ledger=ledger)
+    if not stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130):
+        print("ERROR: write_and_poll_value should report success")
+        failed = True
+    record_calls = [c for c in ledger.calls if c[0] == "record_write"]
+    if record_calls != [("record_write", "number.charge_rate", "charge_rate", 2950.0)]:
+        print(f"ERROR: write_and_poll_value success record_write was {record_calls}")
+        failed = True
+    if record_calls and record_calls[0][3] == 3000:
+        print("ERROR: record_write was passed the requested value, not the read-back")
+        failed = True
+
+    ledger = _RecordingLedger()
+    stub = _stub_inverter(["off", "on"], ledger=ledger)
+    if not stub.write_and_poll_switch("enable", "switch.charge_enable", True):
+        print("ERROR: write_and_poll_switch should report success")
+        failed = True
+    record_calls = [c for c in ledger.calls if c[0] == "record_write"]
+    if record_calls != [("record_write", "switch.charge_enable", "enable", "on")]:
+        print(f"ERROR: write_and_poll_switch success record_write was {record_calls}")
+        failed = True
+
+    ledger = _RecordingLedger()
+    stub = _stub_inverter(["Normal", "Eco"], ledger=ledger)
+    if not stub.write_and_poll_option("inverter_mode", "select.inverter_mode", "Eco"):
+        print("ERROR: write_and_poll_option should report success")
+        failed = True
+    record_calls = [c for c in ledger.calls if c[0] == "record_write"]
+    if record_calls != [("record_write", "select.inverter_mode", "inverter_mode", "Eco")]:
+        print(f"ERROR: write_and_poll_option success record_write was {record_calls}")
+        failed = True
+
+    assert not failed, "test_wiring_successful_write_records_actual_read_back"
+
+
+def test_wiring_ignore_fail_drops_ownership():
+    """ignore_fail returns success without ever polling, so it must not confer ownership.
+
+    write_and_poll_switch has no ignore_fail parameter at all, so this property applies only
+    to write_and_poll_value and write_and_poll_option.
+    """
+    failed = False
+    ledger = _RecordingLedger()
+    stub = _stub_inverter([10.0], ledger=ledger)
+    if not stub.write_and_poll_value("charge_limit", "number.charge_limit", 50.0, fuzzy=0, ignore_fail=True):
+        print("ERROR: write_and_poll_value with ignore_fail should report success")
+        failed = True
+    if ledger.calls != [
+        ("observe", "number.charge_limit", "charge_limit", 10.0),
+        ("note_write_attempt", "number.charge_limit"),
+        ("clear", "number.charge_limit"),
+    ]:
+        print(f"ERROR: write_and_poll_value ignore_fail call list was {ledger.calls}")
+        failed = True
+
+    ledger = _RecordingLedger()
+    stub = _stub_inverter(["Normal"], ledger=ledger)
+    if not stub.write_and_poll_option("inverter_mode", "select.inverter_mode", "Eco", ignore_fail=True):
+        print("ERROR: write_and_poll_option with ignore_fail should report success")
+        failed = True
+    if ledger.calls != [
+        ("observe", "select.inverter_mode", "inverter_mode", "Normal"),
+        ("note_write_attempt", "select.inverter_mode"),
+        ("clear", "select.inverter_mode"),
+    ]:
+        print(f"ERROR: write_and_poll_option ignore_fail call list was {ledger.calls}")
+        failed = True
+
+    assert not failed, "test_wiring_ignore_fail_drops_ownership"
+
+
+def test_wiring_failed_write_clears_ownership():
+    """A write that never verifies must CLEAR ownership, not record anything.
+
+    Expressing this as record_write(read_back=..., ok=False) passed the ledger a value it
+    then discarded; clear(entity_id) says what is meant. Either way the property under test is
+    the same and is the one that matters: a control PredBat has just failed to set must not be
+    left owned, or the next read of it is reported as somebody else's change.
+
+    The write_and_poll_option assertion also pins the fix for the superfluous live fetch an
+    earlier round found - non_raw_reads pins the exact number of live state reads (1 initial +
+    one per retry + 1 in the failure log line), so a reintroduced extra fetch there fails this
+    test even though the fake would return the same value either way.
+    """
+    failed = False
+    for label, entity_id, first_read, drive in (
+        ("write_and_poll_switch", "switch.charge_enable", False, lambda stub, e="switch.charge_enable": stub.write_and_poll_switch("enable", e, True)),
+        ("write_and_poll_value", "number.charge_limit", 10.0, lambda stub, e="number.charge_limit": stub.write_and_poll_value("charge_limit", e, 50.0, fuzzy=0)),
+        ("write_and_poll_option", "select.inverter_mode", "Normal", lambda stub, e="select.inverter_mode": stub.write_and_poll_option("inverter_mode", e, "Eco")),
+    ):
+        ledger = _RecordingLedger()
+        stub = _stub_inverter([first_read], ledger=ledger)
+        if drive(stub):
+            print(f"ERROR: {label} should report failure when the read-back never matches")
+            failed = True
+        if [c for c in ledger.calls if c[0] == "record_write"]:
+            print(f"ERROR: {label} recorded ownership for a write that never verified: {ledger.calls}")
+            failed = True
+        if ("clear", entity_id) not in ledger.calls:
+            print(f"ERROR: {label} failure did not clear ownership: {ledger.calls}")
+            failed = True
+        if label == "write_and_poll_option":
+            expected_reads = INVERTER_MAX_RETRY + 2  # 1 initial + one per retry + 1 in the failure log line
+            if stub.base.non_raw_reads != expected_reads:
+                print(f"ERROR: write_and_poll_option failure path made {stub.base.non_raw_reads} live state reads, expected {expected_reads} - a superfluous extra fetch has crept back in")
+                failed = True
+
+    assert not failed, "test_wiring_failed_write_clears_ownership"
+
+
+def test_wiring_observe_precedes_note_write_attempt():
+    """The read being classified must not be contaminated by the write-attempt flag it is
+    about to set - observe() must be called, and recorded, before note_write_attempt() for
+    the same entity.
+    """
+    failed = False
+    ledger = _RecordingLedger()
+    stub = _stub_inverter(["off", "on"], ledger=ledger)
+    stub.write_and_poll_switch("enable", "switch.charge_enable", True)
+    order = [c[0] for c in ledger.calls]
+    if "observe" not in order or "note_write_attempt" not in order or order.index("observe") > order.index("note_write_attempt"):
+        print(f"ERROR: write_and_poll_switch call order was {ledger.calls}")
+        failed = True
+
+    ledger = _RecordingLedger()
+    stub = _stub_inverter([2000.0, 2950.0], ledger=ledger)
+    stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+    order = [c[0] for c in ledger.calls]
+    if "observe" not in order or "note_write_attempt" not in order or order.index("observe") > order.index("note_write_attempt"):
+        print(f"ERROR: write_and_poll_value call order was {ledger.calls}")
+        failed = True
+
+    ledger = _RecordingLedger()
+    stub = _stub_inverter(["Normal", "Eco"], ledger=ledger)
+    stub.write_and_poll_option("inverter_mode", "select.inverter_mode", "Eco")
+    order = [c[0] for c in ledger.calls]
+    if "observe" not in order or "note_write_attempt" not in order or order.index("observe") > order.index("note_write_attempt"):
+        print(f"ERROR: write_and_poll_option call order was {ledger.calls}")
+        failed = True
+
+    assert not failed, "test_wiring_observe_precedes_note_write_attempt"
+
+
+def test_wiring_dropout_read_is_never_reported_external():
+    """An entity dropout must produce NO event, driven through the REAL write helpers.
+
+    write_and_poll_value coerces a failed read - "unavailable", "unknown", a missing entity -
+    to 0.0 before comparing it to new_value, and write_and_poll_switch maps the same reads to
+    False. Both are plausible-looking values: 0.0 passes is_reading(), is a valid percentage,
+    and rates have no plausibility rule at all, so a coerced dropout walks every suppression
+    rung and lands on EXTERNAL. Customer-facing that reads as "a third party set your charge
+    rate to 0 W", manufactured by a routine integration dropout.
+
+    Ownership is established through the helper itself rather than a hand-written
+    record_write, so the owned value has exactly the shape production stores - a fabricated
+    record could match a coerced read by luck and hide the bug.
+    """
+    failed = False
+    for dropout in ("unavailable", "unknown", None):
+        ledger = ControlLedger()
+        ledger.begin_cycle()
+        # Reads 2000, writes 3000, reads back 2950 (inside fuzzy) - confirmed and owned.
+        stub = _stub_inverter([2000.0, 2950.0], ledger=ledger, generation=1000.0)
+        stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+        if "number.charge_rate" not in ledger.records:
+            print(f"ERROR: the confirming write did not confer ownership, so {dropout!r} proves nothing")
+            failed = True
+        # Next cycle, on a NEWER generation so the freshness gate cannot be what suppresses it.
+        ledger.begin_cycle()
+        stub = _stub_inverter([dropout], ledger=ledger, generation=2000.0)
+        stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+        if ledger.events:
+            print(f"ERROR: a numeric read of {dropout!r} was reported as external: {ledger.events}")
+            failed = True
+
+        ledger = ControlLedger()
+        ledger.begin_cycle()
+        stub = _stub_inverter(["off", "on"], ledger=ledger, generation=1000.0)
+        stub.write_and_poll_switch("enable", "switch.charge_enable", True)
+        if "switch.charge_enable" not in ledger.records:
+            print(f"ERROR: the confirming switch write did not confer ownership, so {dropout!r} proves nothing")
+            failed = True
+        ledger.begin_cycle()
+        stub = _stub_inverter([dropout], ledger=ledger, generation=2000.0)
+        stub.write_and_poll_switch("enable", "switch.charge_enable", True)
+        if ledger.events:
+            print(f"ERROR: a switch read of {dropout!r} was reported as external: {ledger.events}")
+            failed = True
+    assert not failed, "test_wiring_dropout_read_is_never_reported_external"
+
+
+def test_wiring_freshness_gate_survives_a_long_quiet_interval():
+    """A divergence an hour and a dozen cycles after the confirmation must still report.
+
+    Fox is not an echo component the way Deye is - compute_schedule() rebuilds local_schedule
+    from real vendor scheduler data, and the settings poll is hourly, so vendor state can reach
+    the control entity up to an hour after Predbat's write. That makes the freshness gate
+    load-bearing for Fox rather than incidental, and it has to cut both ways: suppress a read
+    OLDER than the confirmation, and pass a genuinely newer one however long the wait.
+
+    The quiet cycles in the middle deliberately keep last_changed pinned at the confirmation
+    time, because Home Assistant only moves it when the value actually changes - so the gate is
+    being fed a generation EQUAL to its confirmation for an hour, and ownership has to survive
+    that intact. Generations are ISO strings here, which is what ha.py actually stores.
+    """
+    failed = False
+    confirmed_at = "2026-08-21T07:00:00+00:00"
+    hourly_poll = "2026-08-21T07:55:00+00:00"  # vendor state finally reaches the entity
+    cached_read = "2026-08-21T06:30:00+00:00"  # a read older than our confirmation
+
+    for divergent_generation, expected_events, label in ((hourly_poll, 1, "newer"), (cached_read, 0, "older")):
+        ledger = ControlLedger()
+        ledger.begin_cycle()
+        stub = _stub_inverter([50.0, 90.0], ledger=ledger, generation=confirmed_at)
+        stub.write_and_poll_value("charge_limit", "number.charge_limit", 90, fuzzy=0)
+        # An hour of 5-minute runs with nothing changing. The value matches, so no write is
+        # needed and last_changed never moves - ownership must ride through all of it.
+        for _ in range(11):
+            ledger.begin_cycle()
+            stub = _stub_inverter([90.0], ledger=ledger, generation=confirmed_at)
+            stub.write_and_poll_value("charge_limit", "number.charge_limit", 90, fuzzy=0)
+        if ledger.events:
+            print(f"ERROR: eleven unchanged cycles produced events: {ledger.events}")
+            failed = True
+        if "number.charge_limit" not in ledger.records:
+            print("ERROR: ownership did not survive an hour of unchanged reads, so the case below proves nothing")
+            failed = True
+        ledger.begin_cycle()
+        stub = _stub_inverter([20.0, 90.0], ledger=ledger, generation=divergent_generation)
+        stub.write_and_poll_value("charge_limit", "number.charge_limit", 90, fuzzy=0)
+        if len(ledger.events) != expected_events:
+            print(f"ERROR: a divergent read on a {label} last_changed produced {len(ledger.events)} events, expected {expected_events}")
+            failed = True
+    assert not failed, "test_wiring_freshness_gate_survives_a_long_quiet_interval"
+
+
+def test_wiring_genuine_external_change_still_reports():
+    """The suppression above must not have been bought by going blind.
+
+    Every other fix in this area moves toward silence, so the one test that has to fail loudly
+    if they went too far is the one that drives a real third-party change through the real
+    helpers and demands an event.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter([2000.0, 2950.0], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+    ledger.begin_cycle()
+    # Somebody has dropped the rate to 500 W between cycles.
+    stub = _stub_inverter([500.0, 2950.0], ledger=ledger, generation=2000.0)
+    stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+    if len(ledger.events) != 1:
+        print(f"ERROR: a genuine external numeric change produced {len(ledger.events)} events, expected 1")
+        failed = True
+
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter(["off", "on"], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_switch("enable", "switch.charge_enable", True)
+    ledger.begin_cycle()
+    # Somebody has turned the switch back off between cycles.
+    stub = _stub_inverter(["off", "on"], ledger=ledger, generation=2000.0)
+    stub.write_and_poll_switch("enable", "switch.charge_enable", True)
+    if len(ledger.events) != 1:
+        print(f"ERROR: a genuine external switch change produced {len(ledger.events)} events, expected 1")
+        failed = True
+    else:
+        event = ledger.events[0]
+        if event["we_set"] != "on" or event["now_reads"] != "off":
+            print(f"ERROR: the switch event did not carry the raw read on both sides: {event}")
+            failed = True
+
+    # And a healthy unchanged read must still be silent, which is what proves the owned value
+    # and the later read are the same shape rather than bool-vs-string.
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter(["off", "on"], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_switch("enable", "switch.charge_enable", True)
+    ledger.begin_cycle()
+    stub = _stub_inverter(["on"], ledger=ledger, generation=2000.0)
+    stub.write_and_poll_switch("enable", "switch.charge_enable", True)
+    if ledger.events:
+        print(f"ERROR: an unchanged healthy switch read was reported as external: {ledger.events}")
+        failed = True
+    assert not failed, "test_wiring_genuine_external_change_still_reports"
+
+
+def test_wiring_other_write_paths_leave_ownership_alone():
+    """Predbat's OTHER write paths must not touch the ledger at all.
+
+    Three mechanisms were tried here - a whole-ledger clear, a narrowed clear, and a deferred
+    invalidation - each against theoretically-constructed configs, and each produced its own crop
+    of defects. None is needed, because the detection pattern is transport-agnostic: read, write,
+    confirm, and report a later differing read. HOW Predbat drove the inverter does not enter into
+    it.
+
+    An MQTT publish reaches a broker topic and no Home Assistant entity, so it has no bearing at
+    all. A service template that writes the value Predbat asked for produces no divergence and so
+    reports nothing on its own; a template that writes something ELSE is a genuine disagreement
+    between the user's automation and Predbat, which is a finding worth surfacing rather than a
+    false positive to suppress.
+    """
+    failed = False
+
+    def _owned():
+        ledger = ControlLedger()
+        ledger.begin_cycle()
+        ledger.record_write("select.charge_start", "charge_start_time", "23:30", now=100.0, generation=100.0)
+        return ledger
+
+    for label, drive in (
+        ("a configured service template", lambda stub: stub.call_service_template("charge_start_service", {"device_id": "abc"}, domain="charge")),
+        ("an MQTT publish", lambda stub: stub.mqtt_message("set/charge", payload=3000)),
+    ):
+        ledger = _owned()
+        stub = _stub_inverter(["23:30"], ledger=ledger)
+        stub.base.args = {"charge_start_service": "script.my_charge_start"}
+        stub.inv_has_mqtt_api = True
+        drive(stub)
+        if "select.charge_start" not in ledger.records:
+            print(f"ERROR: {label} dropped ownership the write helpers had confirmed")
+            failed = True
+        # And the next cycle is live, not suppressed.
+        ledger.begin_cycle()
+        if ledger.observe("select.charge_start", "charge_start_time", "19:42", now=200.0, generation=200.0) != EXTERNAL:
+            print(f"ERROR: {label} suppressed the following cycle")
+            failed = True
+
+    # A template that writes the value Predbat asked for is silent on its own merits - no
+    # suppression needed, because there is no divergence to explain away.
+    ledger = _owned()
+    stub = _stub_inverter(["23:30"], ledger=ledger)
+    stub.base.args = {"charge_start_service": "script.my_charge_start"}
+    stub.call_service_template("charge_start_service", {"device_id": "abc"}, domain="charge")
+    ledger.begin_cycle()
+    if ledger.observe("select.charge_start", "charge_start_time", "23:30", now=200.0, generation=200.0) != OWNED:
+        print("ERROR: a template that wrote the value Predbat asked for was not silent")
+        failed = True
+    if ledger.events:
+        print(f"ERROR: an agreeing template produced an event: {ledger.events}")
+        failed = True
+
+    # call_service_template still reports whether it called anything - unchanged behaviour.
+    ledger = _owned()
+    stub = _stub_inverter(["23:30"], ledger=ledger)
+    stub.base.args = {"charge_start_service": "script.my_charge_start"}
+    if not stub.call_service_template("charge_start_service", {"device_id": "abc"}, domain="charge"):
+        print("ERROR: call_service_template should report that it called something")
+        failed = True
+    stub = _stub_inverter(["23:30"], ledger=ledger)
+    if stub.call_service_template("charge_start_service", {"device_id": "abc"}, domain="charge"):
+        print("ERROR: call_service_template should report that an unconfigured service called nothing")
+        failed = True
+    assert not failed, "test_wiring_other_write_paths_leave_ownership_alone"
+
+
+def test_clear_drops_every_control():
+    """Calibration and read-only clear the WHOLE ledger, not one entity.
+
+    Calibration writes charge rate, battery target and reserve through the ordinary helpers,
+    so they confer ownership - in exactly the mode where the inverter's own firmware is driving
+    its settings and a value found moved next cycle is the inverter, not a third party. That
+    branch (and read-only, belt and braces) therefore calls clear() with no argument, so this
+    pins that the no-argument form drops everything rather than only the last control written.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("number.charge_rate", "charge_rate", 3000, now=100.0, generation=100.0)
+    ledger.record_write("number.charge_limit", "charge_limit", 100.0, now=100.0, generation=100.0)
+    ledger.record_write("number.reserve", "reserve", 0.0, now=100.0, generation=100.0)
+    ledger.clear()
+    if ledger.records:
+        print(f"ERROR: clear() left records behind: {ledger.records}")
+        failed = True
+    ledger.begin_cycle()
+    for entity_id, control, value in [("number.charge_rate", "charge_rate", 500), ("number.charge_limit", "charge_limit", 20.0), ("number.reserve", "reserve", 50.0)]:
+        if ledger.observe(entity_id, control, value, now=400.0, generation=400.0) != UNOWNED:
+            print(f"ERROR: ownership of {entity_id} survived a whole-ledger clear")
+            failed = True
+    if ledger.events:
+        print(f"ERROR: a cleared ledger still produced events: {ledger.events}")
+        failed = True
+    assert not failed, "test_clear_drops_every_control"
+
+
+def test_restore_orders_events_oldest_first():
+    """restore() runs AFTER execute_plan(), so the newest event is the one at risk.
+
+    predbat.py appends this cycle's events during the run and only then restores history, then
+    publishes recent_events()[-20:]. Concatenating history onto the end leaves the newest event
+    FIRST, so on the first run after a restart with a full 24h of history that tail publishes
+    the 20 oldest and silently discards the very event the customer-facing copy quotes.
+    """
+    failed = False
+    ledger = ControlLedger()
+    # This cycle's event, already appended by execute_plan() before restore() runs.
+    ledger.events.append({"at": 100000.0, "control": "charge_start_time", "entity_id": "e_new", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 99000.0})
+    ledger.restore([{"at": 20000.0 + n, "control": "charge_start_time", "entity_id": f"h{n}", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 19000.0} for n in range(20)])
+    if [event["at"] for event in ledger.events] != sorted(event["at"] for event in ledger.events):
+        print(f"ERROR: restored events are not oldest-first: {[e['entity_id'] for e in ledger.events]}")
+        failed = True
+    published = ledger.recent_events(now=100000.0, window_s=86400)[-20:]
+    if not any(event["entity_id"] == "e_new" for event in published):
+        print(f"ERROR: the newest event was dropped by the 20-event publish cap: {[e['entity_id'] for e in published]}")
+        failed = True
+
+    # History that interleaves with events already held must land in the right places.
+    ledger = ControlLedger()
+    ledger.events.append({"at": 500.0, "control": "reserve", "entity_id": "live"})
+    ledger.restore([{"at": 900.0, "entity_id": "later"}, {"at": 100.0, "entity_id": "earlier"}])
+    if [event["entity_id"] for event in ledger.events] != ["earlier", "live", "later"]:
+        print(f"ERROR: restore did not interleave by time: {[e['entity_id'] for e in ledger.events]}")
+        failed = True
+
+    # An "at" that survived a round trip through HA as something unsortable must not raise -
+    # a crash here would take out the whole plan run.
+    ledger = ControlLedger()
+    ledger.events.append({"at": 5.0, "entity_id": "live"})
+    try:
+        ledger.restore([{"at": "not-a-timestamp", "entity_id": "junk"}, {"at": None, "entity_id": "null"}, {"at": 1.0, "entity_id": "early"}])
+    except Exception as e:
+        print(f"ERROR: sorting a malformed 'at' raised: {e}")
+        failed = True
+    if len(ledger.events) != 4:
+        print(f"ERROR: expected all 4 events to survive the sort, got {len(ledger.events)}")
+        failed = True
+    assert not failed, "test_restore_orders_events_oldest_first"
+
+
+def test_recent_events_filters_by_window():
+    """Only events inside the rolling window count."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.events = [
+        {"at": 1000.0, "control": "charge_start_time", "entity_id": "e1", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 900.0},
+        {"at": 90000.0, "control": "charge_start_time", "entity_id": "e1", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 89000.0},
+    ]
+    recent = ledger.recent_events(now=90000.0, window_s=86400)
+    if len(recent) != 1:
+        print(f"ERROR: expected 1 event inside the window, got {len(recent)}")
+        failed = True
+    assert not failed, "test_recent_events_filters_by_window"
+
+
+def test_restore_rehydrates_and_filters():
+    """The 24h window survives a restart by reloading the entity's own attributes."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.restore(
+        [
+            {"at": 1000.0, "control": "charge_start_time", "entity_id": "e1", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 900.0},
+            {"at": 89000.0, "control": "charge_start_time", "entity_id": "e1", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 88000.0},
+            "not a dict",
+            {"missing": "at"},
+        ]
+    )
+    if len(ledger.events) != 2:
+        print(f"ERROR: expected 2 restored events, got {len(ledger.events)}")
+        failed = True
+    ledger.restore(None)
+    if len(ledger.events) != 2:
+        print("ERROR: restoring None should be a no-op, not a wipe")
+        failed = True
+    assert not failed, "test_restore_rehydrates_and_filters"
+
+
+def test_restore_ignores_non_list_attribute():
+    """A corrupt read-back of the "events" attribute must not crash the plan run.
+
+    The attribute round-trips through Home Assistant, so restore() may be handed
+    anything - here a bare int, which a naive `for event in events` would raise on.
+    """
+    failed = False
+    ledger = ControlLedger()
+    for garbage in (42, {"not": "a list"}, "a bare string"):
+        try:
+            ledger.restore(garbage)
+        except Exception as e:
+            print(f"ERROR: restore({garbage!r}) raised: {e}")
+            failed = True
+    if ledger.events:
+        print(f"ERROR: non-list input should not populate events, got {ledger.events}")
+        failed = True
+    assert not failed, "test_restore_ignores_non_list_attribute"
+
+
+def test_sustained_lists_repeat_offenders():
+    """Three or more events on one control in the window is the reportable state."""
+    failed = False
+    ledger = ControlLedger()
+    ledger.events = [{"at": 1000.0 + n, "control": "charge_start_time", "entity_id": "e1", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 900.0} for n in range(3)]
+    ledger.events.append({"at": 1010.0, "control": "reserve", "entity_id": "e2", "we_set": 4, "now_reads": 50, "confirmed_at": 900.0})
+    sustained = ledger.sustained_controls(ledger.recent_events(now=1100.0), threshold=3)
+    if sustained != ["charge_start_time"]:
+        print(f"ERROR: expected only charge_start_time sustained, got {sustained}")
+        failed = True
+    assert not failed, "test_sustained_lists_repeat_offenders"
+
+
+def test_restored_event_with_string_at_does_not_raise():
+    """A restored event round-tripped through HA is not guaranteed to keep its type.
+
+    restore() only checks for a dict with an "at" key, so a malformed "at" (a
+    non-numeric string, here) can still land in self.events. recent_events(), prune()
+    and sustained_controls() must not raise on it - a crash here would take out the
+    whole plan run, which is far worse than losing one event's history.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.restore(
+        [
+            {"at": "not-a-timestamp", "control": "charge_start_time", "entity_id": "e1", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 900.0},
+            {"at": "1000.0", "control": "charge_start_time", "entity_id": "e1", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 900.0},
+        ]
+    )
+    if len(ledger.events) != 2:
+        print(f"ERROR: expected both malformed-but-dict events to be restored, got {len(ledger.events)}")
+        failed = True
+    try:
+        recent = ledger.recent_events(now=1000.0, window_s=86400)
+        sustained = ledger.sustained_controls(ledger.recent_events(now=1000.0))
+        ledger.prune(now=1000.0, window_s=86400)
+    except Exception as e:
+        print(f"ERROR: window methods raised on a string 'at': {e}")
+        failed = True
+        recent = []
+        sustained = []
+    # The non-numeric string can never be judged inside the window, so it is dropped
+    # rather than trusted. The numeric-looking string ("1000.0") is still usable.
+    if len(recent) != 1 or recent[0]["at"] != "1000.0":
+        print(f"ERROR: expected only the numeric-string event to survive, got {recent}")
+        failed = True
+    if sustained:
+        print(f"ERROR: expected no sustained controls from a single surviving event, got {sustained}")
+        failed = True
+    assert not failed, "test_restored_event_with_string_at_does_not_raise"
+
+
+def test_sustained_controls_survives_event_missing_control_key():
+    """restore() only requires an "at" key, so a restored event can carry no "control".
+
+    sustained_controls() sorts control names; Python 3 refuses to order None against a
+    str, so a mix of a control=None event and a real control name must not crash the
+    whole plan run.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.restore(
+        [
+            {"at": 100.0},
+            {"at": 101.0},
+            {"at": 102.0},
+            {"at": 103.0, "control": "charge_start_time"},
+            {"at": 104.0, "control": "charge_start_time"},
+            {"at": 105.0, "control": "charge_start_time"},
+        ]
+    )
+    try:
+        sustained = ledger.sustained_controls(ledger.recent_events(now=200.0), threshold=3)
+    except Exception as e:
+        print(f"ERROR: sustained_controls raised on a control=None event: {e}")
+        failed = True
+        sustained = []
+    if "charge_start_time" not in sustained:
+        print(f"ERROR: expected charge_start_time to still be reported, got {sustained}")
+        failed = True
+    # The list is written straight into the customer-facing "sustained" attribute and
+    # interpolated into a log line, so a nameless event must not reach it at all - counting
+    # them under None produced ["sustained on [None, 'charge_start_time']"].
+    for nothing in (None, "", "   "):
+        if nothing in sustained:
+            print(f"ERROR: {nothing!r} reached the customer-facing sustained list: {sustained}")
+            failed = True
+    # An event with no usable name must not be able to reach the threshold on its own either.
+    ledger = ControlLedger()
+    ledger.restore([{"at": 100.0} for _ in range(5)] + [{"at": 100.0, "control": ""} for _ in range(5)])
+    if ledger.sustained_controls(ledger.recent_events(now=200.0), threshold=3):
+        print(f"ERROR: nameless events alone produced a sustained list: {ledger.sustained_controls(ledger.recent_events(now=200.0))}")
+        failed = True
+    assert not failed, "test_sustained_controls_survives_event_missing_control_key"
+
+
+def test_future_dated_events_are_not_counted():
+    """An event stamped in the future cannot be judged, so it must not reach the customer count.
+
+    recent_events() bounded the window only from above, and `(now - at) <= window_s` is satisfied
+    by ANY negative age, so a future "at" counted for ever - and restore() reloaded it from the
+    published attribute, so a restart did not clear it either. A pod that starts before NTP sync,
+    or a corrupt "events" attribute, reaches that. The count is customer facing, so a permanent
+    phantom event is a permanent false accusation.
+
+    This is a READ-path rule only. prune() deliberately keeps these - see
+    test_prune_keeps_future_dated_events() for why deleting them destroys real history.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.events = [{"at": 10**12, "control": "reserve"}, {"at": 950.0, "control": "reserve"}]
+    if [event["at"] for event in ledger.recent_events(now=1000.0)] != [950.0]:
+        print(f"ERROR: a far-future event was counted: {ledger.recent_events(now=1000.0)}")
+        failed = True
+    if ledger.sustained_controls(ledger.recent_events(now=1000.0), threshold=1) != ["reserve"]:
+        print("ERROR: the sustained list did not match the events inside the window")
+        failed = True
+
+    # Ordinary clock jitter between the write and the publish must NOT be thrown away.
+    ledger = ControlLedger()
+    ledger.events = [{"at": 1030.0, "control": "reserve"}]
+    if len(ledger.recent_events(now=1000.0)) != 1:
+        print("ERROR: a 30s forward jitter was discarded as future-dated")
+        failed = True
+
+    # And an event that has genuinely aged out is still excluded from the other end.
+    ledger = ControlLedger()
+    ledger.events = [{"at": 100.0, "control": "reserve"}, {"at": 90000.0, "control": "reserve"}]
+    if [event["at"] for event in ledger.recent_events(now=100000.0)] != [90000.0]:
+        print("ERROR: the upper window bound stopped working")
+        failed = True
+    assert not failed, "test_future_dated_events_are_not_counted"
+
+
+def test_recent_events_survives_a_malformed_event():
+    """A non-dict event must be dropped, not raise out of the middle of a plan run.
+
+    restore() deliberately does not filter a bad "at", and the attribute round-trips through
+    Home Assistant, so anything can be in the list. _event_time() already tolerated that for
+    sorting; recent_events() re-implemented the parse with narrower exception handling, so a
+    non-dict sorted perfectly happily and then raised AttributeError on the next filter.
+    """
+    failed = False
+    for junk in ("not-a-dict", 42, None, ["at", 100.0]):
+        ledger = ControlLedger()
+        ledger.events = [junk, {"at": 950.0, "control": "reserve"}]
+        try:
+            recent = ledger.recent_events(now=1000.0)
+        except Exception as e:
+            print(f"ERROR: recent_events raised on {junk!r}: {type(e).__name__}: {e}")
+            failed = True
+            continue
+        if recent != [{"at": 950.0, "control": "reserve"}]:
+            print(f"ERROR: {junk!r} was not dropped from the window: {recent}")
+            failed = True
+        try:
+            ledger.sustained_controls(ledger.recent_events(now=1000.0))
+        except Exception as e:
+            print(f"ERROR: sustained_controls raised on {junk!r}: {type(e).__name__}: {e}")
+            failed = True
+    assert not failed, "test_recent_events_survives_a_malformed_event"
+
+
+def test_is_plausible_validates_hour_and_minute_components():
+    """The H M charge-window family carries clock semantics and must be validated.
+
+    adjust_charge_window() writes charge_start_hour/minute and the discharge equivalents
+    whenever inv_charge_time_format is "H M". They fell through to True, so a Modbus or GivTCP
+    glitch returning 255 or -1 walked every suppression rung and became an accusation. The
+    FULL time string is a legitimate read of the same control on `time.` entities (FB00
+    firmware), so it has to stay plausible or that firmware goes silently undetectable.
+    """
+    failed = False
+    for control in ("charge_start_hour", "charge_end_hour", "discharge_start_hour", "discharge_end_hour"):
+        for good in (0, 23, "07", 7.0, "23:30", "23:30:00"):
+            if not is_plausible(control, good):
+                print(f"ERROR: {control} rejected a valid {good!r}")
+                failed = True
+        for bad in (255, 24, -1, "24", "not-an-hour", None):
+            if is_plausible(control, bad):
+                print(f"ERROR: {control} accepted {bad!r}")
+                failed = True
+    for control in ("charge_start_minute", "charge_end_minute", "discharge_start_minute", "discharge_end_minute"):
+        for good in (0, 59, "30", "23:30"):
+            if not is_plausible(control, good):
+                print(f"ERROR: {control} rejected a valid {good!r}")
+                failed = True
+        for bad in (255, 60, -1, "not-a-minute", None):
+            if is_plausible(control, bad):
+                print(f"ERROR: {control} accepted {bad!r}")
+                failed = True
+    assert not failed, "test_is_plausible_validates_hour_and_minute_components"
+
+
+def test_implausible_hour_read_is_suppressed_and_logged():
+    """The rule above must actually suppress through the real helper - and say so in the log.
+
+    All three call sites discard observe()'s verdict, so every suppression rung was invisible:
+    a customer reporting interference against an entity reading 0 gave no way to tell whether
+    the ledger owned nothing, suppressed on the freshness gate, refused the read, or had been
+    wiped. This drives a glitched 255 through write_and_poll_value and demands both silence
+    and a diagnostic.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter([1.0, 5.0], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_value("charge_start_hour", "number.charge_start_hour", 5)
+    if "number.charge_start_hour" not in ledger.records:
+        print("ERROR: the confirming write did not confer ownership, so the case below proves nothing")
+        failed = True
+    ledger.begin_cycle()
+    stub = _stub_inverter([255.0, 5.0], ledger=ledger, generation=2000.0)
+    stub.write_and_poll_value("charge_start_hour", "number.charge_start_hour", 5)
+    if ledger.events:
+        print(f"ERROR: a glitched hour read of 255 was reported as external: {ledger.events}")
+        failed = True
+    if not any("control ledger" in line and IMPLAUSIBLE in line for line in stub.base.logs):
+        print(f"ERROR: the implausible verdict was suppressed silently: {stub.base.logs}")
+        failed = True
+
+    # A verdict of STALE - the other rung a support engineer needs to be able to see.
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter([50.0, 90.0], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_value("charge_limit", "number.charge_limit", 90)
+    stub = _stub_inverter([20.0, 90.0], ledger=ledger, generation=2000.0)  # same cycle
+    stub.write_and_poll_value("charge_limit", "number.charge_limit", 90)
+    if not any("control ledger" in line and STALE in line for line in stub.base.logs):
+        print(f"ERROR: the stale verdict was suppressed silently: {stub.base.logs}")
+        failed = True
+
+    # A healthy owned read must NOT log - the diagnostic has to stay readable.
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter([50.0, 90.0], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_value("charge_limit", "number.charge_limit", 90)
+    ledger.begin_cycle()
+    stub = _stub_inverter([90.0], ledger=ledger, generation=2000.0)
+    stub.write_and_poll_value("charge_limit", "number.charge_limit", 90)
+    if any("control ledger" in line for line in stub.base.logs):
+        print(f"ERROR: a healthy owned read produced a ledger log line: {stub.base.logs}")
+        failed = True
+    assert not failed, "test_implausible_hour_read_is_suppressed_and_logged"
+
+
+def test_steady_control_stays_owned_indefinitely():
+    """A control Predbat sets once and never rewrites must still be watched days later.
+
+    adjust_reserve (inverter.py:1794), adjust_battery_target (:1963) and adjust_charge_window
+    (:3157) only call the write helper when the value DIFFERS, so a reserve sitting at its
+    minimum produces no observe() and no record_write for days on end. Ageing the confirmation
+    out therefore blinds precisely the steady controls most likely to be quietly changed by
+    somebody else, every single day, in silence.
+
+    Elapsed time cannot distinguish "Predbat stopped controlling this" from "Predbat is
+    controlling it and has nothing to change", so the ledger does not try. The residual risk - a
+    user disables a switch, hand-edits the value, re-enables - produces a SINGLE event, and single
+    events are recorded but never surfaced: the customer-visible list needs three on one control
+    inside 24h.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("number.reserve", "reserve", 4.0, now=100.0, generation=100.0)
+    # A week of 5-minute cycles in which the caller never reaches the write helper at all.
+    for _ in range(2016):
+        ledger.begin_cycle()
+    a_week = 100.0 + 7 * 86400.0
+    if ledger.observe("number.reserve", "reserve", 50.0, now=a_week, generation=a_week) != EXTERNAL:
+        print("ERROR: a week-old confirmation stopped reporting - an age-out has come back")
+        failed = True
+    if len(ledger.events) != 1:
+        print(f"ERROR: expected one event from the week-later change, got {ledger.events}")
+        failed = True
+    assert not failed, "test_steady_control_stays_owned_indefinitely"
+
+
+def test_prune_keeps_future_dated_events():
+    """prune() maintains the DURABLE store, so it must not delete what it merely cannot judge.
+
+    The publisher writes the pruned list back to the entity attribute restore() reads, so
+    anything prune() drops is gone for good. A pod that starts before NTP sync with a slow clock
+    makes every restored event compute as future-dated - pruning on that basis deletes a real 24
+    hours of history irrecoverably on the very first publish. The clock corrects; the events have
+    to still be there when it does.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.restore([{"at": 5000.0, "control": "reserve"}, {"at": 5100.0, "control": "reserve"}])
+    # A clock ten minutes slow makes both look future-dated.
+    slow_clock = 4400.0
+    ledger.prune(now=slow_clock)
+    if len(ledger.events) != 2:
+        print(f"ERROR: prune() on a slow clock deleted real history: {ledger.events}")
+        failed = True
+    # They are still not COUNTED while they cannot be judged - the count is a claim, the store is not.
+    if ledger.recent_events(now=slow_clock):
+        print("ERROR: future-dated events were counted as if they could be judged")
+        failed = True
+    # Once the clock corrects they come back.
+    if len(ledger.recent_events(now=5200.0)) != 2:
+        print("ERROR: events were not judged again once the clock corrected")
+        failed = True
+
+    # What HAS genuinely aged out still goes, or the list grows without bound.
+    ledger = ControlLedger()
+    ledger.restore([{"at": 100.0, "control": "reserve"}, {"at": 90000.0, "control": "reserve"}])
+    ledger.prune(now=100000.0)
+    if [event["at"] for event in ledger.events] != [90000.0]:
+        print(f"ERROR: prune() did not drop a genuinely aged-out event: {ledger.events}")
+        failed = True
+
+    # An "at" that cannot be parsed IS garbage - no clock correction fixes it.
+    ledger = ControlLedger()
+    ledger.events = ["junk", {"at": "banana"}, {"at": 950.0, "control": "reserve"}]
+    ledger.prune(now=1000.0)
+    if [event["at"] for event in ledger.events] != [950.0]:
+        print(f"ERROR: prune() kept unparseable events: {ledger.events}")
+        failed = True
+    assert not failed, "test_prune_keeps_future_dated_events"
+
+
+def test_minute_control_rejects_a_wall_clock_on_an_integer_entity():
+    """Which shape is legitimate is decided by the ENTITY, so it is decided by what we own.
+
+    adjust_charge_window() writes int(new_start[3:5]) to a number/select minute entity and the
+    whole time string to a `time.` one, so the control NAME alone cannot say which is valid.
+    An entity we confirmed holding 30 has no business reading "01:30" - that is a corrupt read,
+    not somebody changing the window. An entity we confirmed holding "23:30:00" legitimately
+    reads wall-clock and must not be blinded.
+    """
+    failed = False
+    for control, integer_owned in (("charge_start_minute", 30), ("charge_end_minute", 45), ("charge_start_hour", 7), ("discharge_end_hour", 19)):
+        if is_plausible(control, "01:30", integer_owned):
+            print(f"ERROR: {control} owning {integer_owned} accepted a wall-clock read")
+            failed = True
+        if not is_plausible(control, "01:30", "23:30:00"):
+            print(f"ERROR: {control} owning a time string rejected a wall-clock read - FB00 firmware is blinded")
+            failed = True
+        # With no ownership context both shapes stay acceptable: permissive means fewer accusations.
+        if not is_plausible(control, "01:30"):
+            print(f"ERROR: {control} rejected a wall-clock read with no ownership context")
+            failed = True
+        # And the glitch values are refused whatever we own.
+        for bad in (255, -1):
+            for owned in (integer_owned, "23:30:00", None):
+                if is_plausible(control, bad, owned):
+                    print(f"ERROR: {control} owning {owned!r} accepted {bad}")
+                    failed = True
+    assert not failed, "test_minute_control_rejects_a_wall_clock_on_an_integer_entity"
+
+
+def test_publish_cap_never_drops_an_event_we_just_detected():
+    """The published attribute IS the durable store, so what the cap drops is gone for good.
+
+    Sorting by time does NOT fix this and neither does the list tail - restore() already leaves
+    the store sorted, so the two are identical. On a pod whose clock is behind, this run's real
+    event is stamped with a small "at" and is genuinely the OLDEST by timestamp, so ANY by-time
+    cap discards precisely the event just detected. Events this process detected are therefore
+    protected from the cap whatever their timestamp claims.
+    """
+    failed = False
+
+    def _detect(ledger, at, entity_id):
+        """Drive a real detection so the event is created the way production creates it."""
+        ledger.begin_cycle()
+        ledger.record_write(entity_id, "reserve", 4.0, now=at - 1.0, generation=at - 1.0)
+        ledger.begin_cycle()
+        ledger.observe(entity_id, "reserve", 50.0, now=at, generation=at)
+
+    # A clock an hour behind: the just-detected event looks older than every restored one.
+    ledger = ControlLedger()
+    _detect(ledger, 1000.0, "number.detected_now")
+    ledger.restore([{"at": 5000.0 + n, "control": "reserve", "entity_id": f"h{n}"} for n in range(25)])
+    published = ledger.newest_events(20)
+    if len(published) != 20:
+        print(f"ERROR: expected 20 published events, got {len(published)}")
+        failed = True
+    if not any(event["entity_id"] == "number.detected_now" for event in published):
+        print(f"ERROR: the just-detected event was dropped by the publish cap: {[e['entity_id'] for e in published]}")
+        failed = True
+    if [event["at"] for event in published] != sorted(event["at"] for event in published):
+        print("ERROR: published events are not oldest-first")
+        failed = True
+    # The room it took must come off the OLDEST history, not the newest.
+    if any(event["entity_id"] == "h0" for event in published):
+        print("ERROR: the oldest history survived ahead of newer history")
+        failed = True
+    if not any(event["entity_id"] == "h24" for event in published):
+        print("ERROR: the newest history was dropped")
+        failed = True
+
+    # With a correct clock nothing changes: newest wins, oldest goes.
+    ledger = ControlLedger()
+    _detect(ledger, 100000.0, "number.newest")
+    ledger.restore([{"at": 20000.0 + n, "control": "reserve", "entity_id": f"h{n}"} for n in range(25)])
+    published = ledger.newest_events(20)
+    if not any(event["entity_id"] == "number.newest" for event in published):
+        print("ERROR: the newest event was dropped by the publish cap")
+        failed = True
+    if any(event["entity_id"] == "h0" for event in published):
+        print("ERROR: the oldest event survived the publish cap ahead of newer ones")
+        failed = True
+
+    # Under the cap, everything is published and still oldest-first.
+    ledger = ControlLedger()
+    _detect(ledger, 1000.0, "number.detected_now")
+    ledger.restore([{"at": 5000.0 + n, "control": "reserve", "entity_id": f"h{n}"} for n in range(5)])
+    published = ledger.newest_events(20)
+    if len(published) != 6 or published[0]["entity_id"] != "number.detected_now":
+        print(f"ERROR: an under-cap publish was not the whole store oldest-first: {[e['entity_id'] for e in published]}")
+        failed = True
+
+    # And prune() must not leave the protected set holding events that have aged out.
+    ledger = ControlLedger()
+    _detect(ledger, 1000.0, "number.detected_now")
+    ledger.prune(now=1000.0 + 2 * 86400.0)
+    if ledger.events or ledger.session_events:
+        print(f"ERROR: prune() left aged-out events protected: {ledger.events} {ledger.session_events}")
+        failed = True
+    assert not failed, "test_publish_cap_never_drops_an_event_we_just_detected"
+
+
+def test_plausibility_is_owned_aware_in_both_directions():
+    """A `time.` entity holds whole times, so a bare component read is truncated, not a change.
+
+    The rule was only tight in one direction: an integer entity refused "01:30", but an entity
+    confirmed holding "05:00:00" still accepted "5". Both are corrupt reads of the shape Predbat
+    proved the entity holds, and both must be refused.
+    """
+    failed = False
+    for control in ("charge_start_hour", "charge_end_hour", "charge_start_minute", "discharge_end_minute"):
+        # Confirmed holding a whole time: a bare component is a truncated read.
+        for truncated in ("5", 5, "30", 30):
+            if is_plausible(control, truncated, "05:00:00"):
+                print(f"ERROR: {control} owning '05:00:00' accepted a truncated {truncated!r}")
+                failed = True
+        if not is_plausible(control, "07:30", "05:00:00"):
+            print(f"ERROR: {control} owning '05:00:00' rejected a whole time")
+            failed = True
+
+        # Confirmed holding an integer: a whole time is a corrupt read.
+        if is_plausible(control, "01:30", 30):
+            print(f"ERROR: {control} owning 30 accepted a wall-clock read")
+            failed = True
+        if not is_plausible(control, 15, 30):
+            print(f"ERROR: {control} owning 30 rejected a valid component")
+            failed = True
+
+        # No ownership context: both shapes stay acceptable, glitches still refused.
+        if not is_plausible(control, "01:30") or not is_plausible(control, 15):
+            print(f"ERROR: {control} rejected a valid read with no ownership context")
+            failed = True
+        for bad in (255, -1, "not-a-clock"):
+            for owned in (30, "05:00:00", None):
+                if is_plausible(control, bad, owned):
+                    print(f"ERROR: {control} owning {owned!r} accepted {bad!r}")
+                    failed = True
+    assert not failed, "test_plausibility_is_owned_aware_in_both_directions"
+
+
+def test_begin_cycle_precedes_every_inverter_read():
+    """Every write in a run must share that run's cycle number.
+
+    fetch_inverter_data() runs update_status(), which writes scheduled_charge_enable through
+    write_and_poll_switch and therefore CONFIRMS ownership. With begin_cycle() called after the
+    fetch, those read-path confirmations were stamped with the PREVIOUS cycle number, so the next
+    observe() of them hit the STALE rung whenever execute_plan() had written the entity in the
+    prior run - the feature silently blind on exactly the entity the read path touches.
+
+    Checked against the source because the ordering has no runtime observable: the cycle counter
+    is correct either way, it is only the ordering relative to the fetch that is wrong. Also pins
+    that begin_cycle() is called exactly ONCE per run - the second execute_plan() deliberately
+    shares the cycle, so that a value confirmed in pass 1 and seen diverged in pass 2 classifies
+    STALE rather than being reported.
+    """
+    failed = False
+    import os
+
+    source = open(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "predbat.py")).read()
+    begins = [i for i in range(len(source)) if source.startswith("self.control_ledger.begin_cycle()", i)]
+    fetches = [i for i in range(len(source)) if source.startswith("self.fetch_inverter_data()", i)]
+    if len(begins) != 1:
+        print(f"ERROR: expected exactly one begin_cycle() call, found {len(begins)}")
+        failed = True
+    if not fetches:
+        print("ERROR: found no fetch_inverter_data() calls, so this test proves nothing")
+        failed = True
+    if begins and fetches and begins[0] > min(fetches):
+        print("ERROR: begin_cycle() runs after an inverter fetch, so read-path writes are stamped with the previous cycle")
+        failed = True
+    assert not failed, "test_begin_cycle_precedes_every_inverter_read"
+
+
+def run_control_ledger_tests(my_predbat):
+    """Run all control ledger tests."""
+    failed = False
+    for name, fn in [
+        ("values_match_fuzzy", test_values_match_uses_fuzzy_for_numerics),
+        ("is_plausible", test_is_plausible_rejects_impossible_times),
+        ("generation_from_state", test_generation_from_state),
+        ("generation_engine_record_shape", test_generation_from_state_reads_engine_record_shape),
+        ("is_plausible_time_ranges", test_is_plausible_accepts_time_ranges),
+        ("unowned_never_reports", test_unowned_never_reports),
+        ("confirmed_then_changed", test_confirmed_then_changed_is_external),
+        ("matching_read_stays_owned", test_matching_read_stays_owned),
+        ("failed_write_never_owns", test_failed_write_never_owns),
+        ("ignore_fail_never_owns", test_ignore_fail_write_never_owns),
+        ("same_cycle_is_stale", test_same_cycle_read_is_stale),
+        ("older_generation_is_stale", test_older_generation_is_stale),
+        ("implausible_suppressed", test_implausible_read_is_suppressed),
+        ("write_in_flight_settling", test_write_in_flight_is_settling),
+        ("event_counts_once", test_event_clears_ownership_so_it_counts_once),
+        ("second_event_needs_reconfirm", test_second_event_requires_reconfirmation),
+        ("clear_drops_ownership", test_clear_drops_ownership),
+        ("echo_component_silent", test_echo_component_never_fires),
+        ("shared_ems_entity", test_shared_ems_entity_is_one_record),
+        ("unavailable_read_suppressed", test_unavailable_read_is_suppressed),
+        ("unavailable_readback_never_owns", test_unavailable_readback_never_owns),
+        ("ledger_generation", test_ledger_generation_reads_last_updated),
+        ("wiring_no_write_needed", test_wiring_no_write_needed_skips_note_and_record),
+        ("wiring_successful_write", test_wiring_successful_write_records_actual_read_back),
+        ("wiring_ignore_fail", test_wiring_ignore_fail_drops_ownership),
+        ("wiring_failed_write", test_wiring_failed_write_clears_ownership),
+        ("wiring_observe_before_note", test_wiring_observe_precedes_note_write_attempt),
+        ("wiring_dropout_never_external", test_wiring_dropout_read_is_never_reported_external),
+        ("wiring_freshness_long_interval", test_wiring_freshness_gate_survives_a_long_quiet_interval),
+        ("wiring_genuine_change_reports", test_wiring_genuine_external_change_still_reports),
+        ("wiring_other_write_paths", test_wiring_other_write_paths_leave_ownership_alone),
+        ("clear_drops_every_control", test_clear_drops_every_control),
+        ("restore_orders_oldest_first", test_restore_orders_events_oldest_first),
+        ("recent_events_window", test_recent_events_filters_by_window),
+        ("restore_rehydrates", test_restore_rehydrates_and_filters),
+        ("restore_ignores_non_list", test_restore_ignores_non_list_attribute),
+        ("sustained_controls", test_sustained_lists_repeat_offenders),
+        ("restore_string_at_safe", test_restored_event_with_string_at_does_not_raise),
+        ("sustained_survives_missing_control", test_sustained_controls_survives_event_missing_control_key),
+        ("future_dated_events_not_counted", test_future_dated_events_are_not_counted),
+        ("recent_events_malformed_safe", test_recent_events_survives_a_malformed_event),
+        ("is_plausible_hour_minute", test_is_plausible_validates_hour_and_minute_components),
+        ("implausible_hour_logged", test_implausible_hour_read_is_suppressed_and_logged),
+        ("steady_control_stays_owned", test_steady_control_stays_owned_indefinitely),
+        ("prune_keeps_future_events", test_prune_keeps_future_dated_events),
+        ("minute_rejects_wall_clock", test_minute_control_rejects_a_wall_clock_on_an_integer_entity),
+        ("plausibility_both_directions", test_plausibility_is_owned_aware_in_both_directions),
+        ("publish_cap_keeps_detected", test_publish_cap_never_drops_an_event_we_just_detected),
+        ("begin_cycle_ordering", test_begin_cycle_precedes_every_inverter_read),
+    ]:
+        try:
+            if fn():
+                print(f"  FAILED: control_ledger.{name}")
+                failed = True
+        except Exception as e:
+            print(f"  EXCEPTION in control_ledger.{name}: {e}")
+            import traceback
+
+            traceback.print_exc()
+            failed = True
+    return failed

--- a/apps/predbat/tests/test_metrics_dashboard_control_conflicts.py
+++ b/apps/predbat/tests/test_metrics_dashboard_control_conflicts.py
@@ -1,0 +1,100 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""
+Test that the control ownership ledger's data reaches the Metrics Dashboard: the summary
+counts and event/control detail _emit_snapshot_metrics() writes into the Prometheus registry
+must round-trip through to_dict(), and the dashboard body must actually render them.
+"""
+
+import time
+
+from predbat_metrics import metrics
+from web_metrics_dashboard import get_metrics_dashboard_body
+
+
+def test_control_conflicts_metrics_round_trip(my_predbat):
+    """
+    _emit_snapshot_metrics() reads self.control_ledger.recent_events()/sustained_controls()/
+    newest_events() and must publish counts that agree with the ledger, plus the actual event
+    and sustained-control detail the dashboard table needs - a bare count cannot show WHICH
+    control was touched or WHEN.
+
+    Uses real wall-clock time rather than a synthetic "now": _emit_snapshot_metrics() calls
+    time.time() internally with no way to inject a clock, so events are timestamped close to
+    the real time.time() it will use a moment later, well inside the 24h window.
+    """
+    print("**** test_control_conflicts_metrics_round_trip ****")
+
+    ledger = my_predbat.control_ledger
+    ledger.records.clear()
+    ledger.events.clear()
+    ledger.session_events.clear()
+
+    # sustained_controls() needs 3+ hits on the same control - three conflicts on inverter_mode,
+    # one on reserve, so the dashboard should report 4 changes with exactly one sustained control.
+    now = time.time()
+    for read_value in ("Boost", "Eco", "Away"):
+        ledger.begin_cycle()
+        ledger.record_write("select.inverter_mode", "inverter_mode", "Normal", now=now, generation=now)
+        ledger.begin_cycle()
+        ledger.observe("select.inverter_mode", "inverter_mode", read_value, now=now + 1, generation=now + 1)
+        now += 2
+
+    ledger.begin_cycle()
+    ledger.record_write("number.reserve", "reserve", 4.0, now=now, generation=now)
+    ledger.begin_cycle()
+    ledger.observe("number.reserve", "reserve", 20.0, now=now + 1, generation=now + 1)
+
+    real_conflict_events = ledger.recent_events(time.time())
+    real_sustained = ledger.sustained_controls(real_conflict_events)
+    assert len(real_conflict_events) == 4, f"Expected 4 conflicts set up directly on the ledger, got {len(real_conflict_events)}"
+    assert real_sustained == ["inverter_mode"], f"inverter_mode fired three times and should be sustained, got {real_sustained}"
+
+    my_predbat._emit_snapshot_metrics()
+
+    data = metrics().to_dict()
+
+    assert data["control_conflicts_24h"] == 4, f"Expected control_conflicts_24h=4, got {data['control_conflicts_24h']}"
+    assert data["control_conflicts_sustained_total"] == 1, f"Expected 1 sustained control, got {data['control_conflicts_sustained_total']}"
+    assert data["control_conflicts_sustained_controls"] == ["inverter_mode"], f"Expected sustained controls ['inverter_mode'], got {data['control_conflicts_sustained_controls']}"
+
+    events = data["control_conflicts_events"]
+    assert len(events) == 4, f"Expected 4 events published for the dashboard table, got {len(events)}"
+    controls_seen = sorted(e["control"] for e in events)
+    assert controls_seen == ["inverter_mode", "inverter_mode", "inverter_mode", "reserve"], f"Unexpected controls in published events: {controls_seen}"
+    assert events[0]["entity_id"] == "select.inverter_mode", "Events must stay oldest-first, matching newest_events()"
+
+    print("✓ control_conflicts_24h, sustained total and event/control detail all round-trip through to_dict()")
+    print("✓ Test passed: control_conflicts_metrics_round_trip")
+    return False
+
+
+def test_control_conflicts_dashboard_renders_section(my_predbat):
+    """
+    The dashboard body must contain a Control Conflicts section wired to the fields
+    _emit_snapshot_metrics() publishes - a section with no matching MD_DATA field would render
+    permanently empty.
+    """
+    print("**** test_control_conflicts_dashboard_renders_section ****")
+
+    body = get_metrics_dashboard_body("{}")
+
+    assert "Control Conflicts" in body, "Dashboard body should contain a Control Conflicts section heading"
+    assert "mdConflictCards" in body, "Dashboard body should contain the summary card container"
+    assert "mdConflictTable" in body, "Dashboard body should contain the recent-events table container"
+    assert "mdRenderControlConflicts(d)" in body, "mdRenderAll must call mdRenderControlConflicts so the section refreshes on every 30s poll"
+    assert "d.control_conflicts_events" in body, "Render function must read control_conflicts_events from MD_DATA"
+    assert "d.control_conflicts_sustained_controls" in body, "Render function must read control_conflicts_sustained_controls from MD_DATA"
+    assert "d.control_conflicts_24h" in body, "Render function must read control_conflicts_24h from MD_DATA"
+
+    print("✓ Control Conflicts section present and wired into the 30s refresh cycle")
+    print("✓ Test passed: control_conflicts_dashboard_renders_section")
+    return False

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -206,6 +206,7 @@ from tests.test_integer_config import (
     test_metric_battery_cycle_fractional_value_not_truncated,
 )
 from tests.test_predbat_metrics_data_age import test_data_age_metrics_round_trip
+from tests.test_metrics_dashboard_control_conflicts import test_control_conflicts_metrics_round_trip, test_control_conflicts_dashboard_renders_section
 from tests.test_validate_config import test_validate_config, test_validate_config_retry
 from tests.test_plan_json_rate_adjust import run_test_plan_json_rate_adjust
 from tests.test_plan_why_reason import run_test_plan_why_reason
@@ -519,6 +520,8 @@ def main():
         ("get_ha_config_fractional_default", test_get_ha_config_normalises_int_default_for_fractional_step, "get_ha_config normalises int default to float for fractional-step items (#4296)", False),
         ("metric_battery_cycle_fractional", test_metric_battery_cycle_fractional_value_not_truncated, "metric_battery_cycle fractional value not truncated by get_arg (#4296)", False),
         ("data_age_metrics", test_data_age_metrics_round_trip, "Metrics dashboard data_age_days/data_age_required_days tests", False),
+        ("control_conflicts_metrics", test_control_conflicts_metrics_round_trip, "Metrics dashboard control_conflicts round-trip tests", False),
+        ("control_conflicts_dashboard", test_control_conflicts_dashboard_renders_section, "Metrics dashboard control_conflicts section render tests", False),
         ("plan_json_rate_adjust", run_test_plan_json_rate_adjust, "Plan JSON rate adjust type field tests", False),
         ("plan_why_reason", run_test_plan_why_reason, "Plan JSON per-slot 'why' reason text tests", False),
         # Download tests

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -180,6 +180,7 @@ from tests.test_sunsynk_const import run_sunsynk_const_tests
 from tests.test_sunsynk_auth import run_sunsynk_auth_tests
 from tests.test_sunsynk_api import run_sunsynk_api_tests
 from tests.test_sunsynk_control import run_sunsynk_control_tests
+from tests.test_control_ledger import run_control_ledger_tests
 from tests.test_sunsynk_publish import run_sunsynk_publish_tests
 from tests.test_sunsynk_storage import run_sunsynk_storage_tests
 from tests.test_sunsynk_config import run_sunsynk_config_tests
@@ -478,6 +479,7 @@ def main():
         ("sunsynk_auth", run_sunsynk_auth_tests, "Sunsynk auth tests", False),
         ("sunsynk_api", run_sunsynk_api_tests, "Sunsynk API tests", False),
         ("sunsynk_control", run_sunsynk_control_tests, "Sunsynk control-logic tests", False),
+        ("control_ledger", run_control_ledger_tests, "Control ownership ledger tests", False),
         ("sunsynk_publish", run_sunsynk_publish_tests, "Sunsynk publish tests", False),
         ("sunsynk_storage", run_sunsynk_storage_tests, "Sunsynk storage tests", False),
         ("sunsynk_config", run_sunsynk_config_tests, "Sunsynk config/INVERTER_DEF tests", False),

--- a/apps/predbat/web_metrics_dashboard.py
+++ b/apps/predbat/web_metrics_dashboard.py
@@ -131,6 +131,13 @@ def get_metrics_dashboard_body(data_json):
   <div id="mdApiTable"></div>
   <div style="margin-top:1rem;" class="md-card-grid" id="mdSolarCards"></div>
 </section>
+
+<!-- Section 6: Control Conflicts -->
+<section>
+  <h2>Control Conflicts</h2>
+  <div class="md-card-grid" id="mdConflictCards"></div>
+  <div style="margin-top:1rem;" id="mdConflictTable"></div>
+</section>
 </div>
 
 <script>
@@ -321,6 +328,36 @@ function mdRenderSolar(d) {
   document.getElementById('mdSolarCards').innerHTML = h;
 }
 
+function mdRenderControlConflicts(d) {
+  var events = d.control_conflicts_events || [];
+  var sustained = d.control_conflicts_sustained_controls || [];
+  var count = d.control_conflicts_24h || 0;
+  var cards = [
+    {label:'Changes (24h)',      value: mdFmt(count, 0),              cls: count > 0 ? 'md-status-warn' : 'md-status-ok'},
+    {label:'Sustained Controls', value: mdFmt(d.control_conflicts_sustained_total || 0, 0), cls: sustained.length > 0 ? 'md-status-err' : 'md-status-ok', sub: sustained.length > 0 ? sustained.join(', ') : ''},
+  ];
+  var h = '';
+  cards.forEach(function (c) {
+    h += '<div class="md-card"><div class="md-label">' + c.label + '</div>'
+      + '<div class="md-value ' + c.cls + '">' + c.value + '</div>'
+      + (c.sub ? '<div class="md-sub">' + c.sub + '</div>' : '') + '</div>';
+  });
+  document.getElementById('mdConflictCards').innerHTML = h;
+
+  if (events.length === 0) {
+    document.getElementById('mdConflictTable').innerHTML = '<div class="md-card" style="text-align:center;">No settings changed outside Predbat in the last 24h</div>';
+    return;
+  }
+  var t = '<table><thead><tr><th>When</th><th>Control</th><th>Entity</th><th>Predbat Set</th><th>Now Reads</th></tr></thead><tbody>';
+  /* Newest first for reading, even though the source list is oldest-first for storage. */
+  events.slice().reverse().forEach(function (e) {
+    t += '<tr><td>' + mdAgo(e.at) + '</td><td>' + (e.control || '—') + '</td><td>' + (e.entity_id || '—') + '</td>'
+      + '<td>' + (e.we_set === undefined ? '—' : e.we_set) + '</td><td>' + (e.now_reads === undefined ? '—' : e.now_reads) + '</td></tr>';
+  });
+  t += '</tbody></table>';
+  document.getElementById('mdConflictTable').innerHTML = t;
+}
+
 function mdRebuildCharts(d) {
   if (mdSocChart)    { mdSocChart.destroy();    mdSocChart    = null; }
   if (mdPowerChart)  { mdPowerChart.destroy();  mdPowerChart  = null; }
@@ -333,6 +370,7 @@ function mdRenderAll(d) {
   mdRenderCost(d);
   mdRenderAPI(d);
   mdRenderSolar(d);
+  mdRenderControlConflicts(d);
   if (!mdSocChart) {
     mdInitSOCChart(d); mdInitPowerChart(d); mdInitEnergyChart(d);
   } else {


### PR DESCRIPTION
## What

Predbat writes a control, reads it back to confirm the inverter accepted it, and remembers that value. If a later read differs — and is newer than the confirmation, plausible, and not our own write still propagating — something else changed it. That is published as `predbat.control_conflicts`: a 24-hour count, with the last 20 events and any repeat-offender controls in its attributes.

**The confirmation step is the point.** Comparing intent against a later read cannot separate "a third party changed this" from "our write silently failed". Requiring proof that the inverter accepted the value first removes that ambiguity, which is what makes the signal worth acting on.

Nothing is surfaced to users yet — this publishes an entity and stops there, deliberately, so real fleet behaviour can be observed before anything is shown to anyone.

## Why

Users regularly report Predbat behaving irrationally when a second controller — a phone app, an installer's EMS, a vendor portal schedule, a VPP dispatch — is writing the same inverter. Predbat currently has no way to say so, and absorbs the blame.

## How it works

`write_and_poll_switch/value/option` already read the current value before deciding whether to write. That read is now also an observation point. A small pure-logic module (`control_ledger.py`, no engine dependencies) holds ownership state keyed on the **entity id** — not `(inverter index, control name)`, because a GivEnergy EMS assigns one entity to every inverter index, and index-keyed state would let Predbat's own write look like tampering.

A divergent read is classified through a ladder biased toward silence. It only reports when every innocent explanation has been eliminated:

| Verdict | Meaning |
|---|---|
| `UNOWNED` | we never proved we set this, so nothing was taken |
| `UNAVAILABLE` | the entity is not reporting — a non-reading cannot contradict anything |
| `STALE` | the read is not newer than our confirmation |
| `IMPLAUSIBLE` | the inverter returned something that cannot be a real value |
| `SETTLING` | we wrote since confirming; this is our own change propagating |
| `EXTERNAL` | everything else ruled out |

Ownership is conferred **only** by a verified read-back, and the stored value is the value read back — never the value passed to the write — so units, rounding and time formatting match by construction on every later comparison. An `ignore_fail=True` write returns success without polling, so it drops ownership rather than conferring it.

## Scope and limitations

Stated plainly, because this does not cover everything:

- **GivTCP REST is not instrumented.** Every `adjust_*` branches on `self.rest_data` and calls a `rest_set*` helper with its own read-back loop; those are not hooked. REST users get no detection until they are.
- **Components that republish their own control entities are silent.** `deye.py` and `enphase.py` keep a `local_schedule` and republish Predbat's write back into the control entity, so `read == owned_value` always holds there. This fails safe — no detection rather than false detection — and is tracked in #4636. (`fox.py` also has a `local_schedule` but rebuilds it from real vendor scheduler data in `compute_schedule`, so Fox **is** covered, with up to ~1h latency from its hourly settings poll. `sunsynk.py` binds no control entities at all, so it never reaches these helpers.)
- **Detection is coupled to the write helpers.** Ownership is established by `write_and_poll_*` reading a value back. Predbat's other write paths — a configured `*_service` template, or `mqtt_message()` on an MQTT-API inverter — are simply not tracked, and a control Predbat stops writing is never observed. There is no attempt to guess what those paths touched; earlier revisions of this PR tried three different ways and each one traded silent blindness against false accusations.
- **A `*_service` aimed at an entity Predbat also drives directly will be reported.** If, say, `charge_start_service` sets a work-mode select that `adjust_inverter_mode` also writes, the two carry different intents and the divergence is reported every cycle. That is a genuine configuration conflict — the two mechanisms really are fighting — but a user should know the "something" being reported can be their own template.
- **Post-confirmation quantisation on time controls will produce false positives.** Predbat writes `23:32`, the read-back confirms `23:32`, the inverter snaps to `23:30` and republishes next cycle. Time controls carry no tolerance because `write_and_poll_option` has no `fuzzy` parameter. Left unfixed deliberately — it needs a tolerance model rather than a patch, and the logging-only rollout is intended to measure how often it actually bites.
- **`pause_start_time`/`pause_end_time` can never be owned** — both are written with `ignore_fail=True`, which correctly declines to confer ownership.

## Behaviour when disabled

Everything is reached via `getattr(self.base, "control_ledger", None)` and no-ops when absent, so an engine configuration without a ledger behaves identically to before. The write and retry logic itself is untouched — every changed line in `inverter.py` is a comment, a raw-value alias, or a ledger call.

## Testing

`python3 unit_test.py -t control_ledger` — 60 tests, the majority asserting that the detector stays **silent**: unconfirmed values, stale reads, implausible reads (an inverter returning `00:80` for a time), entity dropouts, `ignore_fail` writes, our own in-flight writes, echo components, and shared EMS entities where one control is assigned to several inverter indices.

Integration tests drive the real `write_and_poll_*` helpers rather than a reimplementation, and pin that a successful write records the value **read back** rather than the value requested.

Regression suites run clean: `inverter_multi`, `ge_cloud` (80/80), `deye_control`, `sunsynk_control`.

## Note on unrelated test failures

Two suites fail on `main` itself, identically with none of this branch's code present — flagging them in case they are not already known, nothing here touches either:

- `test_predbat_metrics_data_age.py` — `data_age_days` 0 != 8, from 9e53b691.
- `multi_car_iog` — a date-sensitive fixture that started failing when the date rolled over; reproduced on a clean `main` checkout.
