### PR TITLE
fix(octopus): re-wire IOG car slots when the live device set changes

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -2207,7 +2207,7 @@ class Fetch:
         if self.num_cars > 0:
             car_charging_limit_percent = [dp1(limit / size * 100) if size else 0 for limit, size in zip(self.car_charging_limit, self.car_charging_battery_size)]
             self.log(
-                "Cars {} charging from battery {} planned {}, charging_now {} smart {}, max_price {}{}, plan_time {}, battery size {}kWh, limit {}% ({}kWh), rate {}kW, exclusive {}".format(
+                "Cars {} charging from battery {} planned {}, charging_now {} smart {}, max_price {}{}, plan_time {}, battery size {}kWh, limit {}% ({}kWh), rate {}kW, exclusive {} (Predbat-led car settings, not Octopus Intelligent state)".format(
                     self.num_cars,
                     self.car_charging_from_battery,
                     self.car_charging_planned,

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -53,6 +53,10 @@ CATALOGUE_FRESH_MINUTES = 24 * 60
 CATALOGUE_STALE_MINUTES = 25 * 60
 OCTOPUS_SLOT_MAX_DEFAULT = 48  # 24 hours with 30-minute slots
 
+# Per-device settings read from the Octopus intelligent settings query. Kept as a list so a poll
+# whose settings query fails can carry the previous values forward rather than dropping the device.
+INTELLIGENT_DEVICE_SETTING_KEYS = ["suspended", "weekday_target_time", "weekday_target_soc", "weekend_target_time", "weekend_target_soc", "minimum_soc", "maximum_soc"]
+
 BASE_TIME = datetime.strptime("00:00", "%H:%M")
 OPTIONS_TIME = [((BASE_TIME + timedelta(seconds=minute * 60)).strftime("%H:%M")) for minute in range(4 * 60, 11 * 60, 30)]
 
@@ -429,6 +433,10 @@ class OctopusAPI(ComponentBase):
         self.saving_sessions = {}
         self.saving_sessions_to_join = []
         self.intelligent_devices = {}
+        # Active device IDs automatic_config() last wired the car slots to - None until it has run.
+        # run() compares this against the live set so a device appearing, disappearing or being
+        # suspended re-wires the slots without waiting for a restart (issue #4648).
+        self.intelligent_config_devices = None
         self.tariff_fetched_at = None
         self.device_fetched_at = None
         self.sensor_updated_at = None
@@ -542,8 +550,22 @@ class OctopusAPI(ComponentBase):
             # Don't save cache every 2 minutes, if we lose it then we re-fresh it anyhow
             await self.save_octopus_cache()
 
-        if first and self.automatic:
-            self.automatic_config(self.tariffs)
+        # Wire the discovered entities into args. This has to come after the sensor refresh above,
+        # and only on a cycle that actually ran it: automatic_config() points octopus_intelligent_slot
+        # at each device's dispatch entity, so that entity must already have been published or the
+        # next fetch cycle reads an entity that does not exist yet. Gating on sensor_due costs
+        # nothing - the device set can only move on a cycle that re-polled it.
+        if self.automatic:
+            active_devices = self.get_active_intelligent_device_ids()
+            if first:
+                self.automatic_config(self.tariffs)
+            elif sensor_due and active_devices != self.intelligent_config_devices:
+                # The set of live, non-suspended Intelligent devices has moved - a second EV
+                # registered on the account, one deregistered, or the customer suspended one in
+                # favour of another. Left alone, the car slots keep watching the old device's
+                # dispatch sensor and Predbat never sees the live IOG window (issue #4648).
+                self.log("OctopusAPI: Live intelligent devices changed from {} to {}, reconfiguring car slots".format(self.intelligent_config_devices, active_devices))
+                self.automatic_config(self.tariffs)
 
         return True
 
@@ -902,6 +924,15 @@ class OctopusAPI(ComponentBase):
             # Re-fetch the saving sessions if we have joined any
             self.saving_sessions = await self.async_get_saving_sessions(account_id)
 
+    def get_active_intelligent_device_ids(self):
+        """
+        Return the sorted list of live intelligent device IDs that are not suspended.
+
+        This is exactly the set automatic_config() wires car slots to, so run() can compare it
+        against the wiring it built last time and re-run the wiring when the account changes.
+        """
+        return sorted(device_id for device_id, device in self.intelligent_devices.items() if not device.get("suspended"))
+
     def get_intelligent_devices(self):
         """
         Get the intelligent device
@@ -1148,7 +1179,12 @@ class OctopusAPI(ComponentBase):
             slot_list = []
             ready_list = []
             limit_list = []
-            for device_id in active_devices:
+            # Sort so a given device always lands in the same car slot. The slot index is what
+            # per-car settings (car_charging_battery_size, car_charging_limit, manual SoC,
+            # exclusive) are keyed on, and self.intelligent_devices is in first-seen order - so
+            # without this a device dropping out of one poll and returning on the next would
+            # re-order the slots and silently apply one car's settings to another.
+            for device_id in sorted(active_devices):
                 index_suffix = self.device_id_to_index_suffix(device_id)
                 slot_list.append(self.get_entity_name("binary_sensor", "intelligent_dispatch", index=index_suffix))
                 ready_list.append(self.get_entity_name("select", "intelligent_target_time", index=index_suffix))
@@ -1160,6 +1196,10 @@ class OctopusAPI(ComponentBase):
             num_cars = self.get_arg("num_cars", 0)
             if num_cars < len(active_devices):
                 self.set_arg("num_cars", len(active_devices))
+            self.log("OctopusAPI: Car slots wired to intelligent devices {}".format(sorted(active_devices)))
+
+        # Record the device set this wiring was built for so run() can spot it changing later
+        self.intelligent_config_devices = self.get_active_intelligent_device_ids()
 
     async def async_get_saving_sessions(self, account_id):
         """
@@ -1873,7 +1913,20 @@ class OctopusAPI(ComponentBase):
                                         device_setting_result["minimum_soc"] = chargingPreferences.get("minimumSoc", None)
                                         device_setting_result["maximum_soc"] = chargingPreferences.get("maximumSoc", None)
                             else:
-                                continue
+                                # Dropping the device here would make async_update_intelligent_devices
+                                # treat it as no longer LIVE and evict it from the cache, so one flaky
+                                # settings query would un-register a real car - and with the device set
+                                # driving car slot re-wiring (issue #4648) that flaps the slots on every
+                                # blip. Carry the last known settings forward instead, so the suspended
+                                # flag only moves when Octopus actually says it has.
+                                cached_device = self.intelligent_devices.get(IntelligentdeviceID, {})
+                                if "suspended" not in cached_device:
+                                    self.log("Warn: OctopusAPI: No settings for intelligent device {} and none cached, skipping it this poll".format(IntelligentdeviceID))
+                                    continue
+                                self.log("Warn: OctopusAPI: Settings fetch failed for intelligent device {}, reusing the last known settings".format(IntelligentdeviceID))
+                                for setting_key in INTELLIGENT_DEVICE_SETTING_KEYS:
+                                    if setting_key in cached_device:
+                                        device_setting_result[setting_key] = cached_device[setting_key]
 
                         if isCharger:
                             for charger in chargePointVariants:

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -1175,9 +1175,11 @@ class OctopusAPI(ComponentBase):
                 self.set_arg("metric_standing_charge", self.get_entity_name("sensor", tariff + "_standing"))
         devices = self.get_intelligent_devices()
         # Also enter this block when the device set has emptied, so the slot args are cleared rather
-        # than left pointing at a device that no longer exists. Only once something has been wired
-        # though (intelligent_config_devices is not None): before the first discovery a user's own
-        # apps.yaml entries are the only wiring there is, and blanking them would break a manual setup.
+        # than left pointing at a device that no longer exists. Only once real devices have actually
+        # been wired though - hence the truthiness test rather than an `is not None` one. The set
+        # below is recorded on every call, including calls that wired nothing, so it is [] and not
+        # None after the first run on an account with no devices; treating that as "previously
+        # wired" would blank a user's own apps.yaml entries, which auto-discovery never touched.
         if devices or self.intelligent_config_devices:
             # Suspended devices (e.g. an old/decommissioned charger still linked to the Octopus
             # account) aren't actively charging, so exclude them from the entity lists and from

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -776,7 +776,11 @@ class OctopusAPI(ComponentBase):
         deviceID = import_tariff.get("deviceID", None)
         if deviceID:
             intelligent_devices = await self.async_get_intelligent_devices(account_id, deviceID)
-            if intelligent_devices:
+            # None means the poll failed, so keep what we have. {} means the poll succeeded and the
+            # account has no live EV devices left - the electricity meter stays in the devices list
+            # after the last EV is deregistered, so that is a real removal and must be pruned or the
+            # dead device stays wired to a car slot forever.
+            if intelligent_devices is not None:
                 # Update existing intelligent devices with new dispatch data.
                 # Always call fetch_previous_dispatch when completed dispatches are available to merge historical data.
                 for device_id in intelligent_devices:
@@ -1170,7 +1174,11 @@ class OctopusAPI(ComponentBase):
             if tariff == "import":
                 self.set_arg("metric_standing_charge", self.get_entity_name("sensor", tariff + "_standing"))
         devices = self.get_intelligent_devices()
-        if devices:
+        # Also enter this block when the device set has emptied, so the slot args are cleared rather
+        # than left pointing at a device that no longer exists. Only once something has been wired
+        # though (intelligent_config_devices is not None): before the first discovery a user's own
+        # apps.yaml entries are the only wiring there is, and blanking them would break a manual setup.
+        if devices or self.intelligent_config_devices:
             # Suspended devices (e.g. an old/decommissioned charger still linked to the Octopus
             # account) aren't actively charging, so exclude them from the entity lists and from
             # the num_cars count below - otherwise a stale suspended device can silently push
@@ -1196,7 +1204,10 @@ class OctopusAPI(ComponentBase):
             num_cars = self.get_arg("num_cars", 0)
             if num_cars < len(active_devices):
                 self.set_arg("num_cars", len(active_devices))
-            self.log("OctopusAPI: Car slots wired to intelligent devices {}".format(sorted(active_devices)))
+            if active_devices:
+                self.log("OctopusAPI: Car slots wired to intelligent devices {}".format(sorted(active_devices)))
+            else:
+                self.log("OctopusAPI: No active intelligent devices remain, cleared the car slot wiring")
 
         # Record the device set this wiring was built for so run() can spot it changing later
         self.intelligent_config_devices = self.get_active_intelligent_device_ids()
@@ -2027,6 +2038,11 @@ class OctopusAPI(ComponentBase):
                         # Store results
                         result = {**intelligent_device, **device_setting_result, "planned_dispatches": planned, "completed_dispatches": completed}
                         results[IntelligentdeviceID] = result
+            else:
+                # The devices query failed. Returning {} here would be indistinguishable from an
+                # account that genuinely has no EVs left on it, and the caller would prune the
+                # cache on every blip - report the failure so it can leave the cache alone.
+                return None
         return results
 
     async def async_intelligent_update_sensor(self, account_id):

--- a/apps/predbat/tests/test_octopus_intelligent_devices.py
+++ b/apps/predbat/tests/test_octopus_intelligent_devices.py
@@ -31,6 +31,8 @@ async def test_octopus_intelligent_devices(my_predbat):
     - Test 9: Future flex dispatch is left untrimmed in planned
     - Test 10: async_update_intelligent_devices prunes a device no longer returned as LIVE
     - Test 11: A transient settings-query failure does not evict a known device
+    - Test 12: A successful poll finding no live EVs is distinguishable from a failed poll
+    - Test 13: The cache empties when the last EV is deregistered, but survives a failed poll
     """
     print("**** Running Octopus intelligent devices tests ****")
     failed = 0
@@ -591,6 +593,88 @@ async def test_octopus_intelligent_devices(my_predbat):
         failed += 1
     else:
         print("PASS: Never-seen device is skipped when its settings query fails")
+
+    # ------------------------------------------------------------------
+    # Test 12: "the devices query failed" and "the account has no EVs on it any more" must not
+    # look the same to the caller. Both used to return {}, so async_update_intelligent_devices
+    # could not tell them apart and skipped pruning for both - which meant deregistering your last
+    # EV left it cached and wired to a car slot forever. A failed query returns None; a successful
+    # query that simply contains no live EV devices returns {}.
+    # ------------------------------------------------------------------
+    print("\n*** Test 12: Failed poll and genuinely empty account are distinguishable ***")
+    api = make_api()
+
+    async def mock_query_devices_fail(query, context, ignore_errors=False, returns_data=True):
+        if "get-intelligent-devices" in context:
+            return None
+        return None
+
+    api.async_graphql_query = AsyncMock(side_effect=mock_query_devices_fail)
+    failed_result = await api.async_get_intelligent_devices("test-account", "device-abc")
+
+    if failed_result is not None:
+        print(f"ERROR: Expected None when the devices query fails, got {failed_result!r}")
+        failed += 1
+    else:
+        print("PASS: Failed devices query reports None")
+
+    # The electricity meter stays in the devices list after the EV is removed, so a genuinely
+    # EV-free account still returns a non-empty devices list - just none of type ELECTRIC_VEHICLES.
+    meter_only_data = {
+        "devices": [
+            {
+                "deviceType": "ELECTRICITY_METERS",
+                "status": {"current": "LIVE"},
+                "__typename": "SmartFlexDevice",
+                "id": "meter-1",
+            }
+        ]
+    }
+
+    async def mock_query_meter_only(query, context, ignore_errors=False, returns_data=True):
+        if "get-intelligent-devices" in context:
+            return meter_only_data
+        return None
+
+    api2 = make_api()
+    api2.async_graphql_query = AsyncMock(side_effect=mock_query_meter_only)
+    empty_result = await api2.async_get_intelligent_devices("test-account", "device-abc")
+
+    if empty_result is None:
+        print("ERROR: Expected {} for an account with no live EVs, got None")
+        failed += 1
+    elif empty_result != {}:
+        print(f"ERROR: Expected no devices for a meter-only account, got {list(empty_result.keys())}")
+        failed += 1
+    else:
+        print("PASS: Account with no live EVs reports an empty result, not a failure")
+
+    # ------------------------------------------------------------------
+    # Test 13: the cache follows that distinction - it empties when the last EV really is gone, and
+    # is left alone when the poll simply failed.
+    # ------------------------------------------------------------------
+    print("\n*** Test 13: Cache empties on a real removal but survives a failed poll ***")
+    api = make_api()
+    api.tariffs = {"import": {"tariffCode": "E-1R-INTELLI-VAR-24-10-29-A", "deviceID": "meter-1"}}
+    api.intelligent_devices = {"device-real": {"device_id": "device-real", "suspended": False, "completed_dispatches": [], "planned_dispatches": []}}
+
+    api.async_get_intelligent_devices = AsyncMock(return_value=None)
+    await api.async_update_intelligent_devices("test-account")
+
+    if "device-real" not in api.intelligent_devices:
+        print("ERROR: A failed poll wiped the intelligent device cache")
+        failed += 1
+    else:
+        print("PASS: Cache retained when the poll fails")
+
+        api.async_get_intelligent_devices = AsyncMock(return_value={})
+        await api.async_update_intelligent_devices("test-account")
+
+        if api.intelligent_devices != {}:
+            print(f"ERROR: Expected the cache to empty once the last EV is deregistered, got {list(api.intelligent_devices.keys())}")
+            failed += 1
+        else:
+            print("PASS: Cache empties once the last EV is deregistered")
 
     if failed == 0:
         print("\n**** All Octopus intelligent devices tests PASSED ****")

--- a/apps/predbat/tests/test_octopus_intelligent_devices.py
+++ b/apps/predbat/tests/test_octopus_intelligent_devices.py
@@ -30,6 +30,7 @@ async def test_octopus_intelligent_devices(my_predbat):
     - Test 8: In-progress flex dispatch not promoted to completed but trimmed to remainder (issue #4114)
     - Test 9: Future flex dispatch is left untrimmed in planned
     - Test 10: async_update_intelligent_devices prunes a device no longer returned as LIVE
+    - Test 11: A transient settings-query failure does not evict a known device
     """
     print("**** Running Octopus intelligent devices tests ****")
     failed = 0
@@ -538,6 +539,58 @@ async def test_octopus_intelligent_devices(my_predbat):
             failed += 1
         else:
             print("PASS: Stale device no longer live was pruned, real device retained")
+
+    # ------------------------------------------------------------------
+    # Test 11: A device whose per-device settings query transiently fails must not be dropped
+    # from the result. Dropping it makes async_update_intelligent_devices treat the device as no
+    # longer LIVE and delete it from the cache (Test 10's pruning path), so one flaky GraphQL call
+    # evicts a real car - and with the device set now driving automatic_config re-wiring
+    # (issue #4648) that would flap the car slots on every blip. Reuse the last known settings
+    # instead, so the suspended flag stays put until Octopus actually tells us otherwise.
+    # ------------------------------------------------------------------
+    print("\n*** Test 11: Transient settings-query failure does not evict a known device ***")
+    api = make_api()
+
+    async def mock_query_settings_fail(query, context, ignore_errors=False, returns_data=True):
+        if "get-intelligent-devices" in context:
+            return device_data
+        elif "get-intelligent-dispatches" in context:
+            return {"flexPlannedDispatches": [], "completedDispatches": []}
+        elif "get-intelligent-settings" in context:
+            return None
+        return None
+
+    # The device is already known from an earlier successful poll, and was suspended at the time
+    api.intelligent_devices = {"device-abc": {"device_id": "device-abc", "suspended": True, "weekday_target_time": "07:00", "completed_dispatches": [], "planned_dispatches": []}}
+    api.async_graphql_query = AsyncMock(side_effect=mock_query_settings_fail)
+
+    result = await api.async_get_intelligent_devices("test-account", "device-abc")
+
+    if "device-abc" not in result:
+        print(f"ERROR: Known device evicted by a transient settings-query failure, got {list(result.keys())}")
+        failed += 1
+    elif result["device-abc"].get("suspended") is not True:
+        print(f"ERROR: Expected the last known suspended state to be retained, got {result['device-abc'].get('suspended')}")
+        failed += 1
+    elif result["device-abc"].get("weekday_target_time") != "07:00":
+        print(f"ERROR: Expected the last known charging preferences to be retained, got {result['device-abc'].get('weekday_target_time')}")
+        failed += 1
+    else:
+        print("PASS: Known device retained with its last known settings when the settings query fails")
+
+    # A device we have never seen before has no settings to fall back on, so it is still skipped
+    # rather than being wired in with an unknown suspended state.
+    api2 = make_api()
+    api2.intelligent_devices = {}
+    api2.async_graphql_query = AsyncMock(side_effect=mock_query_settings_fail)
+
+    result2 = await api2.async_get_intelligent_devices("test-account", "device-abc")
+
+    if "device-abc" in result2:
+        print(f"ERROR: Unknown device should be skipped when its settings cannot be read, got {list(result2.keys())}")
+        failed += 1
+    else:
+        print("PASS: Never-seen device is skipped when its settings query fails")
 
     if failed == 0:
         print("\n**** All Octopus intelligent devices tests PASSED ****")

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -28,6 +28,7 @@ async def test_octopus_misc(my_predbat):
     failed += test_octopus_get_intelligent_vehicle(my_predbat)
     failed += test_octopus_automatic_config_num_cars(my_predbat)
     failed += test_octopus_automatic_config_slot_order(my_predbat)
+    failed += test_octopus_automatic_config_clears_removed_devices(my_predbat)
     failed += await test_octopus_automatic_config_rewire(my_predbat)
     failed += await test_octopus_run(my_predbat)
 
@@ -2037,6 +2038,69 @@ def test_octopus_automatic_config_slot_order(my_predbat):
         return 1
     else:
         print("\n**** ✅ Octopus automatic_config slot order tests PASSED ****")
+        return 0
+
+
+def test_octopus_automatic_config_clears_removed_devices(my_predbat):
+    """
+    Test that automatic_config clears the car slot args once the last intelligent device is gone.
+
+    The wiring block only ran when the device cache was non-empty, so deregistering the last EV
+    would leave octopus_intelligent_slot / octopus_ready_time / octopus_charge_limit pointed at a
+    device that no longer exists. It must not clear them before any device has ever been
+    discovered though, or it would wipe a hand-written apps.yaml config at startup.
+
+    Tests:
+    - Test 1: Slot args are cleared when the last discovered device disappears
+    - Test 2: Manually configured slot args are untouched when no device was ever discovered
+    """
+    print("\n**** Running Octopus automatic_config device removal tests ****")
+    failed = False
+
+    original_args = dict(my_predbat.args)
+
+    print("\n*** Test 1: Slot args cleared when the last discovered device disappears ***")
+    api = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)
+    api.intelligent_devices = {"device-aaa1": {"suspended": False}}
+    api.automatic_config(["import"])
+
+    if not my_predbat.args.get("octopus_intelligent_slot"):
+        print("ERROR: Expected the device to be wired into a slot before it is removed")
+        failed = True
+
+    api.intelligent_devices = {}
+    api.automatic_config(["import"])
+
+    if my_predbat.args.get("octopus_intelligent_slot"):
+        print(f"ERROR: Expected slot args to be cleared, got {my_predbat.args.get('octopus_intelligent_slot')}")
+        failed = True
+    elif my_predbat.args.get("octopus_ready_time") or my_predbat.args.get("octopus_charge_limit"):
+        print(f"ERROR: Expected ready time and charge limit to be cleared, got {my_predbat.args.get('octopus_ready_time')} / {my_predbat.args.get('octopus_charge_limit')}")
+        failed = True
+    else:
+        print("PASS: Slot args cleared once the last discovered device disappears")
+
+    print("\n*** Test 2: Manual slot config untouched when no device was ever discovered ***")
+    my_predbat.args["octopus_intelligent_slot"] = "binary_sensor.manually_configured_dispatching"
+    api2 = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)
+    api2.intelligent_devices = {}
+
+    api2.automatic_config(["import"])
+
+    if my_predbat.args.get("octopus_intelligent_slot") != "binary_sensor.manually_configured_dispatching":
+        print(f"ERROR: Expected the manual slot config to be left alone, got {my_predbat.args.get('octopus_intelligent_slot')}")
+        failed = True
+    else:
+        print("PASS: Manual slot config untouched when no device was ever discovered")
+
+    my_predbat.args.clear()
+    my_predbat.args.update(original_args)
+
+    if failed:
+        print("\n**** ❌ Octopus automatic_config device removal tests FAILED ****")
+        return 1
+    else:
+        print("\n**** ✅ Octopus automatic_config device removal tests PASSED ****")
         return 0
 
 

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -2053,6 +2053,7 @@ def test_octopus_automatic_config_clears_removed_devices(my_predbat):
     Tests:
     - Test 1: Slot args are cleared when the last discovered device disappears
     - Test 2: Manually configured slot args are untouched when no device was ever discovered
+    - Test 3: Manually configured slot args survive repeated runs with no devices
     """
     print("\n**** Running Octopus automatic_config device removal tests ****")
     failed = False
@@ -2092,6 +2093,26 @@ def test_octopus_automatic_config_clears_removed_devices(my_predbat):
         failed = True
     else:
         print("PASS: Manual slot config untouched when no device was ever discovered")
+
+    # Test 3: automatic_config() records the device set it wired on every call, including the calls
+    # where it wired nothing - so after one run with no devices the recorded set is [] rather than
+    # None. The "have we ever wired anything" guard therefore has to test that set for content, not
+    # merely for being set: an `is not None` check would pass here from the second call onwards and
+    # blank a manual apps.yaml config that auto-discovery never touched.
+    print("\n*** Test 3: Manual slot config survives repeated runs with no devices ***")
+    my_predbat.args["octopus_intelligent_slot"] = "binary_sensor.manually_configured_dispatching"
+    api3 = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)
+    api3.intelligent_devices = {}
+
+    api3.automatic_config(["import"])
+    api3.automatic_config(["import"])
+    api3.automatic_config(["import"])
+
+    if my_predbat.args.get("octopus_intelligent_slot") != "binary_sensor.manually_configured_dispatching":
+        print(f"ERROR: Repeated runs with no devices blanked the manual slot config, got {my_predbat.args.get('octopus_intelligent_slot')}")
+        failed = True
+    else:
+        print("PASS: Manual slot config survives repeated runs with no devices")
 
     my_predbat.args.clear()
     my_predbat.args.update(original_args)

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -27,6 +27,8 @@ async def test_octopus_misc(my_predbat):
     failed += test_octopus_get_intelligent_battery_size(my_predbat)
     failed += test_octopus_get_intelligent_vehicle(my_predbat)
     failed += test_octopus_automatic_config_num_cars(my_predbat)
+    failed += test_octopus_automatic_config_slot_order(my_predbat)
+    failed += await test_octopus_automatic_config_rewire(my_predbat)
     failed += await test_octopus_run(my_predbat)
 
     if failed == 0:
@@ -1963,6 +1965,239 @@ def test_octopus_automatic_config_num_cars(my_predbat):
         return 1
     else:
         print("\n**** ✅ Octopus automatic_config num_cars tests PASSED ****")
+        return 0
+
+
+def test_octopus_automatic_config_slot_order(my_predbat):
+    """
+    Test that automatic_config assigns car slots to intelligent devices in a stable order.
+
+    Car-indexed settings (car_charging_battery_size, car_charging_limit, manual SoC, exclusive)
+    are keyed by slot number, so the device that occupies slot N must not change just because
+    the cache happened to be rebuilt in a different order. Before this was pinned, the slot list
+    followed self.intelligent_devices insertion order, so a device dropping out of the live list
+    and coming back re-ordered the slots and silently applied one car's settings to another.
+
+    Tests:
+    - Test 1: Slot order does not depend on the insertion order of intelligent_devices
+    """
+    print("\n**** Running Octopus automatic_config slot order tests ****")
+    failed = False
+
+    original_args = dict(my_predbat.args)
+
+    print("\n*** Test 1: Slot order is independent of intelligent_devices insertion order ***")
+    api = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)
+
+    api.intelligent_devices = {
+        "device-aaa1": {"suspended": False},
+        "device-bbb2": {"suspended": False},
+        "device-ccc3": {"suspended": False},
+    }
+    api.automatic_config(["import"])
+    first_order = list(my_predbat.args.get("octopus_intelligent_slot", []))
+
+    # Same three devices, but cached in a different order - e.g. device-aaa1 dropped out of the
+    # live devices() response for a poll and was re-added afterwards, putting it last.
+    api.intelligent_devices = {
+        "device-bbb2": {"suspended": False},
+        "device-ccc3": {"suspended": False},
+        "device-aaa1": {"suspended": False},
+    }
+    api.automatic_config(["import"])
+    second_order = list(my_predbat.args.get("octopus_intelligent_slot", []))
+
+    if first_order != second_order:
+        print(f"ERROR: Slot order changed with insertion order: {first_order} then {second_order}")
+        failed = True
+    elif len(first_order) != 3:
+        print(f"ERROR: Expected 3 slots, got {first_order}")
+        failed = True
+    else:
+        print("PASS: Slot order is stable regardless of cache insertion order")
+
+    # octopus_ready_time and octopus_charge_limit are indexed by the same slot number, so they
+    # must be ordered to match octopus_intelligent_slot device for device.
+    ready_list = my_predbat.args.get("octopus_ready_time", [])
+    limit_list = my_predbat.args.get("octopus_charge_limit", [])
+    suffixes_slot = [entity.split("_")[-1] for entity in second_order]
+    suffixes_ready = [entity.split("_")[-1] for entity in ready_list]
+    suffixes_limit = [entity.split("_")[-1] for entity in limit_list]
+    if suffixes_slot != suffixes_ready or suffixes_slot != suffixes_limit:
+        print(f"ERROR: Per-slot lists disagree on device order: slot {suffixes_slot}, ready {suffixes_ready}, limit {suffixes_limit}")
+        failed = True
+    else:
+        print("PASS: octopus_ready_time and octopus_charge_limit follow the same device order")
+
+    my_predbat.args.clear()
+    my_predbat.args.update(original_args)
+
+    if failed:
+        print("\n**** ❌ Octopus automatic_config slot order tests FAILED ****")
+        return 1
+    else:
+        print("\n**** ✅ Octopus automatic_config slot order tests PASSED ****")
+        return 0
+
+
+async def test_octopus_automatic_config_rewire(my_predbat):
+    """
+    Test that run() re-wires the car slots when the live/non-suspended intelligent device set changes.
+
+    Issue #4648: automatic_config() only ran on the first successful run() or when the tariff-code
+    set changed, so a second EV appearing on the account - or the customer suspending one device in
+    favour of another - left octopus_intelligent_slot pointing at the wrong device. Predbat then did
+    not recognise the live IOG dispatch window and discharged the home battery through it.
+
+    Tests:
+    - Test 1: No re-wire when a poll finds the active device set unchanged
+    - Test 2: Re-wire when a poll finds a newly registered device
+    - Test 3: Re-wire when suspension swaps between two devices, and slot 0 follows the live device
+    - Test 4: The dispatch sensor is published before the re-wire points args at it
+    - Test 5: No re-wire when automatic configuration is disabled
+    """
+    print("\n**** Running Octopus automatic_config re-wire tests ****")
+    failed = False
+
+    original_args = dict(my_predbat.args)
+
+    # Cycle times far enough apart that the second run is a real dispatch-sensor refresh, which is
+    # the only cycle on which the device set can actually move.
+    first_at = datetime(2025, 1, 1, 10, 0, 0)
+    second_at = datetime(2025, 1, 1, 10, 30, 0)
+
+    def make_api(devices, automatic=True):
+        """Create a run()-mocked API holding the given intelligent device cache."""
+        api = _mock_run_api(my_predbat, key="test-api-key", account_id="test-account", automatic=automatic)
+        api.tariffs = {"import": {}}
+        api.intelligent_devices = devices
+        return api
+
+    async def run_cycle(api, now, first=False, poll_finds=None):
+        """Run one run() cycle at the given time, applying what that cycle's device poll discovers."""
+        if poll_finds is not None:
+            api.async_update_intelligent_devices = AsyncMock(side_effect=lambda *args, **kwargs: poll_finds())
+        with patch("octopus.datetime") as mock_datetime:
+            mock_datetime.now.return_value = now
+            await api.run(seconds=0, first=first)
+
+    # Test 1: a poll that finds nothing new must not re-wire - automatic_config() overwrites
+    # user-visible args and logs, so it should only run when the wiring needs to change.
+    print("\n*** Test 1: No re-wire when a poll finds the active device set unchanged ***")
+    api = make_api({"device-aaa1": {"suspended": False}})
+    await run_cycle(api, first_at, first=True)
+    api.automatic_config = MagicMock()
+
+    await run_cycle(api, second_at)
+
+    if api.automatic_config.call_count != 0:
+        print(f"ERROR: Expected no re-wire when the device set is unchanged, got {api.automatic_config.call_count}")
+        failed = True
+    else:
+        print("PASS: No re-wire when a poll finds the active device set unchanged")
+
+    # Test 2: a second EV registered on the account must be picked up without a restart
+    print("\n*** Test 2: Re-wire when a poll finds a newly registered device ***")
+    api2 = make_api({"device-aaa1": {"suspended": False}})
+    await run_cycle(api2, first_at, first=True)
+
+    def register_second_car():
+        """Simulate the device poll returning a newly registered second EV."""
+        api2.intelligent_devices["device-bbb2"] = {"suspended": False}
+
+    await run_cycle(api2, second_at, poll_finds=register_second_car)
+
+    slot_list = my_predbat.args.get("octopus_intelligent_slot", [])
+    if len(slot_list) != 2:
+        print(f"ERROR: Expected the new device to be wired into a second slot, got {slot_list}")
+        failed = True
+    elif my_predbat.args.get("num_cars") != 2:
+        print(f"ERROR: Expected num_cars to be raised to 2, got {my_predbat.args.get('num_cars')}")
+        failed = True
+    else:
+        print("PASS: Newly registered device re-wired without a restart")
+
+    # Test 3: the observed failure - two EVs, suspension swaps from one to the other. Slot 0 must
+    # follow whichever device is live, otherwise Predbat watches a suspended device's dispatch
+    # sensor and never sees the real dispatch window.
+    print("\n*** Test 3: Re-wire when suspension swaps between two devices ***")
+    api3 = make_api({"device-tesla": {"suspended": False}, "device-vw": {"suspended": True}})
+    my_predbat.args["num_cars"] = 1
+    await run_cycle(api3, first_at, first=True)
+
+    slot_before = list(my_predbat.args.get("octopus_intelligent_slot", []))
+    if len(slot_before) != 1 or "tesla" not in slot_before[0]:
+        print(f"ERROR: Expected slot 0 wired to the live Tesla device, got {slot_before}")
+        failed = True
+
+    def swap_suspension():
+        """Simulate the device poll seeing the Tesla suspended and the VW resumed."""
+        api3.intelligent_devices["device-tesla"]["suspended"] = True
+        api3.intelligent_devices["device-vw"]["suspended"] = False
+
+    await run_cycle(api3, second_at, poll_finds=swap_suspension)
+
+    slot_after = list(my_predbat.args.get("octopus_intelligent_slot", []))
+    if len(slot_after) != 1:
+        print(f"ERROR: Expected exactly one active slot after the swap, got {slot_after}")
+        failed = True
+    elif "vw" not in slot_after[0]:
+        print(f"ERROR: Expected slot 0 to follow the now-live VW device, got {slot_after}")
+        failed = True
+    else:
+        print("PASS: Slot 0 follows the live device after a suspension swap")
+
+    # Test 4: the re-wire points octopus_intelligent_slot at a new device's dispatch entity, so that
+    # entity has to have been published first. Re-wiring before the sensor update would leave a
+    # cycle where fetch_sensor_data_cars() reads an entity that does not exist yet and reports
+    # "octopus_intelligent_slot not set correctly in apps.yaml" against the status sensor.
+    print("\n*** Test 4: Dispatch sensor is published before the re-wire points args at it ***")
+    api4 = make_api({"device-aaa1": {"suspended": False}})
+    await run_cycle(api4, first_at, first=True)
+
+    call_order = []
+    api4.async_intelligent_update_sensor = AsyncMock(side_effect=lambda *args, **kwargs: call_order.append("sensor"))
+    api4.automatic_config = MagicMock(side_effect=lambda *args, **kwargs: call_order.append("config"))
+
+    def register_another_car():
+        """Simulate the device poll returning an additional device."""
+        api4.intelligent_devices["device-bbb2"] = {"suspended": False}
+
+    await run_cycle(api4, second_at, poll_finds=register_another_car)
+
+    if call_order != ["sensor", "config"]:
+        print(f"ERROR: Expected the dispatch sensor to be published before the re-wire, got {call_order}")
+        failed = True
+    else:
+        print("PASS: Dispatch sensor published before the re-wire points args at it")
+
+    # Test 5: automatic=False means the user wired apps.yaml themselves - auto-discovery must never
+    # overwrite that, however the device set moves.
+    print("\n*** Test 5: No re-wire when automatic configuration is disabled ***")
+    api5 = make_api({"device-aaa1": {"suspended": False}}, automatic=False)
+    await run_cycle(api5, first_at, first=True)
+    api5.automatic_config = MagicMock()
+
+    def register_car_manual():
+        """Simulate the device poll returning an additional device on a manually configured setup."""
+        api5.intelligent_devices["device-bbb2"] = {"suspended": False}
+
+    await run_cycle(api5, second_at, poll_finds=register_car_manual)
+
+    if api5.automatic_config.call_count != 0:
+        print(f"ERROR: Expected no re-wire when automatic is disabled, got {api5.automatic_config.call_count}")
+        failed = True
+    else:
+        print("PASS: No re-wire when automatic configuration is disabled")
+
+    my_predbat.args.clear()
+    my_predbat.args.update(original_args)
+
+    if failed:
+        print("\n**** ❌ Octopus automatic_config re-wire tests FAILED ****")
+        return 1
+    else:
+        print("\n**** ✅ Octopus automatic_config re-wire tests PASSED ****")
         return 0
 
 

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -270,6 +270,34 @@ Just keep the single-sensor config (or provide a one-entry list) and car 1 will 
 
 *Note:* The `octopus_slot_max` limit applies per-car, so with two cars on IOG each car is subject to its own slot-count cap.
 
+#### How Predbat picks which car goes in which slot (octopus_automatic)
+
+With **octopus_automatic** set to True, Predbat wires the car slots itself from the devices your Octopus account
+reports as live. Devices that Octopus reports as suspended are skipped, and the remaining devices are assigned to
+car slots in a fixed order, so a given car keeps the same car index across restarts.
+
+Predbat re-checks this on every device poll (roughly every 2 minutes) and re-wires the slots if the set of live,
+non-suspended devices changes - for example when you enrol a second EV, remove one, or suspend one car in favour of
+another. You do not need to restart Predbat for a change made in the Octopus app to be picked up. Each re-wire is
+logged as:
+
+```text
+OctopusAPI: Live intelligent devices changed from [...] to [...], reconfiguring car slots
+OctopusAPI: Car slots wired to intelligent devices [...]
+```
+
+To confirm which car slot is actually following IOG, look for the per-car lines from the plan cycle:
+
+```text
+Car 0 using Octopus Intelligent, charging planned - charging limit ..., ready time ...
+Car 0 using Octopus Intelligent, no charging is planned
+```
+
+The earlier `Cars {n} charging from battery ... smart ... max_price ...` line is **not** the IOG state. It is printed
+during configuration read, before any Octopus dispatch data is merged, and reports the Predbat-led car charging
+settings (`car_charging_plan_smart`, `car_charging_plan_max_price`). It will show `smart: False` and `max_price: 0.0p`
+even when IOG is working correctly, so do not use it to diagnose IOG linkage.
+
 An excellent [worked example of setting up multiple car charging with Predbat](https://github.com/springfall2008/batpred/discussions/3001) is in the 'Show and tell' part of Predbat's GitHub.
 
 ## Ohme car charger direct integration

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -274,7 +274,13 @@ Just keep the single-sensor config (or provide a one-entry list) and car 1 will 
 
 With **octopus_automatic** set to True, Predbat wires the car slots itself from the devices your Octopus account
 reports as live. Devices that Octopus reports as suspended are skipped, and the remaining devices are assigned to
-car slots in a fixed order, so a given car keeps the same car index across restarts.
+car slots in a fixed order, so the same set of cars always produces the same car indexes.
+
+Slots are re-packed when a car goes away, so removing or suspending a car can move the cars after it up an index -
+for example if car 0 is removed, the car that was car 1 becomes car 0. `num_cars` is never reduced automatically, so
+the now-unused slot at the end simply falls back to Predbat-led charging. If you set per-car options in `apps.yaml`
+(**car_charging_battery_size**, **car_charging_limit**, **car_charging_exclusive**) or use manual SoC entry, check
+they still line up after adding or removing a car.
 
 Predbat re-checks this on every device poll (roughly every 2 minutes) and re-wires the slots if the set of live,
 non-suspended devices changes - for example when you enrol a second EV, remove one, or suspend one car in favour of


### PR DESCRIPTION
Fixes #4648

## Problem

`OctopusAPI.automatic_config()` only ran on the component's first successful `run()` or when the account's tariff-code set changed, so the device → car slot wiring never followed the account. Registering a second EV, removing one, or suspending one car in favour of another left `octopus_intelligent_slot` pointing at the wrong device.

Predbat then watched a suspended device's dispatch sensor, missed the live IOG window, and discharged the home battery through a genuine cheap-import dispatch. Because `set_arg()` only touches the in-memory args, the stale wiring was invisible on disk — the only symptom was in the log.

The per-device data itself was never stale: `async_update_intelligent_devices()` refreshes it on the ~2 minute poll. This was purely a "recognised device set → car slot" wiring gap.

## Fix

`run()` now compares the live set of non-suspended intelligent device IDs against the set the current wiring was built for, and re-runs the wiring when it moves. The check sits **after** the dispatch sensor refresh and only on a cycle that ran it, so args never point at an entity that has not been published yet — otherwise the next fetch cycle reports `octopus_intelligent_slot not set correctly in apps.yaml` against the status sensor. Gating on `sensor_due` costs nothing, since the device set can only move on a cycle that re-polled it.

Each re-wire is logged, so this is diagnosable from the log next time:

```text
OctopusAPI: Live intelligent devices changed from [...] to [...], reconfiguring car slots
OctopusAPI: Car slots wired to intelligent devices [...]
```

## Supporting changes

Two changes that make re-wiring on every poll safe rather than hazardous:

**Deterministic slot order.** `automatic_config()` now assigns devices to car slots in sorted order. The slot index is what per-car settings (`car_charging_battery_size`, `car_charging_limit`, manual SoC, `car_charging_exclusive`) are keyed on, and `intelligent_devices` is in first-seen order — so a device dropping out of one poll and returning on the next re-ordered the slots and silently applied one car's settings to another. This was latent while the wiring ran once per process; it becomes live once the wiring runs every poll.

**No eviction on a transient settings failure.** A device whose per-device settings query returned nothing was `continue`d, dropping it from the poll result. `async_update_intelligent_devices()` then treated it as no longer LIVE and deleted it from the cache — so one flaky GraphQL call un-registered a real car, with nothing to restore it until a restart. With the device set now driving re-wiring, that would flap the car slots on every blip. The last known settings are carried forward instead; a device we have never read settings for is still skipped, since its suspended state is unknown.

## Secondary finding from the issue

The `Cars {n} charging from battery ... smart ... max_price ...` log line is printed during config read, before any Octopus dispatch data is merged, and reports the Predbat-led car charging settings. It shows `smart: False` / `max_price: 0.0p` even when IOG linking is working correctly, and was repeatedly mistaken for IOG dispatch state during support triage.

Added a short clarifying clause to that line, and a `docs/car-charging.md` section covering how auto-wiring picks slots, what the re-wire log lines look like, and which lines actually show IOG linkage state (`Car N using Octopus Intelligent ...`).

## Tests

Written test-first — each new behaviour was watched failing before implementing.

`test_octopus_misc.py`:
- `test_octopus_automatic_config_slot_order` — slot order is independent of cache insertion order, and `octopus_ready_time` / `octopus_charge_limit` follow the same device order
- `test_octopus_automatic_config_rewire` — no re-wire when a poll finds the set unchanged; re-wire when a poll finds a newly registered device; slot 0 follows the live device after a suspension swap; the dispatch sensor is published before the re-wire points args at it; no re-wire when `automatic` is disabled

The re-wire tests drive the change through a simulated device poll rather than mutating state directly, so they exercise the real cadence.

`test_octopus_intelligent_devices.py`:
- Test 11 — a transient settings-query failure retains the device with its last known settings; a never-seen device is still skipped

## Verification

- Full suite: `All tests passed (total time: 132.02s)`
- `./run_pre_commit`: all 10 hooks pass
- Docstring coverage unchanged from baseline (91% before and after — pre-existing nested-function gaps)

## Upgrade note

`num_cars` still only ever increases (unchanged, pinned by an existing test). When a car is deregistered the slot list shrinks but `num_cars` stays, and the extra slot falls back to Predbat-led charging.

Worth a release-note mention: the new sorted slot order can reassign car indices for existing multi-car IOG users on upgrade, so per-car settings may need checking once after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)