### PR TITLE
WhatIf: grid connection export limit, independent of battery

### DIFF
--- a/apps/predbat/annual.py
+++ b/apps/predbat/annual.py
@@ -38,6 +38,11 @@ DEFAULT_AZIMUTH = 180
 DEFAULT_EFFICIENCY = 0.95
 DEFAULT_HYBRID = True
 
+# The property's grid-connection export cap. High enough not to bite any real
+# domestic inverter, so an unset value behaves as "no extra restriction" rather
+# than silently clipping exports.
+DEFAULT_EXPORT_LIMIT_KW = 10.0
+
 # A typical domestic panel in 2026. Only used to turn a panel count into kWp.
 DEFAULT_PANEL_WATTS = 400.0
 
@@ -178,7 +183,6 @@ def _validate_battery(raw):
     return {
         "size_kwh": _require_number(raw["size_kwh"], "annual.battery.size_kwh", minimum=0, exclusive_minimum=True),
         "inverter_kw": inverter_kw,
-        "export_limit_kw": _require_number(raw.get("export_limit_kw", inverter_kw), "annual.battery.export_limit_kw", minimum=0),
         "hybrid": _coerce_bool(raw.get("hybrid", DEFAULT_HYBRID)),
         "charge_rate_kw": _require_number(raw.get("charge_rate_kw", inverter_kw), "annual.battery.charge_rate_kw", minimum=0, exclusive_minimum=True),
         "discharge_rate_kw": _require_number(raw.get("discharge_rate_kw", inverter_kw), "annual.battery.discharge_rate_kw", minimum=0, exclusive_minimum=True),
@@ -293,6 +297,15 @@ def validate_config(config, today=None):
     if not solar and battery is None:
         raise AnnualConfigError("annual needs at least one of solar or battery: with neither there is nothing to evaluate")
 
+    # The grid-connection export cap applies whether or not there is a battery, so it lives
+    # at the top level rather than inside the (possibly absent) battery block. A config
+    # written before this moved still has it nested under battery - read it from there as a
+    # fallback so an existing YAML file or stored run keeps behaving the same.
+    raw_battery = raw.get("battery")
+    legacy_export_limit_kw = raw_battery.get("export_limit_kw") if isinstance(raw_battery, dict) else None
+    export_limit_default = legacy_export_limit_kw if legacy_export_limit_kw is not None else DEFAULT_EXPORT_LIMIT_KW
+    export_limit_kw = _require_number(raw.get("export_limit_kw", export_limit_default), "annual.export_limit_kw", minimum=0, exclusive_minimum=True)
+
     samples_per_month = _require_number(raw.get("samples_per_month", DEFAULT_SAMPLES_PER_MONTH), "annual.samples_per_month", minimum=1, integer=True)
 
     if today is None:
@@ -309,6 +322,7 @@ def validate_config(config, today=None):
         "year": year,
         "solar": solar,
         "battery": battery,
+        "export_limit_kw": export_limit_kw,
         "load": _validate_load(raw.get("load")),
         "tariff": _validate_tariff(raw.get("tariff")),
         # The counterfactual bill is what the household would pay with no system at all,
@@ -447,7 +461,7 @@ def create_headless_predbat(work_dir, timezone, log):
     return instance
 
 
-def apply_hardware(predbat, battery, solar):
+def apply_hardware(predbat, battery, solar, export_limit_kw):
     """Map the config's battery block onto the PredBat instance.
 
     Rates are stored internally as kW per minute, matching
@@ -460,7 +474,16 @@ def apply_hardware(predbat, battery, solar):
     whatever it happened to hold before, since clamping only makes sense when a
     caller has deliberately set a starting SOC first — a later task does that
     explicitly, after calling this function.
+
+    ``export_limit_kw`` is the property's grid-connection export cap (independent of
+    whether there is a battery) and is applied as a ``min()`` against whatever the
+    hardware itself would otherwise allow to export - it can only tighten the export
+    limit, never loosen it, and never affects ``inverter_limit`` (the inverter's own
+    charge/discharge rate is unrelated to what the grid connection permits leaving
+    the property).
     """
+    export_limit_predbat_units = export_limit_kw * 1000 / MINUTE_WATT
+
     if battery is None:
         predbat.soc_max = 0.0
         predbat.soc_kw = 0.0
@@ -478,14 +501,14 @@ def apply_hardware(predbat, battery, solar):
         # difference between scenarios - this tool's whole output - is computed against
         # two different caps.
         predbat.inverter_limit = (sum(array["kwp"] for array in solar) if solar else 5.0) * 1000 / MINUTE_WATT
-        predbat.export_limit = predbat.inverter_limit
+        predbat.export_limit = min(predbat.inverter_limit, export_limit_predbat_units)
         predbat.inverter_hybrid = False
         return
 
     predbat.soc_max = battery["size_kwh"]
     predbat.soc_kw = predbat.soc_max
     predbat.inverter_limit = battery["inverter_kw"] * 1000 / MINUTE_WATT
-    predbat.export_limit = battery["export_limit_kw"] * 1000 / MINUTE_WATT
+    predbat.export_limit = min(predbat.inverter_limit, export_limit_predbat_units)
     predbat.battery_rate_max_charge = battery["charge_rate_kw"] * 1000 / MINUTE_WATT
     # Synthetic configs have no separate DC figure to scale proportionally (unlike
     # compare.py's apply_hardware_overrides(), which scales an inherited DC/AC ratio), so
@@ -1038,7 +1061,7 @@ def prepare_sample(predbat, config, weather, tariff, load_source, day, midnight_
     rate_import, rate_export = tariff.rates_for(midnight_utc, PLAN_MINUTES)
     _apply_rates(predbat, rate_import, rate_export)
 
-    apply_hardware(predbat, config["battery"], config["solar"])
+    apply_hardware(predbat, config["battery"], config["solar"], config["export_limit_kw"])
     predbat.soc_kw = START_SOC_KWH
 
 
@@ -1182,7 +1205,7 @@ def _run_scenarios(predbat, config, weather, tariff, load_source, day, midnight_
     # Like scenarios 1 and 2 this is a single prediction with empty windows. It must NOT
     # call calculate_plan(): the planner is what makes a run expensive, and there is
     # nothing to plan without a battery.
-    apply_hardware(predbat, config["battery"], config["solar"])
+    apply_hardware(predbat, config["battery"], config["solar"], config["export_limit_kw"])
     predbat.soc_kw = 0
     predbat.charge_limit_best = []
     predbat.charge_window_best = []
@@ -1194,7 +1217,7 @@ def _run_scenarios(predbat, config, weather, tariff, load_source, day, midnight_
         plans["pv_only"] = _capture_plan(predbat, actual_step, actual_step, load_step, load_step, DAY_MINUTES)
 
     # Scenario 2: PV and battery on a dumb cheapest-rate timer, no export optimisation
-    apply_hardware(predbat, config["battery"], config["solar"])
+    apply_hardware(predbat, config["battery"], config["solar"], config["export_limit_kw"])
     predbat.soc_kw = START_SOC_KWH
     charge_window, charge_limit = _baseline_charge_window(predbat)
     predbat.charge_window_best = charge_window
@@ -1235,7 +1258,7 @@ def _run_scenarios(predbat, config, weather, tariff, load_source, day, midnight_
         # loop from iterating it, so this is a shape placeholder rather than a live car.
         predbat.car_charging_slots = [[]]
 
-    apply_hardware(predbat, config["battery"], config["solar"])
+    apply_hardware(predbat, config["battery"], config["solar"], config["export_limit_kw"])
     predbat.soc_kw = START_SOC_KWH
     predbat.pv_forecast_minute = forecast_pv
     predbat.pv_forecast_minute10 = p10_pv

--- a/apps/predbat/annual.py
+++ b/apps/predbat/annual.py
@@ -304,7 +304,9 @@ def validate_config(config, today=None):
     raw_battery = raw.get("battery")
     legacy_export_limit_kw = raw_battery.get("export_limit_kw") if isinstance(raw_battery, dict) else None
     export_limit_default = legacy_export_limit_kw if legacy_export_limit_kw is not None else DEFAULT_EXPORT_LIMIT_KW
-    export_limit_kw = _require_number(raw.get("export_limit_kw", export_limit_default), "annual.export_limit_kw", minimum=0, exclusive_minimum=True)
+    # minimum=0 inclusive, not exclusive: a G99 zero-export limitation (see the docs) is a
+    # real, supported scenario, and battery.export_limit_kw allowed 0 before this moved.
+    export_limit_kw = _require_number(raw.get("export_limit_kw", export_limit_default), "annual.export_limit_kw", minimum=0)
 
     samples_per_month = _require_number(raw.get("samples_per_month", DEFAULT_SAMPLES_PER_MONTH), "annual.samples_per_month", minimum=1, integer=True)
 

--- a/apps/predbat/tests/test_annual_bootstrap.py
+++ b/apps/predbat/tests/test_annual_bootstrap.py
@@ -67,8 +67,11 @@ def test_annual_bootstrap(my_predbat):
         failed = True
 
     print("Test: apply_hardware maps the battery block onto PredBat's internal units")
-    battery = {"size_kwh": 9.5, "inverter_kw": 5.0, "export_limit_kw": 3.6, "hybrid": True, "charge_rate_kw": 3.7, "discharge_rate_kw": 4.2}
-    apply_hardware(my_predbat, battery, [{"kwp": 5.6}])
+    battery = {"size_kwh": 9.5, "inverter_kw": 5.0, "hybrid": True, "charge_rate_kw": 3.7, "discharge_rate_kw": 4.2}
+    # A grid cap well above the inverter's own rating, so it does not bite here - this
+    # test is about the ordinary hardware mapping, not the cap. The cap itself is
+    # exercised separately below.
+    apply_hardware(my_predbat, battery, [{"kwp": 5.6}], 100.0)
     if abs(my_predbat.soc_max - 9.5) > 1e-9:
         print("  ERROR: soc_max expected 9.5, got {}".format(my_predbat.soc_max))
         failed = True
@@ -78,8 +81,8 @@ def test_annual_bootstrap(my_predbat):
     if abs(my_predbat.inverter_limit - (5.0 * 1000 / MINUTE_WATT)) > 1e-9:
         print("  ERROR: inverter_limit should be in kW per minute, got {}".format(my_predbat.inverter_limit))
         failed = True
-    if abs(my_predbat.export_limit - (3.6 * 1000 / MINUTE_WATT)) > 1e-9:
-        print("  ERROR: export_limit should be in kW per minute, got {}".format(my_predbat.export_limit))
+    if abs(my_predbat.export_limit - (5.0 * 1000 / MINUTE_WATT)) > 1e-9:
+        print("  ERROR: with no restrictive grid cap, export_limit should match inverter_limit, got {}".format(my_predbat.export_limit))
         failed = True
     if abs(my_predbat.battery_rate_max_charge - (3.7 * 1000 / MINUTE_WATT)) > 1e-9:
         print("  ERROR: battery_rate_max_charge should be in kW per minute, got {}".format(my_predbat.battery_rate_max_charge))
@@ -95,7 +98,7 @@ def test_annual_bootstrap(my_predbat):
         failed = True
 
     print("Test: apply_hardware with no battery produces a zero-capacity system")
-    apply_hardware(my_predbat, None, [{"kwp": 5.6}])
+    apply_hardware(my_predbat, None, [{"kwp": 5.6}], 100.0)
     if my_predbat.soc_max != 0.0 or my_predbat.soc_kw != 0.0:
         print("  ERROR: a battery-less run should have soc_max and soc_kw of 0, got {} / {}".format(my_predbat.soc_max, my_predbat.soc_kw))
         failed = True
@@ -113,7 +116,7 @@ def test_annual_bootstrap(my_predbat):
         failed = True
 
     print("Test: apply_hardware with no battery sums kwp across every solar array, not just the first")
-    apply_hardware(my_predbat, None, [{"kwp": 5.6}, {"kwp": 4.0}])
+    apply_hardware(my_predbat, None, [{"kwp": 5.6}, {"kwp": 4.0}], 100.0)
     expected_limit = (5.6 + 4.0) * 1000 / MINUTE_WATT
     if abs(my_predbat.inverter_limit - expected_limit) > 1e-9:
         print("  ERROR: inverter_limit should sum kwp across all arrays, expected {}, got {}".format(expected_limit, my_predbat.inverter_limit))
@@ -122,8 +125,35 @@ def test_annual_bootstrap(my_predbat):
         print("  ERROR: export_limit should track the summed inverter_limit, got {}".format(my_predbat.export_limit))
         failed = True
 
+    print("Test: a grid export cap below the solar-derived limit clips a PV-only run's export_limit")
+    # This is the actual gap the top-level export_limit_kw closes: a PV-only run
+    # previously had no way to express a grid connection cap independent of solar
+    # capacity at all.
+    apply_hardware(my_predbat, None, [{"kwp": 5.6}, {"kwp": 4.0}], 3.6)
+    if abs(my_predbat.inverter_limit - expected_limit) > 1e-9:
+        print("  ERROR: a grid cap must not affect inverter_limit, expected {}, got {}".format(expected_limit, my_predbat.inverter_limit))
+        failed = True
+    if abs(my_predbat.export_limit - (3.6 * 1000 / MINUTE_WATT)) > 1e-9:
+        print("  ERROR: export_limit should be clipped to the grid cap, got {}".format(my_predbat.export_limit))
+        failed = True
+
+    print("Test: a grid export cap below the battery's own inverter rating clips export_limit")
+    apply_hardware(my_predbat, battery, [{"kwp": 5.6}], 3.6)
+    if abs(my_predbat.inverter_limit - (5.0 * 1000 / MINUTE_WATT)) > 1e-9:
+        print("  ERROR: a grid cap must not affect inverter_limit, got {}".format(my_predbat.inverter_limit))
+        failed = True
+    if abs(my_predbat.export_limit - (3.6 * 1000 / MINUTE_WATT)) > 1e-9:
+        print("  ERROR: export_limit should be clipped to the grid cap, got {}".format(my_predbat.export_limit))
+        failed = True
+
+    print("Test: a grid export cap above the battery's own inverter rating does not loosen export_limit")
+    apply_hardware(my_predbat, battery, [{"kwp": 5.6}], 100.0)
+    if abs(my_predbat.export_limit - (5.0 * 1000 / MINUTE_WATT)) > 1e-9:
+        print("  ERROR: a generous grid cap must not raise export_limit above the inverter rating, got {}".format(my_predbat.export_limit))
+        failed = True
+
     print("Test: reset_sample_state clears the leaked fields but leaves apply_hardware's output alone")
-    apply_hardware(my_predbat, battery, [{"kwp": 5.6}])
+    apply_hardware(my_predbat, battery, [{"kwp": 5.6}], 100.0)
     configured_battery_rate_max_export = my_predbat.battery_rate_max_export
     configured_inverter_limit = my_predbat.inverter_limit
 

--- a/apps/predbat/tests/test_annual_config.py
+++ b/apps/predbat/tests/test_annual_config.py
@@ -521,10 +521,13 @@ def test_annual_config(my_predbat):
         print("  ERROR: export_limit_kw should apply on a battery-less run, got {}".format(result["export_limit_kw"]))
         failed = True
 
-    print("Test: a zero export_limit_kw is rejected")
+    print("Test: a zero export_limit_kw is accepted, modelling a G99 zero-export limitation")
     config = base_config()
     config["annual"]["export_limit_kw"] = 0
-    failed = expect_error("zero export_limit_kw", config, "export_limit_kw", failed)
+    result = validate_config(config)
+    if result["export_limit_kw"] != 0:
+        print("  ERROR: a zero export_limit_kw should survive validation as 0, got {}".format(result["export_limit_kw"]))
+        failed = True
 
     print("Test: a negative export_limit_kw is rejected")
     config = base_config()

--- a/apps/predbat/tests/test_annual_config.py
+++ b/apps/predbat/tests/test_annual_config.py
@@ -88,8 +88,8 @@ def test_annual_config(my_predbat):
     if result["battery"]["charge_rate_kw"] != 5.0 or result["battery"]["discharge_rate_kw"] != 5.0:
         print("  ERROR: charge and discharge rates should default to inverter_kw, got {}".format(result["battery"]))
         failed = True
-    if result["battery"]["export_limit_kw"] != 5.0:
-        print("  ERROR: export_limit_kw should default to inverter_kw, got {}".format(result["battery"]))
+    if result["export_limit_kw"] != 10.0:
+        print("  ERROR: export_limit_kw should default to 10.0, got {}".format(result["export_limit_kw"]))
         failed = True
     if result["battery"]["hybrid"] is not True:
         print("  ERROR: hybrid should default to True, got {}".format(result["battery"].get("hybrid")))
@@ -482,5 +482,53 @@ def test_annual_config(my_predbat):
     if validate_config(config)["fast_mode"] is not False:
         print("  ERROR: fast_mode 'false' must coerce to False, not a truthy string")
         failed = True
+
+    print("Test: an explicit top-level export_limit_kw survives validation")
+    config = base_config()
+    config["annual"]["export_limit_kw"] = 3.6
+    if validate_config(config)["export_limit_kw"] != 3.6:
+        print("  ERROR: export_limit_kw should survive validation as 3.6, got {}".format(validate_config(config)["export_limit_kw"]))
+        failed = True
+
+    print("Test: a legacy battery.export_limit_kw is still read for backward compatibility")
+    # This field used to live inside the battery block; an existing hand-written YAML file
+    # or a previously stored run must keep behaving the same after the move.
+    config = base_config()
+    config["annual"]["battery"]["export_limit_kw"] = 2.5
+    result = validate_config(config)
+    if result["export_limit_kw"] != 2.5:
+        print("  ERROR: a legacy battery.export_limit_kw should still set the top-level export_limit_kw, got {}".format(result["export_limit_kw"]))
+        failed = True
+    if "export_limit_kw" in result["battery"]:
+        print("  ERROR: export_limit_kw should no longer appear inside the validated battery block, got {}".format(result["battery"]))
+        failed = True
+
+    print("Test: an explicit top-level export_limit_kw takes priority over the legacy nested one")
+    config = base_config()
+    config["annual"]["export_limit_kw"] = 8.0
+    config["annual"]["battery"]["export_limit_kw"] = 2.5
+    result = validate_config(config)
+    if result["export_limit_kw"] != 8.0:
+        print("  ERROR: the top-level export_limit_kw should win over the legacy battery one, got {}".format(result["export_limit_kw"]))
+        failed = True
+
+    print("Test: export_limit_kw applies to a PV-only run too, with no legacy battery block to read")
+    config = base_config()
+    del config["annual"]["battery"]
+    config["annual"]["export_limit_kw"] = 4.0
+    result = validate_config(config)
+    if result["export_limit_kw"] != 4.0:
+        print("  ERROR: export_limit_kw should apply on a battery-less run, got {}".format(result["export_limit_kw"]))
+        failed = True
+
+    print("Test: a zero export_limit_kw is rejected")
+    config = base_config()
+    config["annual"]["export_limit_kw"] = 0
+    failed = expect_error("zero export_limit_kw", config, "export_limit_kw", failed)
+
+    print("Test: a negative export_limit_kw is rejected")
+    config = base_config()
+    config["annual"]["export_limit_kw"] = -1.0
+    failed = expect_error("negative export_limit_kw", config, "export_limit_kw", failed)
 
     return failed

--- a/apps/predbat/tests/test_web_annual.py
+++ b/apps/predbat/tests/test_web_annual.py
@@ -110,7 +110,7 @@ def valid_postdata():
         "solar_efficiency_0": "0.95",
         "battery_size_kwh": "9.5",
         "battery_inverter_kw": "5.0",
-        "battery_export_limit_kw": "5.0",
+        "export_limit_kw": "5.0",
         "battery_hybrid": "on",
         "load_source": "manual",
         "load_annual_kwh": "3800",
@@ -155,6 +155,9 @@ def test_web_annual(my_predbat):
         if not config["solar"]:
             print("  ERROR: solar should fall back to the default array")
             failed = True
+        if config["export_limit_kw"] != DEFAULT_CONFIG["export_limit_kw"]:
+            print("  ERROR: export_limit_kw should fall back to the default, got {}".format(config["export_limit_kw"]))
+            failed = True
 
         print("Test: prefill_config() never reads apps.yaml (or anything else) from disk")
         # The unconfigured case above is exactly where this matters: apps.yaml may not
@@ -195,8 +198,8 @@ def test_web_annual(my_predbat):
         if config["battery"]["inverter_kw"] != 3.6:
             print("  ERROR: a [3600] inverter_limit should read as 3.6 kW, got {}".format(config["battery"]["inverter_kw"]))
             failed = True
-        if config["battery"]["export_limit_kw"] != 3.6:
-            print("  ERROR: a [3600] export_limit should read as 3.6 kW, got {}".format(config["battery"]["export_limit_kw"]))
+        if config["export_limit_kw"] != 3.6:
+            print("  ERROR: a [3600] export_limit should read as a top-level 3.6 kW, got {}".format(config["export_limit_kw"]))
             failed = True
 
         print("Test: an AC-coupled system is not prefilled as hybrid")
@@ -988,7 +991,7 @@ def test_web_annual_form(my_predbat):
             "solar_efficiency_0": "0.95",
             "battery_size_kwh": "9.5",
             "battery_inverter_kw": "5.0",
-            "battery_export_limit_kw": "5.0",
+            "export_limit_kw": "5.0",
             "battery_hybrid": "on",
             "load_source": "manual",
             "load_annual_kwh": "3800",
@@ -1330,7 +1333,7 @@ def test_web_annual_error_isolation(my_predbat):
     page = make_page(my_predbat)
 
     print("Test: an invalid POST (no location) renders its own validation error")
-    bad_postdata = {"battery_size_kwh": "9.5", "battery_inverter_kw": "5.0", "battery_export_limit_kw": "5.0"}
+    bad_postdata = {"battery_size_kwh": "9.5", "battery_inverter_kw": "5.0", "export_limit_kw": "5.0"}
     response = asyncio.run(page.html_annual_post(FakeRequest(bad_postdata)))
     if "Could not run" not in response.text:
         print("  ERROR: an invalid POST should render its own validation error, got no banner in the response")
@@ -1496,7 +1499,8 @@ def sample_run_results():
         # must describe, rather than whatever the live form happens to hold.
         "config": {
             "solar": [{"kwp": 5.6, "declination": 35, "azimuth": 180}],
-            "battery": {"size_kwh": 9.5, "inverter_kw": 5.0, "export_limit_kw": 5.0, "hybrid": True},
+            "battery": {"size_kwh": 9.5, "inverter_kw": 5.0, "hybrid": True},
+            "export_limit_kw": 5.0,
             "load": {"annual_kwh": 3800, "shape": "night", "car_charging_kwh": 3000, "car_rate_kw": 7.4},
             # Templated, with dno_region beside them: results["config"] is the RAW config
             # (annual.py stores self.config["raw"]), and AnnualTariff substitutes the
@@ -1578,7 +1582,7 @@ def test_web_annual_results(my_predbat):
 
     print("Test: a run states the key settings it actually used")
     details = page._render_run_details(results)
-    for expected in ["5.6 kWp", "9.5 kWh", "Octopus Agile", "Octopus Outgoing Prime", "3,800 kWh a year", "more at night", "3,000 kWh a year", "60p a day"]:
+    for expected in ["5.6 kWp", "9.5 kWh", "Octopus Agile", "Octopus Outgoing Prime", "3,800 kWh a year", "more at night", "3,000 kWh a year", "60p a day", "Grid export limit", "5 kW"]:
         if expected not in details:
             print("  ERROR: the run details should state {}, got {}".format(expected, details))
             failed = True
@@ -2407,7 +2411,7 @@ def test_web_annual_post_numeric_coercion(my_predbat):
         "solar_efficiency_0": "0.9",
         "battery_size_kwh": "9.5",
         "battery_inverter_kw": "5.0",
-        "battery_export_limit_kw": "5.0",
+        "export_limit_kw": "5.0",
         "battery_hybrid": "on",
         "load_source": "manual",
         "load_annual_kwh": "3800",

--- a/apps/predbat/web_annual.py
+++ b/apps/predbat/web_annual.py
@@ -61,7 +61,8 @@ SCENARIO_ORDER = ["no_pvbat", "pv_only", "without_predbat", "with_predbat"]
 DEFAULT_CONFIG = {
     "location": {"postcode": "SW1A 1AA"},
     "solar": [{"kwp": 5.0, "declination": 35, "azimuth": 180, "efficiency": 0.95}],
-    "battery": {"size_kwh": 9.5, "inverter_kw": 5.0, "export_limit_kw": 5.0, "hybrid": True},
+    "battery": {"size_kwh": 9.5, "inverter_kw": 5.0, "hybrid": True},
+    "export_limit_kw": 10.0,
     "load": {"annual_kwh": 3800, "shape": "flat", "car_charging_kwh": 0, "car_rate_kw": 7.4},
     "tariff": {"rates_import": [{"rate": PRICE_CAP_IMPORT_P}], "rates_export": [{"rate": SEG_EXPORT_P}], "standing_charge_p_per_day": PRICE_CAP_STANDING_CHARGE_P},
     "samples_per_month": 2,
@@ -225,14 +226,18 @@ class AnnualPage:
         # internally, and returns the 0.0 default, so every real system silently fell back
         # to the example 5 kW rather than showing its own limits. Summing is what the model
         # wants: two 3.6 kW inverters can move 7.2 kW between them.
-        for arg_name, field, divisor in [("inverter_limit", "inverter_kw", 1000.0), ("export_limit", "export_limit_kw", 1000.0)]:
+        #
+        # inverter_limit is the battery's own inverter rating, so it lands in the battery
+        # block; export_limit is the grid-connection cap, which applies whether or not
+        # there is a battery, so it lands at the top level instead.
+        for arg_name, target, field in [("inverter_limit", config["battery"], "inverter_kw"), ("export_limit", config, "export_limit_kw")]:
             watts = self._arg(arg_name, 0.0, combine=True) or 0
             try:
                 watts = float(watts)
             except (TypeError, ValueError):
                 watts = 0
             if watts > 0:
-                config["battery"][field] = round(watts / divisor, 2)
+                target[field] = round(watts / 1000.0, 2)
 
         # Read the real setting rather than inferring it. This used to set hybrid whenever
         # an inverter_type was present at all, which is true of every configured system -
@@ -444,6 +449,12 @@ class AnnualPage:
         text += self._number_field("longitude", "Longitude", location.get("longitude"))
         text += "</fieldset>\n"
 
+        text += "<fieldset><legend>Grid connection</legend>\n"
+        # Applies whether or not there is a battery - a PV-only system still has a grid
+        # connection with its own export cap - so this lives outside the Battery fieldset.
+        text += self._number_field("export_limit_kw", "Export limit", config.get("export_limit_kw", DEFAULT_CONFIG["export_limit_kw"]), suffix="kW")
+        text += "</fieldset>\n"
+
         text += "<fieldset><legend>Solar</legend>\n"
         for index, array in enumerate(solar):
             mode = "panels" if array.get("panels") else "kwp"
@@ -477,7 +488,6 @@ class AnnualPage:
         text += "<fieldset><legend>Battery</legend>\n"
         text += self._number_field("battery_size_kwh", "Usable capacity", battery.get("size_kwh"), suffix="kWh")
         text += self._number_field("battery_inverter_kw", "Inverter size", battery.get("inverter_kw"), suffix="kW")
-        text += self._number_field("battery_export_limit_kw", "Export limit", battery.get("export_limit_kw"), suffix="kW")
         text += '<div class="annual-field"><label for="battery_hybrid">Hybrid inverter</label><input type="checkbox" id="battery_hybrid" name="battery_hybrid" {}></div>\n'.format("checked" if battery.get("hybrid", True) else "")
         text += "</fieldset>\n"
 
@@ -673,6 +683,10 @@ class AnnualPage:
             location["longitude"] = numeric("longitude")
         config["location"] = location
 
+        # Applies whether or not there is a battery, so it is read unconditionally rather
+        # than alongside the battery block below.
+        config["export_limit_kw"] = numeric("export_limit_kw", DEFAULT_CONFIG["export_limit_kw"])
+
         arrays = []
         index = 0
         while value("solar_kwp_{}".format(index)) is not None or value("solar_panels_{}".format(index)) is not None:
@@ -697,7 +711,6 @@ class AnnualPage:
             config["battery"] = {
                 "size_kwh": numeric("battery_size_kwh"),
                 "inverter_kw": numeric("battery_inverter_kw", 5.0),
-                "export_limit_kw": numeric("battery_export_limit_kw", 5.0),
                 "hybrid": bool(postdata.get("battery_hybrid")),
             }
 
@@ -1206,12 +1219,15 @@ class AnnualPage:
         battery = config.get("battery") or {}
         if isinstance(battery, dict) and battery.get("size_kwh"):
             summary = "{:g} kWh, {:g} kW inverter".format(float(battery["size_kwh"]), float(battery.get("inverter_kw", 0) or 0))
-            if battery.get("export_limit_kw"):
-                summary += ", {:g} kW export limit".format(float(battery["export_limit_kw"]))
             summary += ", hybrid" if battery.get("hybrid", True) else ", AC coupled"
             rows.append(("Battery", html.escape(summary, quote=True)))
         else:
             rows.append(("Battery", "none"))
+
+        # Applies whether or not there is a battery, so it is its own row rather than
+        # folded into the Battery one above - a PV-only run has a grid export cap too.
+        if config.get("export_limit_kw"):
+            rows.append(("Grid export limit", html.escape("{:g} kW".format(float(config["export_limit_kw"])), quote=True)))
 
         load = config.get("load") or {}
         if isinstance(load, dict) and load.get("octopus"):

--- a/docs/annual-prediction.md
+++ b/docs/annual-prediction.md
@@ -465,10 +465,13 @@ annual:
       azimuth: 180               # 180 = south, default 180
       efficiency: 0.95           # default 0.95, must be greater than 0 and at most 1
 
+  export_limit_kw: 10.0          # grid connection export cap, default 10.0; applies with
+                                  # or without a battery (previously battery.export_limit_kw,
+                                  # which is still read for backward compatibility)
+
   battery:                       # omit for a PV-only run
     size_kwh: 9.5
     inverter_kw: 5.0
-    export_limit_kw: 5.0         # defaults to inverter_kw
     hybrid: true                 # false = AC coupled
     charge_rate_kw: 3.6          # defaults to inverter_kw
     discharge_rate_kw: 3.6       # defaults to inverter_kw


### PR DESCRIPTION
## Summary
- Adds `export_limit_kw` as a top-level WhatIf (annual prediction) config field, defaulting to 10kW - the property's grid-connection export cap, combined via `min()` with whatever `apply_hardware()` already derives for export capability (the battery's inverter, or summed solar kWp for a PV-only run).
- Previously this only existed as `battery.export_limit_kw`, so a battery-less run had no way to model a grid export cap at all. It's still read as a legacy fallback so existing hand-written YAML configs and previously stored runs keep behaving the same.
- Web form: moved the "Export limit" field out of the Battery fieldset into its own "Grid connection" fieldset so it's visibly independent of whether a battery is configured; prefill now reads the live instance's real `export_limit` setting into this field.
- No CLI flag changes needed - `annual_cli.py` just feeds YAML into `validate_config()`, so the new key works from the command line automatically.
- Docs updated in `docs/annual-prediction.md`.

## Test plan
- [x] `./run_all --test annual_config --test annual_bootstrap --test web_annual` passes
- [x] `./run_all --quick` passes (full suite, including `annual_scenarios`, `annual_job`, `annual_cli_machine_end_to_end`)
- [x] `./run_pre_commit` passes (ruff, black, cspell, markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)