### PR TITLE
feat(ohme): automatic config split, delivered-energy sensor, and Predbat-led charge control

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -231,8 +231,8 @@ hadashboard
 hahistory
 hainterface
 halfhourly
-hanchu
 Hanchu
+hanchu
 hanchuess
 hanres
 HAOS

--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -443,6 +443,7 @@ pylint
 pypi
 pyproject
 pytest
+pythonhashseed
 pytz
 randn
 rarr

--- a/.cspell/sort_dictionary.py
+++ b/.cspell/sort_dictionary.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Sort the cspell custom dictionary, removing entries that differ only by case.
+
+The upstream pre-commit file-contents-sorter cannot do this. Its --unique deduplicates with a
+set(), which is case-sensitive, while --ignore-case sorts with a case-folded key - so a pair like
+"Hanchu" and "hanchu" both survive and then compare equal. Python's sort is stable, so their order
+is whatever order the set happened to iterate in, and set iteration order for strings varies with
+PYTHONHASHSEED. The result flip-flops between runs, which meant every developer's pre-commit
+reversed whatever CI had just committed.
+
+cspell dictionaries are case-insensitive here (.cspell.json sets no caseSensitive flag), so a
+capitalised duplicate adds nothing. The all-lowercase form is kept where one exists because it
+also matches the capitalised and upper-case spellings, whereas the reverse is not true.
+"""
+
+import sys
+
+
+def tidy(words):
+    """Case-insensitively deduplicate and sort, preferring the all-lowercase spelling."""
+    best = {}
+    for word in words:
+        key = word.lower()
+        # Keep the lowercase spelling when the same word appears in more than one case
+        if key not in best or (word.islower() and not best[key].islower()):
+            best[key] = word
+    # Every key is now unique under lower(), so this ordering is total and cannot vary by run
+    return [best[key] for key in sorted(best)]
+
+
+def sort_file(path):
+    """Rewrite path if sorting changed it, returning 1 when it did."""
+    with open(path, encoding="utf-8") as handle:
+        before = handle.read()
+
+    after = "".join(word + "\n" for word in tidy(line.strip() for line in before.splitlines() if line.strip()))
+    if after == before:
+        return 0
+
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(after)
+    print("Sorted {}".format(path))
+    return 1
+
+
+def main(argv):
+    """Sort each file named on the command line."""
+    return max((sort_file(path) for path in argv), default=0)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v5.0.0
   hooks:
   - id: file-contents-sorter
-    files: ^(\.cspell\/custom-dictionary-workspace.txt|requirements\.txt)$
+    files: ^requirements\.txt$
     args: ["--ignore-case", "--unique"]
   - id: trailing-whitespace
     args: [--markdown-linebreak-ext=md]
@@ -12,6 +12,16 @@ repos:
     exclude: (example_chart.yml)
   - id: check-json
     exclude: ^(\.cspell\.json|\.devcontainer\/devcontainer\.json)$
+# The cspell dictionary needs case-insensitive *uniqueness*, which file-contents-sorter cannot do -
+# its --unique is case-sensitive while --ignore-case sorts case-folded, so case-duplicate entries
+# compare equal and their order varies with PYTHONHASHSEED between runs
+- repo: local
+  hooks:
+  - id: cspell-dictionary-sorter
+    name: cspell dictionary sorter
+    language: python
+    entry: python .cspell/sort_dictionary.py
+    files: ^\.cspell\/custom-dictionary-workspace\.txt$
 - repo: https://gitlab.com/bmares/check-json5
   rev: v1.0.0
   hooks:

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -200,6 +200,13 @@ COMPONENT_LIST = {
                 "required": True,
                 "config": "ohme_password",
             },
+            "ohme_automatic": {
+                "required": False,
+                "default": False,
+                "config": "ohme_automatic",
+            },
+            # Deliberately has no default: unset means "auto-detect from the Octopus component",
+            # which is distinct from an explicit False meaning "never use Ohme for the car slots"
             "ohme_automatic_octopus_intelligent": {
                 "required": False,
                 "config": "ohme_automatic_octopus_intelligent",

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -205,6 +205,11 @@ COMPONENT_LIST = {
                 "default": False,
                 "config": "ohme_automatic",
             },
+            "ohme_control": {
+                "required": False,
+                "default": False,
+                "config": "ohme_control",
+            },
             # Deliberately has no default: unset means "auto-detect from the Octopus component",
             # which is distinct from an explicit False meaning "never use Ohme for the car slots"
             "ohme_automatic_octopus_intelligent": {

--- a/apps/predbat/config/apps.yaml
+++ b/apps/predbat/config/apps.yaml
@@ -298,6 +298,9 @@ pred_bat:
   #ohme_password: !secret ohme_password
   # Register the Ohme charger with Predbat as a car (planned/SoC/energy sensors)
   #ohme_automatic: True
+  # Let Predbat start and stop the charger according to its own car charging plan.
+  # Requires ohme_automatic, and is ignored when the Intelligent slots come from Ohme
+  #ohme_control: True
   # Take the Octopus Intelligent car slots from Ohme rather than from Octopus directly.
   # Leave unset to auto-detect an Intelligent tariff when ohme_automatic is on, or set
   # it explicitly to True/False to override that decision

--- a/apps/predbat/config/apps.yaml
+++ b/apps/predbat/config/apps.yaml
@@ -296,6 +296,11 @@ pred_bat:
   # Ohme EV charger cloud direct integration
   #ohme_login: !secret ohme_login
   #ohme_password: !secret ohme_password
+  # Register the Ohme charger with Predbat as a car (planned/SoC/energy sensors)
+  #ohme_automatic: True
+  # Take the Octopus Intelligent car slots from Ohme rather than from Octopus directly.
+  # Leave unset to auto-detect an Intelligent tariff when ohme_automatic is on, or set
+  # it explicitly to True/False to override that decision
   #ohme_automatic_octopus_intelligent: True
 
   # car_charging_energy defines a daily incrementing sensor which measures the charge added to your car and resets to zero at midnight

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -1180,7 +1180,13 @@ class OctopusAPI(ComponentBase):
         # below is recorded on every call, including calls that wired nothing, so it is [] and not
         # None after the first run on an account with no devices; treating that as "previously
         # wired" would blank a user's own apps.yaml entries, which auto-discovery never touched.
-        if devices or self.intelligent_config_devices:
+        # Another component may have claimed the car slots - the Ohme component does when it is
+        # set to take the Intelligent slots from the charger instead. This method re-runs whenever
+        # the tariff or device set moves, so without this check it would quietly take them back.
+        slot_owner = getattr(self.base, "car_slot_owner", None)
+        if slot_owner and slot_owner != "octopus":
+            self.log("OctopusAPI: Car slots are wired by the {} component, leaving them alone".format(slot_owner))
+        elif devices or self.intelligent_config_devices:
             # Suspended devices (e.g. an old/decommissioned charger still linked to the Octopus
             # account) aren't actively charging, so exclude them from the entity lists and from
             # the num_cars count below - otherwise a stale suspended device can silently push

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -213,6 +213,8 @@ class OhmeAPI(ComponentBase):
         self.control_charging = None
         # Last read-only state acted on, None until the control loop has run once
         self.control_read_only = None
+        # The charger's own target percent as it was before Predbat took control, restored on release
+        self.control_saved_target = None
         self.energy_today = 0.0
         self.energy_today_date = None
         self.energy_last_time = None
@@ -305,6 +307,15 @@ class OhmeAPI(ComponentBase):
         except (KeyError, TypeError):
             return None
 
+    def charger_target(self):
+        """
+        The charger's own target percent, or None when there is no rule to read it from.
+        """
+        try:
+            return self.client.target_soc
+        except (KeyError, TypeError):
+            return None
+
     def refresh_car_windows(self):
         """
         Read Predbat's planned car charging windows into control_windows.
@@ -372,6 +383,13 @@ class OhmeAPI(ComponentBase):
         if not self.control_charging:
             await self.client.async_resume_charge()
         await self.client.async_max_charge(False)
+        # Max charge overrides the charger's own target percent, so put back what the user had
+        # before Predbat took over - otherwise Ohme's smart schedule is left charging to the wrong
+        # level once we hand it back
+        if self.control_saved_target is not None:
+            await self.client.async_set_target(target_percent=self.control_saved_target)
+            self.log("Info: Ohme API: Restored the charger target to {}%".format(self.control_saved_target))
+            self.control_saved_target = None
         self.control_charging = None
 
     async def control_charge(self):
@@ -403,6 +421,9 @@ class OhmeAPI(ComponentBase):
         if drifted:
             self.log("Info: Ohme API: Charger was changed away from what Predbat set, re-applying")
         if should_charge:
+            # Snapshot the user's target before max charge overrides it, so release can put it back
+            if self.control_saved_target is None:
+                self.control_saved_target = self.charger_target()
             self.log("Info: Ohme API: Charge window active, setting max charge")
             await self.client.async_max_charge(True)
         else:

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -53,8 +53,19 @@ ohme_attribute_table = {
     "energy": {"friendly_name": "Ohme Session Energy", "icon": "mdi:lightning-bolt", "unit_of_measurement": "Wh", "device_class": "energy"},
     "battery_percent": {"friendly_name": "Ohme Battery Percent", "icon": "mdi:battery", "unit_of_measurement": "%", "device_class": "battery"},
     "current_vehicle": {"friendly_name": "Ohme Current Vehicle", "icon": "mdi:car"},
+    "connected": {"friendly_name": "Ohme Car Connected", "icon": "mdi:ev-plug-type2"},
+    "energy_today": {"friendly_name": "Ohme Charge Energy Today", "icon": "mdi:ev-station", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total"},
     "approve_charge": {"friendly_name": "Ohme Approve Charge", "icon": "mdi:check-circle-outline"},
 }
+
+# Delivered-energy sensor built by OhmeAPI.update_energy_today() - see that method for why
+# Ohme's own energy figure cannot be used for this
+ENERGY_TODAY_ENTITY = "sensor.predbat_ohme_energy_today"
+
+# Longest gap between power readings we will still integrate over. The charge session is polled
+# every 120 seconds, so a longer gap means Predbat stalled or was restarted and we have no evidence
+# of what the charger did meanwhile - under-counting is safe, inventing energy is not
+MAX_ENERGY_GAP_SECONDS = 600
 
 BASE_TIME = datetime.datetime.strptime("00:00", "%H:%M")
 OPTIONS_TIME = [((BASE_TIME + timedelta(seconds=minute * 60)).strftime("%H:%M")) for minute in range(0, 24 * 60, 1)]
@@ -153,6 +164,11 @@ class ChargerStatus(Enum):
     FINISHED = "finished"
 
 
+# Charger states that mean a car is plugged in and still wants charge, used for car_charging_planned.
+# FINISHED is excluded deliberately - the car is still plugged in but has nothing left to take
+CONNECTED_STATUSES = (ChargerStatus.PENDING_APPROVAL, ChargerStatus.CHARGING, ChargerStatus.PLUGGED_IN, ChargerStatus.PAUSED)
+
+
 class ChargerMode(Enum):
     """Charger mode enum."""
 
@@ -174,13 +190,20 @@ class ChargerPower:
 class OhmeAPI(ComponentBase):
     """Ohme API component for EV charger integration."""
 
-    def initialize(self, email, password, ohme_automatic_octopus_intelligent):
+    def initialize(self, email, password, ohme_automatic=False, ohme_automatic_octopus_intelligent=None):
         """Initialise the Ohme API component"""
         self.email = email
         self.password = password
         self.client = OhmeApiClient(email, password, self.log)
         self.queued_events = []
+        self.ohme_automatic = ohme_automatic
+        # Tri-state: True/False force the Intelligent wiring on or off, None auto-detects it
         self.ohme_automatic_octopus_intelligent = ohme_automatic_octopus_intelligent
+        self.energy_today = 0.0
+        self.energy_today_date = None
+        self.energy_last_time = None
+        self.energy_last_watts = 0.0
+        self.energy_restored = False
 
     def last_updated_time(self):
         """
@@ -218,20 +241,138 @@ class OhmeAPI(ComponentBase):
             await self.client.async_get_charge_session()
             await self.publish_data()
 
-        if first and self.ohme_automatic_octopus_intelligent and self.client.serial:
-            await self.automatic_config_octopus_intelligent()
+        if first and self.client.serial:
+            if self.ohme_automatic:
+                await self.automatic_config()
+            if self.octopus_intelligent_wanted():
+                await self.automatic_config_octopus_intelligent()
 
         self.update_success_timestamp()
         return True
 
+    def octopus_intelligent_wanted(self):
+        """
+        Decide whether to take the Octopus Intelligent car slots from Ohme.
+
+        The apps.yaml flag is a tri-state. Set explicitly it always wins, so a user who wants the
+        slots read straight from Octopus (or who has no Octopus component for us to ask) keeps
+        control. Left unset it is auto-detected, but only when ohme_automatic is on - otherwise
+        enabling this would start rewiring the config of every existing Ohme user who has asked
+        Predbat for nothing.
+        """
+        if self.ohme_automatic_octopus_intelligent is not None:
+            return bool(self.ohme_automatic_octopus_intelligent)
+        if not self.ohme_automatic:
+            return False
+
+        # OctopusAPI has already detected this by the time we run - it sits earlier in
+        # COMPONENT_LIST and Components.start() waits for each component's first run in turn
+        octopus = self.base.components.get_component("octopus") if self.base.components else None
+        if not octopus:
+            return False
+        tariff_code = (getattr(octopus, "tariffs", {}) or {}).get("import", {}).get("tariffCode")
+        if not octopus.is_intelligent_go_tariff(tariff_code):
+            return False
+        self.log("Info: Ohme API: Detected Intelligent Octopus tariff {}, taking the car slots from Ohme".format(tariff_code))
+        return True
+
+    async def automatic_config(self):
+        """
+        Register the Ohme charger with Predbat as a car.
+
+        Covers everything Ohme can tell us about the car itself. The Octopus Intelligent slot
+        wiring is deliberately separate - see automatic_config_octopus_intelligent().
+        """
+        self.log("Info: Ohme API: Registering the Ohme charger as a car")
+        if self.get_arg("num_cars", 0) < 1:
+            self.set_arg("num_cars", 1)
+        self.set_arg("car_charging_planned", ["binary_sensor.predbat_ohme_connected"])
+        self.set_arg("car_charging_soc", ["sensor.predbat_ohme_battery_percent"])
+
+        # Wire up the delivered-energy sensor so car_charging_hold can subtract car charging
+        # precisely instead of falling back to the car_charging_threshold heuristic. This runs
+        # before auto_config(final=True), so an unmatched regex from the apps.yaml default is
+        # still present as its literal "re:" string rather than having been removed yet - treat
+        # that as unconfigured, but leave a real charger (Zappi, Wallbox, hand-set sensor) alone.
+        existing = self.get_arg("car_charging_energy", default=None, indirect=False)
+        if (not existing) or (isinstance(existing, str) and existing.startswith("re:")):
+            self.set_arg_auto("car_charging_energy", ENERGY_TODAY_ENTITY)
+        else:
+            self.log("Info: Ohme API: Leaving car_charging_energy set to {} rather than using {}".format(existing, ENERGY_TODAY_ENTITY))
+
     async def automatic_config_octopus_intelligent(self):
         """
-        Automatically set the predbat entities to use ohme via octopus
+        Automatically set the predbat entities to take the Intelligent car slots from Ohme.
+
+        Claims the car slot args so OctopusAPI.automatic_config() stops re-wiring them to its own
+        dispatch entities - it re-runs whenever the tariff or intelligent device set moves, which
+        would otherwise silently undo this part way through a run.
         """
         self.log("Info: Ohme API: Setting Predbat to use Ohme")
+        self.base.car_slot_owner = "ohme"
         self.set_arg("octopus_intelligent_slot", "binary_sensor.predbat_ohme_slot_active")
         self.set_arg("octopus_ready_time", "select.predbat_ohme_target_time")
         self.set_arg("octopus_charge_limit", "number.predbat_ohme_target_percent")
+
+    def restore_energy_today(self, now):
+        """
+        Seed today's charge energy from the sensor published before the last restart.
+
+        Without this a Predbat restart drops the running total back to zero mid-day, and any
+        charging already delivered today stops being subtracted from the load history.
+        """
+        self.energy_today_date = now.date()
+        previous_date = self.base.load_previous_value_from_ha(ENERGY_TODAY_ENTITY, attribute="energy_date")
+        if previous_date != now.date().isoformat():
+            # Nothing published yet, or a total left over from an earlier day
+            return
+        try:
+            self.energy_today = max(0.0, float(self.base.load_previous_value_from_ha(ENERGY_TODAY_ENTITY)))
+        except (TypeError, ValueError):
+            return
+        self.log("Info: Ohme API: Restored {} kWh of charge energy already delivered today".format(self.energy_today))
+
+    def update_energy_today(self, watts, now):
+        """
+        Integrate the charger's power reading into a daily incrementing energy total (kWh).
+
+        Ohme reports the car's absolute battery content rather than the energy the charger has
+        delivered, so its own energy figure cannot drive car_charging_energy - it reads zero for
+        cars that do not report SoC, and jumps by the whole battery content for those that do.
+        Summing power over time gives a real delivered-energy figure instead, which is what the
+        Home Assistant Ohme integration now recommends since its energy sensor was removed.
+
+        A left Riemann sum is used - each interval is charged at the power seen at its start - so
+        the ramp missed at the beginning of a charge is traded against the tail counted at the end
+        rather than systematically over-counting.
+        """
+        if not self.energy_restored:
+            self.energy_restored = True
+            self.restore_energy_today(now)
+
+        last_time = self.energy_last_time
+        last_watts = self.energy_last_watts
+        self.energy_last_time = now
+        self.energy_last_watts = watts if watts and watts > 0 else 0.0
+
+        if last_time is None or now <= last_time:
+            return self.energy_today
+
+        gap_seconds = (now - last_time).total_seconds()
+        if gap_seconds > MAX_ENERGY_GAP_SECONDS:
+            self.log("Warn: Ohme API: {}s since the last power reading, not counting that gap rather than assuming the charger ran throughout".format(int(gap_seconds)))
+            return self.energy_today
+
+        if self.energy_today_date != now.date():
+            # Past midnight - the finished day's total stays in Home Assistant's history, so start
+            # again and count only the part of this interval that falls on the new day
+            self.energy_today = 0.0
+            self.energy_today_date = now.date()
+            midnight = datetime.datetime.combine(now.date(), datetime.time(0, 0)).replace(tzinfo=now.tzinfo)
+            last_time = max(last_time, midnight)
+
+        self.energy_today += last_watts * (now - last_time).total_seconds() / 3600.0 / 1000.0
+        return self.energy_today
 
     async def publish_data(self):
         """
@@ -281,6 +422,15 @@ class OhmeAPI(ComponentBase):
             self.dashboard_item(entity_name_sensor + "_power_amps", state=power.amps, attributes=ohme_attribute_table.get("power_amps", {}), app="ohme")
             self.dashboard_item(entity_name_sensor + "_power_volts", state=power.volts, attributes=ohme_attribute_table.get("power_volts", {}), app="ohme")
             # self.dashboard_item(entity_name_sensor + "_ct_amps", state=power.ct_amps, attributes=ohme_attribute_table.get("ct_amps", {}), app="ohme")
+
+        # A car is plugged in and still wants charge - drives car_charging_planned under ohme_automatic
+        self.dashboard_item(entity_name_binary_sensor + "_connected", state="on" if self.client.status in CONNECTED_STATUSES else "off", attributes=ohme_attribute_table.get("connected", {}), app="ohme")
+
+        # Delivered-energy total, suitable for car_charging_energy unlike Ohme's own energy figure
+        energy_today = self.update_energy_today(power.watts if power else 0, datetime.datetime.now().astimezone())
+        energy_today_attributes = ohme_attribute_table.get("energy_today", {}).copy()
+        energy_today_attributes["energy_date"] = self.energy_today_date.isoformat() if self.energy_today_date else None
+        self.dashboard_item(ENERGY_TODAY_ENTITY, state=round(energy_today, 3), attributes=energy_today_attributes, app="ohme")
 
         # Publish boolean states
         self.dashboard_item(entity_name_switch + "_max_charge", state=max_charge, attributes=ohme_attribute_table.get("max_charge", {}), app="ohme")
@@ -362,7 +512,9 @@ class OhmeAPI(ComponentBase):
         """
         Number event
         """
-        if entity_id.endswith("_target_soc"):
+        # Must match the entity published by publish_data() (number.predbat_ohme_target_percent),
+        # which is also what ohme_automatic_octopus_intelligent binds octopus_charge_limit to
+        if entity_id.endswith("_target_percent"):
             if (isinstance(value, float) or isinstance(value, int)) and 0 <= value <= 100:
                 await self.client.async_apply_session_rule(target_percent=int(value))
             else:

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -540,10 +540,9 @@ class OhmeAPI(ComponentBase):
             return self.energy_today
 
         gap_seconds = (now - last_time).total_seconds()
-        if gap_seconds > MAX_ENERGY_GAP_SECONDS:
-            self.log("Warn: Ohme API: {}s since the last power reading, not counting that gap rather than assuming the charger ran throughout".format(int(gap_seconds)))
-            return self.energy_today
 
+        # Roll the day over before any early return below, so a stall spanning midnight cannot
+        # leave yesterday's total being published against yesterday's date into the new day
         if self.energy_today_date != now.date():
             # Past midnight - the finished day's total stays in Home Assistant's history, so start
             # again and count only the part of this interval that falls on the new day
@@ -551,6 +550,12 @@ class OhmeAPI(ComponentBase):
             self.energy_today_date = now.date()
             midnight = datetime.datetime.combine(now.date(), datetime.time(0, 0)).replace(tzinfo=now.tzinfo)
             last_time = max(last_time, midnight)
+
+        # Measured against the original gap, not the part of it that fell after midnight - a stall
+        # is no more evidence of what the charger did either side of midnight
+        if gap_seconds > MAX_ENERGY_GAP_SECONDS:
+            self.log("Warn: Ohme API: {}s since the last power reading, not counting that gap rather than assuming the charger ran throughout".format(int(gap_seconds)))
+            return self.energy_today
 
         self.energy_today += last_watts * (now - last_time).total_seconds() / 3600.0 / 1000.0
         return self.energy_today
@@ -608,7 +613,9 @@ class OhmeAPI(ComponentBase):
         self.dashboard_item(entity_name_binary_sensor + "_connected", state="on" if self.client.status in CONNECTED_STATUSES else "off", attributes=ohme_attribute_table.get("connected", {}), app="ohme")
 
         # Delivered-energy total, suitable for car_charging_energy unlike Ohme's own energy figure
-        energy_today = self.update_energy_today(power.watts if power else 0, datetime.datetime.now().astimezone())
+        # Predbat's configured timezone, not the host's - the daily reset and the date this total is
+        # filed under have to follow the user's local midnight, which a UTC container would not
+        energy_today = self.update_energy_today(power.watts if power else 0, self.now_utc_exact)
         energy_today_attributes = ohme_attribute_table.get("energy_today", {}).copy()
         energy_today_attributes["energy_date"] = self.energy_today_date.isoformat() if self.energy_today_date else None
         self.dashboard_item(ENERGY_TODAY_ENTITY, state=round(energy_today, 3), attributes=energy_today_attributes, app="ohme")

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -62,6 +62,13 @@ ohme_attribute_table = {
 # Ohme's own energy figure cannot be used for this
 ENERGY_TODAY_ENTITY = "sensor.predbat_ohme_energy_today"
 
+# How often the Predbat-led control loop re-evaluates the plan. The plan is minute-granular so a
+# finer cadence buys nothing, and this matches the gateway EV charger control loop
+CONTROL_INTERVAL_SECONDS = 60
+
+# Format Predbat writes its planned car charging windows in - see PredBat.time_abs_str()
+PLAN_TIME_FORMAT = "%m-%d %H:%M:%S"
+
 # Longest gap between power readings we will still integrate over. The charge session is polled
 # every 120 seconds, so a longer gap means Predbat stalled or was restarted and we have no evidence
 # of what the charger did meanwhile - under-counting is safe, inventing energy is not
@@ -190,7 +197,7 @@ class ChargerPower:
 class OhmeAPI(ComponentBase):
     """Ohme API component for EV charger integration."""
 
-    def initialize(self, email, password, ohme_automatic=False, ohme_automatic_octopus_intelligent=None):
+    def initialize(self, email, password, ohme_automatic=False, ohme_automatic_octopus_intelligent=None, ohme_control=False):
         """Initialise the Ohme API component"""
         self.email = email
         self.password = password
@@ -199,6 +206,13 @@ class OhmeAPI(ComponentBase):
         self.ohme_automatic = ohme_automatic
         # Tri-state: True/False force the Intelligent wiring on or off, None auto-detects it
         self.ohme_automatic_octopus_intelligent = ohme_automatic_octopus_intelligent
+        self.ohme_control = ohme_control
+        self.control_active = False
+        self.control_windows = []
+        # The state we last pushed to the charger, None until we have acted or after releasing it
+        self.control_charging = None
+        # Last read-only state acted on, None until the control loop has run once
+        self.control_read_only = None
         self.energy_today = 0.0
         self.energy_today_date = None
         self.energy_last_time = None
@@ -244,11 +258,157 @@ class OhmeAPI(ComponentBase):
         if first and self.client.serial:
             if self.ohme_automatic:
                 await self.automatic_config()
-            if self.octopus_intelligent_wanted():
+            octopus_intelligent = self.octopus_intelligent_wanted()
+            if octopus_intelligent:
                 await self.automatic_config_octopus_intelligent()
+            self.enable_control(octopus_intelligent)
+
+        if self.control_active and (seconds % CONTROL_INTERVAL_SECONDS) == 0:
+            await self.control_charge()
 
         self.update_success_timestamp()
         return True
+
+    def enable_control(self, octopus_intelligent):
+        """
+        Decide whether Predbat-led charge control should run, and say why when it will not.
+        """
+        if not self.ohme_control:
+            return
+        if not self.ohme_automatic:
+            self.log("Warn: Ohme API: ohme_control needs ohme_automatic set to register the car, charge control is disabled")
+            return
+        if octopus_intelligent:
+            self.log("Warn: Ohme API: ohme_control is ignored while the Intelligent slots come from Ohme - Octopus already schedules the charge")
+            return
+        self.control_active = True
+        self.log("Info: Ohme API: Predbat-led charge control enabled")
+
+    def control_read_only_now(self):
+        """
+        Is Predbat in read only mode - the effective state rather than just the switch.
+
+        axle_control forces read only by setting the attribute without touching the config arg, so
+        read the attribute first and fall back to the arg for the window before it is first set.
+        """
+        read_only = getattr(self.base, "set_read_only", None)
+        if read_only is None:
+            read_only = self.get_arg("set_read_only", False)
+        return bool(read_only)
+
+    def charger_mode(self):
+        """
+        The charger's current mode, or None when there is no session to read it from.
+        """
+        try:
+            return self.client.mode
+        except (KeyError, TypeError):
+            return None
+
+    def refresh_car_windows(self):
+        """
+        Read Predbat's planned car charging windows into control_windows.
+
+        The binary sensor's own on/off state only refreshes on Predbat's 5 minute cycle, so the
+        planned attribute is parsed and evaluated against the clock here instead - otherwise every
+        window boundary would be acted on up to 5 minutes late.
+
+        Returns True once a plan has been read, False while the sensor has never been published -
+        which is what stops the loop pausing a car on startup before it knows anything.
+        """
+        planned = self.get_state_wrapper("binary_sensor." + self.prefix + "_car_charging_slot", attribute="planned")
+        if planned is None:
+            return False
+
+        now = self.now_utc_exact
+        windows = []
+        for window in planned:
+            try:
+                start = self.local_tz.localize(datetime.datetime.strptime(window["start"], PLAN_TIME_FORMAT).replace(year=now.year))
+                end = self.local_tz.localize(datetime.datetime.strptime(window["end"], PLAN_TIME_FORMAT).replace(year=now.year))
+            except (KeyError, TypeError, ValueError):
+                continue
+            # The plan carries no year, so rebuild it around now for windows that cross New Year
+            if start < now - timedelta(hours=23):
+                start = start.replace(year=start.year + 1)
+                end = end.replace(year=end.year + 1)
+            elif end < start:
+                end = end.replace(year=end.year + 1)
+            windows.append((start, end))
+        self.control_windows = windows
+        return True
+
+    def should_charge_now(self):
+        """
+        Is now inside one of Predbat's planned charging windows.
+        """
+        now = self.now_utc_exact
+        return any(start <= now < end for start, end in self.control_windows)
+
+    def control_drifted(self, should_charge):
+        """
+        Has the charger moved away from the state we last set, e.g. changed in the Ohme app.
+
+        Purely edge-triggered control diverges silently once anything else touches the charger, so
+        the mode we already poll is compared against what we asked for and re-applied if it moved.
+        """
+        if self.control_charging is None:
+            return False
+        mode = self.charger_mode()
+        if mode is None:
+            # Nothing plugged in to correct
+            return False
+        if should_charge:
+            return mode is not ChargerMode.MAX_CHARGE
+        return mode is not ChargerMode.PAUSED
+
+    async def release_charger(self):
+        """
+        Hand the charger back to Ohme's own smart schedule.
+        """
+        if self.control_charging is None:
+            return
+        self.log("Info: Ohme API: Read only mode, releasing the charger back to Ohme")
+        if not self.control_charging:
+            await self.client.async_resume_charge()
+        await self.client.async_max_charge(False)
+        self.control_charging = None
+
+    async def control_charge(self):
+        """
+        Drive the charger from Predbat's car charging plan.
+
+        Predbat holds the charger for as long as it is in control: max charge inside a planned
+        window, paused outside one. Read only mode is the release - it hands the charger back to
+        Ohme rather than leaving a pause in place. A component stop deliberately does not release,
+        as that is nearly always a restart and releasing would glitch an in-progress charge.
+        """
+        if self.control_read_only_now():
+            if self.control_read_only is not True:
+                self.control_read_only = True
+                await self.release_charger()
+            return
+        if self.control_read_only:
+            self.log("Info: Ohme API: Read only mode cleared, resuming charge control")
+        self.control_read_only = False
+
+        if not self.refresh_car_windows():
+            return
+
+        should_charge = self.should_charge_now()
+        drifted = self.control_drifted(should_charge)
+        if should_charge == self.control_charging and not drifted:
+            return
+
+        if drifted:
+            self.log("Info: Ohme API: Charger was changed away from what Predbat set, re-applying")
+        if should_charge:
+            self.log("Info: Ohme API: Charge window active, setting max charge")
+            await self.client.async_max_charge(True)
+        else:
+            self.log("Info: Ohme API: Outside the charge plan, pausing the charger")
+            await self.client.async_pause_charge()
+        self.control_charging = should_charge
 
     def octopus_intelligent_wanted(self):
         """

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -540,16 +540,19 @@ class OhmeAPI(ComponentBase):
             return self.energy_today
 
         gap_seconds = (now - last_time).total_seconds()
+        interval_seconds = gap_seconds
 
         # Roll the day over before any early return below, so a stall spanning midnight cannot
         # leave yesterday's total being published against yesterday's date into the new day
         if self.energy_today_date != now.date():
             # Past midnight - the finished day's total stays in Home Assistant's history, so start
-            # again and count only the part of this interval that falls on the new day
+            # again and count only the part of this interval that falls on the new day. The time of
+            # day is by definition the time elapsed since local midnight, so take it from the wall
+            # clock rather than building a midnight datetime - there is then no timezone offset to
+            # attach, and none to get wrong
             self.energy_today = 0.0
             self.energy_today_date = now.date()
-            midnight = datetime.datetime.combine(now.date(), datetime.time(0, 0)).replace(tzinfo=now.tzinfo)
-            last_time = max(last_time, midnight)
+            interval_seconds = min(interval_seconds, now.hour * 3600 + now.minute * 60 + now.second)
 
         # Measured against the original gap, not the part of it that fell after midnight - a stall
         # is no more evidence of what the charger did either side of midnight
@@ -557,7 +560,7 @@ class OhmeAPI(ComponentBase):
             self.log("Warn: Ohme API: {}s since the last power reading, not counting that gap rather than assuming the charger ran throughout".format(int(gap_seconds)))
             return self.energy_today
 
-        self.energy_today += last_watts * (now - last_time).total_seconds() / 3600.0 / 1000.0
+        self.energy_today += last_watts * interval_seconds / 3600.0 / 1000.0
         return self.energy_today
 
     async def publish_data(self):

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -470,6 +470,11 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.car_charging_threshold = 99
         self.car_charging_energy = {}
         self.car_charging_energy_warned = False
+        # Which component's automatic_config() owns octopus_intelligent_slot/ready_time/charge_limit.
+        # Both OctopusAPI and OhmeAPI can wire the car slots, and Octopus re-runs its automatic_config
+        # whenever the tariff or intelligent device set moves - without a claim it silently takes the
+        # args back off Ohme part way through a run. None means nobody has claimed them.
+        self.car_slot_owner = None
         self.octopus_intelligent_charging = False
         self.octopus_intelligent_ignore_unplugged = False
         self.octopus_intelligent_consider_full = False

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -30,6 +30,7 @@ async def test_octopus_misc(my_predbat):
     failed += test_octopus_automatic_config_slot_order(my_predbat)
     failed += test_octopus_automatic_config_clears_removed_devices(my_predbat)
     failed += await test_octopus_automatic_config_rewire(my_predbat)
+    failed += test_octopus_automatic_config_respects_slot_claim(my_predbat)
     failed += await test_octopus_run(my_predbat)
 
     if failed == 0:
@@ -2123,6 +2124,73 @@ def test_octopus_automatic_config_clears_removed_devices(my_predbat):
     else:
         print("\n**** ✅ Octopus automatic_config device removal tests PASSED ****")
         return 0
+
+
+def test_octopus_automatic_config_respects_slot_claim(my_predbat):
+    """
+    Test that automatic_config leaves the car slot args alone when another component owns them.
+
+    The Ohme component can be configured to take the Intelligent slots from the charger instead,
+    and claims the args when it does. automatic_config() re-runs whenever the tariff or the live
+    device set moves, so without honouring the claim it silently takes them back part way through
+    a run and the wiring flip-flops between the two components.
+
+    Tests:
+    - Test 1: A claim by another component leaves the slot args untouched
+    - Test 2: The rest of automatic_config still runs while claimed
+    - Test 3: No claim, or Octopus's own claim, wires the slots as normal
+    """
+    print("\n**** Running Octopus automatic_config slot claim tests ****")
+    failed = False
+
+    original_args = dict(my_predbat.args)
+    original_owner = getattr(my_predbat, "car_slot_owner", None)
+
+    print("\n*** Test 1: A claim by another component leaves the slot args untouched ***")
+    my_predbat.args["octopus_intelligent_slot"] = "binary_sensor.predbat_ohme_slot_active"
+    my_predbat.car_slot_owner = "ohme"
+    api = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)
+    api.intelligent_devices = {"device-aaa1": {"suspended": False}}
+    api.automatic_config(["import"])
+
+    if my_predbat.args.get("octopus_intelligent_slot") != "binary_sensor.predbat_ohme_slot_active":
+        print(f"ERROR: Expected the Ohme wiring to survive, got {my_predbat.args.get('octopus_intelligent_slot')}")
+        failed = True
+
+    print("\n*** Test 2: The rest of automatic_config still runs while claimed ***")
+    if not my_predbat.args.get("octopus_saving_session"):
+        print("ERROR: Expected saving session wiring to still happen while the slots are claimed")
+        failed = True
+
+    print("\n*** Test 3: No claim wires the slots as normal ***")
+    my_predbat.car_slot_owner = None
+    api2 = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)
+    api2.intelligent_devices = {"device-aaa1": {"suspended": False}}
+    api2.automatic_config(["import"])
+
+    if my_predbat.args.get("octopus_intelligent_slot") == "binary_sensor.predbat_ohme_slot_active":
+        print("ERROR: Expected Octopus to wire its own slots when unclaimed")
+        failed = True
+
+    # And Octopus owning the claim itself is not treated as someone else's
+    my_predbat.args["octopus_intelligent_slot"] = None
+    my_predbat.car_slot_owner = "octopus"
+    api3 = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)
+    api3.intelligent_devices = {"device-aaa1": {"suspended": False}}
+    api3.automatic_config(["import"])
+
+    if not my_predbat.args.get("octopus_intelligent_slot"):
+        print("ERROR: Expected Octopus's own claim not to block its wiring")
+        failed = True
+
+    my_predbat.args = original_args
+    my_predbat.car_slot_owner = original_owner
+
+    if failed:
+        print("\n**** \u274c Octopus automatic_config slot claim tests FAILED ****")
+        return 1
+    print("\n**** \u2705 Octopus automatic_config slot claim tests PASSED ****")
+    return 0
 
 
 async def test_octopus_automatic_config_rewire(my_predbat):

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -285,6 +285,7 @@ def test_ohme(my_predbat=None):
         ("control_drift", _test_ohme_control_reapplies_on_drift, "control re-applies after app changes"),
         ("control_read_only", _test_ohme_control_read_only_release, "read only releases the charger"),
         ("control_read_only_src", _test_ohme_control_read_only_effective, "read only uses the effective state"),
+        ("control_target_restore", _test_ohme_control_restores_target, "release restores the charger target"),
         ("auto_config_keeps", _test_ohme_auto_config_keeps_existing_car_charging_energy, "auto config keeps a real charger sensor"),
         ("publish_data", _test_ohme_publish_data, "OhmeAPI publish_data"),
         ("publish_disconnected", _test_ohme_publish_data_disconnected, "OhmeAPI publish_data disconnected"),
@@ -1588,6 +1589,7 @@ class MockOhmeAPI(OhmeAPI):
         self.control_windows = []
         self.control_charging = None
         self.control_read_only = None
+        self.control_saved_target = None
         self.prefix = "predbat"
         self.local_tz = pytz.timezone("Europe/London")
         self.states = {}
@@ -1859,6 +1861,42 @@ def _test_ohme_control_read_only_release(my_predbat=None):
     assert any("Read only mode cleared" in msg for msg in api.log_messages), f"Expected a resume log, got {api.log_messages}"
 
     print("PASS: read only released and resumed the charger")
+    return 0
+
+
+def _test_ohme_control_restores_target(my_predbat=None):
+    """Test the user's charger target is put back when Predbat releases the charger"""
+    print("**** Running test_ohme_control_restores_target ****")
+
+    tz = pytz.timezone("Europe/London")
+    window = _ohme_plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+    api = _ohme_control_api(windows=[window], now=tz.localize(datetime.datetime(2026, 8, 22, 23, 30)))
+    # The user's own target, which max charge overrides while Predbat is in control
+    api.client._charge_session = {"mode": "SMART_CHARGE", "power": {"watt": 0}, "appliedRule": {"targetPercent": 70, "targetTime": 25200}}
+    api.client._last_rule = {"targetPercent": 70}
+
+    run_async(api.control_charge())
+    assert api.control_saved_target == 70, f"Expected the target to be snapshotted before max charge, got {api.control_saved_target}"
+
+    # Snapshot must be taken before the max charge command, not after it
+    assert "maxCharge=true" in api.client.request_log[0]["url"], f"Expected max charge, got {api.client.request_log[0]['url']}"
+
+    # Releasing puts the user's target back so Ohme's own schedule is left correct
+    api.base.set_read_only = True
+    run_async(api.control_charge())
+
+    urls = [request["url"] for request in api.client.request_log]
+    assert any("toPercent=70" in url for url in urls), f"Expected the target to be restored, got {urls}"
+    assert api.control_saved_target is None, "Expected the saved target to be cleared after restoring"
+    assert any("Restored the charger target to 70%" in msg for msg in api.log_messages), f"Expected a restore log, got {api.log_messages}"
+
+    # Taking control again snapshots afresh rather than reusing the old value
+    api.base.set_read_only = False
+    api.client._charge_session = {"mode": "SMART_CHARGE", "power": {"watt": 0}, "appliedRule": {"targetPercent": 90, "targetTime": 25200}}
+    run_async(api.control_charge())
+    assert api.control_saved_target == 90, f"Expected a fresh snapshot, got {api.control_saved_target}"
+
+    print("PASS: the charger target was restored on release")
     return 0
 
 

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -19,6 +19,8 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from ohme import (
+    ENERGY_TODAY_ENTITY,
+    MAX_ENERGY_GAP_SECONDS,
     OhmeAPI,
     OhmeApiClient,
     ChargerStatus,
@@ -260,6 +262,21 @@ def test_ohme(my_predbat=None):
         ("update_schedule_all", _test_ohme_client_async_update_schedule_all_params, "async_update_schedule all params"),
         ("update_schedule_partial", _test_ohme_client_async_update_schedule_partial_params, "async_update_schedule partial"),
         ("update_schedule_no_rule", _test_ohme_client_async_update_schedule_no_rule, "async_update_schedule no rule"),
+        ("energy_steady", _test_ohme_energy_today_steady_power, "energy_today integrates steady power"),
+        ("energy_left_sum", _test_ohme_energy_today_left_riemann, "energy_today uses a left Riemann sum"),
+        ("energy_gap", _test_ohme_energy_today_long_gap, "energy_today skips over-long gaps"),
+        ("energy_midnight", _test_ohme_energy_today_midnight_rollover, "energy_today resets at midnight"),
+        ("energy_restore", _test_ohme_energy_today_restore, "energy_today restores across a restart"),
+        ("energy_restore_stale", _test_ohme_energy_today_restore_stale, "energy_today ignores a stale total"),
+        ("energy_published", _test_ohme_energy_today_published, "publish_data publishes energy_today"),
+        ("auto_config_energy", _test_ohme_auto_config_wires_car_charging_energy, "auto config wires car_charging_energy"),
+        ("iog_flag_forces_on", _test_ohme_iog_flag_forces_on, "explicit flag forces Intelligent on"),
+        ("iog_flag_forces_off", _test_ohme_iog_flag_forces_off, "explicit flag forces Intelligent off"),
+        ("iog_autodetect", _test_ohme_iog_autodetected_from_octopus, "Intelligent auto-detected from Octopus"),
+        ("iog_autodetect_gated", _test_ohme_iog_autodetect_needs_ohme_automatic, "auto-detect needs ohme_automatic"),
+        ("iog_claims_slots", _test_ohme_iog_claims_car_slots, "Intelligent wiring claims the car slots"),
+        ("connected_sensor", _test_ohme_connected_sensor, "connected binary sensor tracks plug state"),
+        ("auto_config_keeps", _test_ohme_auto_config_keeps_existing_car_charging_energy, "auto config keeps a real charger sensor"),
         ("publish_data", _test_ohme_publish_data, "OhmeAPI publish_data"),
         ("publish_disconnected", _test_ohme_publish_data_disconnected, "OhmeAPI publish_data disconnected"),
         ("run_first", _test_ohme_run_first_call, "OhmeAPI run first call"),
@@ -272,6 +289,7 @@ def test_ohme(my_predbat=None):
         ("select_target_time", _test_ohme_select_event_handler_target_time, "select_event_handler target_time"),
         ("select_invalid_time", _test_ohme_select_event_handler_invalid_time, "select_event_handler invalid time"),
         ("number_target_soc", _test_ohme_number_event_handler_target_soc, "number_event_handler target_soc"),
+        ("number_entities_wired", _test_ohme_number_event_handler_matches_published_entities, "published number entities are all handled"),
         ("number_target_soc_invalid", _test_ohme_number_event_handler_target_soc_invalid, "number_event_handler invalid SoC"),
         ("number_preconditioning", _test_ohme_number_event_handler_preconditioning, "number_event_handler preconditioning"),
         ("number_preconditioning_off", _test_ohme_number_event_handler_preconditioning_off, "number_event_handler preconditioning off"),
@@ -1502,6 +1520,47 @@ def _test_ohme_client_async_update_schedule_no_rule(my_predbat=None):
 # OhmeAPI Component Tests
 # ============================================================================
 
+class MockOctopusComponent:
+    """Stand-in for the OctopusAPI component, reporting a tariff code"""
+
+    def __init__(self, tariff_code=None):
+        """Initialize with the import tariff code to report"""
+        self.tariffs = {"import": {"tariffCode": tariff_code}} if tariff_code else {}
+
+    @staticmethod
+    def is_intelligent_go_tariff(tariff_code):
+        """Mirror of OctopusAPI.is_intelligent_go_tariff"""
+        if not tariff_code:
+            return False
+        return ("INTELLI-" in tariff_code) or ("IOG-" in tariff_code)
+
+
+class MockComponents:
+    """Stand-in for the component registry"""
+
+    def __init__(self):
+        """Initialize with no components registered"""
+        self.components = {}
+
+    def get_component(self, name):
+        """Return the registered stand-in component, if any"""
+        return self.components.get(name)
+
+
+class MockOhmeBase:
+    """Stand-in for the PredBat base object, serving previously published entity values"""
+
+    def __init__(self, api):
+        """Initialize with a back-reference to the owning mock API"""
+        self.api = api
+        self.car_slot_owner = None
+        self.components = MockComponents()
+
+    def load_previous_value_from_ha(self, entity, attribute=None):
+        """Return whatever the test staged for this entity/attribute"""
+        return self.api.previous_values.get((entity, attribute))
+
+
 class MockOhmeAPI(OhmeAPI):
     """Mock OhmeAPI for testing publish_data without ComponentBase dependencies"""
 
@@ -1513,10 +1572,33 @@ class MockOhmeAPI(OhmeAPI):
         self.log_messages = []
         self.dashboard_items = {}
         self.queued_events = []
-        self.ohme_automatic_octopus_intelligent = False
+        self.ohme_automatic = False
+        self.ohme_automatic_octopus_intelligent = None
+        self.energy_today = 0.0
+        self.energy_today_date = None
+        self.energy_last_time = None
+        self.energy_last_watts = 0.0
+        self.energy_restored = False
+
+        # Stand-in for the PredBat base object, so arg wiring and state read-back can be tested
+        self.args = {}
+        self.previous_values = {}
+        self.base = MockOhmeBase(self)
 
         # Create mock client
         self.client = MockOhmeApiClient()
+
+    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
+        """Mock get_arg reading from the stub args"""
+        return self.args.get(arg, default)
+
+    def set_arg(self, arg, value):
+        """Mock set_arg writing to the stub args"""
+        self.args[arg] = value
+
+    def set_arg_auto(self, arg, value):
+        """Mock set_arg_auto - the real one logs then delegates to set_arg"""
+        self.set_arg(arg, value)
 
     def log(self, message):
         """Mock log function"""
@@ -1529,6 +1611,330 @@ class MockOhmeAPI(OhmeAPI):
             "attributes": attributes,
             "app": app
         }
+
+
+def _ohme_energy_api(start_watts=0.0):
+    """Build a MockOhmeAPI with the energy accumulator primed at a known time"""
+    api = MockOhmeAPI()
+    now = datetime.datetime(2026, 8, 22, 23, 0, 0).astimezone()
+    api.update_energy_today(start_watts, now)
+    return api, now
+
+
+def _test_ohme_energy_today_steady_power(my_predbat=None):
+    """Test energy_today integrates a steady power reading into kWh"""
+    print("**** Running test_ohme_energy_today_steady_power ****")
+
+    # 7200W held across six 120s polls is 7200 * (720/3600) = 1.44 kWh
+    api, now = _ohme_energy_api(start_watts=7200)
+    for step in range(1, 7):
+        energy = api.update_energy_today(7200, now + datetime.timedelta(seconds=120 * step))
+
+    assert abs(energy - 1.44) < 1e-6, f"Expected 1.44 kWh, got {energy}"
+    assert api.energy_today_date == now.date(), f"Expected date {now.date()}, got {api.energy_today_date}"
+
+    print(f"PASS: energy_today integrated steady power to {energy} kWh")
+    return 0
+
+
+def _test_ohme_energy_today_left_riemann(my_predbat=None):
+    """Test energy_today charges each interval at the power seen at its start"""
+    print("**** Running test_ohme_energy_today_left_riemann ****")
+
+    # Charger idle, then 7200W for one interval, then idle again. A left sum credits the
+    # interval that *followed* the 7200W reading, so exactly one interval is counted
+    api, now = _ohme_energy_api(start_watts=0)
+    api.update_energy_today(7200, now + datetime.timedelta(seconds=120))  # idle interval -> 0
+    energy = api.update_energy_today(0, now + datetime.timedelta(seconds=240))  # 7200W interval
+
+    expected = 7200 * (120 / 3600.0) / 1000.0
+    assert abs(energy - expected) < 1e-6, f"Expected {expected} kWh, got {energy}"
+
+    # A further idle poll must not add anything
+    energy = api.update_energy_today(0, now + datetime.timedelta(seconds=360))
+    assert abs(energy - expected) < 1e-6, f"Expected {expected} kWh after idle poll, got {energy}"
+
+    print(f"PASS: left Riemann sum counted one interval as {energy} kWh")
+    return 0
+
+
+def _test_ohme_energy_today_long_gap(my_predbat=None):
+    """Test energy_today does not invent energy across an over-long polling gap"""
+    print("**** Running test_ohme_energy_today_long_gap ****")
+
+    # Predbat stalled - we have no evidence the charger ran, so the gap must not be counted
+    api, now = _ohme_energy_api(start_watts=7200)
+    energy = api.update_energy_today(7200, now + datetime.timedelta(seconds=MAX_ENERGY_GAP_SECONDS + 60))
+
+    assert energy == 0.0, f"Expected 0 kWh across the gap, got {energy}"
+    assert any("not counting that gap" in msg for msg in api.log_messages), f"Expected a gap warning, got {api.log_messages}"
+
+    # Polling resumes normally afterwards
+    energy = api.update_energy_today(7200, now + datetime.timedelta(seconds=MAX_ENERGY_GAP_SECONDS + 180))
+    assert abs(energy - 7200 * (120 / 3600.0) / 1000.0) < 1e-6, f"Expected counting to resume, got {energy}"
+
+    print("PASS: energy_today skipped the gap and resumed afterwards")
+    return 0
+
+
+def _test_ohme_energy_today_midnight_rollover(my_predbat=None):
+    """Test energy_today resets at midnight and counts only the new day's share"""
+    print("**** Running test_ohme_energy_today_midnight_rollover ****")
+
+    # Charging at 7200W from 23:58, polled again at 00:02 - only the 120s after midnight counts
+    api = MockOhmeAPI()
+    before = datetime.datetime(2026, 8, 22, 23, 58, 0).astimezone()
+    api.update_energy_today(7200, before)
+    api.update_energy_today(7200, datetime.datetime(2026, 8, 22, 23, 59, 0).astimezone())
+    assert api.energy_today > 0, "Expected energy to accumulate before midnight"
+
+    after = datetime.datetime(2026, 8, 23, 0, 2, 0).astimezone()
+    energy = api.update_energy_today(7200, after)
+
+    expected = 7200 * (120 / 3600.0) / 1000.0
+    assert abs(energy - expected) < 1e-6, f"Expected only the post-midnight {expected} kWh, got {energy}"
+    assert api.energy_today_date == after.date(), f"Expected date to roll to {after.date()}, got {api.energy_today_date}"
+
+    print(f"PASS: energy_today reset at midnight and counted {energy} kWh into the new day")
+    return 0
+
+
+def _test_ohme_energy_today_restore(my_predbat=None):
+    """Test energy_today picks up today's total again after a restart"""
+    print("**** Running test_ohme_energy_today_restore ****")
+
+    api = MockOhmeAPI()
+    now = datetime.datetime(2026, 8, 22, 18, 0, 0).astimezone()
+    api.previous_values[(ENERGY_TODAY_ENTITY, "energy_date")] = now.date().isoformat()
+    api.previous_values[(ENERGY_TODAY_ENTITY, None)] = "12.5"
+
+    api.update_energy_today(7200, now)
+    assert abs(api.energy_today - 12.5) < 1e-6, f"Expected 12.5 kWh restored, got {api.energy_today}"
+
+    # And carries on from there
+    energy = api.update_energy_today(7200, now + datetime.timedelta(seconds=120))
+    assert abs(energy - (12.5 + 0.24)) < 1e-6, f"Expected 12.74 kWh, got {energy}"
+
+    print(f"PASS: energy_today restored 12.5 kWh and continued to {energy} kWh")
+    return 0
+
+
+def _test_ohme_energy_today_restore_stale(my_predbat=None):
+    """Test energy_today ignores a total published on an earlier day"""
+    print("**** Running test_ohme_energy_today_restore_stale ****")
+
+    api = MockOhmeAPI()
+    now = datetime.datetime(2026, 8, 22, 6, 0, 0).astimezone()
+    api.previous_values[(ENERGY_TODAY_ENTITY, "energy_date")] = "2026-08-21"
+    api.previous_values[(ENERGY_TODAY_ENTITY, None)] = "30.0"
+
+    api.update_energy_today(0, now)
+    assert api.energy_today == 0.0, f"Expected yesterday's total to be ignored, got {api.energy_today}"
+
+    print("PASS: energy_today ignored a stale total from an earlier day")
+    return 0
+
+
+def _test_ohme_energy_today_published(my_predbat=None):
+    """Test publish_data publishes energy_today with the attributes Home Assistant needs"""
+    print("**** Running test_ohme_energy_today_published ****")
+
+    api = MockOhmeAPI()
+    api.client._charge_session = {
+        "mode": "SMART_CHARGE",
+        "power": {"watt": 7200, "amp": 32, "volt": 230},
+        "appliedRule": {"targetPercent": 80, "targetTime": 25200},
+        "batterySoc": {"wh": 15000, "percent": 75},
+        "allSessionSlots": [],
+    }
+    api.client._next_session = {"targetPercent": 80, "targetTime": 25200}
+    api.client._last_rule = {"targetPercent": 80}
+    api.client._cars = [{"name": "Tesla Model 3"}]
+
+    run_async(api.publish_data())
+
+    assert ENERGY_TODAY_ENTITY in api.dashboard_items, f"Expected {ENERGY_TODAY_ENTITY} to be published, got {list(api.dashboard_items)}"
+    item = api.dashboard_items[ENERGY_TODAY_ENTITY]
+    assert item["attributes"]["unit_of_measurement"] == "kWh", f"Expected kWh, got {item['attributes']}"
+    assert item["attributes"]["device_class"] == "energy", f"Expected device_class energy, got {item['attributes']}"
+    assert item["attributes"]["energy_date"] == datetime.datetime.now().astimezone().date().isoformat(), f"Expected today's date attribute, got {item['attributes']}"
+
+    # First publish has no prior reading to integrate over, so it starts at zero
+    assert item["state"] == 0.0, f"Expected 0.0 kWh on the first publish, got {item['state']}"
+
+    print("PASS: publish_data published energy_today correctly")
+    return 0
+
+
+def _ohme_api_with_octopus(tariff_code=None):
+    """Build a MockOhmeAPI with an Octopus component reporting the given tariff code"""
+    api = MockOhmeAPI()
+    if tariff_code is not None:
+        api.base.components.components["octopus"] = MockOctopusComponent(tariff_code)
+    return api
+
+
+def _test_ohme_iog_flag_forces_on(my_predbat=None):
+    """Test an explicit flag turns Intelligent on even with no Octopus component"""
+    print("**** Running test_ohme_iog_flag_forces_on ****")
+
+    # The case that matters: no Predbat Octopus component to detect from, so the user says so
+    api = MockOhmeAPI()
+    api.ohme_automatic_octopus_intelligent = True
+    assert api.octopus_intelligent_wanted() is True, "Expected the explicit flag to force Intelligent on"
+
+    # And it still wins when ohme_automatic is off, preserving existing configurations
+    api = MockOhmeAPI()
+    api.ohme_automatic = False
+    api.ohme_automatic_octopus_intelligent = True
+    assert api.octopus_intelligent_wanted() is True, "Expected the flag to work without ohme_automatic"
+
+    print("PASS: explicit flag forced Intelligent on")
+    return 0
+
+
+def _test_ohme_iog_flag_forces_off(my_predbat=None):
+    """Test an explicit False beats auto-detection"""
+    print("**** Running test_ohme_iog_flag_forces_off ****")
+
+    # Detection would say yes, but the user wants the slots straight from Octopus
+    api = _ohme_api_with_octopus("E-1R-INTELLI-VAR-22-10-14-A")
+    api.ohme_automatic = True
+    api.ohme_automatic_octopus_intelligent = False
+    assert api.octopus_intelligent_wanted() is False, "Expected an explicit False to beat detection"
+
+    print("PASS: explicit False beat auto-detection")
+    return 0
+
+
+def _test_ohme_iog_autodetected_from_octopus(my_predbat=None):
+    """Test Intelligent is auto-detected from the Octopus component's tariff code"""
+    print("**** Running test_ohme_iog_autodetected_from_octopus ****")
+
+    api = _ohme_api_with_octopus("E-1R-INTELLI-VAR-22-10-14-A")
+    api.ohme_automatic = True
+    assert api.octopus_intelligent_wanted() is True, "Expected an INTELLI tariff to be detected"
+
+    # A non-Intelligent tariff must not trigger it
+    api = _ohme_api_with_octopus("E-1R-AGILE-24-10-01-A")
+    api.ohme_automatic = True
+    assert api.octopus_intelligent_wanted() is False, "Expected Agile not to be detected as Intelligent"
+
+    # Neither must a missing Octopus component
+    api = MockOhmeAPI()
+    api.ohme_automatic = True
+    assert api.octopus_intelligent_wanted() is False, "Expected no detection without an Octopus component"
+
+    print("PASS: Intelligent auto-detected from the Octopus tariff code")
+    return 0
+
+
+def _test_ohme_iog_autodetect_needs_ohme_automatic(my_predbat=None):
+    """Test auto-detection stays off for users who asked Predbat for nothing"""
+    print("**** Running test_ohme_iog_autodetect_needs_ohme_automatic ****")
+
+    # An existing user with neither flag set must keep getting no automatic wiring at all,
+    # even though the tariff is Intelligent and we could detect it
+    api = _ohme_api_with_octopus("E-1R-INTELLI-VAR-22-10-14-A")
+    api.ohme_automatic = False
+    assert api.octopus_intelligent_wanted() is False, "Expected no auto-detection without ohme_automatic"
+
+    print("PASS: auto-detection stayed off without ohme_automatic")
+    return 0
+
+
+def _test_ohme_iog_claims_car_slots(my_predbat=None):
+    """Test the Intelligent wiring claims the car slots so Octopus stops re-wiring them"""
+    print("**** Running test_ohme_iog_claims_car_slots ****")
+
+    api = MockOhmeAPI()
+    assert api.base.car_slot_owner is None, "Expected no owner before configuring"
+
+    run_async(api.automatic_config_octopus_intelligent())
+
+    assert api.base.car_slot_owner == "ohme", f"Expected ohme to own the car slots, got {api.base.car_slot_owner}"
+    assert api.args.get("octopus_intelligent_slot") == "binary_sensor.predbat_ohme_slot_active", f"Expected slot entity, got {api.args.get('octopus_intelligent_slot')}"
+    assert api.args.get("octopus_ready_time") == "select.predbat_ohme_target_time", f"Expected ready time entity, got {api.args.get('octopus_ready_time')}"
+    assert api.args.get("octopus_charge_limit") == "number.predbat_ohme_target_percent", f"Expected charge limit entity, got {api.args.get('octopus_charge_limit')}"
+
+    # Car registration is a separate concern and must not have happened here
+    assert api.args.get("car_charging_energy") is None, f"Expected no car registration, got {api.args.get('car_charging_energy')}"
+
+    print("PASS: Intelligent wiring claimed the car slots")
+    return 0
+
+
+def _test_ohme_connected_sensor(my_predbat=None):
+    """Test the connected binary sensor reflects whether a car wants charge"""
+    print("**** Running test_ohme_connected_sensor ****")
+
+    # Statuses that mean a car is plugged in and still wants charge
+    for mode, session, expected in [
+        ("SMART_CHARGE", {"mode": "SMART_CHARGE", "power": {"watt": 7200}}, "on"),  # charging
+        ("SMART_CHARGE", {"mode": "SMART_CHARGE", "power": {"watt": 0}}, "on"),  # plugged in
+        ("PENDING_APPROVAL", {"mode": "PENDING_APPROVAL"}, "on"),
+        ("STOPPED", {"mode": "STOPPED"}, "on"),  # paused
+        ("DISCONNECTED", {"mode": "DISCONNECTED"}, "off"),  # unplugged
+        ("FINISHED_CHARGE", {"mode": "FINISHED_CHARGE"}, "off"),  # nothing left to take
+    ]:
+        api = MockOhmeAPI()
+        # publish_data reads the applied rule for any session that is in progress
+        api.client._charge_session = dict(session, appliedRule={"targetPercent": 80, "targetTime": 25200})
+        api.client._next_session = {"targetPercent": 80, "targetTime": 25200}
+        api.client._last_rule = {"targetPercent": 80}
+        api.client._cars = []
+        run_async(api.publish_data())
+
+        state = api.dashboard_items["binary_sensor.predbat_ohme_connected"]["state"]
+        assert state == expected, f"Expected {mode} to publish connected={expected}, got {state}"
+
+    print("PASS: connected binary sensor tracked the plug state")
+    return 0
+
+
+def _test_ohme_auto_config_wires_car_charging_energy(my_predbat=None):
+    """Test car registration points car_charging_energy at the delivered-energy sensor"""
+    print("**** Running test_ohme_auto_config_wires_car_charging_energy ****")
+
+    # Nothing configured at all
+    api = MockOhmeAPI()
+    run_async(api.automatic_config())
+    assert api.args.get("car_charging_energy") == ENERGY_TODAY_ENTITY, f"Expected {ENERGY_TODAY_ENTITY}, got {api.args.get('car_charging_energy')}"
+
+    # The apps.yaml default regex, still unresolved because no Zappi or Wallbox matched it.
+    # auto_config(final=True) has not run yet at this point in startup, so it is still present
+    api = MockOhmeAPI()
+    api.args["car_charging_energy"] = "re:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)"
+    run_async(api.automatic_config())
+    assert api.args.get("car_charging_energy") == ENERGY_TODAY_ENTITY, f"Expected unmatched regex to be replaced, got {api.args.get('car_charging_energy')}"
+
+    # The rest of the car registration happens too
+    assert api.args.get("num_cars") == 1, f"Expected num_cars 1, got {api.args.get('num_cars')}"
+    assert api.args.get("car_charging_planned") == ["binary_sensor.predbat_ohme_connected"], f"Expected connected sensor, got {api.args.get('car_charging_planned')}"
+    assert api.args.get("car_charging_soc") == ["sensor.predbat_ohme_battery_percent"], f"Expected battery percent sensor, got {api.args.get('car_charging_soc')}"
+
+    # ...but the Octopus Intelligent args are left to the separate method
+    assert api.args.get("octopus_intelligent_slot") is None, f"Expected no slot wiring from car registration, got {api.args.get('octopus_intelligent_slot')}"
+
+    print("PASS: auto config wired car_charging_energy")
+    return 0
+
+
+def _test_ohme_auto_config_keeps_existing_car_charging_energy(my_predbat=None):
+    """Test auto config leaves a real charger's energy sensor alone"""
+    print("**** Running test_ohme_auto_config_keeps_existing_car_charging_energy ****")
+
+    # A resolved Zappi sensor means the user has another charger measuring car energy - taking
+    # that over with an Ohme-only figure would lose the car charging it is already reporting
+    api = MockOhmeAPI()
+    api.args["car_charging_energy"] = "sensor.myenergi_zappi_1234_charge_added_session"
+    run_async(api.automatic_config())
+
+    assert api.args.get("car_charging_energy") == "sensor.myenergi_zappi_1234_charge_added_session", f"Expected the Zappi sensor to be kept, got {api.args.get('car_charging_energy')}"
+    assert any("Leaving car_charging_energy" in msg for msg in api.log_messages), f"Expected a note about keeping it, got {api.log_messages}"
+
+    print("PASS: auto config kept the existing car_charging_energy sensor")
+    return 0
 
 
 def _test_ohme_publish_data(my_predbat=None):
@@ -2063,7 +2469,7 @@ def _test_ohme_number_event_handler_target_soc(my_predbat=None):
     api.client._last_rule = {"targetPercent": 80}
 
     # Call number_event_handler with valid target SoC
-    run_async(api.number_event_handler("number.predbat_ohme_target_soc", 90))
+    run_async(api.number_event_handler("number.predbat_ohme_target_percent", 90))
 
     # Verify request was made
     assert len(api.client.request_log) == 1, f"Expected 1 request, got {len(api.client.request_log)}"
@@ -2072,6 +2478,45 @@ def _test_ohme_number_event_handler_target_soc(my_predbat=None):
     assert "toPercent=90" in request["url"], f"Expected toPercent=90 in URL, got {request['url']}"
 
     print("PASS: number_event_handler correctly handles target_soc")
+    return 0
+
+
+def _test_ohme_number_event_handler_matches_published_entities(my_predbat=None):
+    """Test every number entity published by publish_data is accepted by number_event_handler"""
+    print("**** Running test_ohme_number_event_handler_matches_published_entities ****")
+
+    # Publish the full entity set so we test against the real entity names rather than
+    # hand-written ones - a mismatch between publish_data and the handler silently drops
+    # the user's change, which is how number.predbat_ohme_target_percent was left inert
+    api = MockOhmeAPI()
+    api.client._charge_session = {
+        "mode": "SMART_CHARGE",
+        "power": {"watt": 7200, "amp": 32, "volt": 230},
+        "appliedRule": {"targetPercent": 80, "targetTime": 25200},
+        "batterySoc": {"wh": 15000, "percent": 75},
+        "allSessionSlots": [],
+    }
+    api.client._next_session = {"targetPercent": 80, "targetTime": 25200}
+    api.client._last_rule = {"targetPercent": 80, "preconditioningEnabled": True, "preconditionLengthMins": 30}
+    api.client._cars = [{"name": "Tesla Model 3"}]
+    run_async(api.publish_data())
+
+    published = [entity_id for entity_id in api.dashboard_items if entity_id.startswith("number.")]
+    assert published, "Expected publish_data to publish at least one number entity"
+    assert "number.predbat_ohme_target_percent" in published, f"Expected target percent entity to be published, got {published}"
+
+    # Every published number entity must reach the API when changed
+    for entity_id in published:
+        api.client.request_log = []
+        run_async(api.number_event_handler(entity_id, 50))
+        assert len(api.client.request_log) == 1, f"Entity {entity_id} is published but number_event_handler made {len(api.client.request_log)} requests - it is not wired up"
+
+    # Specifically check the target percent value reaches the rule
+    api.client.request_log = []
+    run_async(api.number_event_handler("number.predbat_ohme_target_percent", 65))
+    assert "toPercent=65" in api.client.request_log[0]["url"], f"Expected toPercent=65, got {api.client.request_log[0]['url']}"
+
+    print(f"PASS: all {len(published)} published number entities are handled")
     return 0
 
 
@@ -2087,7 +2532,7 @@ def _test_ohme_number_event_handler_target_soc_invalid(my_predbat=None):
     api.client._last_rule = {"targetPercent": 80}
 
     # Test with value > 100
-    run_async(api.number_event_handler("number.predbat_ohme_target_soc", 150))
+    run_async(api.number_event_handler("number.predbat_ohme_target_percent", 150))
 
     # Verify no request was made
     assert len(api.client.request_log) == 0, f"Expected 0 requests, got {len(api.client.request_log)}"

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -267,9 +267,11 @@ def test_ohme(my_predbat=None):
         ("energy_left_sum", _test_ohme_energy_today_left_riemann, "energy_today uses a left Riemann sum"),
         ("energy_gap", _test_ohme_energy_today_long_gap, "energy_today skips over-long gaps"),
         ("energy_midnight", _test_ohme_energy_today_midnight_rollover, "energy_today resets at midnight"),
+        ("energy_gap_midnight", _test_ohme_energy_today_gap_across_midnight, "energy_today rolls the day over a long gap"),
         ("energy_restore", _test_ohme_energy_today_restore, "energy_today restores across a restart"),
         ("energy_restore_stale", _test_ohme_energy_today_restore_stale, "energy_today ignores a stale total"),
         ("energy_published", _test_ohme_energy_today_published, "publish_data publishes energy_today"),
+        ("energy_timezone", _test_ohme_energy_today_uses_configured_timezone, "energy_today follows the configured timezone"),
         ("auto_config_energy", _test_ohme_auto_config_wires_car_charging_energy, "auto config wires car_charging_energy"),
         ("iog_flag_forces_on", _test_ohme_iog_flag_forces_on, "explicit flag forces Intelligent on"),
         ("iog_flag_forces_off", _test_ohme_iog_flag_forces_off, "explicit flag forces Intelligent off"),
@@ -2009,6 +2011,34 @@ def _test_ohme_energy_today_midnight_rollover(my_predbat=None):
     return 0
 
 
+def _test_ohme_energy_today_gap_across_midnight(my_predbat=None):
+    """Test a stall spanning midnight still rolls the day over"""
+    print("**** Running test_ohme_energy_today_gap_across_midnight ****")
+
+    # Charging yesterday evening, then Predbat stalls until after midnight. The gap is too long to
+    # integrate, but the day must still roll - otherwise the first publish of the new day reports
+    # yesterday's total against yesterday's date
+    api = MockOhmeAPI()
+    before = datetime.datetime(2026, 8, 22, 23, 0, 0).astimezone()
+    api.update_energy_today(7200, before)
+    api.update_energy_today(7200, datetime.datetime(2026, 8, 22, 23, 2, 0).astimezone())
+    assert api.energy_today > 0, "Expected energy to accumulate before the stall"
+
+    after = datetime.datetime(2026, 8, 23, 0, 30, 0).astimezone()
+    energy = api.update_energy_today(7200, after)
+
+    assert energy == 0.0, f"Expected the new day to start at zero, got {energy}"
+    assert api.energy_today_date == after.date(), f"Expected the date to roll to {after.date()}, got {api.energy_today_date}"
+    assert any("not counting that gap" in msg for msg in api.log_messages), f"Expected the gap to still be skipped, got {api.log_messages}"
+
+    # The stalled interval itself is not counted - we have no evidence the charger ran through it
+    energy = api.update_energy_today(7200, after + datetime.timedelta(seconds=120))
+    assert abs(energy - 7200 * (120 / 3600.0) / 1000.0) < 1e-6, f"Expected only the post-stall interval, got {energy}"
+
+    print("PASS: the day rolled over across a long gap")
+    return 0
+
+
 def _test_ohme_energy_today_restore(my_predbat=None):
     """Test energy_today picks up today's total again after a restart"""
     print("**** Running test_ohme_energy_today_restore ****")
@@ -2067,7 +2097,10 @@ def _test_ohme_energy_today_published(my_predbat=None):
     item = api.dashboard_items[ENERGY_TODAY_ENTITY]
     assert item["attributes"]["unit_of_measurement"] == "kWh", f"Expected kWh, got {item['attributes']}"
     assert item["attributes"]["device_class"] == "energy", f"Expected device_class energy, got {item['attributes']}"
-    assert item["attributes"]["energy_date"] == datetime.datetime.now().astimezone().date().isoformat(), f"Expected today's date attribute, got {item['attributes']}"
+    # Compared against the accumulator's own date rather than a fresh now(), which would make the
+    # test straddle midnight and fail on a correct publish. The date itself is covered by the
+    # rollover tests
+    assert item["attributes"]["energy_date"] == api.energy_today_date.isoformat(), f"Expected the published date to match the accumulator, got {item['attributes']}"
 
     # First publish has no prior reading to integrate over, so it starts at zero
     assert item["state"] == 0.0, f"Expected 0.0 kWh on the first publish, got {item['state']}"
@@ -2199,6 +2232,34 @@ def _test_ohme_connected_sensor(my_predbat=None):
         assert state == expected, f"Expected {mode} to publish connected={expected}, got {state}"
 
     print("PASS: connected binary sensor tracked the plug state")
+    return 0
+
+
+def _test_ohme_energy_today_uses_configured_timezone(my_predbat=None):
+    """Test the daily total follows Predbat's configured timezone, not the host clock"""
+    print("**** Running test_ohme_energy_today_uses_configured_timezone ****")
+
+    # A container running UTC with timezone: Europe/London configured must still reset at the
+    # user's local midnight, so publish_data has to take its clock from Predbat rather than now()
+    api = MockOhmeAPI()
+    api._now_override = api.local_tz.localize(datetime.datetime(2026, 1, 2, 3, 4, 5))
+    api.client._charge_session = {
+        "mode": "SMART_CHARGE",
+        "power": {"watt": 7200, "amp": 32, "volt": 230},
+        "appliedRule": {"targetPercent": 80, "targetTime": 25200},
+        "allSessionSlots": [],
+    }
+    api.client._next_session = {"targetPercent": 80, "targetTime": 25200}
+    api.client._last_rule = {"targetPercent": 80}
+    api.client._cars = []
+
+    run_async(api.publish_data())
+
+    published = api.dashboard_items[ENERGY_TODAY_ENTITY]["attributes"]["energy_date"]
+    assert published == "2026-01-02", f"Expected the configured clock's date, got {published}"
+    assert api.energy_today_date == datetime.date(2026, 1, 2), f"Expected the accumulator to follow it too, got {api.energy_today_date}"
+
+    print("PASS: energy_today followed the configured timezone")
     return 0
 
 

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -7,6 +7,7 @@ Unit tests for Ohme EV charger integration
 import datetime
 import time
 import unittest.mock
+import pytz
 from unittest.mock import patch, MagicMock, AsyncMock
 from typing import Dict, Optional
 from tests.test_infra import run_async
@@ -276,6 +277,14 @@ def test_ohme(my_predbat=None):
         ("iog_autodetect_gated", _test_ohme_iog_autodetect_needs_ohme_automatic, "auto-detect needs ohme_automatic"),
         ("iog_claims_slots", _test_ohme_iog_claims_car_slots, "Intelligent wiring claims the car slots"),
         ("connected_sensor", _test_ohme_connected_sensor, "connected binary sensor tracks plug state"),
+        ("control_enable", _test_ohme_control_enable_rules, "ohme_control enable rules"),
+        ("control_windows", _test_ohme_control_window_parsing, "control window parsing"),
+        ("control_midnight", _test_ohme_control_window_year_rollover, "control windows across new year"),
+        ("control_startup", _test_ohme_control_waits_for_plan, "control waits for a published plan"),
+        ("control_edges", _test_ohme_control_edge_triggered, "control only acts on transitions"),
+        ("control_drift", _test_ohme_control_reapplies_on_drift, "control re-applies after app changes"),
+        ("control_read_only", _test_ohme_control_read_only_release, "read only releases the charger"),
+        ("control_read_only_src", _test_ohme_control_read_only_effective, "read only uses the effective state"),
         ("auto_config_keeps", _test_ohme_auto_config_keeps_existing_car_charging_energy, "auto config keeps a real charger sensor"),
         ("publish_data", _test_ohme_publish_data, "OhmeAPI publish_data"),
         ("publish_disconnected", _test_ohme_publish_data_disconnected, "OhmeAPI publish_data disconnected"),
@@ -1574,6 +1583,14 @@ class MockOhmeAPI(OhmeAPI):
         self.queued_events = []
         self.ohme_automatic = False
         self.ohme_automatic_octopus_intelligent = None
+        self.ohme_control = False
+        self.control_active = False
+        self.control_windows = []
+        self.control_charging = None
+        self.control_read_only = None
+        self.prefix = "predbat"
+        self.local_tz = pytz.timezone("Europe/London")
+        self.states = {}
         self.energy_today = 0.0
         self.energy_today_date = None
         self.energy_last_time = None
@@ -1600,6 +1617,15 @@ class MockOhmeAPI(OhmeAPI):
         """Mock set_arg_auto - the real one logs then delegates to set_arg"""
         self.set_arg(arg, value)
 
+    def get_state_wrapper(self, entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False):
+        """Mock state read, serving whatever the test staged"""
+        return self.states.get((entity_id, attribute), default)
+
+    @property
+    def now_utc_exact(self):
+        """Current local time, overridable by tests via _now_override"""
+        return getattr(self, "_now_override", None) or datetime.datetime.now(self.local_tz)
+
     def log(self, message):
         """Mock log function"""
         self.log_messages.append(message)
@@ -1611,6 +1637,252 @@ class MockOhmeAPI(OhmeAPI):
             "attributes": attributes,
             "app": app
         }
+
+
+def _ohme_control_api(windows=None, now=None, read_only=False):
+    """Build a MockOhmeAPI with control enabled and a staged car charging plan"""
+    api = MockOhmeAPI()
+    api.ohme_automatic = True
+    api.ohme_control = True
+    api.control_active = True
+    api.base.set_read_only = read_only
+    api._now_override = now or datetime.datetime(2026, 8, 22, 23, 0, 0, tzinfo=datetime.timezone.utc).astimezone(api.local_tz)
+    if windows is not None:
+        api.states[("binary_sensor.predbat_car_charging_slot", "planned")] = windows
+    # A plugged-in car so charger_mode() has something to read
+    api.client._charge_session = {"mode": "SMART_CHARGE", "power": {"watt": 0}}
+    return api
+
+
+def _ohme_plan_window(start, end):
+    """Build a planned window in the format Predbat publishes"""
+    return {"start": start.strftime("%m-%d %H:%M:%S"), "end": end.strftime("%m-%d %H:%M:%S"), "kwh": 7.0}
+
+
+def _test_ohme_control_enable_rules(my_predbat=None):
+    """Test when Predbat-led charge control is allowed to run"""
+    print("**** Running test_ohme_control_enable_rules ****")
+
+    # Off by default
+    api = MockOhmeAPI()
+    api.enable_control(False)
+    assert api.control_active is False, "Expected control off when ohme_control is not set"
+
+    # Needs the car registered, or there is no plan to enforce
+    api = MockOhmeAPI()
+    api.ohme_control = True
+    api.ohme_automatic = False
+    api.enable_control(False)
+    assert api.control_active is False, "Expected control to need ohme_automatic"
+    assert any("needs ohme_automatic" in msg for msg in api.log_messages), f"Expected a warning, got {api.log_messages}"
+
+    # Pointless alongside Intelligent - Octopus already schedules the charge
+    api = MockOhmeAPI()
+    api.ohme_control = True
+    api.ohme_automatic = True
+    api.enable_control(True)
+    assert api.control_active is False, "Expected control to stand down in Intelligent mode"
+    assert any("Octopus already schedules" in msg for msg in api.log_messages), f"Expected a warning, got {api.log_messages}"
+
+    # Enabled when both conditions hold
+    api = MockOhmeAPI()
+    api.ohme_control = True
+    api.ohme_automatic = True
+    api.enable_control(False)
+    assert api.control_active is True, "Expected control to enable"
+
+    print("PASS: control enable rules held")
+    return 0
+
+
+def _test_ohme_control_window_parsing(my_predbat=None):
+    """Test planned windows are parsed and matched against the clock"""
+    print("**** Running test_ohme_control_window_parsing ****")
+
+    tz = pytz.timezone("Europe/London")
+    now = tz.localize(datetime.datetime(2026, 8, 22, 23, 30, 0))
+    inside = _ohme_plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+    api = _ohme_control_api(windows=[inside], now=now)
+
+    assert api.refresh_car_windows() is True, "Expected the plan to be read"
+    assert len(api.control_windows) == 1, f"Expected one window, got {api.control_windows}"
+    assert api.should_charge_now() is True, "Expected 23:30 to fall inside a 23:00-01:00 window"
+
+    # Just before the window starts, and exactly at the end, are both outside
+    api._now_override = tz.localize(datetime.datetime(2026, 8, 22, 22, 59, 0))
+    assert api.should_charge_now() is False, "Expected 22:59 to be outside the window"
+    api._now_override = tz.localize(datetime.datetime(2026, 8, 23, 1, 0, 0))
+    assert api.should_charge_now() is False, "Expected the window end to be exclusive"
+
+    # A malformed entry is skipped rather than killing the whole plan
+    api.states[("binary_sensor.predbat_car_charging_slot", "planned")] = [{"start": "nonsense"}, inside]
+    assert api.refresh_car_windows() is True, "Expected a malformed entry to be tolerated"
+    assert len(api.control_windows) == 1, f"Expected the good window to survive, got {api.control_windows}"
+
+    print("PASS: control window parsing handled the plan")
+    return 0
+
+
+def _test_ohme_control_window_year_rollover(my_predbat=None):
+    """Test windows that straddle new year are rebuilt around now"""
+    print("**** Running test_ohme_control_window_year_rollover ****")
+
+    tz = pytz.timezone("Europe/London")
+    # 23:30 on new year's eve, charging into 01:30 on new year's day. The plan carries no year,
+    # so the end parses as January of the *current* year and must be pushed forward
+    now = tz.localize(datetime.datetime(2026, 12, 31, 23, 45, 0))
+    window = {"start": "12-31 23:30:00", "end": "01-01 01:30:00", "kwh": 7.0}
+    api = _ohme_control_api(windows=[window], now=now)
+
+    api.refresh_car_windows()
+    start, end = api.control_windows[0]
+    assert end > start, f"Expected the window end to follow its start, got {start} to {end}"
+    assert api.should_charge_now() is True, "Expected to be charging at 23:45 on new year's eve"
+
+    print("PASS: new year window handled")
+    return 0
+
+
+def _test_ohme_control_waits_for_plan(my_predbat=None):
+    """Test control sends nothing until a plan has actually been published"""
+    print("**** Running test_ohme_control_waits_for_plan ****")
+
+    # No plan sensor yet - pausing a car on no information would be the wrong default
+    api = _ohme_control_api(windows=None)
+    run_async(api.control_charge())
+
+    assert len(api.client.request_log) == 0, f"Expected no commands before a plan exists, got {api.client.request_log}"
+    assert api.control_charging is None, "Expected no tracked state before a plan exists"
+
+    # An empty plan is a real answer, not a missing one - the charger is held paused
+    api.states[("binary_sensor.predbat_car_charging_slot", "planned")] = []
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == 1, f"Expected a pause once the plan is known, got {api.client.request_log}"
+    assert "stop" in api.client.request_log[0]["url"], f"Expected a pause command, got {api.client.request_log[0]['url']}"
+
+    print("PASS: control waited for a published plan")
+    return 0
+
+
+def _test_ohme_control_edge_triggered(my_predbat=None):
+    """Test control commands the charger only when the desired state changes"""
+    print("**** Running test_ohme_control_edge_triggered ****")
+
+    tz = pytz.timezone("Europe/London")
+    window = _ohme_plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+    api = _ohme_control_api(windows=[window], now=tz.localize(datetime.datetime(2026, 8, 22, 23, 30)))
+
+    # Entering the window sets max charge once
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == 1, f"Expected one command, got {api.client.request_log}"
+    assert "maxCharge=true" in api.client.request_log[0]["url"], f"Expected max charge, got {api.client.request_log[0]['url']}"
+
+    # Still inside it, and the charger already agrees - no repeat command
+    api.client._charge_session = {"mode": "MAX_CHARGE"}
+    run_async(api.control_charge())
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == 1, f"Expected no repeat commands, got {api.client.request_log}"
+
+    # Leaving the window pauses once
+    api._now_override = tz.localize(datetime.datetime(2026, 8, 23, 1, 30))
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == 2, f"Expected a pause command, got {api.client.request_log}"
+    assert "stop" in api.client.request_log[1]["url"], f"Expected a pause, got {api.client.request_log[1]['url']}"
+
+    api.client._charge_session = {"mode": "STOPPED"}
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == 2, f"Expected no repeat pause, got {api.client.request_log}"
+
+    print("PASS: control was edge triggered")
+    return 0
+
+
+def _test_ohme_control_reapplies_on_drift(my_predbat=None):
+    """Test control corrects the charger after someone changes it in the Ohme app"""
+    print("**** Running test_ohme_control_reapplies_on_drift ****")
+
+    tz = pytz.timezone("Europe/London")
+    window = _ohme_plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+    api = _ohme_control_api(windows=[window], now=tz.localize(datetime.datetime(2026, 8, 22, 23, 30)))
+
+    run_async(api.control_charge())
+    api.client._charge_session = {"mode": "MAX_CHARGE"}
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == 1, "Expected a settled state before drifting"
+
+    # Someone pauses it in the Ohme app while Predbat still wants it charging
+    api.client._charge_session = {"mode": "STOPPED"}
+    run_async(api.control_charge())
+
+    assert len(api.client.request_log) == 2, f"Expected the change to be corrected, got {api.client.request_log}"
+    assert "maxCharge=true" in api.client.request_log[1]["url"], f"Expected max charge re-applied, got {api.client.request_log[1]['url']}"
+    assert any("changed away from what Predbat set" in msg for msg in api.log_messages), f"Expected a drift log, got {api.log_messages}"
+
+    # An unplugged charger has nothing to correct
+    api.client._charge_session = {"mode": "DISCONNECTED"}
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == 2, f"Expected no command for an unplugged charger, got {api.client.request_log}"
+
+    print("PASS: control re-applied after drift")
+    return 0
+
+
+def _test_ohme_control_read_only_release(my_predbat=None):
+    """Test read only mode hands the charger back and control resumes when it clears"""
+    print("**** Running test_ohme_control_read_only_release ****")
+
+    tz = pytz.timezone("Europe/London")
+    window = _ohme_plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+    api = _ohme_control_api(windows=[window], now=tz.localize(datetime.datetime(2026, 8, 22, 23, 30)))
+
+    run_async(api.control_charge())
+    assert api.control_charging is True, "Expected Predbat to be holding the charger"
+
+    # Read only - hand it back to Ohme's own schedule
+    api.base.set_read_only = True
+    run_async(api.control_charge())
+    assert any("releasing the charger back to Ohme" in msg for msg in api.log_messages), f"Expected a release log, got {api.log_messages}"
+    assert "maxCharge=false" in api.client.request_log[-1]["url"], f"Expected max charge cleared, got {api.client.request_log[-1]['url']}"
+    assert api.control_charging is None, "Expected tracked state cleared after releasing"
+
+    # Staying in read only must not keep sending commands
+    count = len(api.client.request_log)
+    run_async(api.control_charge())
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == count, f"Expected no further commands while read only, got {api.client.request_log}"
+
+    # Clearing read only resumes control
+    api.base.set_read_only = False
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == count + 1, f"Expected control to resume, got {api.client.request_log}"
+    assert "maxCharge=true" in api.client.request_log[-1]["url"], f"Expected max charge re-applied, got {api.client.request_log[-1]['url']}"
+    assert any("Read only mode cleared" in msg for msg in api.log_messages), f"Expected a resume log, got {api.log_messages}"
+
+    print("PASS: read only released and resumed the charger")
+    return 0
+
+
+def _test_ohme_control_read_only_effective(my_predbat=None):
+    """Test read only follows the effective state, not just the config switch"""
+    print("**** Running test_ohme_control_read_only_effective ****")
+
+    # axle_control forces read only via the attribute without touching the arg
+    api = MockOhmeAPI()
+    api.base.set_read_only = True
+    api.args["set_read_only"] = False
+    assert api.control_read_only_now() is True, "Expected the attribute to win over the arg"
+
+    # Before the attribute is first set, fall back to the configured value
+    api = MockOhmeAPI()
+    api.base.set_read_only = None
+    api.args["set_read_only"] = True
+    assert api.control_read_only_now() is True, "Expected the arg to be used as a fallback"
+
+    api.args["set_read_only"] = False
+    assert api.control_read_only_now() is False, "Expected control to run when not read only"
+
+    print("PASS: read only used the effective state")
+    return 0
 
 
 def _ohme_energy_api(start_watts=0.0):

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -339,6 +339,30 @@ those settings - previously both could write them and the wiring would alternate
 
 Setting only **ohme_automatic_octopus_intelligent** (with no `ohme_automatic`) still behaves as it did before: the Intelligent slots are wired, and nothing else is.
 
+### Predbat-led Ohme charging
+
+**ohme_control** lets Predbat start and stop the charger itself, according to its own car charging plan:
+
+```yaml
+  ohme_login: "user@domain"
+  ohme_password: "xxxxxxxxx"
+  ohme_automatic: true
+  ohme_control: true
+```
+
+It requires `ohme_automatic` (there is no plan to enforce until the car is registered) and is ignored when the Intelligent slots come from Ohme, as Octopus already schedules the charge in that case.
+
+You must still set `car_charging_battery_size` and `car_charging_limit` yourself - Ohme cannot report either, and Predbat needs them to work out how much charge to add.
+
+Predbat sets the charger to max charge while a planned window is running, and pauses it the rest of the time. It re-reads the plan every minute rather than following the
+`binary_sensor.predbat_car_charging_slot` state directly, so window boundaries are acted on promptly instead of waiting for Predbat's next full update. If you change the charger in the
+Ohme app while Predbat is in control, Predbat notices at its next poll and puts it back.
+
+**While `ohme_control` is on, Predbat owns the charger.** Outside a planned window it holds the charger paused, including when nothing is planned at all. Switching Predbat to
+[read only mode](customisation.md#predbat-mode) is what releases it - Predbat then hands the charger back to Ohme's own smart schedule, and picks it up again when you turn read only
+off. A component restart deliberately does *not* release the charger, so restarting Predbat will not interrupt a charge in progress. If Predbat stops unexpectedly while the charger is
+paused, it stays paused until you turn read only on, disable `ohme_control`, or resume the charge in the Ohme app.
+
 **Note:** It's recommended to store `ohme_password` in `secrets.yaml` and reference it as `ohme_password: !secret ohme_password` - see [Storing secrets](apps-yaml.md#storing-secrets).
 
 ### Ohme charge energy

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -310,15 +310,49 @@ An excellent [worked example of setting up multiple car charging with Predbat](h
 
 Predbat can talk directly to the Ohme charger by configuring your Ohme account details in `apps.yaml`.
 
-When **ohme_automatic_octopus_intelligent** is set to `true` then Predbat is automatically configured to take Octopus Intelligent car charging slots from Ohme (rather than from Octopus Intelligent directly).
+```yaml
+  ohme_login: "user@domain"
+  ohme_password: "xxxxxxxxx"
+  ohme_automatic: true
+```
+
+There are two separate automatic settings, so you can have Predbat plan for the car without involving Octopus Intelligent at all:
+
+**ohme_automatic** registers the Ohme charger with Predbat as a car. Predbat wires `num_cars`, `car_charging_planned` (from `binary_sensor.predbat_ohme_connected`, on whenever a car is
+plugged in and still wants charge), `car_charging_soc` (from `sensor.predbat_ohme_battery_percent`) and `car_charging_energy` (see [Ohme charge energy](#ohme-charge-energy) below).
+The car's battery size and target charge level are left to your existing `car_charging_battery_size` and `car_charging_limit` settings, as Ohme cannot report them.
+
+**ohme_automatic_octopus_intelligent** takes the Octopus Intelligent car charging slots from Ohme rather than from Octopus Intelligent directly, by pointing `octopus_intelligent_slot`,
+`octopus_ready_time` and `octopus_charge_limit` at the Ohme entities. Left unset it is auto-detected: if `ohme_automatic` is on and the Octopus component reports an Intelligent tariff,
+Predbat uses the Ohme slots. Set it explicitly to override that either way - `true` forces it on (needed if you have no Octopus component for Predbat to detect from), `false` forces it
+off so the slots come from Octopus directly.
 
 ```yaml
   ohme_login: "user@domain"
   ohme_password: "xxxxxxxxx"
+  ohme_automatic: true
   ohme_automatic_octopus_intelligent: true
 ```
 
+If you run the Octopus component as well, only one of them can own the car slot wiring. Whichever source is in use, Predbat records the owner so the other component stops re-wiring
+those settings - previously both could write them and the wiring would alternate as Octopus re-detected your tariff or devices.
+
+Setting only **ohme_automatic_octopus_intelligent** (with no `ohme_automatic`) still behaves as it did before: the Intelligent slots are wired, and nothing else is.
+
 **Note:** It's recommended to store `ohme_password` in `secrets.yaml` and reference it as `ohme_password: !secret ohme_password` - see [Storing secrets](apps-yaml.md#storing-secrets).
+
+### Ohme charge energy
+
+Predbat publishes `sensor.predbat_ohme_energy_today` - the energy the charger has delivered to the car so far today, in kWh, resetting at midnight.
+
+Ohme's API does not report delivered energy directly; the figure it does report is the car's own battery level, which reads zero for cars that don't report their state of charge
+and jumps by the whole battery content for those that do. Predbat therefore builds the sensor itself by summing the charger's power reading over time, the same approach the
+Home Assistant Ohme integration recommends now that its own `energy` sensor has been [removed](devices.md#ohme-ha-in-built-integration). The charge session is polled every two
+minutes, so expect an error of up to a couple of hundred Wh per charging session - fine for filtering car charging out of your house load, but not a revenue-grade meter reading.
+
+When **ohme_automatic** is set to `true`, Predbat points [car_charging_energy](apps-yaml.md#car-charging-integration) at this sensor automatically so that
+[car charging hold](#filtering-car-charging-energy-from-house-load) can subtract your car charging precisely rather than falling back to the `car_charging_threshold` heuristic. If you already have
+another charger's energy sensor configured - a Zappi or Wallbox, say - Predbat leaves your setting alone and logs that it has done so.
 
 ## GivEnergy Gateway OCPP EV charger
 

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -352,7 +352,10 @@ Setting only **ohme_automatic_octopus_intelligent** (with no `ohme_automatic`) s
 
 It requires `ohme_automatic` (there is no plan to enforce until the car is registered) and is ignored when the Intelligent slots come from Ohme, as Octopus already schedules the charge in that case.
 
-You must still set `car_charging_battery_size` and `car_charging_limit` yourself - Ohme cannot report either, and Predbat needs them to work out how much charge to add.
+You must still set `car_charging_battery_size` and `car_charging_limit` yourself - Ohme cannot report either, and Predbat needs them to work out how much charge to add. Getting these
+right matters more than usual here: setting the charger to max charge overrides its own target percentage, so **the length of Predbat's planned window is the only thing limiting the
+charge** - the target you have set in the Ohme app will not stop it. Predbat restores that target when it releases the charger, so your normal Ohme charging is unaffected once Predbat
+is no longer in control.
 
 Predbat sets the charger to max charge while a planned window is running, and pauses it the rest of the time. It re-reads the plan every minute rather than following the
 `binary_sensor.predbat_car_charging_slot` state directly, so window boundaries are acted on promptly instead of waiting for Predbat's next full update. If you change the charger in the

--- a/docs/components.md
+++ b/docs/components.md
@@ -491,6 +491,8 @@ Integrates with Ohme EV chargers to monitor charging sessions and coordinate cha
 - Requires your Ohme account credentials
 - Can automatically manage Intelligent Octopus charging slots
 - Monitors real-time charging status and energy consumption
+- Publishes `sensor.predbat_ohme_energy_today`, the energy delivered to the car today, and wires it to `car_charging_energy` when `ohme_automatic_octopus_intelligent` is set -
+  see [Ohme charge energy](car-charging.md#ohme-charge-energy)
 
 #### Configuration Options (ohme)
 
@@ -498,7 +500,8 @@ Integrates with Ohme EV chargers to monitor charging sessions and coordinate cha
 | ------ | ---- | -------- | ------- | ---------- | ----------- |
 | `email` | String | Yes | - | `ohme_login` | Your Ohme account email address |
 | `password` | String | Yes | - | `ohme_password` | Your Ohme account password |
-| `ohme_automatic_octopus_intelligent` | Boolean | No | - | `ohme_automatic_octopus_intelligent` | Set to `true` to automatically sync with Intelligent Octopus |
+| `ohme_automatic` | Boolean | No | `False` | `ohme_automatic` | Set to `true` to register the Ohme charger with Predbat as a car |
+| `ohme_automatic_octopus_intelligent` | Boolean | No | auto | `ohme_automatic_octopus_intelligent` | Take the Intelligent car slots from Ohme. Left unset it is auto-detected when `ohme_automatic` is on; set it explicitly to override |
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -491,8 +491,8 @@ Integrates with Ohme EV chargers to monitor charging sessions and coordinate cha
 - Requires your Ohme account credentials
 - Can automatically manage Intelligent Octopus charging slots
 - Monitors real-time charging status and energy consumption
-- Publishes `sensor.predbat_ohme_energy_today`, the energy delivered to the car today, and wires it to `car_charging_energy` when `ohme_automatic_octopus_intelligent` is set -
-  see [Ohme charge energy](car-charging.md#ohme-charge-energy)
+- Publishes `sensor.predbat_ohme_energy_today`, the energy delivered to the car today, and wires it to `car_charging_energy` when `ohme_automatic` is set.
+  See [Ohme charge energy](car-charging.md#ohme-charge-energy)
 
 #### Configuration Options (ohme)
 
@@ -502,7 +502,7 @@ Integrates with Ohme EV chargers to monitor charging sessions and coordinate cha
 | `password` | String | Yes | - | `ohme_password` | Your Ohme account password |
 | `ohme_automatic` | Boolean | No | `False` | `ohme_automatic` | Set to `true` to register the Ohme charger with Predbat as a car |
 | `ohme_control` | Boolean | No | `False` | `ohme_control` | Set to `true` to let Predbat start and stop the charger from its own plan. Requires `ohme_automatic`; released by read only mode |
-| `ohme_automatic_octopus_intelligent` | Boolean | No | auto | `ohme_automatic_octopus_intelligent` | Take the Intelligent car slots from Ohme. Left unset it is auto-detected when `ohme_automatic` is on; set it explicitly to override |
+| `ohme_automatic_octopus_intelligent` | Boolean | No | unset (auto-detect) | `ohme_automatic_octopus_intelligent` | Take the Intelligent car slots from Ohme. Omit the setting entirely to auto-detect it when `ohme_automatic` is on, or give it `true`/`false` to override. Do not write `auto` - any value other than `true`/`false` is read as true |
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -501,6 +501,7 @@ Integrates with Ohme EV chargers to monitor charging sessions and coordinate cha
 | `email` | String | Yes | - | `ohme_login` | Your Ohme account email address |
 | `password` | String | Yes | - | `ohme_password` | Your Ohme account password |
 | `ohme_automatic` | Boolean | No | `False` | `ohme_automatic` | Set to `true` to register the Ohme charger with Predbat as a car |
+| `ohme_control` | Boolean | No | `False` | `ohme_control` | Set to `true` to let Predbat start and stop the charger from its own plan. Requires `ohme_automatic`; released by read only mode |
 | `ohme_automatic_octopus_intelligent` | Boolean | No | auto | `ohme_automatic_octopus_intelligent` | Take the Intelligent car slots from Ohme. Left unset it is auto-detected when `ohme_automatic` is on; set it explicitly to override |
 
 ---


### PR DESCRIPTION
Two commits: the automatic-config split plus a usable car energy sensor, then Predbat-led control of the charger on top.

## Why

1. **`number.predbat_ohme_target_percent` was inert.** `publish_data()` publishes `_target_percent`, but `number_event_handler` matched `_target_soc` — an entity that has never been published. Two existing tests asserted against that same non-existent name, so they passed while the real entity did nothing. This is the entity `ohme_automatic_octopus_intelligent` points `octopus_charge_limit` at.

2. **No usable car energy figure.** Ohme's energy field is the car's *absolute battery content*, not energy delivered — it reads 0 for cars that don't report SoC, and jumps by the whole battery content for those that do. Home Assistant removed its equivalent sensor in 2026.8.0 for exactly this reason and recommends integrating the power sensor instead. Predbat had no automatic `car_charging_energy` for Ohme, so `car_charging_hold` fell back to the `car_charging_threshold` heuristic.

3. **Two components fought over the car slot args.** Both `OctopusAPI.automatic_config()` and Ohme wire `octopus_intelligent_slot` / `octopus_ready_time` / `octopus_charge_limit`. Octopus re-runs its version whenever the tariff structure or live intelligent device set moves, so it silently took the args back off Ohme part way through a run.

4. **No way to have Predbat plan the car itself.** The gateway OCPP charger has `gateway_evc_control`; Ohme had no equivalent.

## Commit 1 — automatic config split and energy sensor

**`sensor.predbat_ohme_energy_today`** — a daily incrementing kWh total, built by summing the polled charge power (left Riemann sum, so the ramp missed at the start of a charge trades against the tail counted at the end). It restores from the previously published value across a Predbat restart, resets at midnight counting only the new day's share of the straddling interval, and refuses to integrate gaps longer than 10 minutes — under-counting is safe, inventing energy is not.

Accuracy is bounded by roughly one poll interval per start/stop edge (~250 Wh at 7.4 kW), so low single-digit percent over an IOG night. Fine for filtering car charging out of house load; not a meter reading.

**Automatic config split in two**, following the `gateway_evc_automatic` / `gateway_evc_control` precedent:

| Setting | Does |
|---|---|
| `ohme_automatic` | Registers the charger as a car: `num_cars`, `car_charging_planned` (new `binary_sensor.predbat_ohme_connected`), `car_charging_soc`, `car_charging_energy`. No Octopus involvement. |
| `ohme_automatic_octopus_intelligent` | Only the three `octopus_*` slot args. Now tri-state. |

The Intelligent flag left **unset** is auto-detected from the Octopus component's `is_intelligent_go_tariff()`, but only when `ohme_automatic` is on — otherwise shipping detection would start rewiring the config of every existing Ohme user who asked Predbat for nothing. Set **explicitly** it overrides either way, which is the only route for users with no Predbat Octopus component to detect from.

`car_charging_planned` uses a binary sensor rather than the status string so the global `car_charging_planned_response` list doesn't have to be overwritten — that list applies to every car. It's on for `pending_approval`/`charging`/`plugged_in`/`paused`, off for `unplugged`/`finished`.

**Car slot ownership.** `self.car_slot_owner` on the base; Ohme claims it when it wires the slots, and `OctopusAPI.automatic_config()` skips its slot block when another component holds the claim, logging who owns it. The rest of its wiring (saving session, rates, standing charge) still runs, and it still records `intelligent_config_devices` so `run()` doesn't re-trigger every cycle.

## Commit 2 — Predbat-led charge control

**`ohme_control`** — Predbat drives the charger from its own car charging plan: max charge while a planned window runs, paused the rest of the time. Requires `ohme_automatic`, and stands down in Intelligent mode where Octopus already schedules the charge — both with a warning rather than silent inaction.

You still set `car_charging_battery_size` and `car_charging_limit` yourself; Ohme cannot report either.

- **Every 60s from the `planned` attribute**, not the sensor's own `on`/`off` state, which only refreshes on Predbat's 5-minute cycle and would put every window boundary up to 5 minutes late. Reuses gateway's New Year window handling; a malformed entry is skipped rather than discarding the plan.
- **Edge-triggered, with drift correction.** Commands go out only on a transition, but the mode already polled every 120s is compared against what was asked for, so a change made in the Ohme app is corrected instead of leaving the tracked state quietly wrong.
- **Read-only mode is the release.** Entering it hands the charger back to Ohme's smart schedule; leaving it resumes control. The *effective* read-only state is used, not just the config switch, so an `axle_control`-forced read-only counts ([fetch.py:2700-2704](https://github.com/springfall2008/batpred/blob/main/apps/predbat/fetch.py#L2700-L2704)).
- **A component stop deliberately does not release** — that is nearly always a restart, and releasing would glitch a charge in progress.
- **Nothing is sent until a plan has been published.** A missing sensor attribute is distinguished from an empty plan, so startup cannot pause a car on no information, while a genuinely empty plan still holds the charger paused.

While `ohme_control` is on, Predbat owns the charger — outside a planned window it holds it paused, including when nothing is planned. This is documented explicitly, along with the consequence: if Predbat stops unexpectedly while paused, the charger stays paused until you enable read only, disable `ohme_control`, or resume in the Ohme app.

## Compatibility

- Setting only `ohme_automatic_octopus_intelligent: true` behaves exactly as before.
- Neither flag set → nothing happens, as before.
- `car_charging_energy` is only claimed when unset or an unmatched `re:` default. A resolved Zappi/Wallbox or hand-set sensor is left alone with a log line. (Ohme's auto-config runs between `auto_config()` and `auto_config(final=True)`, so an unmatched regex is still present as its literal string rather than removed — hence the explicit `re:` check.)
- `sensor.predbat_ohme_energy` is untouched; changing its meaning would break anyone relying on it. It remains a deprecation candidate.

## Verified

- `./run_all --quick` — all tests pass
- `./run_pre_commit` — clean
- 93 ohme tests (up from 69) plus `test_octopus_automatic_config_respects_slot_claim`
- The `target_percent` fix has a regression test that publishes the full entity set and asserts every `number.*` entity reaches the API when changed — reverting the one-line fix makes it fail with the original symptom

## Notes

Registering the car and IOG mode coexist safely — in IOG mode `car_charging_planned` feeds the `octopus_intelligent_ignore_unplugged` check and is then overwritten by the slot result, and `car_planning_on_rates` is already false when IOG is active. `car_charging_now` is deliberately left unwired since `octopus_intelligent_slot` already points at the same `slot_active` entity.

Ohme's `tariff.dsrTariff` was considered as a second detection signal for users with no Octopus component, but DSR plausibly covers other smart tariffs too, so detection goes through Octopus only.

**Max charge and the target percent.** `async_max_charge(True)` is assumed to override the charger's own target percentage, so while Predbat is in control the length of its planned window is the only thing limiting the charge — the target set in the Ohme app will not stop it. That is acceptable while Predbat owns the charger, since it sizes the window to deliver the planned kWh, but it means `car_charging_battery_size` and `car_charging_limit` need to be right; this is called out in the docs.

It must not outlive that ownership though, so the target is snapshotted before the first max charge command and restored on release — otherwise handing the charger back would leave Ohme's own smart schedule charging to the wrong level. A fresh snapshot is taken each time control is retaken.

This is a deliberately pessimistic assumption: whether the charger really ignores the target in max-charge mode is device behaviour the code cannot answer, and `appliedRule.toPercent` on the session poll would confirm it either way on real hardware. Assuming the override costs one extra API call on release and is safe if the assumption turns out to be wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
