### PR TITLE
fix(ha): send target as a sibling of service_data in websocket call_service

### DIFF
--- a/apps/predbat/ha.py
+++ b/apps/predbat/ha.py
@@ -700,9 +700,14 @@ class HAInterface(ComponentBase):
                                         # nested target is rejected with invalid_format: extra keys not allowed
                                         # @ data['target'] (#4662). Callers commonly configure services with a
                                         # target: entity_id: ... block (the standard HA action syntax), which
-                                        # lands as a "target" key inside service_data, so it must be pulled out here.
-                                        target = service_data.pop("target", None) if isinstance(service_data, dict) else None
-                                        call_frame = {"id": sid, "type": "call_service", "domain": domain, "service": service, "service_data": service_data, "return_response": return_response}
+                                        # lands as a "target" key inside service_data, so it must be pulled out
+                                        # here. Pop from a copy, not service_data itself - the original dict is
+                                        # the same object async_call_service_websocket_command() logs on failure
+                                        # ("Warn: Service call ... data ... failed"), so mutating it in place
+                                        # would silently drop target from that diagnostic.
+                                        outgoing_data = dict(service_data) if isinstance(service_data, dict) else service_data
+                                        target = outgoing_data.pop("target", None) if isinstance(outgoing_data, dict) else None
+                                        call_frame = {"id": sid, "type": "call_service", "domain": domain, "service": service, "service_data": outgoing_data, "return_response": return_response}
                                         if target:
                                             call_frame["target"] = target
                                         await websocket.send_json(call_frame)

--- a/apps/predbat/ha.py
+++ b/apps/predbat/ha.py
@@ -695,7 +695,17 @@ class HAInterface(ComponentBase):
                                     if domain == "fire_event":
                                         await websocket.send_json({"id": sid, "type": domain, "event_type": service, "event_data": {"service": service_data["event_service"], "domain": service_data["event_domain"]}})
                                     else:
-                                        await websocket.send_json({"id": sid, "type": "call_service", "domain": domain, "service": service, "service_data": service_data, "return_response": return_response})
+                                        # HA's call_service command expects 'target' (entity_id/device_id/area_id
+                                        # addressing) as a sibling of service_data, not nested inside it - a
+                                        # nested target is rejected with invalid_format: extra keys not allowed
+                                        # @ data['target'] (#4662). Callers commonly configure services with a
+                                        # target: entity_id: ... block (the standard HA action syntax), which
+                                        # lands as a "target" key inside service_data, so it must be pulled out here.
+                                        target = service_data.pop("target", None) if isinstance(service_data, dict) else None
+                                        call_frame = {"id": sid, "type": "call_service", "domain": domain, "service": service, "service_data": service_data, "return_response": return_response}
+                                        if target:
+                                            call_frame["target"] = target
+                                        await websocket.send_json(call_frame)
 
                                     # Track pending request (only if send succeeded)
                                     with self.ws_pending_lock:

--- a/apps/predbat/tests/test_hainterface_websocket.py
+++ b/apps/predbat/tests/test_hainterface_websocket.py
@@ -1011,6 +1011,16 @@ def test_hainterface_socketloop_call_service_target_field(my_predbat=None):
     else:
         print("✓ target sent as a top-level sibling field, not nested inside service_data")
 
+    # The queued service_data dict is the same object async_call_service_websocket_command() logs
+    # on failure (ha.py's "Warn: Service call ... data ... failed" line) - socketLoop() must not
+    # mutate it when building the outbound frame, or that failure log silently loses the target
+    # that was actually part of the service definition.
+    if "target" not in queued_service_data:
+        print(f"ERROR: socketLoop() mutated the original queued service_data (target missing): {queued_service_data}")
+        failed += 1
+    else:
+        print("✓ original queued service_data left unchanged (target still present)")
+
     return failed
 
 

--- a/apps/predbat/tests/test_hainterface_websocket.py
+++ b/apps/predbat/tests/test_hainterface_websocket.py
@@ -940,6 +940,80 @@ def test_hainterface_socketloop_service_register(my_predbat=None):
     return failed
 
 
+def test_hainterface_socketloop_call_service_target_field(my_predbat=None):
+    """Regression test for #4662: a queued call_service command whose service_data carries a
+    'target' key (the apps.yaml 'target: entity_id: ...' config style used for input_boolean
+    bridges) must be sent with target as a sibling of service_data in the outgoing websocket
+    frame, not left nested inside service_data. HA rejects a nested target with
+    invalid_format: extra keys not allowed @ data['target'], which silently blocked every
+    charge/discharge input_boolean service call.
+    """
+    print("\n=== Testing #4662: call_service queued command with target field ===")
+    failed = 0
+
+    import threading
+
+    mock_base = MockBase()
+    ha_interface = create_ha_interface(mock_base, ha_key="test_key", ha_url="http://localhost:8123")
+
+    mock_ws = MagicMock()
+    mock_ws.send_json = AsyncMock()
+
+    queued_event = threading.Event()
+    queued_result = {"response": None, "success": None, "error": None}
+    queued_service_data = {"target": {"entity_id": "input_boolean.predbat_charge_start"}}
+    queued_cmd = ("input_boolean", "turn_on", queued_service_data, False, queued_event, queued_result)
+
+    call_count = [0]
+
+    async def mock_receive():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            with ha_interface.ws_pending_lock:
+                ha_interface.ws_command_queue.append(queued_cmd)
+            return create_mock_websocket_message(WSMsgType.TEXT, {"type": "auth_ok"})
+        ha_interface.api_stop = True
+        return create_mock_websocket_message(WSMsgType.CLOSED, None)
+
+    mock_ws.receive = mock_receive
+
+    async def mock_sleep(delay):
+        ha_interface.api_stop = True
+
+    with patch("ha.ClientSession") as mock_session_class:
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock()
+        mock_session.ws_connect = MagicMock()
+        mock_session.ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_session.ws_connect.return_value.__aexit__ = AsyncMock()
+        mock_session_class.return_value = mock_session
+
+        with patch("ha.asyncio.sleep", new=mock_sleep):
+            run_async(ha_interface.socketLoop())
+
+    sent_frame = None
+    for call in mock_ws.send_json.call_args_list:
+        payload = call.args[0]
+        if payload.get("type") == "call_service" and payload.get("domain") == "input_boolean":
+            sent_frame = payload
+            break
+
+    if sent_frame is None:
+        print("ERROR: input_boolean/turn_on call_service was never sent by socketLoop - test setup is wrong")
+        failed += 1
+    elif "target" in sent_frame.get("service_data", {}):
+        print(f"ERROR: target should not be nested inside service_data, got {sent_frame.get('service_data')}")
+        failed += 1
+    elif sent_frame.get("target") != {"entity_id": "input_boolean.predbat_charge_start"}:
+        print(f"ERROR: Expected top-level target with entity_id, got {sent_frame.get('target')}")
+        failed += 1
+    else:
+        print("✓ target sent as a top-level sibling field, not nested inside service_data")
+
+    return failed
+
+
 def run_hainterface_websocket_tests(my_predbat):
     """Run all HAInterface websocket tests"""
     print("\n" + "=" * 80)
@@ -961,6 +1035,7 @@ def run_hainterface_websocket_tests(my_predbat):
     failed += test_hainterface_socketloop_service_register(my_predbat)
     failed += test_hainterface_socketloop_connection_drop_unblocks_queued_command(my_predbat)
     failed += test_hainterface_socketloop_result_null_success(my_predbat)
+    failed += test_hainterface_socketloop_call_service_target_field(my_predbat)
 
     print("\n" + "=" * 80)
     if failed == 0:

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -3542,7 +3542,9 @@ automation) rather than a flat `entity_id`, that's supported too:
         entity_id: input_boolean.predbat_charge_start
 ```
 
-`target` is sent to Home Assistant as its own field, exactly as `entity_id`, `device_id` and `option` are.
+`target` is the only key handled specially: it is pulled out and sent to Home Assistant as its own top-level
+field. Every other key (`entity_id`, `device_id`, `option`, etc.) continues to be sent as part of the service
+data, as before.
 
 Note: By default the service will only be called once until things change, e.g. **charge_start_service** will be called once and then won't be called again until **charge_stop_service** stops the charge.
 If however, you want the service to be called on each Predbat run then you should set **repeat** to True for the given service e.g:

--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -3532,6 +3532,18 @@ You can also call more than one service e.g:
       entity_id: switch.tsunami_charger
 ```
 
+If you need to address the entity using Home Assistant's `target` syntax (e.g. copying an example from an
+automation) rather than a flat `entity_id`, that's supported too:
+
+```yaml
+  charge_start_service:
+    - service: input_boolean.turn_on
+      target:
+        entity_id: input_boolean.predbat_charge_start
+```
+
+`target` is sent to Home Assistant as its own field, exactly as `entity_id`, `device_id` and `option` are.
+
 Note: By default the service will only be called once until things change, e.g. **charge_start_service** will be called once and then won't be called again until **charge_stop_service** stops the charge.
 If however, you want the service to be called on each Predbat run then you should set **repeat** to True for the given service e.g:
 


### PR DESCRIPTION
## Summary
- HA's `call_service` websocket command expects `target` (entity_id/device_id/area_id addressing) as a sibling of `service_data`, not nested inside it. Predbat's `call_service_template()`/`call_service()` forwarded any key from a dict-style service definition verbatim into `service_data`, so a service configured with the common `target: entity_id: ...` syntax (matching standard HA action/automation syntax, and easy to reach for when wiring up a generic `input_boolean` Service API bridge) ended up with `target` nested inside `service_data`.
- HA rejects that shape with `invalid_format: extra keys not allowed @ data['target']`, which silently blocked every charge/discharge/freeze service call while Predbat's internal plan and `predbat.status` kept reporting normally, since the failure is only logged as a `Warn:` and never propagated back to plan/status state.
- Fix: in `socketLoop()`'s queued-command send, pop `target` out of `service_data` and send it as its own top-level field in the outgoing `call_service` frame.
- Documented the `target:` addressing form as supported alongside the existing flat `entity_id:` form in `has_service_api`.

Fixes #4662

## Test plan
- [x] New regression test `test_hainterface_socketloop_call_service_target_field` drives a real `socketLoop()` iteration with a queued `input_boolean.turn_on` command carrying a nested `target`, and asserts the frame sent over the websocket has `target` as a sibling field, not nested inside `service_data`. Confirmed RED before the fix, GREEN after.
- [x] `./run_all --test hainterface_service --test hainterface_websocket --test hainterface_lifecycle --test hainterface_state --test hainterface_api --test inverter` — all pass.
- [x] `./run_all --quick` — 155 passed, identical to a clean `main` checkout (one pre-existing, order-dependent `test_web_functions.py` crash reproduces identically on unmodified `main`, unrelated to this change).
- [x] `pre-commit run --all-files` (ruff, black, cspell, markdownlint, etc.) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)