### PR TITLE
fix(load_ml): guard against zero-filled exogenous inputs, and report rollout accuracy

### DIFF
--- a/apps/predbat/load_ml_component.py
+++ b/apps/predbat/load_ml_component.py
@@ -1142,6 +1142,10 @@ class LoadMLComponent(ComponentBase):
                 "power_today_h1": dp2(power_today_h1),
                 "power_today_h8": dp2(power_today_h8),
                 "mae_kwh": round(float(self.predictor.validation_mae), 4) if self.predictor and self.predictor.validation_mae is not None else None,
+                # Multi-step rollout error and the daily-pattern baseline it is scored against.
+                # mae_kwh above is teacher-forced and stays small even when the rollout collapses.
+                "rollout_mae_kwh": round(float(self.predictor.rollout_mae), 4) if self.predictor and self.predictor.rollout_mae is not None else None,
+                "pattern_mae_kwh": round(float(self.predictor.pattern_mae), 4) if self.predictor and self.predictor.pattern_mae is not None else None,
                 "bias_kwh": round(self.predictor.validation_bias, 4) if self.predictor and self.predictor.validation_bias is not None else None,
                 "last_trained": self.last_train_time.isoformat() if self.last_train_time else None,
                 "model_age_hours": round(model_age_hours, 1) if model_age_hours is not None else None,

--- a/apps/predbat/load_predictor.py
+++ b/apps/predbat/load_predictor.py
@@ -1723,14 +1723,16 @@ class LoadPredictor:
         # Seed previous value from the most recent historical chunk for the step-to-step cap
         prev_energy_value = lookback_buffer[0] if lookback_buffer else baseline_floor
 
-        # Last known exogenous values, carried forward when a forward forecast runs out.
-        # Rates and temperature are 3 of the 5 input channels (864 of 1446 features), and
-        # a 48-hour rollout outruns both forecasts. Filling the gap with 0.0 puts 0 p/kWh
-        # and 0 degrees into the network, far outside anything training saw. Measured on a
-        # real model: with no forward rate data the 48-hour rollout peaks at 1.9 kW against
-        # a 10.5 kW true peak; carrying the last known value forward restores it to 9.9 kW.
-        # The damage is concentrated in the first few hours of missing data - a forecast
-        # that reaches 12h ahead is unaffected at any horizon.
+        # Last known exogenous values, carried forward when a forward forecast is missing.
+        # Normally it is not: rate_replicate() extends rates past the forecast horizon and
+        # publish_rates() emits them to minutes_now + forecast_minutes + 24h, so a healthy
+        # system supplies the whole rollout. This guards the case where the source entity
+        # is unavailable - before the first plan cycle publishes it, or after a failed rate
+        # fetch. Rates and temperature are 3 of the 5 input channels (864 of 1446 features),
+        # so filling the gap with 0.0 puts 0 p/kWh and 0 degrees into the network, far
+        # outside anything training saw: measured on a real model, the 48-hour rollout then
+        # peaks at 1.9 kW against a 10.5 kW true peak. Carrying the last value forward
+        # restores it to 9.9 kW, and changes nothing when the forecast is present.
         # PV is left at 0.0: past the solar forecast there is no generation to assume, and
         # holding a daytime value overnight would be worse than zero.
         last_temp_value = temp_lookback_buffer[0] if temp_lookback_buffer else 0.0

--- a/apps/predbat/load_predictor.py
+++ b/apps/predbat/load_predictor.py
@@ -224,6 +224,11 @@ class LoadPredictor:
         self.training_timestamp = None
         self.validation_mae = None
         self.validation_bias = None  # Signed metric: mean(predicted - actual); + = over-predicting, - = under-predicting
+        # Holdout scores for the multi-step rollout and the daily-pattern baseline it is
+        # blended with, reported for diagnosis only. validation_mae above is teacher-forced
+        # and stays small even when the multi-step rollout has degenerated.
+        self.rollout_mae = None
+        self.pattern_mae = None
         self.epochs_trained = 0
         self.model_initialized = False
 
@@ -802,6 +807,12 @@ class LoadPredictor:
         this feeds each predicted chunk back as the next step's context, exposing
         how compounding errors accumulate over the holdout window.
 
+        The same holdout is also scored against the day-of-week daily-pattern baseline
+        that predict() blends in. A one-step-ahead model can post an excellent
+        teacher-forced MAE and still collapse to a flat line once it is fed its own
+        output, at which point the trivial pattern is the better long-range forecast.
+        Reporting both makes that visible; neither figure changes the forecast.
+
         Args:
             load_minutes: Dict of {minute: kwh_per_step} historical load data
             now_utc: Current UTC timestamp used during training
@@ -812,10 +823,10 @@ class LoadPredictor:
             validation_holdout_hours: Size of the holdout window (must match training)
 
         Returns:
-            (ar_mae, ar_bias) in kWh per chunk, or (None, None) on failure.
+            (ar_mae, ar_bias, pattern_mae) in kWh per chunk, or (None, None, None) on failure.
         """
         if not self.model_initialized or self.weights is None:
-            return None, None
+            return None, None, None
 
         energy_per_step = load_minutes
         pv_energy_per_step = pv_minutes if pv_minutes else {}
@@ -824,7 +835,7 @@ class LoadPredictor:
         export_rate_values = export_rates if export_rates else {}
 
         if not energy_per_step:
-            return None, None
+            return None, None, None
 
         # Chunk data identically to _create_dataset
         chunked_energy, alignment_offset = self._chunk_energy_to_aligned(energy_per_step, now_utc)
@@ -834,7 +845,7 @@ class LoadPredictor:
         chunked_export = self._chunk_instantaneous_to_aligned(export_rate_values, alignment_offset)
 
         if not chunked_energy:
-            return None, None
+            return None, None, None
 
         # Holdout window: chunks 0 .. validation_end_chunk-1 (most-recent = 0)
         validation_end_chunk = validation_holdout_hours * 60 // CHUNK_MINUTES
@@ -842,7 +853,7 @@ class LoadPredictor:
         # We need LOOKBACK_STEPS real chunks immediately before the holdout as context
         context_start = validation_end_chunk  # chunk just before the holdout starts
         if (context_start + LOOKBACK_STEPS - 1) not in chunked_energy:
-            return None, None
+            return None, None, None
 
         # Initialise lookback buffers from real data (index 0 = most-recent context)
         ar_load = [chunked_energy.get(context_start + lb, 0.0) for lb in range(LOOKBACK_STEPS)]
@@ -853,6 +864,12 @@ class LoadPredictor:
 
         errors = []
         biases = []
+        pattern_errors = []
+
+        # Daily-pattern baseline, built only from data outside the holdout so the
+        # comparison is on the same footing as the model rollout
+        holdout_minutes = validation_holdout_hours * 60
+        baseline_patterns = self._compute_daily_pattern({minute: value for minute, value in energy_per_step.items() if minute >= holdout_minutes}, now_utc)
 
         # Step from oldest holdout chunk down to newest (autoregressive order)
         for step in range(validation_end_chunk):
@@ -886,6 +903,10 @@ class LoadPredictor:
             errors.append(abs(pred_value - true_value))
             biases.append(pred_value - true_value)
 
+            slot = (minute_of_day // CHUNK_MINUTES) * CHUNK_MINUTES
+            pattern_value = baseline_patterns[day_of_week].get(slot, baseline_patterns[None].get(slot, 0.0))
+            pattern_errors.append(abs(pattern_value - true_value))
+
             # Feed predicted load back; use real exogenous values (they are known history)
             ar_load.insert(0, pred_value)
             ar_load.pop()
@@ -899,9 +920,9 @@ class LoadPredictor:
             ar_exp.pop()
 
         if not errors:
-            return None, None
+            return None, None, None
 
-        return float(np.mean(errors)), float(np.mean(biases))
+        return float(np.mean(errors)), float(np.mean(biases)), float(np.mean(pattern_errors))
 
     @staticmethod
     def _feature_mean_std(X, block=512):
@@ -1393,7 +1414,7 @@ class LoadPredictor:
 
         # Autoregressive diagnostic: run a full AR rollout over the holdout period
         # to expose compounding error (teacher-forced val_mae won't show this)
-        ar_mae, ar_bias = self._ar_rollout_diagnostic(
+        ar_mae, ar_bias, pattern_mae = self._ar_rollout_diagnostic(
             load_minutes,
             now_utc,
             pv_minutes=pv_minutes,
@@ -1402,10 +1423,14 @@ class LoadPredictor:
             export_rates=export_rates,
             validation_holdout_hours=validation_holdout_hours,
         )
+        self.rollout_mae = ar_mae
+        self.pattern_mae = pattern_mae
         if ar_mae is not None:
             mean_y_val = float(np.mean(y_val)) if float(np.mean(y_val)) > 1e-8 else 1e-8
             ar_drift = ar_mae - best_val_loss
             self.log("ML Predictor: AR rollout over holdout: ar_mae={:.4f} kWh ar_bias={:+.4f} kWh ({:+.1f}%) [drift vs teacher-forced: {:+.4f} kWh]".format(ar_mae, ar_bias, 100.0 * ar_bias / mean_y_val, ar_drift))
+        if ar_mae is not None and pattern_mae is not None:
+            self.log("ML Predictor: Holdout rollout vs daily-pattern baseline: rollout_mae={:.4f} kWh pattern_mae={:.4f} kWh -> long-range forecast led by {}".format(ar_mae, pattern_mae, "daily pattern" if pattern_mae < ar_mae else "model"))
 
         return best_val_loss
 
@@ -1698,6 +1723,21 @@ class LoadPredictor:
         # Seed previous value from the most recent historical chunk for the step-to-step cap
         prev_energy_value = lookback_buffer[0] if lookback_buffer else baseline_floor
 
+        # Last known exogenous values, carried forward when a forward forecast runs out.
+        # Rates and temperature are 3 of the 5 input channels (864 of 1446 features), and
+        # a 48-hour rollout outruns both forecasts. Filling the gap with 0.0 puts 0 p/kWh
+        # and 0 degrees into the network, far outside anything training saw. Measured on a
+        # real model: with no forward rate data the 48-hour rollout peaks at 1.9 kW against
+        # a 10.5 kW true peak; carrying the last known value forward restores it to 9.9 kW.
+        # The damage is concentrated in the first few hours of missing data - a forecast
+        # that reaches 12h ahead is unaffected at any horizon.
+        # PV is left at 0.0: past the solar forecast there is no generation to assume, and
+        # holding a daytime value overnight would be worse than zero.
+        last_temp_value = temp_lookback_buffer[0] if temp_lookback_buffer else 0.0
+        last_import_rate = import_rate_buffer[0] if import_rate_buffer else 0.0
+        last_export_rate = export_rate_buffer[0] if export_rate_buffer else 0.0
+        exog_carried_steps = 0
+
         self.log("ML Predictor: Starting autoregressive prediction loop for {} steps ({} hours), prev_energy value {} max_dow {}".format(PREDICT_HORIZON, PREDICT_HORIZON * CHUNK_MINUTES / 60, prev_energy_value, max_energy_by_dow))
 
         for step_idx in range(PREDICT_HORIZON):
@@ -1714,13 +1754,21 @@ class LoadPredictor:
             # Future PV energy: sum of the CHUNK_STEPS 5-min future values for this chunk
             # Future 5-min keys are negative (e.g. -5, -10, ...) going forward in time
             next_pv_value = sum(pv_energy_per_step.get(-(step_idx * CHUNK_MINUTES + (j + 1) * STEP_MINUTES), 0.0) for j in range(CHUNK_STEPS))
-            # Future temperature: average of CHUNK_STEPS 5-min future values
-            temp_future = [temp_values.get(-(step_idx * CHUNK_MINUTES + (j + 1) * STEP_MINUTES), 0.0) for j in range(CHUNK_STEPS)]
+            # Future temperature and rates: average over the chunk, holding the last known
+            # value wherever the forward forecast has run out rather than dropping to zero
+            temp_future, imp_future, exp_future = [], [], []
+            for j in range(CHUNK_STEPS):
+                future_key = -(step_idx * CHUNK_MINUTES + (j + 1) * STEP_MINUTES)
+                if future_key not in import_rate_values and future_key not in temp_values and future_key not in export_rate_values:
+                    exog_carried_steps += 1
+                last_temp_value = temp_values.get(future_key, last_temp_value)
+                last_import_rate = import_rate_values.get(future_key, last_import_rate)
+                last_export_rate = export_rate_values.get(future_key, last_export_rate)
+                temp_future.append(last_temp_value)
+                imp_future.append(last_import_rate)
+                exp_future.append(last_export_rate)
             next_temp_value = float(np.mean(temp_future))
-            # Future import/export rates: average over the chunk
-            imp_future = [import_rate_values.get(-(step_idx * CHUNK_MINUTES + (j + 1) * STEP_MINUTES), 0.0) for j in range(CHUNK_STEPS)]
             next_import_rate = float(np.mean(imp_future))
-            exp_future = [export_rate_values.get(-(step_idx * CHUNK_MINUTES + (j + 1) * STEP_MINUTES), 0.0) for j in range(CHUNK_STEPS)]
             next_export_rate = float(np.mean(exp_future))
 
             # Combine features: [load_lookback..., pv_lookback..., temp_lookback..., import_rates..., export_rates..., time_features...]
@@ -1778,6 +1826,11 @@ class LoadPredictor:
             export_rate_buffer.insert(0, next_export_rate)
             export_rate_buffer.pop()
 
+        # Only worth reporting when there was exogenous data to carry; a setup with no
+        # temperature or rate sensors legitimately runs the whole rollout without any
+        if exog_carried_steps and (temp_values or import_rate_values or export_rate_values):
+            self.log("ML Predictor: Forward temperature/rate forecast ran out for {} of {} rollout steps, last known values carried forward".format(exog_carried_steps, PREDICT_HORIZON * CHUNK_STEPS))
+
         # Convert to cumulative kWh format at STEP_MINUTES resolution.
         # Each CHUNK_MINUTES prediction is split into CHUNK_STEPS equal 5-min sub-steps
         # so that the output matches the format expected by fetch_extra_load_forecast
@@ -1817,6 +1870,8 @@ class LoadPredictor:
                 "training_timestamp": self.training_timestamp.isoformat() if self.training_timestamp else None,
                 "validation_mae": float(self.validation_mae) if self.validation_mae else None,
                 "validation_bias": float(self.validation_bias) if self.validation_bias is not None else None,
+                "rollout_mae": float(self.rollout_mae) if self.rollout_mae is not None else None,
+                "pattern_mae": float(self.pattern_mae) if self.pattern_mae is not None else None,
                 "epochs_trained": self.epochs_trained,
                 "learning_rate": self.learning_rate,
                 "max_load_kw": self.max_load_kw,
@@ -1934,6 +1989,8 @@ class LoadPredictor:
                 self.training_timestamp = datetime.fromisoformat(metadata["training_timestamp"])
             self.validation_mae = metadata.get("validation_mae")
             self.validation_bias = metadata.get("validation_bias", None)
+            self.rollout_mae = metadata.get("rollout_mae", None)
+            self.pattern_mae = metadata.get("pattern_mae", None)
             self.epochs_trained = metadata.get("epochs_trained", 0)
             # Restore dropout rate; fall back to 0.1 for models saved before this feature
             self.dropout_rate = metadata.get("dropout_rate", 0.1)

--- a/apps/predbat/tests/test_load_ml_rollout.py
+++ b/apps/predbat/tests/test_load_ml_rollout.py
@@ -1,0 +1,229 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+
+"""Regression tests for long-range degradation of the ML load forecast (#4673).
+
+Issue #4673 reported a 48-hour forecast with spikes far above and below anything in
+the history, for a household with ~10 kWh of free-rate load every day between 05:00
+and 06:00. Replaying the reporter's saved model and history surfaced two defects.
+Whether either one caused their report is unconfirmed - that needs their logs.
+
+1. Missing forward exogenous data was silently zero-filled. Rates and temperature are
+   3 of the 5 input channels (864 of 1446 features), and a 48-hour rollout outruns
+   both forecasts; predict() substituted 0.0, putting 0 p/kWh and 0 degrees into a
+   network trained on 33.6 p/kWh and 7 degrees. Measured on the reporter's own model,
+   removing forward rate data moved the +8h forecast from 0.28 kWh MAE to 2.6-2.8 kWh,
+   with errors of -10 kWh (daily event erased) or +11 kWh (load invented) depending on
+   which rate channel was missing. Note the effect needs the forecast to be missing
+   within the first few hours: one that reaches 12h ahead is unaffected, so a rate plan
+   merely ending at the 48h horizon does not reproduce the reported chart.
+
+2. No visibility of multi-step accuracy. The published mae_kwh is teacher-forced and
+   stays small however badly the rollout behaves, so there was nothing to diagnose
+   from. The rollout is now scored against the daily-pattern baseline predict()
+   already blends in, and both figures are published. This is reporting only - it
+   does not change the forecast.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+
+from load_predictor import (
+    HIDDEN_SIZES,
+    LoadPredictor,
+    NUM_EXPORT_RATE_FEATURES,
+    NUM_IMPORT_RATE_FEATURES,
+    NUM_LOAD_FEATURES,
+    NUM_PV_FEATURES,
+    NUM_TEMP_FEATURES,
+    OUTPUT_STEPS,
+    STEP_MINUTES,
+    TOTAL_FEATURES,
+)
+
+# Synthetic household matching the shape reported in #4673
+SPIKE_HOUR = 5  # Local hour of the free-rate window
+SPIKE_KW = 11.0  # Load during the free hour
+BASE_KW = 0.2  # Load the rest of the day
+HISTORY_DAYS = 21
+
+
+def _spike_profile_kwh(dt):
+    """Per-5-min energy for a household with one large repeatable daily event."""
+    kw = SPIKE_KW if dt.hour == SPIKE_HOUR else BASE_KW
+    return kw * STEP_MINUTES / 60.0
+
+
+def _spike_history(now_utc, days=HISTORY_DAYS):
+    """Build {minute: kwh_per_step} history keyed by minutes back from now_utc."""
+    return {minute: _spike_profile_kwh(now_utc - timedelta(minutes=minute)) for minute in range(0, days * 24 * 60, STEP_MINUTES)}
+
+
+def _collapsed_predictor(constant_kwh_per_step):
+    """
+    Build a predictor whose network emits a constant, reproducing rollout collapse.
+
+    Every weight is zero and every bias except the output bias is zero, so the forward
+    pass returns the output bias regardless of its input. That is the degenerate state
+    a lag-dominated model falls into once it is fed its own predictions, and it lets
+    these tests exercise the real predict() path without training a model first.
+    """
+    predictor = LoadPredictor(log_func=lambda *args, **kwargs: None, max_load_kw=50.0)
+    layer_sizes = [TOTAL_FEATURES] + HIDDEN_SIZES + [OUTPUT_STEPS]
+    predictor.weights = [np.zeros((layer_sizes[i], layer_sizes[i + 1]), dtype=np.float32) for i in range(len(layer_sizes) - 1)]
+    predictor.biases = [np.zeros(layer_sizes[i + 1], dtype=np.float32) for i in range(len(layer_sizes) - 1)]
+
+    # Normalisation is the identity so the output bias *is* the predicted kWh per step
+    predictor.feature_mean = np.zeros(TOTAL_FEATURES, dtype=np.float32)
+    predictor.feature_std = np.ones(TOTAL_FEATURES, dtype=np.float32)
+    predictor.target_mean = 0.0
+    predictor.target_std = 1.0
+    predictor.biases[-1][:] = constant_kwh_per_step
+
+    # Adam state is not exercised here but save() serialises it
+    predictor.m_weights = [np.zeros_like(w) for w in predictor.weights]
+    predictor.v_weights = [np.zeros_like(w) for w in predictor.weights]
+    predictor.m_biases = [np.zeros_like(b) for b in predictor.biases]
+    predictor.v_biases = [np.zeros_like(b) for b in predictor.biases]
+
+    predictor.model_initialized = True
+    predictor.training_timestamp = datetime.now(timezone.utc)
+    return predictor
+
+
+def _test_rollout_diagnostic_scores_the_daily_pattern_baseline():
+    """The rollout diagnostic reports the daily-pattern baseline alongside the model."""
+    now_utc = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+    history = _spike_history(now_utc)
+    mean_energy = float(np.mean(list(history.values())))
+    predictor = _collapsed_predictor(mean_energy)
+
+    rollout_mae, _rollout_bias, pattern_mae = predictor._ar_rollout_diagnostic(history, now_utc, validation_holdout_hours=48)
+
+    assert rollout_mae is not None, "Rollout diagnostic should score the model over the holdout"
+    assert pattern_mae is not None, "Rollout diagnostic should also score the daily-pattern baseline"
+    assert pattern_mae < rollout_mae, "Daily pattern should beat a collapsed rollout on a strongly repeatable profile, got pattern={:.4f} rollout={:.4f}".format(pattern_mae, rollout_mae)
+
+
+def _test_rate_forecast_running_out_does_not_zero_the_model_inputs():
+    """When the forward rate plan ends, the rollout must not fall back to 0 p/kWh.
+
+    Rates are 576 of the 1446 input features. predbat's rates entity only reaches the end
+    of tomorrow, so a 48-hour rollout always runs past it; substituting 0.0 there drags
+    40% of the inputs far outside anything the model saw in training (#4673).
+    """
+    now_utc = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+    midnight_utc = now_utc.replace(hour=0, minute=0)
+    history = _spike_history(now_utc)
+    # Flat tariff over the whole history, and no forward plan at all (negative keys absent)
+    import_rates = {minute: 33.6 for minute in history}
+    export_rates = {minute: 11.5 for minute in history}
+    predictor = _collapsed_predictor(float(np.mean(list(history.values()))))
+
+    captured = []
+    original_normalize = predictor._normalize_features
+
+    def _capture(features, **kwargs):
+        """Record the raw feature row on its way into the network."""
+        captured.append(np.asarray(features, dtype=np.float64).reshape(-1).copy())
+        return original_normalize(features, **kwargs)
+
+    predictor._normalize_features = _capture
+    predictor.predict(history, now_utc, midnight_utc, import_rates=import_rates, export_rates=export_rates)
+
+    import_offset = NUM_LOAD_FEATURES + NUM_PV_FEATURES + NUM_TEMP_FEATURES
+    export_offset = import_offset + NUM_IMPORT_RATE_FEATURES
+    final_row = captured[-1]
+    import_block = final_row[import_offset : import_offset + NUM_IMPORT_RATE_FEATURES]
+    export_block = final_row[export_offset : export_offset + NUM_EXPORT_RATE_FEATURES]
+
+    assert import_block.min() > 0.0, "Import rate features should never be zero-filled; {} of {} were zero at the end of the rollout".format(int((import_block == 0.0).sum()), len(import_block))
+    assert export_block.min() > 0.0, "Export rate features should never be zero-filled; {} of {} were zero at the end of the rollout".format(int((export_block == 0.0).sum()), len(export_block))
+
+
+def _test_holdout_scores_survive_a_save_load_roundtrip():
+    """Saved models carry their holdout scores, so they survive a restart."""
+    import os
+    import tempfile
+
+    predictor = _collapsed_predictor(0.05)
+    predictor.rollout_mae = 0.0421
+    predictor.pattern_mae = 0.0117
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "model.npz")
+        assert predictor.save(path), "Model should save"
+
+        reloaded = LoadPredictor(log_func=lambda *args, **kwargs: None, max_load_kw=50.0)
+        assert reloaded.load(path), "Model should load"
+
+    assert reloaded.rollout_mae == predictor.rollout_mae, "rollout_mae should survive the roundtrip, got {}".format(reloaded.rollout_mae)
+    assert reloaded.pattern_mae == predictor.pattern_mae, "pattern_mae should survive the roundtrip, got {}".format(reloaded.pattern_mae)
+
+
+def _test_stats_sensor_exposes_the_holdout_scores():
+    """The stats sensor reports rollout and pattern error, not just teacher-forced MAE."""
+    from load_ml_component import LoadMLComponent
+
+    class MockBase:
+        """Minimal PredBat stand-in for driving _publish_entity."""
+
+        def __init__(self):
+            """Set up the attributes the component reads."""
+            self.prefix = "predbat"
+            self.config_root = None
+            self.now_utc = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+            self.midnight_utc = datetime(2026, 8, 24, 0, 0, tzinfo=timezone.utc)
+            self.minutes_now = 720
+            self.local_tz = timezone.utc
+            self.args = {}
+            self.dashboard_calls = []
+
+        def log(self, msg):
+            """Swallow log output."""
+
+        def get_arg(self, key, default=None, **kwargs):
+            """Return the handful of settings the component asks for."""
+            return {"load_today": ["sensor.load_today"], "load_power": None, "car_charging_energy": None}.get(key, default)
+
+    mock_base = MockBase()
+    component = LoadMLComponent(mock_base, load_ml_enable=True)
+    component.dashboard_item = lambda entity_id, state, attributes, app: mock_base.dashboard_calls.append((entity_id, attributes))
+
+    component.load_minutes_now = 10.5
+    component.load_minutes_now_time = mock_base.now_utc
+    component.current_predictions = {0: 0.1, 60: 1.3, 480: 9.7}
+    component.predictor.validation_mae = 0.0065
+    component.predictor.rollout_mae = 0.0421
+    component.predictor.pattern_mae = 0.0117
+
+    component._publish_entity()
+
+    stats = dict(mock_base.dashboard_calls)["sensor.predbat_load_ml_stats"]
+    assert stats.get("rollout_mae_kwh") == 0.0421, "Stats should report the rollout MAE, got {}".format(stats.get("rollout_mae_kwh"))
+    assert stats.get("pattern_mae_kwh") == 0.0117, "Stats should report the daily-pattern MAE, got {}".format(stats.get("pattern_mae_kwh"))
+
+
+def run_load_ml_rollout_tests(my_predbat=None):
+    """Run the autoregressive rollout regression tests, returning a failure count."""
+    failed = 0
+    for test in (
+        _test_rollout_diagnostic_scores_the_daily_pattern_baseline,
+        _test_rate_forecast_running_out_does_not_zero_the_model_inputs,
+        _test_holdout_scores_survive_a_save_load_roundtrip,
+        _test_stats_sensor_exposes_the_holdout_scores,
+    ):
+        print("  Running {}...".format(test.__name__), end=" ")
+        try:
+            test()
+            print("PASS")
+        except Exception as error:  # pylint: disable=broad-except
+            print("FAIL: {}".format(error))
+            failed += 1
+    return failed

--- a/apps/predbat/tests/test_load_ml_rollout.py
+++ b/apps/predbat/tests/test_load_ml_rollout.py
@@ -14,14 +14,12 @@ and 06:00. Replaying the reporter's saved model and history surfaced two defects
 Whether either one caused their report is unconfirmed - that needs their logs.
 
 1. Missing forward exogenous data was silently zero-filled. Rates and temperature are
-   3 of the 5 input channels (864 of 1446 features), and a 48-hour rollout outruns
-   both forecasts; predict() substituted 0.0, putting 0 p/kWh and 0 degrees into a
+   3 of the 5 input channels (864 of 1446 features), and predict() substituted 0.0
+   wherever the forward forecast was absent, putting 0 p/kWh and 0 degrees into a
    network trained on 33.6 p/kWh and 7 degrees. Measured on the reporter's own model,
-   removing forward rate data moved the +8h forecast from 0.28 kWh MAE to 2.6-2.8 kWh,
-   with errors of -10 kWh (daily event erased) or +11 kWh (load invented) depending on
-   which rate channel was missing. Note the effect needs the forecast to be missing
-   within the first few hours: one that reaches 12h ahead is unaffected, so a rate plan
-   merely ending at the 48h horizon does not reproduce the reported chart.
+   removing forward rate data moved the +8h forecast from 0.28 kWh MAE to 2.6-2.8 kWh.
+   A healthy system does not hit this - rate_replicate() and publish_rates() cover the
+   whole rollout - so it guards startup and failed-fetch cases rather than steady state.
 
 2. No visibility of multi-step accuracy. The published mae_kwh is teacher-forced and
    stays small however badly the rollout behaves, so there was nothing to diagnose

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -238,6 +238,7 @@ from tests.test_component_base import test_component_base_all
 from tests.test_mock_base import test_mock_base_all
 from tests.test_solis import run_solis_tests
 from tests.test_load_ml import test_load_ml
+from tests.test_load_ml_rollout import run_load_ml_rollout_tests
 from tests.test_ml_memory import run_ml_memory_tests
 from tests.test_ml_training_perf import run_ml_training_perf_tests
 from tests.test_temperature import test_temperature
@@ -639,6 +640,8 @@ def main():
         ("tariff_catalogue", test_tariff_catalogue, "Tariff catalogue tests", False),
         ("annual_integration", run_annual_integration_isolated, "Annual prediction integration tests", True),
         ("load_ml", test_load_ml, "ML Load Forecaster tests (MLP, training, persistence, validation)", True),
+        # Autoregressive rollout collapse: long-range forecast must keep repeatable daily events (#4673)
+        ("load_ml_rollout", run_load_ml_rollout_tests, "ML load rollout vs daily-pattern blend tests", False),
         # ML training memory: dataset construction, normalisation dtype and statistics accuracy
         ("ml_memory", run_ml_memory_tests, "ML training memory tests", False),
         # Production-scale ML training harness against a captured history fixture

--- a/docs/load-ml.md
+++ b/docs/load-ml.md
@@ -12,6 +12,7 @@ This prediction is based on historical load patterns, time-of-day patterns, day-
 - [Setup Instructions](#setup-instructions)
 - [Understanding the Model](#understanding-the-model)
 - [Monitoring and Troubleshooting](#monitoring-and-troubleshooting)
+- [Rollout Accuracy](#rollout-accuracy)
 - [Model Persistence](#model-persistence)
 - [Advanced Training Options](#advanced-training-options)
 
@@ -98,6 +99,14 @@ The model uses an autoregressive approach:
 5. Continues for 576 steps to cover 48 hours
 
 To prevent drift in long-range predictions, the model blends autoregressive predictions with historical daily patterns. The blending uses **day-of-week-aware patterns**: separate average profiles are maintained for each of the 7 days of the week (Monday–Sunday), so the weekend fallback differs from weekday. If a particular day of the week has insufficient data (fewer than 2 complete observations per slot), the global all-days average is used instead.
+
+The model leads at the start of the rollout and its weight decays linearly to 50% at the 48-hour horizon. Whether that hand-over is fast enough for your data is reported rather than adjusted automatically - see [Rollout Accuracy](#rollout-accuracy).
+
+### Forward Rate and Temperature Data
+
+Rates and temperature make up 3 of the 5 input channels (864 of the 1446 features). The forward rate plan only reaches the end of tomorrow and the temperature forecast is usually shorter, so a 48-hour rollout always runs past the end of both. Where that happens the last known value is carried forward, keeping those inputs in the range the model was trained on. Filling them with zero instead would feed 0 p/kWh and 0 °C into the network and badly distort the forecast. PV is the exception and is left at zero past the end of the solar forecast, since there is no generation to assume.
+
+If you see `Forward temperature/rate forecast ran out for N of 576 rollout steps` in the log, that is this fallback engaging - normal for the tail of a 48-hour forecast, but a large N early in the day can mean your rate data is not being published as far ahead as it should be.
 
 ### Training Process
 
@@ -439,6 +448,22 @@ View model status in Predbat logs:
 ```text
 ML Component: Model status: active, last trained: 2024-02-07 10:30:00
 ML Component: Validation MAE: 0.3245 kWh
+```
+
+### Rollout Accuracy
+
+`sensor.predbat_load_ml_stats` publishes three error figures, and they measure different things:
+
+| Attribute | What it measures |
+|-----------|------------------|
+| `mae_kwh` | Teacher-forced, one step ahead with real data in the lookback. Stays small even when the long-range forecast is useless, so do not read it as overall accuracy. |
+| `rollout_mae_kwh` | Full autoregressive rollout across the holdout, feeding each prediction back in. This is the number that reflects what you see on the 8-hour chart trace. |
+| `pattern_mae_kwh` | The day-of-week daily-pattern baseline over the same holdout, for comparison. |
+
+If `pattern_mae_kwh` is lower than `rollout_mae_kwh`, the network is not beating a simple historical average at range, and the long-range part of the forecast is worth treating with suspicion. Both figures are reported only; neither changes the forecast. The same comparison is logged after each training run:
+
+```text
+ML Predictor: Holdout rollout vs daily-pattern baseline: rollout_mae=0.0050 kWh pattern_mae=0.0715 kWh -> long-range forecast led by model
 ```
 
 ### Tracking Normalisation Drift

--- a/docs/load-ml.md
+++ b/docs/load-ml.md
@@ -104,9 +104,9 @@ The model leads at the start of the rollout and its weight decays linearly to 50
 
 ### Forward Rate and Temperature Data
 
-Rates and temperature make up 3 of the 5 input channels (864 of the 1446 features). The forward rate plan only reaches the end of tomorrow and the temperature forecast is usually shorter, so a 48-hour rollout always runs past the end of both. Where that happens the last known value is carried forward, keeping those inputs in the range the model was trained on. Filling them with zero instead would feed 0 p/kWh and 0 °C into the network and badly distort the forecast. PV is the exception and is left at zero past the end of the solar forecast, since there is no generation to assume.
+Rates and temperature make up 3 of the 5 input channels (864 of the 1446 features). Normally both are supplied across the whole rollout: rates are extended by `rate_replicate()` and published out past the forecast horizon, and the temperature forecast comes from the Temperature component. Where a forward value is missing anyway - before the first plan cycle has published the rates entity, or after a failed rate fetch - the last known value is carried forward, keeping those inputs in the range the model was trained on. Filling them with zero would feed 0 p/kWh and 0 °C into the network and badly distort the forecast. PV is the exception and is left at zero past the end of the solar forecast, since there is no generation to assume.
 
-If you see `Forward temperature/rate forecast ran out for N of 576 rollout steps` in the log, that is this fallback engaging - normal for the tail of a 48-hour forecast, but a large N early in the day can mean your rate data is not being published as far ahead as it should be.
+If you see `Forward temperature/rate forecast ran out for N of 576 rollout steps` in the log, that is this fallback engaging. A small N at the tail is unremarkable; a large N means your rate or temperature data is not reaching the model, which is worth investigating in its own right.
 
 ### Training Process
 


### PR DESCRIPTION
## What

Rates and temperature are 3 of the 5 input channels to the ML load model — 864 of 1446 features. Where a forward value was missing, `predict()` substituted `0.0`, feeding **0 p/kWh and 0 °C** into a network trained on ~33.6 p/kWh and ~7 °C. Nothing logged it.

**This is a startup and failure-path guard, not a steady-state bug.** A healthy system supplies the whole rollout: `rate_replicate()` extends rates past the forecast horizon, `publish_rates()` emits them out to `minutes_now + forecast_minutes + 24h`, and `minute_data()` returns them as forward keys covering all 576 steps. I verified that last step rather than assuming it. The gap only opens when the source entity is unavailable — before the first plan cycle publishes it, or after a failed rate fetch.

This carries the last known value forward there instead, and logs when it engages. PV keeps its `0.0` default deliberately: past the solar forecast there is no generation to assume, and holding a daytime value overnight would be worse.

## Why it matters despite being an edge case

Measured by replaying a user's saved `predbat_ml_model.npz` against their own history:

| Forward exog data | +8h MAE (before) | +8h MAE (after) | 48h rollout peak (before → after) |
|---|---|---|---|
| fully supplied | 0.28 kWh | 0.28 kWh | 10.5 kW → 10.5 kW |
| absent | 2.43 kWh | **0.40 kWh** | **1.9 kW → 9.9 kW** |

Their true peak is 10.5 kW. With the inputs zeroed the rollout flattens to 1.9 kW — the household's large daily event vanishes entirely, and the plan is built on it. The fully-supplied case is byte-identical before and after, so there is no behaviour change when data is present.

## Also: multi-step accuracy is now reported

`validation_mae` / `mae_kwh` is teacher-forced one-step-ahead and stays small however badly the rollout behaves — it reads 0.0065 kWh on the model above. There was no published signal for multi-step quality at all.

`_ar_rollout_diagnostic` now also scores the day-of-week daily-pattern baseline it is blended against, and `rollout_mae_kwh` / `pattern_mae_kwh` are persisted with the model and published on `sensor.<prefix>_load_ml_stats`. If `pattern_mae_kwh` is the lower of the two, the network is not beating a simple historical average at range. **Both are reporting only and do not change the forecast.**

This is arguably the more useful half. The model retrains every two hours, and nothing currently reveals whether a given retrain produced a good long-range rollout or a collapsed one.

## Relationship to #4673

Raised while investigating #4673, **deliberately not marked as fixing it**. Replaying that reporter's model with correctly supplied inputs reproduces no anomaly (+8h MAE 0.28 kWh), so this is not the cause of their chart and their report stays open.

## Testing

New `apps/predbat/tests/test_load_ml_rollout.py`, registered as `load_ml_rollout` (fast, no training). Four tests: rate features are never zero-filled, the diagnostic reports the pattern baseline, the scores survive a save/load roundtrip, and the stats sensor exposes them.

Full suite: 264 tests pass. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
