### PR TITLE
test(web): restore the shared components object after the debug-history route tests

### DIFF
--- a/apps/predbat/tests/test_web_debug_history_routes.py
+++ b/apps/predbat/tests/test_web_debug_history_routes.py
@@ -33,6 +33,9 @@ class FakeRequest:
 def _make_web(my_predbat, storage=None):
     """Build a minimal WebInterface bound to my_predbat, bypassing ComponentBase.__init__
     (which would stand up the real aiohttp app) - same pattern as test_web_chart_currency.py.
+
+    Note this replaces my_predbat.components, which is shared with every other test in the run - the
+    caller is responsible for putting the original back (see the finally block below).
     """
     w = WebInterface.__new__(WebInterface)
     w.base = my_predbat
@@ -52,6 +55,11 @@ def test_web_debug_history_routes(my_predbat):
     print("**** Testing debug-history web routes ****")
 
     tmpdir = tempfile.mkdtemp(prefix="predbat_test_debug_history_routes_")
+    # _make_web() swaps components out for a stub on the shared my_predbat, so it has to go back
+    # afterwards. Left in place, the next test to reach is_running() dies on
+    # components.is_all_alive(), which the stub does not have - test_web_functions is the one that
+    # trips over it, several tests later and with nothing to point back to here.
+    saved_components = my_predbat.components
     try:
         print("Test: no storage component available - list is empty, downloads 404 without raising")
         w_no_storage = _make_web(my_predbat, storage=None)
@@ -140,6 +148,32 @@ def test_web_debug_history_routes(my_predbat):
             failed = True
 
     finally:
+        my_predbat.components = saved_components
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return failed
+
+
+def test_web_debug_history_routes_restores_components(my_predbat):
+    """The routes test must leave my_predbat.components exactly as it found it.
+
+    my_predbat is shared across the whole run, so a stub left behind here surfaces as an
+    AttributeError in an unrelated test much later - is_running() calling components.is_all_alive()
+    on a SimpleNamespace. Asserted on identity: whatever the caller had before is what it must get
+    back, and a different-but-plausible object would be just as wrong for whoever ran first.
+
+    Note is_running() guards with "if self.components", so the harness leaving this as None is
+    harmless - it is specifically a truthy stub missing the method that breaks things, which is why
+    a straight truthiness check would not catch this.
+    """
+    print("**** Testing debug-history routes leave components intact ****")
+    failed = False
+    before = my_predbat.components
+
+    test_web_debug_history_routes(my_predbat)
+
+    if my_predbat.components is not before:
+        print("  ERROR: components was not restored, got {} instead of the original".format(type(my_predbat.components).__name__))
+        failed = True
 
     return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -103,7 +103,7 @@ from tests.test_hainterface_websocket import run_hainterface_websocket_tests
 from tests.test_history_chunking import run_history_chunking_tests
 from tests.test_web_if import run_test_web_if
 from tests.test_web_chart_currency import test_rates_chart_series_names_use_currency_symbol
-from tests.test_web_debug_history_routes import test_web_debug_history_routes
+from tests.test_web_debug_history_routes import test_web_debug_history_routes, test_web_debug_history_routes_restores_components
 from tests.test_debug_history_client_js import test_debug_history_client_js
 from tests.test_metrics_dashboard_soc_refresh import test_soc_chart_center_text_reads_live_data
 from tests.test_web_functions import run_web_functions_tests, run_web_logo_image_tests
@@ -440,6 +440,7 @@ def main():
         ("web_if", run_test_web_if, "Web interface tests", False),
         ("web_chart_currency", test_rates_chart_series_names_use_currency_symbol, "Rates chart series names follow currency_symbols tests", False),
         ("web_debug_history_routes", test_web_debug_history_routes, "Debug-history web routes tests (#4438 review items 4, 6, 21)", False),
+        ("web_debug_history_isolation", test_web_debug_history_routes_restores_components, "Debug-history routes restore the shared components object", False),
         ("debug_history_client_js", test_debug_history_client_js, "Debug-history client-side JS structure tests (#4438 review item 22)", False),
         ("metrics_dashboard_soc_refresh", test_soc_chart_center_text_reads_live_data, "Metrics dashboard SoC chart live-refresh tests", False),
         ("web_functions", run_web_functions_tests, "Web function unit tests", False),


### PR DESCRIPTION
_make_web() in test_web_debug_history_routes.py swaps my_predbat.components for a SimpleNamespace stub, and my_predbat is shared across the whole run. It's never put back, so the next test to call is_running() dies on components.is_all_alive():
  AttributeError: 'types.SimpleNamespace' object has no attribute 'is_all_alive'

test_web_functions is what actually trips over it, several tests later, with nothing in the failure pointing back to the cause. Both tests pass in isolation — this only appears in a full-suite run, so ./run_all on current main should be failing.

The stub is restored in the existing finally block, plus a companion test asserting the routes test leaves components as it found it. That assertion is on identity rather than truthiness: is_running() guards with if self.components, so the harness leaving it as None is harmless — it's specifically a truthy stub missing the method that breaks things.