### PR TITLE
fix(deye,sunsynk): honour read-only in the cloud reconcile loop

### DIFF
--- a/apps/predbat/deye.py
+++ b/apps/predbat/deye.py
@@ -1015,6 +1015,10 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         self.pending_orders.pop(sn, None)
         return "success"
 
+    def _is_read_only(self):
+        """Return True when Predbat is in read-only mode and must not write to the inverter."""
+        return self.get_state_wrapper(f"switch.{self.prefix}_set_read_only", default="off") == "on"
+
     def _sensor_name(self, sn, leaf):
         """Return a namespaced DEYE sensor entity id."""
         return f"sensor.{self.prefix}_deye_{sn.lower()}_{leaf}"
@@ -1648,7 +1652,14 @@ class DeyeAPI(ComponentBase, OAuthMixin):
         an order-poll cache invalidation). Inverters Predbat has not yet driven via
         the write button (not in ``control_active``) are left untouched, so a startup
         cycle never clobbers an inverter before there is a plan.
+
+        A no-op while ``switch.predbat_set_read_only`` is on: the top-level work mode is
+        time-aware, so a window transition changes the payload even with no plan change,
+        and without this guard that transition would write to the inverter regardless of
+        read-only.
         """
+        if self._is_read_only():
+            return
         for sn in self.device_list:
             if sn not in self.control_active:
                 continue

--- a/apps/predbat/sunsynk.py
+++ b/apps/predbat/sunsynk.py
@@ -1330,6 +1330,27 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
         current_soc = int(self._as_float(self.device_values.get(sn, {}).get("soc"), 0))
         return await self.apply_settings(sn, schedule, current_soc, force=force)
 
+    def _is_read_only(self):
+        """Return True when Predbat is in read-only mode and must not write to the inverter."""
+        return self.get_state_wrapper(f"switch.{self.prefix}_set_read_only", default="off") == "on"
+
+    async def _reconcile_control(self, sn):
+        """Re-apply sn's schedule if Predbat already controls it, unforced (matches deye.py's _reconcile_control).
+
+        A no-op for an inverter Predbat has not yet driven via the write button (not in
+        ``control_active``), and a no-op while ``switch.predbat_set_read_only`` is on: the
+        top-level work mode is time-aware, so a window transition changes the payload even
+        with no plan change, and without this guard that transition would write to the
+        inverter regardless of read-only.
+        """
+        if sn not in self.control_active or self._is_read_only():
+            return
+        try:
+            if await self.apply_schedule(sn):
+                await self.save_control()
+        except Exception as error:
+            self.log(f"Warn: Sunsynk schedule apply failed for {sn}: {error}")
+
     async def _handle_control_event(self, entity_id, value):
         """Route one control-entity event to the right inverter and apply it."""
         sn = self._sn_from_entity(entity_id)
@@ -1727,17 +1748,7 @@ class SunsynkAPI(ComponentBase, OAuthMixin):
                 await self.get_schedule_settings_ha(sn)
             except Exception as error:
                 self.log(f"Warn: Sunsynk schedule read failed for {sn}: {error}")
-            # Only inverters Predbat has actually been asked to drive (write button pressed
-            # at least once) are re-applied here, matching deye.py's _reconcile_control: a
-            # startup cycle must never clobber an inverter before there is a plan. Without
-            # this gate the second tick posted a whole settings object built from entities
-            # Predbat had never written - wiping the user's own time-of-use programme.
-            if sn in self.control_active:
-                try:
-                    if await self.apply_schedule(sn):
-                        await self.save_control()
-                except Exception as error:
-                    self.log(f"Warn: Sunsynk schedule apply failed for {sn}: {error}")
+            await self._reconcile_control(sn)
             # Published every tick, not just first: this is Predbat's control surface and
             # must keep reflecting local_schedule as it changes, matching deye.py's run().
             await self.publish_schedule_settings_ha(sn)

--- a/apps/predbat/tests/test_deye_control.py
+++ b/apps/predbat/tests/test_deye_control.py
@@ -263,6 +263,30 @@ def test_reconcile_only_controlled_inverters():
     assert not failed, "test_reconcile_only_controlled_inverters"
 
 
+def test_reconcile_control_skips_while_read_only():
+    """_reconcile_control must not write to the inverter while switch.predbat_set_read_only is on."""
+    failed = False
+    d = MockDeye()
+    d.device_list = ["INV1"]
+    d.control_active = {"INV1"}
+    d.local_schedule = {"INV1": {"reserve": 10, "charge": {"enable": False}, "export": {"enable": False}}}
+    d.device_values = {"INV1": {"soc": 50}}
+    d.base.get_state_wrapper.return_value = "on"
+    calls = []
+
+    async def fake_apply(sn, schedule, current_soc, force=False):
+        """Record reconcile applies."""
+        calls.append((sn, force))
+        return False
+
+    with patch.object(d, "apply_dynamic_control", side_effect=fake_apply):
+        run_async_local(d._reconcile_control())
+    if calls:
+        print(f"ERROR: reconcile must not write while read-only is on: {calls}")
+        failed = True
+    assert not failed, "test_reconcile_control_skips_while_read_only"
+
+
 def test_poll_order_empty_response_stays_pending():
     """An empty/error response (network/auth) must NOT falsely confirm the order."""
     failed = False
@@ -1135,6 +1159,7 @@ def run_deye_control_tests(my_predbat):
         ("apply_write", test_apply_dynamic_control_writes_and_caches_on_change),
         ("active_workmode_time", test_active_workmode_follows_time),
         ("reconcile_controlled", test_reconcile_only_controlled_inverters),
+        ("reconcile_read_only", test_reconcile_control_skips_while_read_only),
         ("poll_order", test_poll_order_success),
         ("poll_order_empty_pending", test_poll_order_empty_response_stays_pending),
         ("run_forces_rewrite_after_max_polls", test_run_forces_rewrite_after_max_unconfirmed_polls),

--- a/apps/predbat/tests/test_sunsynk_control.py
+++ b/apps/predbat/tests/test_sunsynk_control.py
@@ -559,6 +559,67 @@ def test_apply_settings_respects_control_enable():
     assert not failed, "test_apply_settings_respects_control_enable"
 
 
+def test_reconcile_control_applies_a_controlled_inverter():
+    """_reconcile_control re-applies the schedule of an inverter Predbat already controls."""
+    failed = False
+    s = MockSunsynk()
+    s.control_active = {"INV1"}
+    calls = []
+
+    async def fake_apply(sn):
+        """Record reconcile applies."""
+        calls.append(sn)
+        return False
+
+    with patch.object(s, "apply_schedule", side_effect=fake_apply):
+        run_async_local(s._reconcile_control("INV1"))
+    if calls != ["INV1"]:
+        print(f"ERROR: reconcile should apply the controlled inverter: {calls}")
+        failed = True
+    assert not failed, "test_reconcile_control_applies_a_controlled_inverter"
+
+
+def test_reconcile_control_skips_an_uncontrolled_inverter():
+    """_reconcile_control must not write to an inverter Predbat has not yet driven via the write button."""
+    failed = False
+    s = MockSunsynk()
+    s.control_active = set()  # INV1 not yet driven by Predbat
+    calls = []
+
+    async def fake_apply(sn):
+        """Record reconcile applies, which must not happen here."""
+        calls.append(sn)
+        return False
+
+    with patch.object(s, "apply_schedule", side_effect=fake_apply):
+        run_async_local(s._reconcile_control("INV1"))
+    if calls:
+        print(f"ERROR: reconcile should not apply an uncontrolled inverter: {calls}")
+        failed = True
+    assert not failed, "test_reconcile_control_skips_an_uncontrolled_inverter"
+
+
+def test_reconcile_control_skips_while_read_only():
+    """_reconcile_control must not write to the inverter while switch.predbat_set_read_only is on."""
+    failed = False
+    s = MockSunsynk()
+    s.control_active = {"INV1"}
+    s.base.get_state_wrapper.return_value = "on"
+    calls = []
+
+    async def fake_apply(sn):
+        """Record reconcile applies, which must not happen here."""
+        calls.append(sn)
+        return False
+
+    with patch.object(s, "apply_schedule", side_effect=fake_apply):
+        run_async_local(s._reconcile_control("INV1"))
+    if calls:
+        print(f"ERROR: reconcile must not write while read-only is on: {calls}")
+        failed = True
+    assert not failed, "test_reconcile_control_skips_while_read_only"
+
+
 def test_apply_settings_skips_when_the_payload_is_empty():
     """apply_settings must not post a payload that build_settings_payload refused to build.
 
@@ -1222,6 +1283,9 @@ def run_sunsynk_control_tests(my_predbat):
         ("apply_ignores_volatile_field", test_apply_settings_ignores_a_volatile_unowned_field),
         ("apply_fails_closed", test_apply_settings_fails_closed_without_a_read),
         ("apply_control_enable", test_apply_settings_respects_control_enable),
+        ("reconcile_applies_controlled", test_reconcile_control_applies_a_controlled_inverter),
+        ("reconcile_skips_uncontrolled", test_reconcile_control_skips_an_uncontrolled_inverter),
+        ("reconcile_skips_read_only", test_reconcile_control_skips_while_read_only),
         ("apply_skips_empty_payload", test_apply_settings_skips_when_the_payload_is_empty),
         ("apply_failed_write", test_apply_settings_reports_a_failed_write),
         ("note_settle_normalises_types", test_note_settle_normalises_wire_types_before_comparing),


### PR DESCRIPTION
## Summary

- `DeyeAPI._reconcile_control()` re-applies every controlled inverter's `local_schedule` on each component tick, entirely independent of `execute.py`'s `set_read_only` gate — `deye.py` never referenced `read_only` anywhere. Because the top-level work mode is time-aware, a window transition (e.g. charge → export) changes the payload even with no plan change, so a write went out to the inverter regardless of read-only state.
- Reported live in #4436: read-only was enabled at 21:36, and the component still submitted a control order at 21:54 — 18 minutes after the user asked Predbat to stop touching the inverter.
- `sunsynk.py`'s `run()` has the identical unguarded per-tick reconcile block. Its own existing comment says it "matches deye.py's `_reconcile_control`" — same root cause, same fix, fixed proactively here since it isn't filed as its own issue.

## Fix

- Added `_is_read_only()` to both components, mirroring the existing pattern already used in `enphase.py`/`solax.py`/`sigenergy.py` (reads `switch.predbat_set_read_only` via `get_state_wrapper`).
- `deye.py`: `_reconcile_control()` now returns immediately while read-only is on.
- `sunsynk.py`: extracted the per-tick reconcile step (previously inlined in `run()`) into its own `_reconcile_control(sn)`, gated on both `control_active` and `_is_read_only()` — matches Deye's structure and makes it independently testable.

## Scope

This fixes the confirmed bug only: the component's own background reconcile loop bypassing read-only. It deliberately does **not** add a Deye/Sunsynk-specific "reset to safe mode" path. Both `DeyeCloud` and `SunsynkCloud` are registered as full `INVERTER_DEF` entries (`config.py`), and `automatic_config()` wires the standard control args (`reserve`, `scheduled_charge_enable`, `schedule_write_button`, etc.) to the same entities the generic `execute.py::reset_inverter()` writes when `inverter_needs_reset_force == "set_read_only"`. So a safe-mode reset already appears to reach both components via the standard engine while Predbat keeps running — that path is untested end-to-end and is a separate question from the bug fixed here, worth its own follow-up if it turns out not to work as expected.

## Testing

- New tests: `test_reconcile_control_skips_while_read_only` (deye); `test_reconcile_control_applies_a_controlled_inverter`, `test_reconcile_control_skips_an_uncontrolled_inverter`, `test_reconcile_control_skips_while_read_only` (sunsynk) — watched all three fail for the right reason before implementing.
- `./run_all --test deye_control --test sunsynk_control` — pass
- `./run_all --quick` (full suite) — pass
- `pre-commit run --all-files` — pass

Related to #4436 — addresses the read-only write-path half of that issue; leaving it open rather than auto-closing since the issue's second claim (explicit safe-mode reset) needs separate live verification against the generic engine path described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)