### PR TITLE
Address Copilot review comments from #4653

### DIFF
--- a/apps/predbat/download.py
+++ b/apps/predbat/download.py
@@ -584,6 +584,13 @@ def predbat_update_move(version, files):
 
     The staged files are re-verified against the staged manifest first, and nothing is
     moved unless every one of them matches, so a corrupted file is never installed.
+
+    The git_version.txt dev marker is cleared before the move runs, not after: a hot-reload
+    triggered by the move itself (predbat.py's mtime changing partway through the mv chain)
+    could otherwise start a new process that reads a now-stale marker before this function
+    gets a chance to clear it. The trade-off is that a failed move loses that diagnostic
+    marker too - acceptable since verify_staged_files() has already ruled out a bad
+    download by this point, so a failure here is a rarer, lower-stakes filesystem issue.
     """
     if not files:
         return False
@@ -601,9 +608,9 @@ def predbat_update_move(version, files):
             cmd += "mv -f {} {} && ".format(os.path.join(this_path, file + "." + tag), os.path.join(this_path, file))
         cmd += "echo 'Update complete'"
         clear_deploy_git_version(this_path)
-        os.system(cmd)
+        result = os.system(cmd)
 
-        return True
+        return result == 0
     return False
 
 

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -1637,8 +1637,15 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         except ValueError:
             return False
 
-        # Check if the last updated time is within the last 15 minutes
-        if (datetime.now(timezone.utc) - predbat_last_updated).total_seconds() > 15 * 60:
+        # Check if the last updated time is within the last 15 minutes. An install upgraded
+        # from before record_status() wrote a timezone-aware last_updated may still have the
+        # old naive format persisted in HA until the next record_status() call overwrites it -
+        # comparing against a timezone-aware "now" in that case would raise TypeError.
+        if predbat_last_updated.tzinfo is None:
+            now = datetime.now()
+        else:
+            now = datetime.now(timezone.utc)
+        if (now - predbat_last_updated).total_seconds() > 15 * 60:
             return False
         return True
 

--- a/apps/predbat/tests/test_download.py
+++ b/apps/predbat/tests/test_download.py
@@ -80,6 +80,7 @@ def test_download(my_predbat):
         ("download_file_failure", _test_download_predbat_file_failure, "Download file failure"),
         ("download_file_no_filename", _test_download_predbat_file_no_filename, "Download file no filename"),
         ("update_move_success", _test_predbat_update_move_success, "Move files success"),
+        ("update_move_mv_failure", _test_predbat_update_move_mv_failure, "Move files propagates a failed mv chain as False"),
         ("update_move_empty", _test_predbat_update_move_empty_files, "Move files empty list"),
         ("update_move_none", _test_predbat_update_move_none_files, "Move files none list"),
         ("update_move_invalid_version", _test_predbat_update_move_invalid_version, "Move files invalid version"),
@@ -667,6 +668,7 @@ def _test_predbat_update_move_success(my_predbat):
         # Mock os.system and os.path.dirname
         with patch("download.os.path.dirname", return_value=temp_dir):
             with patch("download.os.system") as mock_system:
+                mock_system.return_value = 0
                 result = predbat_update_move(tag, test_files)
 
                 assert result is True
@@ -678,6 +680,43 @@ def _test_predbat_update_move_success(my_predbat):
                 assert "config.py" in call_args
                 assert "manifest.yaml" in call_args
                 assert "echo 'Update complete'" in call_args
+
+    finally:
+        shutil.rmtree(temp_dir)
+    return 0
+
+
+def _test_predbat_update_move_mv_failure(my_predbat):
+    """
+    Test predbat_update_move propagates a failed mv chain via its return value, rather than
+    always reporting success regardless of whether the files actually moved
+    """
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        test_files = ["predbat.py", "config.py"]
+        tag = "v8.30.8"
+
+        for filename in test_files:
+            tagged_file = os.path.join(temp_dir, filename + "." + tag)
+            with open(tagged_file, "w") as f:
+                f.write("content of {}\n".format(filename))
+
+        _write_staged_manifest(temp_dir, tag, test_files)
+
+        # The dev marker is cleared unconditionally before the mv chain runs (see
+        # predbat_update_move's docstring) - write one here to confirm that still happens
+        # even when the mv chain itself then fails.
+        with open(os.path.join(temp_dir, "git_version.txt"), "w") as f:
+            f.write("abc1234")
+
+        with patch("download.os.path.dirname", return_value=temp_dir):
+            with patch("download.os.system") as mock_system:
+                mock_system.return_value = 256  # non-zero: the mv chain failed
+                result = predbat_update_move(tag, test_files)
+
+                assert result is False
+                assert not os.path.exists(os.path.join(temp_dir, "git_version.txt"))
 
     finally:
         shutil.rmtree(temp_dir)
@@ -711,6 +750,7 @@ def _test_predbat_update_move_invalid_version(my_predbat):
         # Even with empty version, the function should still run (just with empty tag)
         with patch("download.os.path.dirname", return_value=temp_dir):
             with patch("download.os.system") as mock_system:
+                mock_system.return_value = 0
                 result = predbat_update_move("", ["test.py"])
                 # Should still return True and call os.system
                 assert result is True
@@ -1547,6 +1587,7 @@ def _test_update_move_verifies_staged_files(my_predbat):
 
         with patch("download.os.path.dirname", return_value=temp_dir):
             with patch("download.os.system") as mock_system:
+                mock_system.return_value = 0
                 assert predbat_update_move(tag, files + ["manifest.yaml"]) is True
                 assert mock_system.called
 
@@ -1629,6 +1670,7 @@ def _test_update_move_without_manifest_proceeds(my_predbat):
 
         with patch("download.os.path.dirname", return_value=temp_dir):
             with patch("download.os.system") as mock_system:
+                mock_system.return_value = 0
                 assert predbat_update_move(tag, ["predbat.py"]) is True
                 assert mock_system.called
 

--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -177,6 +177,43 @@ def run_web_functions_tests(my_predbat):
         failed += 1
 
     # -------------------------------------------------------------------------
+    # is_running() must handle both the legacy naive last_updated format (pre-existing
+    # installs, before record_status() started writing a timezone-aware value) and the
+    # current timezone-aware format, without raising on the naive/aware datetime subtraction
+    print("Test: is_running() handles both naive and timezone-aware last_updated")
+    original_stop_thread = my_predbat.stop_thread
+    original_fatal_error = my_predbat.fatal_error
+    my_predbat.stop_thread = False
+    my_predbat.fatal_error = False
+    my_predbat.dashboard_index = [status_entity]
+
+    set_entity(my_predbat, status_entity, state="Idle", error=False, last_updated="2026-07-10 14:40:10.512590")
+    try:
+        result = my_predbat.is_running()
+    except TypeError as e:
+        print(f"  ERROR: is_running() raised on a legacy naive last_updated: {e}")
+        failed += 1
+    else:
+        if result is not False:
+            print(f"  ERROR: expected is_running() False for a stale (2026-07-10) naive last_updated, got: {result}")
+            failed += 1
+
+    set_entity(my_predbat, status_entity, state="Idle", error=False, last_updated="2026-07-10T14:40:10+0100")
+    try:
+        result = my_predbat.is_running()
+    except TypeError as e:
+        print(f"  ERROR: is_running() raised on a timezone-aware last_updated: {e}")
+        failed += 1
+    else:
+        if result is not False:
+            print(f"  ERROR: expected is_running() False for a stale (2026-07-10) aware last_updated, got: {result}")
+            failed += 1
+
+    my_predbat.dashboard_index = original_dashboard_index
+    my_predbat.stop_thread = original_stop_thread
+    my_predbat.fatal_error = original_fatal_error
+
+    # -------------------------------------------------------------------------
     # Currency unit display in the web config pages (issue #4071)
     # The web UI must show the user's configured currency symbol, not the raw "p".
     failed += run_currency_unit_tests(my_predbat, web)


### PR DESCRIPTION
## Summary
Follow-up to #4653 (merged), addressing the two Copilot review comments that weren't resolved before merge:

- **`predbat.py:1636`** - `is_running()` compared a timezone-aware `datetime.now(timezone.utc)` against `predbat_last_updated`, which raises `TypeError` if that value was parsed from the old naive `str(datetime.now())` format still persisted from before this PR's fix (e.g. right after upgrading an existing install, until the next `record_status()` call overwrites the attribute). Now branches on whether the parsed value has `tzinfo`.
- **`download.py:604`** - `predbat_update_move()` returned `True` unconditionally regardless of whether the `mv` chain actually succeeded. Now returns the real result of `os.system(cmd) == 0`.

Deliberately *not* changing where `clear_deploy_git_version()` is called relative to the `mv` - Copilot suggested only clearing it after a successful move, but the PR discussion on #4653 specifically ordered it *before* the move to close a hot-reload race (a new process starting mid-move could otherwise read a stale marker). Losing the marker on a failed mv is an acceptable trade-off given `verify_staged_files()` has already ruled out a bad download by that point.

## Test plan
- [x] New test: `is_running()` round-trips both a legacy naive `last_updated` and the current timezone-aware format without raising
- [x] New test: a failed `mv` chain (`os.system` returns non-zero) propagates through `predbat_update_move()`'s return value, and the dev marker is still cleared
- [x] Updated the 4 existing `predbat_update_move` tests that mock `os.system` to set `return_value = 0`, matching the new success check
- [x] `./run_all --test download --test github -k web` and `pre-commit` (ruff, black, cspell) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)