### PR TITLE
feat(myenergi): drive the Zappi from Predbat's car charging plan

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -147,6 +147,7 @@ dwindow
 eauth
 echargingpile
 Eddi
+eddis
 elif
 elinter
 eload
@@ -646,5 +647,5 @@ ylabel
 YOURSERIAL
 yuanzhi
 zappi
-Zappis
+zappis
 zigbee

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -234,6 +234,7 @@ COMPONENT_LIST = {
             "automatic": {"required": False, "config": "myenergi_automatic", "default": True},
             "enable_controls": {"required": False, "config": "myenergi_enable_controls", "default": True},
             "poll_seconds": {"required": False, "config": "myenergi_poll_seconds", "default": 60},
+            "zappi_control": {"required": False, "config": "myenergi_zappi_control", "default": False},
         },
         # Gate activation on having at least one auth path — api_key is the direct
         # transport's local hub credential, key is the cloud transport's access token.

--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -2590,6 +2590,7 @@ APPS_SCHEMA = {
     "myenergi_automatic": {"type": "boolean"},
     "myenergi_enable_controls": {"type": "boolean"},
     "myenergi_poll_seconds": {"type": "integer", "zero": False},
+    "myenergi_zappi_control": {"type": "boolean"},
     "fox_key": {"type": "string", "empty": False},
     "fox_automatic": {"type": "boolean"},
     "fox_automatic_ignore_pv": {"type": "boolean"},

--- a/apps/predbat/myenergi.py
+++ b/apps/predbat/myenergi.py
@@ -1077,14 +1077,16 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
                 return False
             if devices:
                 self.devices = {device.device_id: device for device in devices}
+                if first:
+                    # Before the first publish: the switch has to carry its restored state
+                    # from the start, or a restart with control switched off would show it
+                    # on for a cycle and then flip, looking like Predbat taking control back
+                    await self.load_control_enabled()
+                    self.enable_control()
                 await self.publish_data()
                 if self.automatic and not self._auto_configured:
                     self.automatic_config()
                     self._auto_configured = True
-                if first:
-                    # After the first poll, so the Zappis are known before control decides
-                    await self.load_control_enabled()
-                    self.enable_control()
                 if self.control_active:
                     try:
                         await self.control_tick(self.now_utc_exact)
@@ -1192,9 +1194,11 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
 
     async def publish_data(self):
         """Publish every known device as Predbat entities."""
-        if self.zappi_control:
-            # Only published when the feature is configured, so no dead control appears
-            # in the dashboard of everyone who is only monitoring.
+        if self.control_active:
+            # Published only when control could actually act on it. Gating on the config
+            # key alone would leave a switch reading "on" for a feature that cannot run -
+            # monitor-only mode, or automatic configuration off - and making that switch
+            # merely respond to a toggle would keep it live without making it honest.
             self.dashboard_item(
                 "switch.{}_myenergi_zappi_control".format(self.prefix),
                 state="on" if self.control_enabled else "off",

--- a/apps/predbat/myenergi.py
+++ b/apps/predbat/myenergi.py
@@ -25,6 +25,7 @@ can configure today, and a bearer-token transport for the official 3rd party API
 
 import argparse
 import asyncio
+import datetime
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -80,6 +81,11 @@ EDDI_DEFAULT_BOOST_TARGET = "heater1"
 # identical MyEnergiDevice values for equivalent device states.
 CLOUD_MODE_TO_NAME = {"fast": "Fast", "eco": "Eco", "eco+": "Eco+", "stop": "Stopped"}
 
+# The supply modes that can be set, and their cloud-API spelling. Derived from the map
+# above so the two vocabularies cannot drift apart. ZAPPI_CHARGE_MODES[0] ("None") is a
+# state the device reports, not a mode either API accepts.
+ZAPPI_MODE_TO_CLOUD = {name: cloud for cloud, name in CLOUD_MODE_TO_NAME.items()}
+
 CLOUD_STATUS_TO_NAME = {
     "ev_not_connected": "Paused",
     "waiting_for_surplus": "Paused",
@@ -105,6 +111,20 @@ BOOST_MINUTES_MAX = 240
 
 # Boosting a Zappi is only accepted while it is in one of the green-energy modes.
 ZAPPI_BOOSTABLE_MODES = ("Eco", "Eco+")
+
+# How output.py formats the start/end of each planned car charging window. It carries no
+# year, so a parsed window has to be rebuilt around the current time.
+PLAN_TIME_FORMAT = "%m-%d %H:%M:%S"
+
+# The two modes Predbat-led charge control drives a Zappi between, and the mode a
+# released Zappi falls back to when nothing was saved to restore.
+ZAPPI_MODE_CHARGING = "Fast"
+ZAPPI_MODE_STOPPED = "Stopped"
+ZAPPI_MODE_RELEASE = "Eco+"
+
+# Where the control switch state is persisted, so turning control off survives a restart.
+MYENERGI_STORAGE_MODULE = "myenergi"
+MYENERGI_CONTROL_STATE = "control_state"
 
 # aiohttp only grew DigestAuthMiddleware and ClientSession(middlewares=...) in 3.12, and
 # the direct transport cannot authenticate without them. requirements.txt pins the floor,
@@ -175,6 +195,18 @@ def _boost_units(amount):
     int() alone truncates toward zero, so a 9.8 kWh selection would be sent as 9.
     """
     return max(0, int(round(_to_float(amount))))
+
+
+def validate_zappi_mode(device, mode):
+    """Check a supply mode change is one this device can accept.
+
+    Raises rather than defaulting, because the Eddi mode command is a different endpoint
+    with its own vocabulary - falling through would silently address the wrong device.
+    """
+    if device.kind != DEVICE_KIND_ZAPPI:
+        raise MyEnergiApiError("cannot set a supply mode on device kind '{}'".format(device.kind))
+    if mode not in ZAPPI_MODE_TO_CLOUD:
+        raise MyEnergiApiError("unknown Zappi supply mode '{}'".format(mode))
 
 
 def digest_auth_available():
@@ -327,16 +359,16 @@ class MyEnergiTransport(ABC):
     async def cancel_boost(self, device):
         """Cancel an active boost on a device."""
 
+    @abstractmethod
+    async def set_mode(self, device, mode):
+        """Set a device's supply mode, named as ZAPPI_CHARGE_MODES spells it."""
+
     def _not_implemented(self, what):
         """Warn once that a control is not implemented in this release, and return False."""
         if what not in self._warned_stubs:
             self._warned_stubs.add(what)
             self.log("Warn: myenergi: {} is not implemented in this release".format(what))
         return False
-
-    async def set_mode(self, device, mode):
-        """Set the device supply mode. Not implemented in this release."""
-        return self._not_implemented("set_mode")
 
     async def set_priority(self, device, priority):
         """Set the device diversion priority. Not implemented in this release."""
@@ -514,6 +546,13 @@ class MyEnergiDirectTransport(MyEnergiTransport):
         if code != 0:
             raise MyEnergiApiError("myenergi refused {} with status {}".format(path, code))
 
+    async def set_mode(self, device, mode):
+        """Set a Zappi's supply mode, e.g. Fast to charge now or Stopped to hold off."""
+        validate_zappi_mode(device, mode)
+        path = "/cgi-zappi-mode-Z{}-{}-0-0-0000".format(device.serial, ZAPPI_CHARGE_MODES.index(mode))
+        self._check_command_status(await self._request(path), path)
+        return True
+
     async def send_boost(self, device, amount, target_time=None):
         """Start a boost, choosing the manual or smart command for a Zappi."""
         if device.kind == DEVICE_KIND_ZAPPI:
@@ -663,6 +702,13 @@ class MyEnergiCloudTransport(MyEnergiTransport):
             raise MyEnergiApiError("no myenergi device could be read this poll, {} skipped".format(skipped))
         return devices
 
+    async def set_mode(self, device, mode):
+        """Set a Zappi's supply mode, translating the name into the API's own spelling."""
+        validate_zappi_mode(device, mode)
+        body = {"supplyMode": ZAPPI_MODE_TO_CLOUD[mode]}
+        await self._request("POST", "/devices/{}/mode".format(device.device_id), body=body)
+        return True
+
     async def send_boost(self, device, amount, target_time=None):
         """Start a boost, selecting the request body shape by device class.
 
@@ -698,6 +744,7 @@ myenergi_attribute_table = {
     "session_energy": {"friendly_name": "myenergi Session Energy", "icon": "mdi:lightning-bolt", "unit_of_measurement": "kWh", "device_class": "energy", "state_class": "total_increasing"},
     "charging": {"friendly_name": "myenergi Charging", "icon": "mdi:battery-charging"},
     "boost": {"friendly_name": "myenergi Boost", "icon": "mdi:rocket-launch"},
+    "zappi_control": {"friendly_name": "myenergi Zappi Charge Control", "icon": "mdi:ev-station"},
     "boost_energy": {"friendly_name": "myenergi Boost Energy", "icon": "mdi:rocket-launch", "unit_of_measurement": "kWh", "min": BOOST_ENERGY_MIN, "max": BOOST_ENERGY_MAX, "step": 1},
     "boost_minutes": {"friendly_name": "myenergi Boost Minutes", "icon": "mdi:rocket-launch", "unit_of_measurement": "minutes", "min": BOOST_MINUTES_MIN, "max": BOOST_MINUTES_MAX, "step": 5},
     "temp_1": {"friendly_name": "myenergi Temperature 1", "icon": "mdi:thermometer", "unit_of_measurement": "°C", "device_class": "temperature", "state_class": "measurement"},
@@ -718,19 +765,27 @@ MAX_POLL_SECONDS = 30 * 60
 class MyEnergiAPI(ComponentBase, OAuthMixin):
     """myenergi component providing Zappi and Eddi monitoring and boost control."""
 
-    def initialize(self, auth_method=None, hub_serial=None, api_key=None, key=None, token_expires_at=None, token_hash=None, automatic=True, enable_controls=True, poll_seconds=60):
+    def initialize(self, auth_method=None, hub_serial=None, api_key=None, key=None, token_expires_at=None, token_hash=None, automatic=True, enable_controls=True, poll_seconds=60, zappi_control=False):
         """Select a transport from the configured credentials and set up component state."""
         configured_auth_method = (auth_method or "direct").lower()
         self.hub_serial = hub_serial
         self.api_key = api_key
         self.automatic = automatic
         self.enable_controls = enable_controls
+        self.zappi_control = bool(zappi_control)
         # ComponentBase.start() calls run() on a fixed 60 second cadence, so the poll
         # interval can only be a whole number of those intervals.
         self.poll_seconds = min(MAX_POLL_SECONDS, max(MIN_POLL_SECONDS, int(round(_to_float(poll_seconds, MIN_POLL_SECONDS) / 60.0)) * 60))
 
         self.devices = {}
         self.boost_amounts = {}
+        self.control_windows = {}
+        self.control_modes = {}
+        self.control_saved_modes = {}
+        self.control_active = False
+        # The runtime switch, on unless the user turns it off. Restored from storage at startup.
+        self.control_enabled = True
+        self.control_released = False
         self.queued_events = []
         self._auto_configured = False
         self.transport = None
@@ -805,6 +860,182 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
             self.log("Info: myenergi: setting iboost_energy_today to {}".format(eddi_entity))
             self.set_arg_auto("iboost_energy_today", eddi_entity)
 
+    def refresh_car_windows(self, now):
+        """Read Predbat's planned car charging windows for every car into control_windows.
+
+        Returns True once at least one car's plan has been read, False while no slot sensor
+        has ever been published - which is what stops the loop stopping a car on startup,
+        before Predbat has decided anything.
+
+        The caller passes now so every car is judged against the same instant, and so the
+        parsing stays a pure function of the plan and the clock.
+        """
+        windows = {}
+        found = False
+        for car_n in range(self.num_cars):
+            postfix = "" if car_n == 0 else "_{}".format(car_n)
+            planned = self.get_state_wrapper("binary_sensor.{}_car_charging_slot{}".format(self.prefix, postfix), attribute="planned")
+            if planned is None:
+                continue
+            found = True
+            windows[car_n] = self._parse_plan_windows(planned, now)
+        self.control_windows = windows
+        return found
+
+    def _parse_plan_windows(self, planned, now):
+        """Turn one car's published plan into a list of localised (start, end) pairs."""
+        parsed = []
+        for window in planned:
+            try:
+                start = self.local_tz.localize(datetime.datetime.strptime(window["start"], PLAN_TIME_FORMAT).replace(year=now.year))
+                end = self.local_tz.localize(datetime.datetime.strptime(window["end"], PLAN_TIME_FORMAT).replace(year=now.year))
+            except (KeyError, TypeError, ValueError):
+                # One malformed entry must not cost the rest of the plan
+                continue
+            # The plan carries no year, so rebuild it around now for windows crossing New Year
+            if start < now - datetime.timedelta(hours=23):
+                start = start.replace(year=start.year + 1)
+                end = end.replace(year=end.year + 1)
+            elif end < start:
+                end = end.replace(year=end.year + 1)
+            parsed.append((start, end))
+        return parsed
+
+    def should_charge_now(self, car_n, now):
+        """Is now inside one of the planned charging windows for this car."""
+        return any(start <= now < end for start, end in self.control_windows.get(car_n, []))
+
+    def enable_control(self):
+        """Decide whether Predbat-led Zappi control should run, and say why when it will not.
+
+        Control needs automatic configuration because a Zappi is driven from its own car's
+        plan, and it is auto-config that establishes which Zappi is which car.
+        """
+        if not self.zappi_control:
+            return
+        if not self.automatic:
+            self.log("Warn: myenergi: myenergi_zappi_control needs myenergi_automatic to map each Zappi to a car, Zappi control is disabled")
+            return
+        if not self.enable_controls:
+            self.log("Warn: myenergi: myenergi_zappi_control is ignored while myenergi_enable_controls is off")
+            return
+        self.control_active = True
+        self.log("Info: myenergi: Predbat-led Zappi charge control enabled")
+
+    async def save_control_enabled(self):
+        """Persist the control switch so an off survives a restart.
+
+        Without this a restart would silently hand Predbat back a Zappi the user had
+        deliberately released, which they would only notice when the car charged at the
+        wrong time. Fails soft: no Storage component just means the switch is not sticky.
+        """
+        if self.storage is None:
+            return
+        try:
+            await self.storage.save(MYENERGI_STORAGE_MODULE, MYENERGI_CONTROL_STATE, {"control_enabled": self.control_enabled})
+        except Exception as exc:
+            self.log("Warn: myenergi: could not save the Zappi control switch state: {}".format(exc))
+
+    async def load_control_enabled(self):
+        """Restore the control switch from storage, leaving it on when nothing is saved."""
+        if self.storage is None:
+            return
+        try:
+            saved = await self.storage.load(MYENERGI_STORAGE_MODULE, MYENERGI_CONTROL_STATE)
+        except Exception as exc:
+            self.log("Warn: myenergi: could not read the Zappi control switch state: {}".format(exc))
+            return
+        if isinstance(saved, dict) and "control_enabled" in saved:
+            self.control_enabled = bool(saved["control_enabled"])
+            if not self.control_enabled:
+                self.log("Info: myenergi: Zappi charge control is switched off from the last session")
+
+    def control_read_only_now(self):
+        """Is Predbat in read only mode - the live attribute rather than just the config arg.
+
+        axle_control forces read only by setting the attribute without touching the arg, so
+        read the attribute first and fall back to the arg for the window before it is set.
+        """
+        read_only = getattr(self.base, "set_read_only", None)
+        if read_only is None:
+            read_only = self.get_arg("set_read_only", False)
+        return bool(read_only)
+
+    async def control_tick(self, now):
+        """Run one cycle of Zappi control, releasing rather than just going quiet.
+
+        Read only mode and the control switch are both releases: Predbat may have left a
+        Zappi Stopped, and walking away from that would strand the car unable to charge.
+        """
+        if not self.control_active:
+            return
+        reason = None
+        if self.control_read_only_now():
+            reason = "Predbat is in read only mode"
+        elif not self.control_enabled:
+            reason = "the Zappi control switch is off"
+        if reason:
+            if not self.control_released:
+                self.log("Info: myenergi: releasing the Zappis because {}".format(reason))
+                await self.release_zappis()
+                self.control_released = True
+            return
+        if self.control_released:
+            self.log("Info: myenergi: resuming Zappi charge control")
+            self.control_released = False
+        await self.control_charge(now)
+
+    async def release_zappis(self):
+        """Hand every held Zappi back, restoring the mode it had before Predbat took over.
+
+        Falls back to Eco+ when nothing was saved - a restart, or a device that reported a
+        mode neither API accepts back - so a released Zappi always lands somewhere useful
+        rather than being left Stopped.
+        """
+        for device in self.controlled_zappis():
+            if device.device_id not in self.control_modes:
+                continue
+            mode = self.control_saved_modes.get(device.device_id)
+            if mode not in ZAPPI_MODE_TO_CLOUD:
+                mode = ZAPPI_MODE_RELEASE
+            self.log("Info: myenergi: releasing {} back to {}".format(device.name, mode))
+            await self.transport.set_mode(device, mode)
+        self.control_modes = {}
+        self.control_saved_modes = {}
+
+    def controlled_zappis(self):
+        """The Zappis to drive, in serial order, so Zappi N is the same car as auto-config's Nth.
+
+        automatic_config() wires car_charging_energy and car_charging_planned as per-car
+        lists in this same order, so the two cannot disagree about which Zappi is which car.
+        """
+        return [device for device in sorted(self.devices.values(), key=lambda item: item.serial) if device.kind == DEVICE_KIND_ZAPPI]
+
+    async def control_charge(self, now):
+        """Drive every controlled Zappi from its car's charge plan.
+
+        Predbat holds the charger for as long as it is in control: Fast inside a planned
+        window, Stopped outside one. Fast is the only mode that draws what the plan assumed,
+        since the window was chosen for its rate rather than for sunshine.
+
+        The caller passes now so every Zappi is judged against one instant.
+        """
+        if not self.refresh_car_windows(now):
+            return
+        for car_n, device in enumerate(self.controlled_zappis()):
+            wanted = ZAPPI_MODE_CHARGING if self.should_charge_now(car_n, now) else ZAPPI_MODE_STOPPED
+            asked = self.control_modes.get(device.device_id)
+            if asked == wanted and device.mode == wanted:
+                continue
+            if asked == wanted:
+                self.log("Info: myenergi: {} was changed away from {}, re-applying".format(device.name, wanted))
+            # Remember where the charger was before Predbat first moved it, so release can put it back
+            if device.device_id not in self.control_saved_modes:
+                self.control_saved_modes[device.device_id] = device.mode
+            self.log("Info: myenergi: setting {} to {} for car {}".format(device.name, wanted, car_n))
+            await self.transport.set_mode(device, wanted)
+            self.control_modes[device.device_id] = wanted
+
     def boost_amount_for(self, device):
         """Return the currently selected boost amount for a device."""
         default = DEFAULT_ZAPPI_BOOST_KWH if device.kind == DEVICE_KIND_ZAPPI else DEFAULT_EDDI_BOOST_MINUTES
@@ -850,6 +1081,19 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
                 if self.automatic and not self._auto_configured:
                     self.automatic_config()
                     self._auto_configured = True
+                if first:
+                    # After the first poll, so the Zappis are known before control decides
+                    await self.load_control_enabled()
+                    self.enable_control()
+                if self.control_active:
+                    try:
+                        await self.control_tick(self.now_utc_exact)
+                    except MyEnergiError as exc:
+                        # myenergi can refuse a mode for reasons Predbat cannot see - nothing
+                        # plugged in, a fault on the charger. Monitoring still succeeded, so
+                        # this is a warning rather than a failed cycle. Nothing is recorded as
+                        # set, so the next cycle tries again.
+                        self.log("Warn: myenergi: Zappi charge control failed: {}".format(exc))
             elif first:
                 self.log("Warn: myenergi: connected but no Zappi or Eddi devices were found")
             # Stamped only by a cycle that actually polled, so the health check reflects
@@ -921,6 +1165,11 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
         """
         if not self.enable_controls:
             return False
+        if entity_id.endswith("_myenergi_zappi_control"):
+            self.control_enabled = service == "turn_on"
+            self.log("Info: myenergi: Zappi charge control switched {}".format("on" if self.control_enabled else "off"))
+            await self.save_control_enabled()
+            return True
         if not entity_id.endswith("_boost"):
             return False
         device = self.device_for_entity(entity_id)
@@ -943,6 +1192,15 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
 
     async def publish_data(self):
         """Publish every known device as Predbat entities."""
+        if self.zappi_control:
+            # Only published when the feature is configured, so no dead control appears
+            # in the dashboard of everyone who is only monitoring.
+            self.dashboard_item(
+                "switch.{}_myenergi_zappi_control".format(self.prefix),
+                state="on" if self.control_enabled else "off",
+                attributes=myenergi_attribute_table["zappi_control"],
+                app="myenergi",
+            )
         for device in self.devices.values():
             prefix = self.entity_prefix(device)
             self.dashboard_item("sensor.{}_status".format(prefix), state=device.status, attributes=myenergi_attribute_table["status"], app="myenergi")

--- a/apps/predbat/myenergi.py
+++ b/apps/predbat/myenergi.py
@@ -1253,6 +1253,25 @@ async def run_myenergi_cli(args):  # pragma: no cover
         for device in devices:
             print("{:<12} {:<10} {:<16} {:<10} {:>10.0f} {:>12.2f}".format(device.device_id, device.kind, device.status, device.mode, device.power_w, device.session_energy_kwh))
 
+    # The three supply modes Predbat-led charge control drives a Zappi between, so the
+    # same commands the component issues can be exercised by hand against a live charger.
+    mode = None
+    if args.start_charge:
+        mode = ZAPPI_MODE_CHARGING
+    elif args.stop_charge:
+        mode = ZAPPI_MODE_STOPPED
+    elif args.release:
+        mode = ZAPPI_MODE_RELEASE
+    if mode:
+        zappi = next((item for item in devices if item.kind == DEVICE_KIND_ZAPPI), None)
+        if not zappi:
+            print("No Zappi found to control")
+            return
+        print("Setting {} to {}...".format(zappi.name, mode))
+        await component.transport.set_mode(zappi, mode)
+        print("Done - run again with no action to see the new mode")
+        return
+
     target_kind = args.boost or args.cancel_boost
     if target_kind:
         device = next((item for item in devices if item.kind == target_kind), None)
@@ -1278,6 +1297,12 @@ def main():  # pragma: no cover
     parser.add_argument("--boost", choices=SUPPORTED_KINDS, default=None, help="Send a boost to the first matching device")
     parser.add_argument("--cancel-boost", choices=SUPPORTED_KINDS, default=None, help="Cancel a boost on the first matching device")
     parser.add_argument("--amount", type=int, default=DEFAULT_ZAPPI_BOOST_KWH, help="Boost amount: kWh for a Zappi, minutes for an Eddi")
+    # The mode actions are mutually exclusive, and are the same three commands Predbat-led
+    # charge control issues - --release is what a hand-back does, and is how to undo --stop-charge
+    charge_group = parser.add_mutually_exclusive_group()
+    charge_group.add_argument("--start-charge", action="store_true", help="Put the first Zappi in {} to charge now, as a planned window does".format(ZAPPI_MODE_CHARGING))
+    charge_group.add_argument("--stop-charge", action="store_true", help="Put the first Zappi in {}, as being outside a planned window does".format(ZAPPI_MODE_STOPPED))
+    charge_group.add_argument("--release", action="store_true", help="Put the first Zappi back in {}, as releasing it does".format(ZAPPI_MODE_RELEASE))
     parser.add_argument("--raw", action="store_true", help="Print the full normalised device records")
 
     args = parser.parse_args()

--- a/apps/predbat/tests/test_myenergi.py
+++ b/apps/predbat/tests/test_myenergi.py
@@ -1209,6 +1209,48 @@ def test_control_switch_is_published_and_toggles_control():
     print("  ✓ The zappi control switch is published and toggles control")
 
 
+def test_control_switch_is_not_published_when_control_cannot_run():
+    """No switch appears when control could never act on it, rather than one that lies.
+
+    With myenergi_enable_controls off the component is monitor only and enable_control()
+    refuses, so a published switch would sit there reading "on" for a feature that cannot
+    run. Toggling it would only make it responsive, not honest - so it is not published.
+    """
+    component = _controlling_component(enable_controls=False)
+    assert component.control_active is False
+    run_async(component.publish_data())
+    assert component.base.get_state_wrapper("switch.predbat_myenergi_zappi_control") is None
+
+    # It reappears, with its remembered state, once controls are allowed again
+    allowed = _controlling_component()
+    assert allowed.control_active is True
+    run_async(allowed.publish_data())
+    assert allowed.base.get_state_wrapper("switch.predbat_myenergi_zappi_control") == "on"
+    print("  ✓ No control switch appears when control could not act on it")
+
+
+def test_control_switch_publishes_its_restored_state_on_the_first_cycle():
+    """A restart with control switched off must not show the switch on, even briefly.
+
+    The saved state has to be restored before the first publish, or the switch reads "on"
+    for a cycle and then flips - which looks like Predbat taking control back.
+    """
+    component = _control_component(plans={0: [NIGHT_WINDOW]}, zappi_control=True)
+    component.transport.fetch_devices = AsyncMock(return_value=[_zappi(12345678)])
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    async def _load_off():
+        """Stand in for storage returning a switched-off control state."""
+        component.control_enabled = False
+
+    component.load_control_enabled = _load_off
+
+    run_async(component.run(0, True))
+    assert component.base.get_state_wrapper("switch.predbat_myenergi_zappi_control") == "off"
+    component.transport.set_mode.assert_not_awaited()
+    print("  ✓ The control switch publishes its restored state on the first cycle")
+
+
 def test_control_switch_is_not_published_without_the_feature():
     """With myenergi_zappi_control unset there is no switch, so no dead control appears."""
     component = _control_component()
@@ -2321,6 +2363,8 @@ def test_myenergi(my_predbat=None):
     test_control_releases_to_eco_plus_when_nothing_was_saved()
     test_control_stops_and_resumes_on_read_only()
     test_control_switch_is_published_and_toggles_control()
+    test_control_switch_is_not_published_when_control_cannot_run()
+    test_control_switch_publishes_its_restored_state_on_the_first_cycle()
     test_control_switch_is_not_published_without_the_feature()
     test_run_enables_control_and_drives_the_zappi()
     test_run_does_not_control_when_the_feature_is_off()

--- a/apps/predbat/tests/test_myenergi.py
+++ b/apps/predbat/tests/test_myenergi.py
@@ -5,12 +5,14 @@ Unit tests for the myenergi Zappi and Eddi integration
 """
 
 import asyncio
+import datetime
 import json
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
+import pytz
 
 # Add parent directory to path for imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -236,25 +238,28 @@ class _StubTransport(MyEnergiTransport):
         """Pretend to cancel a boost."""
         return True
 
+    async def set_mode(self, device, mode):
+        """Pretend to set a supply mode."""
+        return True
+
 
 def test_transport_stubs():
     """Every unimplemented control returns False and warns exactly once."""
     messages = []
     transport = _StubTransport(messages.append)
 
-    assert run_async(transport.set_mode(None, "Eco")) is False
     assert run_async(transport.set_priority(None, 1)) is False
     assert run_async(transport.set_min_green_level(None, 50)) is False
     assert run_async(transport.set_phase_setting(None, "1")) is False
     assert run_async(transport.get_schedule(None)) is False
     assert run_async(transport.set_schedule(None, [])) is False
 
-    assert len(messages) == 6, "Each stub should warn once, got {}".format(messages)
+    assert len(messages) == 5, "Each stub should warn once, got {}".format(messages)
     assert all("not implemented" in message for message in messages)
 
     # A second call must not warn again
-    assert run_async(transport.set_mode(None, "Eco")) is False
-    assert len(messages) == 6, "Repeat calls must not warn again"
+    assert run_async(transport.set_priority(None, 1)) is False
+    assert len(messages) == 5, "Repeat calls must not warn again"
     print("  ✓ Stubbed controls warn once and return False")
 
 
@@ -383,6 +388,53 @@ def test_direct_smart_boost_url():
 
     assert calls[0] == "https://s18.myenergi.net/cgi-zappi-mode-Z12345678-0-11-15-0730", calls[0]
     print("  ✓ Direct transport smart boost URL")
+
+
+def test_direct_set_mode():
+    """Setting a Zappi supply mode issues the documented mode command.
+
+    The mode index comes from ZAPPI_CHARGE_MODES, so Fast is 1 and Stopped is 4 - the
+    two Predbat-led charge control drives the charger with.
+    """
+    zappi = normalise_direct_device(MOCK_DIRECT_ZAPPI, DEVICE_KIND_ZAPPI)
+    transport = MyEnergiDirectTransport(print, "12345678", "secret-key")
+    transport.base_url = "https://s18.myenergi.net"
+    transport.needs_asn_refresh = False
+
+    session, calls = _direct_session([_direct_response({"status": 0}) for _ in range(3)])
+    with patch("aiohttp.ClientSession", return_value=session):
+        assert run_async(transport.set_mode(zappi, "Fast")) is True
+        assert run_async(transport.set_mode(zappi, "Stopped")) is True
+        assert run_async(transport.set_mode(zappi, "Eco+")) is True
+
+    assert calls[0] == "https://s18.myenergi.net/cgi-zappi-mode-Z12345678-1-0-0-0000", calls[0]
+    assert calls[1] == "https://s18.myenergi.net/cgi-zappi-mode-Z12345678-4-0-0-0000", calls[1]
+    assert calls[2] == "https://s18.myenergi.net/cgi-zappi-mode-Z12345678-3-0-0-0000", calls[2]
+    print("  ✓ Direct transport sets the Zappi supply mode")
+
+
+def test_direct_set_mode_rejects_bad_input():
+    """An unknown mode, or a non-Zappi device, is refused without issuing a request.
+
+    The Eddi mode command is a different endpoint with a different vocabulary, so
+    falling through to the Zappi one would silently address the wrong device.
+    """
+    zappi = normalise_direct_device(MOCK_DIRECT_ZAPPI, DEVICE_KIND_ZAPPI)
+    eddi = normalise_direct_device(MOCK_DIRECT_EDDI, DEVICE_KIND_EDDI)
+    transport = MyEnergiDirectTransport(print, "12345678", "secret-key")
+    transport.base_url = "https://s18.myenergi.net"
+    transport.needs_asn_refresh = False
+
+    session, calls = _direct_session([_direct_response({"status": 0})])
+    with patch("aiohttp.ClientSession", return_value=session):
+        for device, mode in ((zappi, "Turbo"), (eddi, "Fast")):
+            try:
+                run_async(transport.set_mode(device, mode))
+                raise AssertionError("Expected MyEnergiApiError for {} {}".format(device.kind, mode))
+            except MyEnergiApiError:
+                pass
+    assert calls == [], "No request may be made for an unsupported mode or device kind"
+    print("  ✓ Direct transport refuses an unknown mode or a non-Zappi device")
 
 
 def test_direct_401_is_auth_error():
@@ -654,6 +706,30 @@ def test_cloud_boost_bodies():
     print("  ✓ Cloud transport boost bodies")
 
 
+def test_cloud_set_mode():
+    """The cloud transport posts the mode in the API's own lowercase vocabulary."""
+    zappi = normalise_cloud_device(MOCK_CLOUD_ZAPPI_STATUS, MOCK_CLOUD_ZAPPI_META)
+    eddi = normalise_cloud_device(MOCK_CLOUD_EDDI_STATUS, MOCK_CLOUD_EDDI_META)
+    transport = MyEnergiCloudTransport(print, lambda: "jwt-token")
+
+    session, calls = _cloud_session([_cloud_response({"commandId": "c1"}) for _ in range(2)])
+    with patch("aiohttp.ClientSession", return_value=session):
+        assert run_async(transport.set_mode(zappi, "Fast")) is True
+        assert run_async(transport.set_mode(zappi, "Stopped")) is True
+        for device, mode in ((zappi, "Turbo"), (eddi, "Fast")):
+            try:
+                run_async(transport.set_mode(device, mode))
+                raise AssertionError("Expected MyEnergiApiError for {} {}".format(device.kind, mode))
+            except MyEnergiApiError:
+                pass
+
+    assert calls[0] == ("POST", "https://api.s18.myenergi.net/devices/ZA12345678/mode", {"supplyMode": "fast"}), calls[0]
+    # "Stopped" is the reported state, "stop" is what the API accepts - the two differ
+    assert calls[1] == ("POST", "https://api.s18.myenergi.net/devices/ZA12345678/mode", {"supplyMode": "stop"}), calls[1]
+    assert len(calls) == 2, "A bad mode or device kind must not reach the API: {}".format(calls)
+    print("  ✓ Cloud transport sets the Zappi supply mode")
+
+
 def test_cloud_sets_bearer_header():
     """Requests carry the current bearer token from the supplied callable, re-read on every call.
 
@@ -853,6 +929,385 @@ def _make_component(**overrides):
     }
     args.update(overrides)
     return MyEnergiAPI(base, **args)
+
+
+CONTROL_TZ = pytz.timezone("Europe/London")
+
+
+def _plan_window(start, end):
+    """Build one planned-window dict in the shape output.py publishes."""
+    return {"start": start.strftime("%m-%d %H:%M:%S"), "end": end.strftime("%m-%d %H:%M:%S")}
+
+
+def _control_component(plans=None, **overrides):
+    """Build a component on a pytz clock, with car charging plans already published.
+
+    plans maps car number to a list of _plan_window() dicts; car 0's slot sensor has no
+    postfix and later cars carry _1, _2 ... exactly as output.py names them.
+    """
+    component = _make_component(**overrides)
+    component.local_tz = CONTROL_TZ
+    component.base.local_tz = CONTROL_TZ
+    # A Zappi is controlled from its own car's plan, so there must be that many cars
+    component.base.num_cars = max([car_n + 1 for car_n in (plans or {})] or [1])
+    for car_n, windows in (plans or {}).items():
+        postfix = "" if car_n == 0 else "_{}".format(car_n)
+        component.base.set_state_wrapper("binary_sensor.predbat_car_charging_slot" + postfix, "off", {"planned": windows})
+    return component
+
+
+def test_control_window_parsing():
+    """Planned windows are read per car and matched against the clock.
+
+    The slot sensor's own on/off state only refreshes on Predbat's five minute cycle, so
+    the planned attribute is evaluated against the live clock here instead - otherwise
+    every window boundary would be acted on up to five minutes late.
+    """
+    inside = _plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+    component = _control_component(plans={0: [inside]})
+
+    assert component.refresh_car_windows(CONTROL_TZ.localize(datetime.datetime(2026, 8, 22, 23, 30))) is True
+    assert component.should_charge_now(0, CONTROL_TZ.localize(datetime.datetime(2026, 8, 22, 23, 30))) is True
+    assert component.should_charge_now(0, CONTROL_TZ.localize(datetime.datetime(2026, 8, 22, 22, 59))) is False
+    # The window end is exclusive, so the boundary minute is already outside
+    assert component.should_charge_now(0, CONTROL_TZ.localize(datetime.datetime(2026, 8, 23, 1, 0))) is False
+    print("  ✓ Planned car charging windows are parsed and matched against the clock")
+
+
+def test_control_windows_are_per_car():
+    """Each car's own slot sensor drives its own Zappi, so car 1 does not follow car 0."""
+    car0 = _plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+    car1 = _plan_window(datetime.datetime(2026, 8, 23, 4, 0), datetime.datetime(2026, 8, 23, 5, 0))
+    component = _control_component(plans={0: [car0], 1: [car1]})
+
+    now = CONTROL_TZ.localize(datetime.datetime(2026, 8, 22, 23, 30))
+    assert component.refresh_car_windows(now) is True
+    assert component.should_charge_now(0, now) is True
+    assert component.should_charge_now(1, now) is False, "Car 1's window has not started yet"
+
+    later = CONTROL_TZ.localize(datetime.datetime(2026, 8, 23, 4, 30))
+    assert component.should_charge_now(0, later) is False
+    assert component.should_charge_now(1, later) is True
+    print("  ✓ Each car's plan drives its own Zappi")
+
+
+def test_control_windows_tolerate_a_bad_entry_and_a_missing_plan():
+    """A malformed window is skipped, and an unpublished plan reports nothing to act on.
+
+    Returning False for a plan that has never been published is what stops the loop
+    stopping a car on startup, before Predbat has decided anything.
+    """
+    good = _plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+    now = CONTROL_TZ.localize(datetime.datetime(2026, 8, 22, 23, 30))
+
+    component = _control_component(plans={0: [{"start": "nonsense"}, good]})
+    assert component.refresh_car_windows(now) is True
+    assert component.should_charge_now(0, now) is True, "The good window must survive a bad neighbour"
+
+    never_published = _control_component()
+    assert never_published.refresh_car_windows(now) is False
+    assert never_published.should_charge_now(0, now) is False
+    print("  ✓ A malformed window is skipped and a missing plan is not acted on")
+
+
+def test_control_windows_cross_the_year_boundary():
+    """A plan carries no year, so a window rebuilt around now must not land in the past."""
+    # Published on 31 December for a window running into 1 January
+    window = _plan_window(datetime.datetime(2026, 12, 31, 23, 30), datetime.datetime(2027, 1, 1, 1, 30))
+    component = _control_component(plans={0: [window]})
+
+    now = CONTROL_TZ.localize(datetime.datetime(2026, 12, 31, 23, 45))
+    assert component.refresh_car_windows(now) is True
+    assert component.should_charge_now(0, now) is True, "A window straddling New Year must still match"
+    print("  ✓ Windows crossing the year boundary are rebuilt around now")
+
+
+def _zappi(serial, mode_index=3):
+    """Build a direct-API Zappi with a chosen supply mode (3 is Eco+)."""
+    return normalise_direct_device(dict(MOCK_DIRECT_ZAPPI, sno=serial, zmo=mode_index), DEVICE_KIND_ZAPPI)
+
+
+IN_WINDOW = CONTROL_TZ.localize(datetime.datetime(2026, 8, 22, 23, 30))
+OUT_OF_WINDOW = CONTROL_TZ.localize(datetime.datetime(2026, 8, 22, 20, 0))
+NIGHT_WINDOW = _plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+
+
+def test_control_charge_sets_fast_inside_and_stopped_outside():
+    """Predbat holds the Zappi in Fast for a planned window and Stopped the rest of the time.
+
+    Fast is the only mode that draws what the plan assumed - the window was chosen because
+    the rate is cheap, not because there is sun, so Eco+ would leave the car uncharged.
+    """
+    component = _control_component(plans={0: [NIGHT_WINDOW]})
+    component.devices = {"Z12345678": _zappi(12345678)}
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    run_async(component.control_charge(IN_WINDOW))
+    assert component.transport.set_mode.await_args.args[1] == "Fast", component.transport.set_mode.await_args
+
+    run_async(component.control_charge(OUT_OF_WINDOW))
+    assert component.transport.set_mode.await_args.args[1] == "Stopped", component.transport.set_mode.await_args
+    print("  ✓ Fast inside a planned window, Stopped outside it")
+
+
+def test_control_charge_maps_each_zappi_to_its_own_car():
+    """Zappis are matched to cars in serial order, the same order auto-config wires them.
+
+    Car 0 is charging and car 1 is not, so the two Zappis must be driven differently in
+    the same pass - a single shared decision would charge or stop both.
+    """
+    component = _control_component(plans={0: [NIGHT_WINDOW], 1: []})
+    component.devices = {"Z12345678": _zappi(12345678), "Z22223333": _zappi(22223333)}
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    run_async(component.control_charge(IN_WINDOW))
+    by_serial = {call.args[0].serial: call.args[1] for call in component.transport.set_mode.await_args_list}
+    assert by_serial == {"12345678": "Fast", "22223333": "Stopped"}, by_serial
+    print("  ✓ Each Zappi follows its own car's plan")
+
+
+def test_control_charge_is_edge_triggered_but_corrects_drift():
+    """A settled Zappi is left alone, but one changed in the myenergi app is put back.
+
+    Purely edge-triggered control diverges silently the moment anything else touches the
+    charger, so the mode already polled is compared against what was asked for.
+    """
+    component = _control_component(plans={0: [NIGHT_WINDOW]})
+    component.devices = {"Z12345678": _zappi(12345678)}
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    run_async(component.control_charge(IN_WINDOW))
+    assert component.transport.set_mode.await_count == 1
+    # The poll now reports Fast, matching what was set, so nothing more is sent
+    component.devices["Z12345678"] = _zappi(12345678, mode_index=1)
+    run_async(component.control_charge(IN_WINDOW))
+    assert component.transport.set_mode.await_count == 1, "A settled charger must not be re-commanded"
+
+    # Someone switches it to Eco+ in the myenergi app - Predbat puts it back
+    component.devices["Z12345678"] = _zappi(12345678, mode_index=3)
+    run_async(component.control_charge(IN_WINDOW))
+    assert component.transport.set_mode.await_count == 2, "Drift away from the set mode must be corrected"
+    assert component.transport.set_mode.await_args.args[1] == "Fast"
+    print("  ✓ Control is edge triggered but corrects drift")
+
+
+def test_control_charge_ignores_eddis():
+    """Only Zappis are driven - an Eddi has no car plan and a different mode vocabulary."""
+    component = _control_component(plans={0: [NIGHT_WINDOW]})
+    component.devices = {"E87654321": normalise_direct_device(MOCK_DIRECT_EDDI, DEVICE_KIND_EDDI)}
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    run_async(component.control_charge(IN_WINDOW))
+    component.transport.set_mode.assert_not_awaited()
+    print("  ✓ Eddis are never driven by car charge control")
+
+
+def test_control_charge_does_nothing_before_a_plan_exists():
+    """With no slot sensor published yet, nothing is commanded.
+
+    Otherwise the first cycle after a restart would stop a car that Predbat has not yet
+    decided anything about.
+    """
+    component = _control_component()
+    component.devices = {"Z12345678": _zappi(12345678)}
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    run_async(component.control_charge(IN_WINDOW))
+    component.transport.set_mode.assert_not_awaited()
+    print("  ✓ Nothing is commanded before Predbat has published a plan")
+
+
+def _controlling_component(plans=None, **overrides):
+    """Build a component with Zappi control fully enabled and one Zappi already held."""
+    args = {"zappi_control": True}
+    args.update(overrides)
+    component = _control_component(plans=plans, **args)
+    component.devices = {"Z12345678": _zappi(12345678)}
+    component.transport.set_mode = AsyncMock(return_value=True)
+    # Capture the component's own log so the gating reasons can be asserted on
+    component.log_messages = []
+    component.log = component.log_messages.append
+    component.enable_control()
+    return component
+
+
+def test_control_gating_refuses_with_a_reason():
+    """Control only runs when it is asked for and can work, and says why when it will not."""
+    assert _controlling_component().control_active is True
+
+    for overrides, expected in (
+        ({"zappi_control": False}, None),
+        ({"automatic": False}, "myenergi_automatic"),
+        ({"enable_controls": False}, "myenergi_enable_controls"),
+    ):
+        component = _controlling_component(**overrides)
+        assert component.control_active is False, overrides
+        if expected:
+            assert any(expected in message for message in component.log_messages), (overrides, component.log_messages)
+    print("  ✓ Zappi control refuses to run without its prerequisites, and says which")
+
+
+def test_control_releases_to_the_saved_mode():
+    """Releasing puts the Zappi back where it was before Predbat first moved it."""
+    component = _controlling_component(plans={0: [NIGHT_WINDOW]})
+    run_async(component.control_tick(IN_WINDOW))
+    assert component.transport.set_mode.await_args.args[1] == "Fast"
+
+    # The switch going off is a release, not just a pause in commanding
+    component.control_enabled = False
+    run_async(component.control_tick(IN_WINDOW))
+    assert component.transport.set_mode.await_args.args[1] == "Eco+", "The Zappi was in Eco+ before Predbat took over"
+    assert component.control_modes == {}, "A released Zappi is no longer held"
+    print("  ✓ Releasing restores the mode the Zappi had before Predbat took over")
+
+
+def test_control_releases_to_eco_plus_when_nothing_was_saved():
+    """With no saved mode - a restart, or a mode that cannot be set - release falls back to Eco+."""
+    component = _controlling_component(plans={0: [NIGHT_WINDOW]})
+    component.control_modes = {"Z12345678": "Fast"}
+    component.control_saved_modes = {}
+    component.control_enabled = False
+
+    run_async(component.control_tick(IN_WINDOW))
+    assert component.transport.set_mode.await_args.args[1] == "Eco+", component.transport.set_mode.await_args
+    print("  ✓ Release falls back to Eco+ when there is nothing saved")
+
+
+def test_control_stops_and_resumes_on_read_only():
+    """Read only mode releases the Zappis, and clearing it resumes control."""
+    component = _controlling_component(plans={0: [NIGHT_WINDOW]})
+    run_async(component.control_tick(IN_WINDOW))
+    assert component.transport.set_mode.await_count == 1
+
+    component.base.args["set_read_only"] = True
+    run_async(component.control_tick(IN_WINDOW))
+    assert component.transport.set_mode.await_args.args[1] == "Eco+", "Read only must release, not just stop commanding"
+
+    # Still read only - nothing more is sent, there is nothing left to release
+    run_async(component.control_tick(IN_WINDOW))
+    assert component.transport.set_mode.await_count == 2
+
+    component.base.args["set_read_only"] = False
+    run_async(component.control_tick(IN_WINDOW))
+    assert component.transport.set_mode.await_args.args[1] == "Fast", "Clearing read only must resume control"
+    print("  ✓ Read only releases the Zappis and clearing it resumes control")
+
+
+def test_control_switch_is_published_and_toggles_control():
+    """The control switch is published on, and turning it off hands the Zappis back."""
+    component = _controlling_component(plans={0: [NIGHT_WINDOW]})
+    run_async(component.publish_data())
+    assert component.base.get_state_wrapper("switch.predbat_myenergi_zappi_control") == "on"
+
+    run_async(component.switch_event_handler("switch.predbat_myenergi_zappi_control", "turn_off"))
+    assert component.control_enabled is False
+    run_async(component.publish_data())
+    assert component.base.get_state_wrapper("switch.predbat_myenergi_zappi_control") == "off"
+
+    run_async(component.switch_event_handler("switch.predbat_myenergi_zappi_control", "turn_on"))
+    assert component.control_enabled is True
+    print("  ✓ The zappi control switch is published and toggles control")
+
+
+def test_control_switch_is_not_published_without_the_feature():
+    """With myenergi_zappi_control unset there is no switch, so no dead control appears."""
+    component = _control_component()
+    component.devices = {"Z12345678": _zappi(12345678)}
+    run_async(component.publish_data())
+    assert component.base.get_state_wrapper("switch.predbat_myenergi_zappi_control") is None
+    print("  ✓ No control switch appears when the feature is off")
+
+
+def test_run_enables_control_and_drives_the_zappi():
+    """The run loop turns control on once, restores the switch, and drives the plan."""
+    component = _control_component(plans={0: [NIGHT_WINDOW]}, zappi_control=True)
+    zappi = _zappi(12345678)
+    component.transport.fetch_devices = AsyncMock(return_value=[zappi])
+    component.transport.set_mode = AsyncMock(return_value=True)
+    component.load_control_enabled = AsyncMock()
+
+    assert run_async(component.run(0, True)) is True
+    assert component.control_active is True
+    component.load_control_enabled.assert_awaited_once()
+    # A real poll drove the Zappi from the plan without waiting for a second cycle
+    assert component.transport.set_mode.await_count == 1, component.transport.set_mode.await_args_list
+    print("  ✓ The run loop enables control and drives the Zappi from the plan")
+
+
+def test_run_does_not_control_when_the_feature_is_off():
+    """With myenergi_zappi_control unset the run loop never touches a Zappi's mode."""
+    component = _control_component(plans={0: [NIGHT_WINDOW]})
+    component.transport.fetch_devices = AsyncMock(return_value=[_zappi(12345678)])
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    assert run_async(component.run(0, True)) is True
+    assert component.control_active is False
+    component.transport.set_mode.assert_not_awaited()
+    print("  ✓ The run loop leaves the Zappi alone when control is off")
+
+
+def test_control_switch_state_survives_a_restart():
+    """Turning control off is persisted, so a restart does not silently resume control."""
+    saved = {}
+
+    class _Storage:
+        """Minimal in-memory stand-in for the Storage component."""
+
+        async def save(self, module, filename, data, format="yaml", expiry=None):
+            """Record the saved payload."""
+            saved[(module, filename)] = data
+
+        async def load(self, module, filename):
+            """Return a previously saved payload, or None."""
+            return saved.get((module, filename))
+
+    class _Components:
+        """Stand-in for the component registry, serving only the storage component."""
+
+        def __init__(self, storage):
+            """Hold the storage stand-in to serve."""
+            self.storage = storage
+
+        def get_component(self, name):
+            """Return the storage stand-in, and nothing else."""
+            return self.storage if name == "storage" else None
+
+    storage = _Storage()
+    component = _controlling_component(plans={0: [NIGHT_WINDOW]})
+    # ComponentBase.storage is a read-only property resolving through base.components.
+    # Each test builds its own MockBase, so this cannot leak into any other test.
+    component.base.components = _Components(storage)
+
+    run_async(component.switch_event_handler("switch.predbat_myenergi_zappi_control", "turn_off"))
+    assert saved, "Turning the switch off must be persisted"
+
+    restarted = _controlling_component(plans={0: [NIGHT_WINDOW]})
+    restarted.base.components = _Components(storage)
+    assert restarted.control_enabled is True, "A fresh component starts with control on"
+    run_async(restarted.load_control_enabled())
+    assert restarted.control_enabled is False, "The saved off state must survive a restart"
+    print("  ✓ The control switch state survives a restart")
+
+
+def test_control_failure_does_not_break_the_poll():
+    """A refused mode command is a warning, not a failed cycle.
+
+    myenergi can refuse a mode for reasons Predbat cannot see - nothing plugged in, a
+    fault on the charger. Letting that escape would mark the whole component errored and
+    skip the success timestamp, so repeated refusals would eventually report it unhealthy
+    even though monitoring is working perfectly.
+    """
+    component = _control_component(plans={0: [NIGHT_WINDOW]}, zappi_control=True)
+    zappi = _zappi(12345678)
+    component.transport.fetch_devices = AsyncMock(return_value=[zappi])
+    component.transport.set_mode = AsyncMock(side_effect=MyEnergiApiError("myenergi refused the mode"))
+    component.load_control_enabled = AsyncMock()
+
+    assert run_async(component.run(0, True)) is True, "A refused mode must not fail the cycle"
+    assert component.last_success_timestamp is not None, "Monitoring still succeeded, so the poll counts"
+    # Nothing was recorded as set, so the next cycle tries again rather than assuming it stuck
+    assert component.control_modes == {}, component.control_modes
+    print("  ✓ A refused mode command warns without failing the poll")
 
 
 def test_component_selects_transport():
@@ -1820,6 +2275,8 @@ def test_myenergi(my_predbat=None):
     test_direct_503_without_header_is_api_error()
     test_direct_boost_urls()
     test_direct_smart_boost_url()
+    test_direct_set_mode()
+    test_direct_set_mode_rejects_bad_input()
     test_direct_401_is_auth_error()
     test_direct_non_200_sets_needs_asn_refresh()
     test_direct_timeout_sets_needs_asn_refresh()
@@ -1828,6 +2285,7 @@ def test_myenergi(my_predbat=None):
     test_direct_resolve_asn_timeout_is_api_error()
     test_cloud_fetch_devices()
     test_cloud_boost_bodies()
+    test_cloud_set_mode()
     test_cloud_sets_bearer_header()
     test_cloud_unauthorised_raises_auth_error()
     test_cloud_non_200_is_api_error()
@@ -1849,6 +2307,25 @@ def test_myenergi(my_predbat=None):
     test_cloud_device_list_cache_expires_on_the_clock()
     test_cloud_one_bad_device_does_not_lose_the_others()
     test_cloud_auth_error_still_aborts_the_poll()
+    test_control_window_parsing()
+    test_control_windows_are_per_car()
+    test_control_windows_tolerate_a_bad_entry_and_a_missing_plan()
+    test_control_windows_cross_the_year_boundary()
+    test_control_charge_sets_fast_inside_and_stopped_outside()
+    test_control_charge_maps_each_zappi_to_its_own_car()
+    test_control_charge_is_edge_triggered_but_corrects_drift()
+    test_control_charge_ignores_eddis()
+    test_control_charge_does_nothing_before_a_plan_exists()
+    test_control_gating_refuses_with_a_reason()
+    test_control_releases_to_the_saved_mode()
+    test_control_releases_to_eco_plus_when_nothing_was_saved()
+    test_control_stops_and_resumes_on_read_only()
+    test_control_switch_is_published_and_toggles_control()
+    test_control_switch_is_not_published_without_the_feature()
+    test_run_enables_control_and_drives_the_zappi()
+    test_run_does_not_control_when_the_feature_is_off()
+    test_control_switch_state_survives_a_restart()
+    test_control_failure_does_not_break_the_poll()
     test_component_selects_transport()
     test_component_publishes_entities()
     test_component_retains_last_good_reading()

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -1917,6 +1917,7 @@ The direct transport (the default) needs your hub serial number and an API key y
 - **myenergi_automatic** - Set to `false` to stop Predbat wiring the device sensors into **car_charging_energy**, **car_charging_planned** and **iboost_energy_today** automatically (default: `true`)
 - **myenergi_enable_controls** - Set to `false` for monitor-only operation (default: `true`)
 - **myenergi_poll_seconds** - Poll interval in seconds, rounded to the nearest whole multiple of 60, minimum 60 and maximum 1800 (default: `60`)
+- **myenergi_zappi_control** - Set to `true` to let Predbat drive your Zappi from its car charging plan: Fast inside a planned charging window, Stopped outside one (default: `false`). Needs **myenergi_automatic** and **myenergi_enable_controls**, since it is automatic configuration that maps each Zappi to a car. A `switch.predbat_myenergi_zappi_control` entity appears when this is set, on by default, so you can hand the Zappi back without editing apps.yaml; releasing restores the mode the Zappi had before Predbat took over, or Eco+ when nothing was saved. Note the manual boost switch will refuse while control is on, as myenergi only accepts a boost in Eco or Eco+.
 
 The component only starts when at least one of `myenergi_api_key`, `myenergi_key` or `myenergi_token_hash` is set. That test is a plain any-of and does not look at `myenergi_auth_method`, so a credential belonging to the transport you did not select still starts the component — it then logs which setting is missing rather than failing silently.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -638,6 +638,10 @@ python3 myenergi.py --hub-serial YOUR_HUB_SERIAL --api-key YOUR_API_KEY
 
 Add `--boost zappi` or `--boost eddi` (with `--amount`) to send a test boost, or `--cancel-boost zappi`/`--cancel-boost eddi` to cancel one. Use `--token` in place of `--hub-serial`/`--api-key` to test the cloud OAuth transport instead.
 
+To try the charge control commands against a real Zappi without enabling the feature, `--start-charge` puts it in Fast exactly as a planned window does, `--stop-charge` puts it in Stopped as being outside one does, and `--release` puts it back in Eco+ as handing it back does. Run the command again with no action to see the mode that took effect.
+
+Note `--stop-charge` leaves the Zappi stopped, so remember to `--release` it afterwards or set the mode you want in the myenergi app.
+
 ---
 
 ### Fox ESS API (fox)

--- a/docs/components.md
+++ b/docs/components.md
@@ -551,6 +551,7 @@ Predbat supports both of myenergi's APIs:
 | `automatic` | Boolean | No | true | `myenergi_automatic` | Set to `false` to stop Predbat wiring the device sensors into `car_charging_energy`, `car_charging_planned` and `iboost_energy_today` automatically |
 | `enable_controls` | Boolean | No | true | `myenergi_enable_controls` | Set to `false` for monitor-only operation |
 | `poll_seconds` | Integer | No | 60 | `myenergi_poll_seconds` | Poll interval in seconds, rounded to the nearest whole multiple of 60, minimum 60 and maximum 1800 (a longer gap would make Predbat's own health check report the component as failed) |
+| `zappi_control` | Boolean | No | false | `myenergi_zappi_control` | Set to `true` to let Predbat drive your Zappi from its car charging plan — see [Zappi charge control](#zappi-charge-control-myenergi) |
 
 The component only starts when at least one of `myenergi_api_key`, `myenergi_key` or `myenergi_token_hash`
 is set. That test is a plain any-of and does not look at `myenergi_auth_method`, so a credential belonging
@@ -592,7 +593,33 @@ Turning a boost switch on sends a boost of the amount selected on the companion 
 
 myenergi only accepts a Zappi boost while the charger is in Eco or Eco+ mode. Predbat checks that one condition before calling, and logs a warning instead. Every other reason a boost can be refused — an Eddi already at its maximum tank temperature, for instance — is only discovered from myenergi's reply, so Predbat issues the call and logs `myenergi: control failed` when it comes back refused. The switch reverts to the device's real state on the next poll either way.
 
-Not implemented in this release: mode selection, priority, minimum green level, phase setting, and charging schedules. These exist on the transport interface as reserved methods, ready for a later release, and nothing in Predbat calls them — there is no entity or service that can reach them, so there is nothing for you to try. If a future release wires one up before it is implemented, it warns once per control rather than failing silently. Super schedules, managed mode and Libbi batteries are out of scope entirely for this release; the component only supports Zappi and Eddi devices and does not expose any control surface for them.
+Not implemented in this release: priority, minimum green level, phase setting, and charging schedules. These exist on the transport interface as reserved methods, ready for a later release, and nothing in Predbat calls them — there is no entity or service that can reach them, so there is nothing for you to try. If a future release wires one up before it is implemented, it warns once per control rather than failing silently. Super schedules, managed mode and Libbi batteries are out of scope entirely for this release; the component only supports Zappi and Eddi devices and does not expose any control surface for them.
+
+#### Zappi charge control (myenergi)
+
+With `myenergi_zappi_control: true` Predbat drives your Zappi from the car charging plan it has already worked out, instead of you scheduling the charge on the Zappi itself.
+
+Inside a planned charging window Predbat puts the Zappi in **Fast**, and outside one it puts it in **Stopped**. Fast is used because the window was chosen for its electricity rate rather than for sunshine — Eco or Eco+ would only charge from surplus, and the car would not get what the plan assumed.
+
+Each Zappi follows its own car. Zappis are matched to cars in serial number order, the same order `car_charging_energy` and `car_charging_planned` are wired in, so your first Zappi follows car 0's plan, your second follows car 1's, and so on.
+
+Predbat re-checks the Zappi every minute. If the mode is changed in the myenergi app while Predbat is in control, it is put back — otherwise control would drift away silently.
+
+##### The control switch
+
+A `switch.predbat_myenergi_zappi_control` entity appears once `myenergi_zappi_control` is set. It starts **on**, and turning it off hands your Zappi back without editing `apps.yaml`. The setting is remembered across restarts, so a restart will not quietly take control back.
+
+##### When Predbat hands the Zappi back
+
+Predbat releases the Zappi when the control switch is turned off, or when Predbat itself is put in read only mode. Releasing restores the mode the Zappi was in before Predbat first changed it, falling back to **Eco+** when there is nothing saved — after a restart, for instance. It deliberately does not simply stop sending commands, because Predbat may have left the Zappi Stopped and walking away would leave the car unable to charge.
+
+##### Two things to expect
+
+Charge control needs `myenergi_automatic`, because it is automatic configuration that establishes which Zappi belongs to which car. It also needs `myenergi_enable_controls`. If either is off, Predbat logs which one and leaves the Zappi alone.
+
+While Predbat is in control the Zappi is in Fast or Stopped, and myenergi only accepts a boost in Eco or Eco+ — so the manual boost switch will refuse for as long as control is on. Turn the control switch off if you want to boost by hand.
+
+Outside a planned window the Zappi is Stopped, which means it will not divert surplus solar to the car either. If you would rather keep solar diversion, leave `myenergi_zappi_control` off and let the Zappi run its own modes.
 
 #### Known limitation (myenergi)
 


### PR DESCRIPTION
Follow-up to #4667. Adds `myenergi_zappi_control`, letting Predbat drive a Zappi from the car charging plan it has already worked out, instead of the charge being scheduled on the Zappi itself.

Follows the shape `ohme.py` established in #4665 — gate, read plan, correct drift, release — with the differences a Zappi brings.

## Behaviour

- **Inside a planned window: Fast. Outside: Stopped.** Fast because the window was chosen for its electricity rate rather than for sunshine; Eco or Eco+ would only charge from surplus and the car would not get what the plan assumed.
- **Each Zappi follows its own car**, matched in serial order — the same order `automatic_config()` wires `car_charging_energy` and `car_charging_planned` in, so the two cannot disagree about which Zappi is which car. Car 0 reads `binary_sensor.predbat_car_charging_slot`, car 1 reads `..._car_charging_slot_1`, and so on.
- **Drift is corrected.** The mode already polled is compared against what was asked for and re-applied. Purely edge-triggered control diverges silently the moment anything else touches the charger.
- **Nothing happens until a plan exists.** With no slot sensor published yet the loop does nothing, so a restart cannot stop a car Predbat has not yet decided anything about.
- The plan's `planned` attribute is evaluated against the live clock each minute rather than the sensor's own on/off state, which only refreshes on Predbat's five minute cycle — otherwise every window boundary would be acted on up to five minutes late.

## The control switch

`switch.predbat_myenergi_zappi_control` appears once `myenergi_zappi_control` is set. It starts **on**, and turning it off hands the charger back without editing `apps.yaml`. The state is persisted through the Storage component, so a restart does not quietly resume control of a Zappi that was deliberately released.

It is a component-level switch rather than a `CONFIG_ITEM`, and carries the `predbat_myenergi_` prefix because event routing matches on that substring — named otherwise it would publish but never receive its own turn-on/turn-off events.

## Release

Predbat releases the Zappi when the switch is turned off, or when Predbat is put in read only mode. Releasing restores the mode the Zappi was in before Predbat first changed it, falling back to **Eco+** when nothing was saved (after a restart, or a device reporting a mode neither API accepts back).

It deliberately does not just stop sending commands: Predbat may have left the Zappi **Stopped**, and walking away would leave the car unable to charge until someone noticed.

## Notes for reviewers

- **`set_mode` is implemented on both transports** to support this — direct `GET /cgi-zappi-mode-Z{serial}-{index}-0-0-0000`, cloud `POST /devices/{id}/mode`. It is therefore no longer one of the reserved stubs, and is now abstract on `MyEnergiTransport` since every transport must provide it. The docs' not-implemented list shrinks accordingly.
- **A refused mode command is a warning, not a failed cycle.** myenergi can refuse for reasons Predbat cannot see (nothing plugged in, a charger fault). Letting that escape would skip the success timestamp and eventually report the component unhealthy even though monitoring is fine. Nothing is recorded as set, so the next cycle retries.
- **Two consequences documented for users:** the manual boost switch will refuse while control is on, since myenergi only accepts a boost in Eco or Eco+; and Stopped outside a window means surplus solar no longer goes to the car, so anyone who wants diversion should leave this off.
- Control requires `myenergi_automatic` (it is auto-config that maps Zappis to cars) and `myenergi_enable_controls`. Each refusal logs which prerequisite is missing rather than going quiet.

## Testing

23 new tests in `apps/predbat/tests/test_myenergi.py`, built test-first: `set_mode` on both transports including bad mode and wrong device kind, window parsing (per car, malformed entries, missing plan, the New Year rollover), Fast/Stopped selection, per-car mapping, drift correction, the three gating refusals, release to saved mode and to the Eco+ fallback, read-only release and resume, the switch publishing and toggling, persistence across a restart, and a refused command not failing the poll.

Full `./run_all --quick` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
