### PR TITLE
fix(load_ml): report liveness during training

### DIFF
--- a/apps/predbat/load_ml_component.py
+++ b/apps/predbat/load_ml_component.py
@@ -997,6 +997,7 @@ class LoadMLComponent(ComponentBase):
                     curriculum_window_days=window_days,
                     curriculum_step_days=5,
                     max_intermediate_passes=8,
+                    progress_callback=self.update_success_timestamp,
                 )
             else:
                 val_mae = self.predictor.train_curriculum(
@@ -1013,6 +1014,7 @@ class LoadMLComponent(ComponentBase):
                     curriculum_window_days=window_days,
                     curriculum_step_days=step_days,
                     max_intermediate_passes=max_intermediate_passes,
+                    progress_callback=self.update_success_timestamp,
                 )
 
             if val_mae is not None:

--- a/apps/predbat/load_predictor.py
+++ b/apps/predbat/load_predictor.py
@@ -1187,6 +1187,7 @@ class LoadPredictor:
         lr_decay="cosine",
         ema_smoothing_alpha=0.3,
         huber_delta=1.35,
+        progress_callback=None,
     ):
         """
         Train or fine-tune the model.
@@ -1211,6 +1212,9 @@ class LoadPredictor:
             huber_delta: Huber loss transition point in normalised target units (default 1.35; errors within
                          this threshold are penalised quadratically, beyond it linearly)
             ema_smoothing_alpha: EMA alpha for smoothing the early-stopping metric across epochs (0=no smoothing, 0.3=moderate)
+            progress_callback: Called with no arguments once per epoch, so a caller whose liveness is
+                               judged on how recently it reported success can stay alive through a
+                               training run longer than that window. Exceptions are logged and swallowed
 
         Returns:
             Validation MAE or None if training failed
@@ -1376,6 +1380,17 @@ class LoadPredictor:
                 )
             )
 
+            # Heartbeat. A curriculum run is many passes of many epochs and routinely takes over an
+            # hour, but the caller only gets to mark itself healthy once the whole thing returns - so
+            # a component that is training perfectly well trips the liveness timeout and is reported
+            # dead. One call per epoch is a fine enough pulse and costs nothing. Guarded because a
+            # progress hook must never be able to abort an hour of training.
+            if progress_callback:
+                try:
+                    progress_callback()
+                except Exception as e:
+                    self.log("Warn: ML Predictor: progress callback raised {}, continuing training".format(e))
+
             # Early stopping uses EMA-smoothed combined metric so a single noisy epoch
             # cannot prematurely checkpoint a suboptimal set of weights.
             # Weight checkpointing uses the raw epoch weights (not a smoothed version).
@@ -1478,6 +1493,7 @@ class LoadPredictor:
         curriculum_step_days=7,
         max_intermediate_passes=0,
         huber_delta=1.35,
+        progress_callback=None,
     ):
         """
                 Train using curriculum learning: progressively expand the training window
@@ -1508,6 +1524,9 @@ class LoadPredictor:
                     patience: Early-stopping patience per pass
                     validation_holdout_hours: Holdout window for the final pass
                     norm_ema_alpha: Normalisation EMA alpha for passes after the first
+                    progress_callback: Called with no arguments once per epoch across every pass, so a
+                                       run that lasts longer than the caller's liveness timeout can
+                                       still report itself alive
                     curriculum_window_days: Initial training window size in days (default 7)
                     curriculum_step_days: Days added per subsequent pass (default 7)
                     max_intermediate_passes: Maximum number of intermediate passes to run;
@@ -1562,6 +1581,7 @@ class LoadPredictor:
                 validation_holdout_hours=validation_holdout_hours,
                 norm_ema_alpha=norm_ema_alpha,
                 huber_delta=huber_delta,
+                progress_callback=progress_callback,
             )
 
         total_passes = len(window_sizes) + 1  # intermediate passes + final full pass
@@ -1598,6 +1618,7 @@ class LoadPredictor:
                 validation_holdout_hours=validation_holdout_hours,
                 norm_ema_alpha=norm_ema_alpha,
                 huber_delta=huber_delta,
+                progress_callback=progress_callback,
             )
 
             if pass_mae is None:
@@ -1622,6 +1643,7 @@ class LoadPredictor:
             validation_holdout_hours=validation_holdout_hours,
             norm_ema_alpha=norm_ema_alpha,
             huber_delta=huber_delta,
+            progress_callback=progress_callback,
         )
 
         if final_mae is not None:

--- a/apps/predbat/tests/test_load_ml.py
+++ b/apps/predbat/tests/test_load_ml.py
@@ -54,6 +54,8 @@ def test_load_ml(my_predbat=None):
         ("cold_start", _test_cold_start, "Cold start with insufficient data"),
         ("fine_tune", _test_fine_tune, "Fine-tune on recent data"),
         ("curriculum_training", _test_curriculum_training, "Curriculum training with progressive window expansion"),
+        ("training_progress_callback", _test_training_progress_callback, "Training reports liveness through progress_callback"),
+        ("component_alive_during_training", _test_component_marks_itself_alive_during_training, "Component keeps its success timestamp fresh while training"),
         ("prediction", _test_prediction, "End-to-end prediction"),
         ("prediction_with_pv", _test_prediction_with_pv, "Prediction with PV forecast data"),
         ("prediction_with_temp", _test_prediction_with_temp, "Prediction with temperature forecast data"),
@@ -3317,3 +3319,147 @@ def _test_curriculum_90day_intermediate_passes():
     assert val_mae is not None, "90-day curriculum training should succeed"
     assert not np.isnan(val_mae), "val_mae must not be NaN"
     assert predictor.model_initialized, "Model must be initialized after curriculum training"
+
+
+def _test_training_progress_callback():
+    """Test that a long training run can report liveness through progress_callback.
+
+    Without this the component only marks itself successful once the whole curriculum returns.
+    Real runs measured 63-90 minutes against a 60 minute liveness window in components.is_alive(),
+    so a perfectly healthy trainer was reported dead - and the dashboard showed "(unhealthy)" -
+    for the tail of every retrain.
+    """
+    from load_predictor import LoadPredictor
+
+    now_utc = datetime.now(timezone.utc)
+    np.random.seed(42)
+    load_data = _create_synthetic_load_data(n_days=7, now_utc=now_utc)
+
+    # A plain train() pulses once per epoch
+    calls = []
+    predictor = LoadPredictor(learning_rate=0.01)
+    predictor.train(load_data, now_utc, epochs=3, patience=3, progress_callback=lambda: calls.append(1))
+    assert len(calls) == 3, f"expected one callback per epoch (3), got {len(calls)}"
+
+    # Omitting it must stay valid - every existing caller relies on that
+    predictor_none = LoadPredictor(learning_rate=0.01)
+    predictor_none.train(load_data, now_utc, epochs=2, patience=3)
+
+    # Curriculum threads it through every pass, so the pulse never stops for a whole pass
+    load_data_28 = _create_synthetic_load_data(n_days=28, now_utc=now_utc)
+    curriculum_calls = []
+    predictor_c = LoadPredictor(learning_rate=0.01)
+    val_mae = predictor_c.train_curriculum(
+        load_data_28,
+        now_utc,
+        epochs=3,
+        patience=3,
+        curriculum_window_days=7,
+        curriculum_step_days=7,
+        progress_callback=lambda: curriculum_calls.append(1),
+    )
+    assert val_mae is not None, "curriculum training should still succeed with a progress callback"
+    # 28 days at window 7 step 7 gives 3 intermediate passes plus the final one, 3 epochs each
+    assert len(curriculum_calls) >= 6, f"expected the callback to fire across multiple passes, got {len(curriculum_calls)}"
+
+    # A callback that raises must not abort an hour of training
+    raised = []
+
+    def bad_callback():
+        raised.append(1)
+        raise RuntimeError("callback blew up")
+
+    predictor_bad = LoadPredictor(learning_rate=0.01)
+    val_mae_bad = predictor_bad.train(load_data, now_utc, epochs=3, patience=3, progress_callback=bad_callback)
+    assert len(raised) == 3, f"a raising callback should still be called every epoch, got {len(raised)}"
+    assert val_mae_bad is not None, "training must survive a callback that raises"
+
+    return True
+
+
+def _test_component_marks_itself_alive_during_training():
+    """_do_training must hand the trainer the component's own timestamp updater.
+
+    Driven through the real _do_training rather than by calling train_curriculum directly - a test
+    that passes the callback itself proves only that the test passes it, and would keep passing if
+    load_ml_component stopped wiring it up. That regression is invisible until a training run
+    silently crosses the liveness window again hours later.
+    """
+    import asyncio
+
+    from load_ml_component import LoadMLComponent
+
+    now_utc = datetime.now(timezone.utc)
+    recorded = {}
+
+    class FakeBase:
+        """Minimal stand-in for the PredBat instance the component reads through."""
+
+        def __init__(self):
+            """Expose only what _do_training touches."""
+            self.now_utc = now_utc
+
+        def log(self, msg, **kwargs):
+            """Swallow component logging."""
+            return None
+
+    class FakePredictor:
+        """Captures the kwargs the component passes, and pulses the callback like a real run."""
+
+        def train_curriculum(self, *args, **kwargs):
+            """Record every call's progress callback and fire it once, as an epoch would.
+
+            Every call, not just the last: with is_initial the component runs the initial curriculum
+            and then a fine-tune pass, so keeping only the most recent kwargs would let an unwired
+            first call hide behind a correctly wired second one.
+            """
+            callback = kwargs.get("progress_callback")
+            recorded.setdefault("calls", []).append(callback)
+            if callback:
+                callback()
+            return 0.05
+
+    component = LoadMLComponent.__new__(LoadMLComponent)
+    component.base = FakeBase()
+    component.log = component.base.log
+    component.last_success_timestamp = None
+    component.predictor = FakePredictor()
+    component.data_lock = asyncio.Lock()
+    component.load_data = {1: 0.1}
+    component.load_data_age_days = 10
+    component.pv_data = None
+    component.temperature_data = None
+    component.import_rates_data = None
+    component.export_rates_data = None
+    component.ml_epochs_initial = 3
+    component.ml_epochs_update = 3
+    component.ml_time_decay_days = 30
+    component.ml_validation_holdout_hours = 48
+    component.ml_patience_initial = 3
+    component.ml_patience_update = 3
+    component.ml_curriculum_max_passes = 4
+    component.ml_curriculum_window_days = 7
+    component.ml_curriculum_step_days = 1
+    component.ml_validation_threshold = 2.0
+    component.model_filepath = None
+    component.model_valid = False
+    component.model_status = "not_initialized"
+    component.last_train_time = None
+    component.initial_training_done = False
+
+    # Both paths, because _do_training picks a different train_curriculum call site for each - the
+    # initial curriculum or the fine-tune - and wiring only one of them up leaves the other able to
+    # blow past the liveness window unnoticed
+    for is_initial in (False, True):
+        recorded.clear()
+        component.last_success_timestamp = None
+        asyncio.run(component._do_training(is_initial=is_initial))
+
+        calls = recorded.get("calls", [])
+        assert len(calls) == 1, f"is_initial={is_initial}: expected exactly 1 train_curriculum call, got {len(calls)}"
+        for n, callback in enumerate(calls):
+            assert callback is not None, f"_do_training(is_initial={is_initial}) call {n + 1} must pass a progress_callback to train_curriculum"
+            assert callback == component.update_success_timestamp, f"is_initial={is_initial} call {n + 1}: the callback must be the component's own update_success_timestamp, not some other hook"
+        assert component.last_success_timestamp is not None, f"is_initial={is_initial}: firing the callback must move last_success_timestamp so components.is_alive() sees a recent success"
+
+    return True


### PR DESCRIPTION
The component marks itself successful once per loop iteration, at the end - but a curriculum retrain is five passes of thirty epochs and routinely runs longer than the sixty minute window components.is_alive() allows between successes. is_all_alive() then fails, is_running() returns False, and the dashboard shows the whole of Predbat as "(unhealthy)" while nothing is actually wrong.

Restarting the component appears to fix it because that resets the clock, which is exactly why this looked like a crash and stayed hidden - there is nothing in the log, because nothing failed.

train() and train_curriculum() take an optional progress_callback, invoked once per epoch, and the component passes its own update_success_timestamp. On the observed hardware an epoch is around forty seconds, so the pulse has two orders of magnitude of headroom against the window. The hook is guarded: a progress callback must never be able to abort an hour of training.

Both of _do_training's train_curriculum call sites are wired, and the test drives the real _do_training for is_initial True and False, asserting on every call rather than the last - with is_initial the initial curriculum is followed by a fine-tune pass, so recording only the most recent call would let an unwired first one hide behind a correct second. Verified by deleting each call site in turn and confirming the test fails.