### PR TITLE
fix(solis): don't enrol an inverter Solis reports as having no battery

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1248,16 +1248,33 @@ class SolisAPI(ComponentBase, OAuthMixin):
         """True only when Solis Cloud explicitly declares this inverter has no battery attached.
 
         Deliberately narrow: absence of these fields (older firmware, other models) means "unknown",
-        which leaves the inverter enrolled exactly as before. Never infer from batteryHealthSoh - a
-        real pack reporting SoH 0 is a documented, valid response and still says batteryType
-        'PYLON_LV'. Never infer from the lifetime counters either: batteryTotalChargeEnergy and
-        friends survive the pack being physically removed, so an inverter that once cycled MWh can
-        still legitimately report no battery today.
+        which leaves the inverter enrolled exactly as before.
+
+        Match on the self-describing name, in both the places Solis reports it. The `noBattery`
+        boolean is checked too but cannot be relied on alone - one firmware sets it True, another
+        leaves it None on an inverter that says "No Battery" everywhere else.
+
+        The name is matched negatively rather than against a list of known batteries, because the
+        positive values vary by pack ('PYLON_LV', 'Lithium Battery LV', ...) and an unrecognised
+        battery must never be read as no battery.
+
+        Never infer from batteryHealthSoh - a real pack reporting SoH 0 is a documented, valid
+        response and still names its battery type. Never infer from the lifetime counters either:
+        batteryTotalChargeEnergy and friends survive the pack being physically removed, so an
+        inverter that once cycled MWh can still legitimately report no battery today.
+
+        (batteryTypeCode is '0000' in this state, against '0001'/'0063' for real packs, but it is
+        left out on purpose: a code that means "unknown" on some firmware would silently unenrol a
+        working battery, and the names above already cover every case seen.)
         """
         if str(detail.get("batteryType", "")).strip().lower() == "no battery":
             return True
         for entry in detail.get("batteryList") or []:
-            if isinstance(entry, dict) and entry.get("noBattery") is True:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("noBattery") is True:
+                return True
+            if str(entry.get("batteryTypeName", "")).strip().lower() == "no battery":
                 return True
         return False
 

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1264,7 +1264,7 @@ class SolisAPI(ComponentBase, OAuthMixin):
         inverter that once cycled MWh can still legitimately report no battery today.
 
         (batteryTypeCode is '0000' in this state, against '0001'/'0063' for real packs, but it is
-        left out on purpose: a code that means "unknown" on some firmware would silently unenrol a
+        left out on purpose: a code that means "unknown" on some firmware would silently ignore a
         working battery, and the names above already cover every case seen.)
         """
         if str(detail.get("batteryType", "")).strip().lower() == "no battery":

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1243,6 +1243,24 @@ class SolisAPI(ComponentBase, OAuthMixin):
 
     # ==================== Configuration and Polling ====================
 
+    @staticmethod
+    def _reports_no_battery(detail):
+        """True only when Solis Cloud explicitly declares this inverter has no battery attached.
+
+        Deliberately narrow: absence of these fields (older firmware, other models) means "unknown",
+        which leaves the inverter enrolled exactly as before. Never infer from batteryHealthSoh - a
+        real pack reporting SoH 0 is a documented, valid response and still says batteryType
+        'PYLON_LV'. Never infer from the lifetime counters either: batteryTotalChargeEnergy and
+        friends survive the pack being physically removed, so an inverter that once cycled MWh can
+        still legitimately report no battery today.
+        """
+        if str(detail.get("batteryType", "")).strip().lower() == "no battery":
+            return True
+        for entry in detail.get("batteryList") or []:
+            if isinstance(entry, dict) and entry.get("noBattery") is True:
+                return True
+        return False
+
     async def automatic_config(self):
         """Automatically configure Predbat base args based on discovered inverters"""
         if not self.inverter_sn:
@@ -1253,6 +1271,9 @@ class SolisAPI(ComponentBase, OAuthMixin):
         batteries = []
         for inverter_sn in self.inverter_sn:
             detail = self.inverter_details.get(inverter_sn, {})
+            if self._reports_no_battery(detail):
+                self.log("Solis API: Skipping inverter {} - Solis Cloud reports no battery attached (batteryType {!r}), so it will not be managed as a battery inverter".format(inverter_sn, detail.get("batteryType")))
+                continue
             battery_soh = detail.get("batteryHealthSoh")
             try:
                 battery_soh = float(battery_soh) / 100.0

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -1028,6 +1028,110 @@ async def test_with_retry_aborts_on_oauth_failed():
     return failed
 
 
+# Battery blocks as SolisCloud inverterDetail actually returns them. Trimmed to the fields the
+# enrolment gate looks at; captured from a live two-inverter account where the battery had been
+# moved off the older inverter onto a newer one.
+_DETAIL_WITH_BATTERY = {
+    "batteryHealthSoh": 100.0,
+    "batteryType": "PYLON_LV",
+    "batteryTypeCode": "0001",
+    "batteryVoltage": 51.28,
+    "batteryCDEnableSet": 1,
+    "batteryJump": {"canJump": True, "batteryCount": 1, "batterySn": "1031260253072197BAT01"},
+    "batteryList": [{"batteryTypeName": "PYLON_LV", "battSn": "PYLON", "batteryVoltage": 51.28}],
+}
+
+_DETAIL_NO_BATTERY = {
+    "batteryHealthSoh": 0.0,
+    "batteryType": "No Battery",
+    "batteryTypeCode": "0000",
+    "batteryVoltage": 0.0,
+    "batteryCDEnableSet": 0,
+    "batteryJump": {"canJump": False, "batteryCount": 0},
+    "batteryList": [{"batteryTypeName": "No Battery", "battSn": "", "noBattery": True, "batteryVoltage": 0.0}],
+    # Lifetime counters survive the battery being removed - this inverter really did cycle
+    # 7.3 MWh before the pack was taken off it, so they must NOT be read as "has a battery".
+    "batteryTotalChargeEnergy": 7.332,
+    "batteryTotalDischargeEnergy": 6.619,
+    "batteryYearChargeEnergy": 1.159,
+    "batteryMonthChargeEnergy": 0.0,
+}
+
+# A real pack that happens to report SoH 0 - a documented, valid SolisCloud response. It must stay
+# enrolled; SoH alone can never be the reason to drop an inverter.
+_DETAIL_REAL_BATTERY_ZERO_SOH = {
+    "batteryHealthSoh": 0.0,
+    "batteryType": "PYLON_LV",
+    "batteryTypeCode": "0001",
+    "batteryVoltage": 50.9,
+    "batteryCDEnableSet": 1,
+    "batteryJump": {"canJump": True, "batteryCount": 1},
+    "batteryList": [{"batteryTypeName": "PYLON_LV", "battSn": "PYLON", "batteryVoltage": 50.9}],
+}
+
+
+async def _run_automatic_config(details):
+    """Run automatic_config() over `details` ({sn: detail}) and return the recorded set_arg_auto args."""
+    api = MockSolisAPI()
+    api.inverter_sn = list(details.keys())
+    api.inverter_details = dict(details)
+    recorded = {}
+    api.set_arg_auto = lambda key, value: recorded.__setitem__(key, value)
+    await api.automatic_config()
+    return recorded, api
+
+
+async def test_automatic_config_skips_no_battery_inverter():
+    """An inverter SolisCloud reports as having no battery must not be enrolled as a battery inverter.
+
+    Enrolling it makes num_inverters too high; every per-inverter arg is then short by one entry, so
+    inverter N reads out of range, and inverter.py invents an 8 kWh battery for hardware that has none.
+    """
+    failed = False
+    print("**** Testing automatic_config skips a No Battery inverter ****")
+
+    with_batt = "1031260253072197"
+    no_batt = "6031042245160206"
+    recorded, api = await _run_automatic_config({with_batt: _DETAIL_WITH_BATTERY, no_batt: _DETAIL_NO_BATTERY})
+
+    if recorded.get("num_inverters") != 1:
+        print("ERROR: expected num_inverters 1 (only the inverter with a battery), got {}".format(recorded.get("num_inverters")))
+        failed = True
+
+    soc_entities = recorded.get("soc_percent") or []
+    if len(soc_entities) != 1 or no_batt.lower() in " ".join(soc_entities):
+        print("ERROR: expected only the battery inverter to be wired up, got soc_percent={}".format(soc_entities))
+        failed = True
+    if soc_entities and with_batt.lower() not in " ".join(soc_entities):
+        print("ERROR: the inverter that does have a battery was dropped, got soc_percent={}".format(soc_entities))
+        failed = True
+
+    if not any("no battery" in m.lower() for m in api.log_messages):
+        print("ERROR: expected a log line explaining the inverter was skipped for having no battery")
+        failed = True
+
+    if not failed:
+        print("PASSED: automatic_config skips a No Battery inverter")
+    return failed
+
+
+async def test_automatic_config_keeps_real_battery_reporting_zero_soh():
+    """SoH 0 on a real pack is a valid SolisCloud response - such an inverter must stay enrolled."""
+    failed = False
+    print("**** Testing automatic_config keeps a real battery reporting SoH 0 ****")
+
+    sn = "1031260253072197"
+    recorded, _ = await _run_automatic_config({sn: _DETAIL_REAL_BATTERY_ZERO_SOH})
+
+    if recorded.get("num_inverters") != 1:
+        print("ERROR: a real battery reporting SoH 0 must stay enrolled, got num_inverters={}".format(recorded.get("num_inverters")))
+        failed = True
+
+    if not failed:
+        print("PASSED: automatic_config keeps a real battery reporting SoH 0")
+    return failed
+
+
 def run_solis_tests(my_predbat):
     """
     Run all Solis API tests
@@ -1046,6 +1150,8 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_oauth_endpoint_namespace_translation())
         failed |= asyncio.run(test_oauth_execute_request_aborts_when_token_missing())
         failed |= asyncio.run(test_with_retry_aborts_on_oauth_failed())
+        failed |= asyncio.run(test_automatic_config_skips_no_battery_inverter())
+        failed |= asyncio.run(test_automatic_config_keeps_real_battery_reporting_zero_soh())
         failed |= asyncio.run(test_read_cid())
         failed |= asyncio.run(test_read_batch())
         failed |= asyncio.run(test_read_and_write_cid())

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -1057,6 +1057,33 @@ _DETAIL_NO_BATTERY = {
     "batteryMonthChargeEnergy": 0.0,
 }
 
+# A second firmware, from a different account. Same "No Battery" verdict, but reported differently:
+# noBattery is None rather than True, batteryJump is None rather than a dict, and the only positive
+# statements are the two name fields. This is why the boolean cannot be the sole signal.
+_DETAIL_NO_BATTERY_ALT_FIRMWARE = {
+    "batteryHealthSoh": 0.0,
+    "batteryType": "No Battery",
+    "batteryTypeCode": "0000",
+    "batteryVoltage": 0.0,
+    "batteryCDEnableSet": 0,
+    "batteryJump": None,
+    "batteryList": [{"batteryType": 0, "batteryTypeName": "No Battery", "battSn": "", "noBattery": None, "batteryVoltage": 0.0}],
+    "batteryTotalChargeEnergy": 0.0,
+}
+
+# A real pack on that same firmware. Note the type name is 'Lithium Battery LV', not 'PYLON_LV' -
+# the positive values vary by pack, which is why detection matches "No Battery" rather than a
+# whitelist of known batteries.
+_DETAIL_WITH_BATTERY_ALT_FIRMWARE = {
+    "batteryHealthSoh": 100.0,
+    "batteryType": "Lithium Battery LV",
+    "batteryTypeCode": "0063",
+    "batteryVoltage": 54.83,
+    "batteryCDEnableSet": 1,
+    "batteryJump": None,
+    "batteryList": [{"batteryType": 99, "batteryTypeName": "Lithium Battery LV", "battSn": "", "noBattery": None, "batteryVoltage": 54.83}],
+}
+
 # A real pack that happens to report SoH 0 - a documented, valid SolisCloud response. It must stay
 # enrolled; SoH alone can never be the reason to drop an inverter.
 _DETAIL_REAL_BATTERY_ZERO_SOH = {
@@ -1115,6 +1142,59 @@ async def test_automatic_config_skips_no_battery_inverter():
     return failed
 
 
+async def test_automatic_config_skips_no_battery_on_alt_firmware():
+    """The other firmware leaves noBattery as None - only the name fields say "No Battery"."""
+    failed = False
+    print("**** Testing automatic_config skips a No Battery inverter on the alternate firmware ****")
+
+    with_batt = "6031052256280133"
+    no_batt = "6031052254150188"
+    recorded, _ = await _run_automatic_config({with_batt: _DETAIL_WITH_BATTERY_ALT_FIRMWARE, no_batt: _DETAIL_NO_BATTERY_ALT_FIRMWARE})
+
+    if recorded.get("num_inverters") != 1:
+        print("ERROR: expected num_inverters 1, got {} - noBattery is None here, so the name fields must carry it".format(recorded.get("num_inverters")))
+        failed = True
+
+    soc_entities = recorded.get("soc_percent") or []
+    if len(soc_entities) != 1 or no_batt.lower() in " ".join(soc_entities):
+        print("ERROR: expected only the battery inverter to be wired up, got soc_percent={}".format(soc_entities))
+        failed = True
+    if soc_entities and with_batt.lower() not in " ".join(soc_entities):
+        print("ERROR: the 'Lithium Battery LV' inverter was dropped - detection must not whitelist pack names, got soc_percent={}".format(soc_entities))
+        failed = True
+
+    if not failed:
+        print("PASSED: automatic_config skips a No Battery inverter on the alternate firmware")
+    return failed
+
+
+async def test_automatic_config_skips_no_battery_named_only_in_battery_list():
+    """ "No Battery" stated only inside batteryList must still be believed.
+
+    Which of Solis's battery fields are populated varies by firmware - one sets noBattery True,
+    another leaves it None, batteryJump is a dict on one and None on the other. So no single field
+    can be the only thing standing between us and inventing an 8 kWh battery; every place Solis
+    names the battery type is checked.
+    """
+    failed = False
+    print("**** Testing automatic_config believes 'No Battery' stated only in batteryList ****")
+
+    detail = {
+        "batteryHealthSoh": 0.0,
+        # No top-level batteryType at all - the list is the only statement.
+        "batteryList": [{"batteryTypeName": "No Battery", "noBattery": None}],
+    }
+    recorded, _ = await _run_automatic_config({"6000000000000001": detail})
+
+    if recorded.get("num_inverters") is not None:
+        print("ERROR: expected no configuration at all (no inverters with batteries), got num_inverters={}".format(recorded.get("num_inverters")))
+        failed = True
+
+    if not failed:
+        print("PASSED: automatic_config believes 'No Battery' stated only in batteryList")
+    return failed
+
+
 async def test_automatic_config_keeps_real_battery_reporting_zero_soh():
     """SoH 0 on a real pack is a valid SolisCloud response - such an inverter must stay enrolled."""
     failed = False
@@ -1151,6 +1231,8 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_oauth_execute_request_aborts_when_token_missing())
         failed |= asyncio.run(test_with_retry_aborts_on_oauth_failed())
         failed |= asyncio.run(test_automatic_config_skips_no_battery_inverter())
+        failed |= asyncio.run(test_automatic_config_skips_no_battery_on_alt_firmware())
+        failed |= asyncio.run(test_automatic_config_skips_no_battery_named_only_in_battery_list())
         failed |= asyncio.run(test_automatic_config_keeps_real_battery_reporting_zero_soh())
         failed |= asyncio.run(test_read_cid())
         failed |= asyncio.run(test_read_batch())


### PR DESCRIPTION
## Problem

`automatic_config()` picks which inverters to manage as battery inverters by checking only that `batteryHealthSoh` parses to a number. SoH 0 passes that gate deliberately — a real pack reporting SoH 0 is a documented, valid Solis Cloud response, and the existing comment says so.

But Solis Cloud also states the no-battery case outright, and we were ignoring it. Probing `inverterDetail` on a live two-inverter account:

| field | no battery | has a battery |
|---|---|---|
| `batteryType` | `'No Battery'` | `'PYLON_LV'` |
| `batteryTypeCode` | `'0000'` | `'0001'` |
| `batteryList[0].noBattery` | `True` | *(absent)* |
| `batteryList[0].battSn` | `''` | `'PYLON'` |
| `batteryJump` | `canJump: False, batteryCount: 0` | `canJump: True, batteryCount: 1` |
| `batteryCDEnableSet` | `0` | `1` |
| SoH / voltage / SoC | 0 / 0 V / 0 | 100 / 51.28 V / 37% |

Enrolling the battery-less inverter inflates `num_inverters`. Every per-inverter arg is then one entry short, so the extra inverter reads out of range:

```
Warn: Out of range index 1 within item soc_max value [25.68]
Warn: Return bad float value None from soc_max using default 0.0
Warn: Unable to determine battery size for inverter 1, using 8 kWh default for this cycle ...
Error: Completed run status Read-Only with Errors reported (check log)
```

`inverter.py` then invents an **8 kWh battery for hardware that has none**, and plans against it — on this account, charging a 25.68 kWh battery as though it were 33.68 kWh. The status sensor is also pinned to "Read-Only with Errors" every cycle.

## Fix

Gate on the explicit declaration only: `batteryType == 'No Battery'`, or a `batteryList` entry with `noBattery: True`. Absence of those fields (older firmware, other models) still means "unknown" and keeps the inverter enrolled, so **the SoH-0 case is untouched** — a real pack reporting SoH 0 still says `batteryType: 'PYLON_LV'` and stays enrolled.

Two things are deliberately **not** used as signals:

- **`batteryHealthSoh`** — per the existing comment.
- **The lifetime counters.** `batteryTotalChargeEnergy` and friends survive the pack being physically removed. The battery-less inverter above still reports 7.332 MWh charged lifetime and 1.159 MWh this year, with **0.0 this month** — because the battery was moved onto a newer inverter (which has only 3.96 MWh lifetime, i.e. less than the one it was moved from). "It has cycled MWh" does not mean "it has a battery now", and that's the trap most likely to catch the next reader.

## Testing

Two new tests in `test_solis.py`, using battery blocks captured verbatim from the live API:

- `test_automatic_config_skips_no_battery_inverter` — two inverters in, only the one with a battery enrolled, `num_inverters == 1`, and a log line explaining the skip. Fails on `main` with `num_inverters == 2` and both inverters wired up.
- `test_automatic_config_keeps_real_battery_reporting_zero_soh` — regression guard for the documented SoH-0 case. Passes before and after.

Full suite: `python3 ../apps/predbat/unit_test.py --quick` — 244 tests. Before: 2 failures (`solis`, `data_age_metrics`). After: 1 (`data_age_metrics` only). `data_age_metrics` fails identically on unmodified `main` (`Expected data_age_days=8, got 0`) and is unrelated.

`black --check` clean.

## Note

Related to #4637, which stops the out-of-range read being reported as a *status error*. That one is hygiene; this is the actual cause. They're independent and this one is the more important of the two.
