### PR TITLE
fix(execute): stop the export target draining the battery below the reserve

### DIFF
--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -624,10 +624,11 @@ class Execute:
             # Set the SoC just before or within the charge window
             if self.set_soc_enable:
                 if isExporting:
+                    export_target_percent = self.export_target_soc_percent()
                     if not disabled_export and not self.set_reserve_enable:
                         # If we are discharging and not setting reserve then we should reset the target SoC to the discharge target
                         # as some inverters can use this as a target for discharge
-                        self.adjust_battery_target_multi(inverter, int(self.export_limits_best[0]), isCharging, isExporting)
+                        self.adjust_battery_target_multi(inverter, export_target_percent, isCharging, isExporting)
                     elif not inverter.inv_has_discharge_enable_time:
                         self.adjust_battery_target_multi(inverter, 0, isCharging, isExporting)
                     elif not self.inverter_hybrid and self.inverter_soc_reset and inverter.inv_has_target_soc:
@@ -642,7 +643,7 @@ class Execute:
                     if self.set_export_freeze and self.export_limits_best[0] == EXPORT_LIMIT_FREEZE:
                         inverter.adjust_export_immediate(inverter.soc_percent, freeze=True)
                     elif not disabled_export:
-                        inverter.adjust_export_immediate(int(self.export_limits_best[0]))
+                        inverter.adjust_export_immediate(export_target_percent)
                     else:
                         inverter.adjust_export_immediate(int(EXPORT_LIMIT_IDLE))  # Dead code right, but kept in case other logic changes
 
@@ -798,6 +799,27 @@ class Execute:
         if not check:
             inverter.adjust_battery_target(new_soc_percent, is_charging, is_exporting)
         return new_soc_percent
+
+    def export_target_soc_percent(self):
+        """
+        Work out the SoC % to hand to the inverter as the export target
+
+        Normally this is just the planned export limit. Where Predbat does not own a reserve register
+        (set_reserve_enable off) the target is the only thing carrying the floor, so it is raised to the
+        reserve. A planned limit of 0 means "empty it as far as you are allowed" - discharge_soc resolves
+        that against the reserve when deciding how far to actually export, but an inverter whose service
+        maps this target onto a device reserve would be told to drain the battery flat instead.
+
+        Left alone when Predbat does own the reserve: adjust_reserve enforces the floor there and the two
+        registers are independent, so raising the target would change behaviour for no benefit.
+
+        Returns:
+        - int: export target as a percentage of the battery
+        """
+        target = int(self.export_limits_best[0])
+        if not self.set_reserve_enable:
+            target = max(target, calc_percent_limit(max(self.reserve, self.best_soc_min), self.soc_max))
+        return target
 
     def is_freeze_charge(self, charge_limit_kwh):
         """

--- a/apps/predbat/tests/test_execute.py
+++ b/apps/predbat/tests/test_execute.py
@@ -520,10 +520,55 @@ def test_fetch_inverter_data_no_extra_pv_when_sensors_match_inverters(my_predbat
     return False
 
 
+def test_export_target_soc_percent(my_predbat):
+    """
+    The export target must carry the reserve floor when Predbat owns no reserve register
+
+    A planned export limit of 0 means "empty it as far as you are allowed". Handing that raw to an
+    inverter whose service maps it onto a device reserve tells it to drain the battery flat, which is
+    what a Powerwall driven by service hooks actually did.
+    """
+    print("  - test_export_target_soc_percent")
+    failed = False
+    saved = (my_predbat.export_limits_best, my_predbat.set_reserve_enable, my_predbat.reserve, my_predbat.best_soc_min, my_predbat.soc_max)
+
+    my_predbat.soc_max = 10.0
+    my_predbat.reserve = 1.0  # 10%
+    my_predbat.best_soc_min = 0.0
+
+    cases = [
+        # (export limit, reserve control, expected target)
+        (0, False, 10),  # the reported bug: 0 would drain the battery flat
+        (5, False, 10),  # below the reserve, still raised
+        (20, False, 20),  # above the reserve, left alone
+        (0, True, 0),  # Predbat owns the reserve, so the target is not its job
+        (20, True, 20),
+    ]
+    for limit, reserve_enable, expect in cases:
+        my_predbat.export_limits_best = [limit]
+        my_predbat.set_reserve_enable = reserve_enable
+        got = my_predbat.export_target_soc_percent()
+        if got != expect:
+            print("ERROR: export target for limit {} with set_reserve_enable={} should be {} got {}".format(limit, reserve_enable, expect, got))
+            failed = True
+
+    # best_soc_min above the reserve wins, matching how discharge_soc resolves the floor
+    my_predbat.best_soc_min = 3.0  # 30%
+    my_predbat.export_limits_best = [0]
+    my_predbat.set_reserve_enable = False
+    if my_predbat.export_target_soc_percent() != 30:
+        print("ERROR: export target should follow best_soc_min of 30%, got {}".format(my_predbat.export_target_soc_percent()))
+        failed = True
+
+    my_predbat.export_limits_best, my_predbat.set_reserve_enable, my_predbat.reserve, my_predbat.best_soc_min, my_predbat.soc_max = saved
+    return failed
+
+
 def run_execute_tests(my_predbat):
     print("**** Running execute tests ****\n")
 
-    failed = test_fetch_inverter_data_extra_pv_sensors(my_predbat)
+    failed = test_export_target_soc_percent(my_predbat)
+    failed |= test_fetch_inverter_data_extra_pv_sensors(my_predbat)
     failed |= test_fetch_inverter_data_extra_pv_sensors_invalid_value(my_predbat)
     failed |= test_fetch_inverter_data_no_extra_pv_when_sensors_match_inverters(my_predbat)
     if failed:


### PR DESCRIPTION
An export limit of 0 means "empty it as far as you are allowed", and the reserve is what says how far that is. discharge_soc resolves it that way when deciding how far to actually export, but the raw unclamped limit was handed to adjust_export_immediate and adjust_battery_target_multi. On an inverter whose service maps that target onto a device reserve, the result is an instruction to drain the battery flat.

Observed on a Powerwall driven by service hooks: Predbat logged "current SoC 10.719kWh and target 1.35kWh" - correctly targeting the 5% reserve - while simultaneously writing backup_reserve 0 to the device, which then discharged past 5% towards empty.

Extracted as export_target_soc_percent() so the rule is named and testable. The clamp applies only when set_reserve_enable is off. Where Predbat owns the reserve register that register already enforces the floor and the two are independent, so raising the target there would change long-standing behaviour for no benefit.
