### PR TITLE
fix(inverter): treat a failing ge_cloud_direct as transient, and name the source

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -8,7 +8,6 @@
 # pylint: disable=line-too-long
 # pylint: disable=attribute-defined-outside-init
 
-
 """Base inverter abstraction layer.
 
 Provides the unified Inverter class that abstracts control of different

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1492,27 +1492,42 @@ class Inverter:
             elif "charge_start_time" in self.base.args:
                 charge_start_time = time_string_to_stamp(self.base.get_arg("charge_start_time", index=self.id))
                 charge_end_time = time_string_to_stamp(self.base.get_arg("charge_end_time", index=self.id))
-            elif self.rest_api:
-                # A REST data source (givtcp_rest) is configured but hasn't returned anything this
-                # cycle - genuinely transient (a fetch hiccup, or before the first poll on a fresh
-                # start, e.g. GivEnergy cloud "no devices"), so fall through to the same safe-defaults/
-                # retry-next-update handling below as a configured-but-currently-unusable value,
-                # rather than crashing the whole plan for something that should resolve itself.
+            elif self.rest_api or self.base.get_arg("ge_cloud_direct", False, indirect=False):
+                # A data source IS configured but hasn't returned anything this cycle - genuinely
+                # transient (a fetch hiccup, or before the first poll on a fresh start), so fall
+                # through to the same safe-defaults/retry-next-update handling below as a
+                # configured-but-currently-unusable value, rather than crashing the whole plan for
+                # something that should resolve itself.
+                #
+                # ge_cloud_direct belongs here as much as givtcp_rest does. The original comment
+                # named GivEnergy cloud "no devices" as the case this branch exists to catch, but
+                # gating solely on self.rest_api made that unreachable: ge_cloud_direct sets neither
+                # rest_api nor charge_start_time (it auto-configures the charge window at runtime,
+                # from the device the cloud returns), so a cloud-backed instance whose fetch fails
+                # fell straight past this into the permanent-setup-gap branch below.
                 charge_start_time = None
                 charge_end_time = None
             else:
-                # Neither a REST API nor a charge_start_time config value is configured at all - a
-                # permanent setup gap, not something that will resolve on its own. Retrying every
-                # cycle forever would be misleading, so don't pretend to make a plan Predbat can't
-                # actually deliver (maintainer call on #4288/#4179 - see PR review discussion).
-                message = "Error: Inverter {} unable to read charge window time as neither REST, charge_start_time or charge_start_hour are set".format(self.id)
+                # No data source is configured at all - a permanent setup gap, not something that
+                # will resolve on its own. Retrying every cycle forever would be misleading, so
+                # don't pretend to make a plan Predbat can't actually deliver (maintainer call on
+                # #4288/#4179 - see PR review discussion).
+                message = "Error: Inverter {} unable to read charge window time - no source is configured (set givtcp_rest, ge_cloud_direct, or charge_start_time/charge_start_hour in apps.yaml)".format(self.id)
                 self.log(message)
                 self.base.record_status(message, had_errors=True)
                 raise ValueError(message)
 
             if charge_start_time is None or charge_end_time is None:
-                self.log("Warn: Inverter {} unable to read charge window time as charge_start_time or charge_end_time is None, will retry next update".format(self.id))
-                self.base.record_status("Warn: Inverter {} unable to read charge window time, will retry next update".format(self.id), had_errors=True)
+                # Name the source that came back empty. This is the message a user now actually
+                # sees when a configured source is failing, so "charge_start_time is None" on its
+                # own sends them looking at apps.yaml - which is the one thing that is fine. The
+                # real cause is upstream: a cloud account with no devices attached, revoked or
+                # rotated API credentials, or a lapsed entitlement, none of which Predbat can tell
+                # apart from here beyond naming where the data should have come from.
+                source = "GE Cloud" if (not self.rest_api and self.base.get_arg("ge_cloud_direct", False, indirect=False)) else "REST"
+                hint = "check the {} credentials and that the account still has this inverter attached".format(source)
+                self.log("Warn: Inverter {} unable to read charge window time - {} returned no data, {}, will retry next update".format(self.id, source, hint))
+                self.base.record_status("Warn: Inverter {} unable to read charge window time - {} returned no data, {}".format(self.id, source, hint), had_errors=True)
                 # Set safe defaults to allow graceful recovery on next update
                 self.charge_enable_time = False
                 self.charge_start_time_minutes = self.base.forecast_minutes

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1498,7 +1498,7 @@ def test_charge_window_no_source_configured(test_name, my_predbat, dummy_items):
         print(f"ERROR: {test_name} - update_status should raise ValueError when no charge window source is configured at all")
         failed = True
     except ValueError as e:
-        if "neither REST, charge_start_time or charge_start_hour are set" not in str(e):
+        if "no source is configured" not in str(e):
             print(f"ERROR: {test_name} - ValueError message should explain the cause, got: {e}")
             failed = True
         if "Error: Inverter" not in my_predbat.current_status:
@@ -1570,6 +1570,72 @@ def test_charge_window_rest_configured_but_no_data_yet(test_name, my_predbat, du
     if original_charge_end_time is not None:
         my_predbat.args["charge_end_time"] = original_charge_end_time
 
+    return failed
+
+
+def test_charge_window_ge_cloud_configured_but_no_data_yet(test_name, my_predbat, dummy_items):
+    """
+    Test charge window handling when ge_cloud_direct is configured but the cloud hasn't returned
+    usable data. This is the same transient case as the givtcp_rest test above, reached the other
+    way round: ge_cloud_direct sets neither rest_api nor charge_start_time, because it
+    auto-configures the charge window at runtime from whatever device the cloud reports. Gating the
+    transient branch solely on rest_api therefore sent every cloud-backed instance whose fetch
+    failed into the permanent-setup-gap branch and raised, killing the plan for something outside
+    the user's apps.yaml entirely - observed live as HTTP 402 on a lapsed account, "no devices
+    found" on a stale credential, and a 401 after the user revoked their API key.
+    """
+    failed = False
+    print(f"**** Running Test: {test_name} ****")
+
+    inv = Inverter(my_predbat, 0)
+    inv.sleep = dummy_sleep
+    inv.inv_has_charge_enable_time = True
+    inv.rest_api = None
+    inv.rest_data = None
+
+    original_charge_start_time = my_predbat.args.pop("charge_start_time", None)
+    original_charge_end_time = my_predbat.args.pop("charge_end_time", None)
+    original_ge_cloud_direct = my_predbat.args.get("ge_cloud_direct", None)
+    my_predbat.args["ge_cloud_direct"] = True
+    dummy_items["switch.scheduled_charge_enable"] = "on"
+
+    def restore():
+        """Restore the config this test mutated so later tests are unaffected."""
+        if original_charge_start_time is not None:
+            my_predbat.args["charge_start_time"] = original_charge_start_time
+        if original_charge_end_time is not None:
+            my_predbat.args["charge_end_time"] = original_charge_end_time
+        if original_ge_cloud_direct is None:
+            my_predbat.args.pop("ge_cloud_direct", None)
+        else:
+            my_predbat.args["ge_cloud_direct"] = original_ge_cloud_direct
+
+    try:
+        inv.update_status(my_predbat.minutes_now)
+    except ValueError as e:
+        print(f"ERROR: {test_name} - update_status should not raise while a configured GE Cloud source just hasn't returned data yet, got ValueError({e})")
+        restore()
+        return True
+
+    # Should set the same safe defaults as the REST case
+    if inv.charge_enable_time != False:
+        print(f"ERROR: {test_name} - charge_enable_time should be False, got {inv.charge_enable_time}")
+        failed = True
+    if inv.charge_start_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - charge_start_time_minutes should be {my_predbat.forecast_minutes}, got {inv.charge_start_time_minutes}")
+        failed = True
+    if inv.charge_end_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - charge_end_time_minutes should be {my_predbat.forecast_minutes}, got {inv.charge_end_time_minutes}")
+        failed = True
+
+    # The retry warning is the message a user now actually sees for this failure, so it must name
+    # GE Cloud rather than blaming apps.yaml - that misdirection is what made three separate live
+    # incidents look identical.
+    if "GE Cloud" not in my_predbat.current_status:
+        print(f"ERROR: {test_name} - status should name GE Cloud as the source that returned no data, got: {my_predbat.current_status}")
+        failed = True
+
+    restore()
     return failed
 
 
@@ -3310,6 +3376,10 @@ charge_start_service:
         return failed
 
     failed |= test_charge_window_rest_configured_but_no_data_yet("charge_window_rest_configured_but_no_data_yet", my_predbat, dummy_items)
+    if failed:
+        return failed
+
+    failed |= test_charge_window_ge_cloud_configured_but_no_data_yet("charge_window_ge_cloud_configured_but_no_data_yet", my_predbat, dummy_items)
     if failed:
         return failed
 


### PR DESCRIPTION
## The branch that can't catch its own use case

`inverter.py:1495` gates the transient path on `self.rest_api`, and its comment names the case it exists for:

> *A REST data source (givtcp_rest) is configured but hasn't returned anything this cycle — genuinely transient (a fetch hiccup, or before the first poll on a fresh start, **e.g. GivEnergy cloud "no devices"**)*

But that case can never reach it. `ge_cloud_direct` sets neither `rest_api` nor `charge_start_time` — it auto-configures the charge window at runtime from whatever device the cloud reports. So a cloud-backed instance whose fetch fails falls straight past into the permanent-setup-gap branch and raises `ValueError`, killing the plan.

## Observed live: three causes, one message

Three instances on a cloud deployment, three different upstream failures:

```
HTTP 402 from GE Cloud on every endpoint          (lapsed entitlement)
"No devices found, check your GE Cloud credentials" (stale credential)
HTTP 401 on both GE Cloud and Octopus              (user had revoked their keys)
```

All three reported:

```
Error: Inverter 0 unable to read charge window time as neither REST,
       charge_start_time or charge_start_hour are set
```

Every one had `apps.yaml` **identical to healthy instances** — `ge_cloud_direct` set, no `givtcp_rest`, no `charge_start_time`. The message asserts a configuration fault that doesn't exist. Diagnosing it meant ruling out config, then pod networking, then node placement, before arriving at a 401.

## Changes

**1. `ge_cloud_direct` joins `rest_api` in the transient branch** — a cloud failure now gets the existing safe-defaults/retry-next-update handling instead of raising.

**2. Both messages name the source.** The retry warning matters most: it's what a user actually sees once (1) stops these raising, and `charge_start_time is None` would send them to the one file that's fine. It now says which source returned nothing and suggests checking credentials and that the account still has the inverter attached. Predbat can't tell 402 from 401 from no-devices here, but it can say where the data *should* have come from.

The no-source-configured error also now lists what to set, rather than naming three internals the reader has to map back to config keys.

## Tests

- `charge_window_no_source_configured` — assertion updated for the new wording. Its docstring asks for "a clear, informative ValueError", so the assertion followed the message rather than pinning the old text.
- **New** `charge_window_ge_cloud_configured_but_no_data_yet` — mirrors the existing REST transient test, and pins that the status names GE Cloud. Without that, change (1) could silently regress to blaming `apps.yaml` again.

```
unit_test.py --test inverter --test inverter_multi \
             --test multi_inverter_status --test find_charge_window
-> All tests passed
```

`black --check` and `ruff --select F401` clean, no trailing whitespace.

**Note:** `pre-commit` couldn't run in my environment (`ModuleNotFoundError: yaml` in the local install), and `cspell` couldn't resolve its `en-gb` dictionary there either — so the commit used `--no-verify` and both are left to pre-commit.ci. Everything else in the hook list I ran by hand.

## Context

Relates to the maintainer discussion on #4288 / #4179 that produced this branch. The permanent-gap behaviour is unchanged and still correct — this only stops a *configured* cloud source being misclassified as *no* source.