### PR TITLE
control: close eight defects found in continued review of #4638

### DIFF
--- a/apps/predbat/control_ledger.py
+++ b/apps/predbat/control_ledger.py
@@ -35,6 +35,7 @@ IMPLAUSIBLE = "implausible"  # the inverter returned something that cannot be a 
 SETTLING = "settling"  # exception-path guard: a write was noted that never resolved (see observe())
 EXTERNAL = "external"  # everything else ruled out - somebody else changed it
 UNAVAILABLE = "unavailable"  # the entity is not reporting - a non-reading cannot contradict anything
+PENDING = "pending"  # diverged once, with no timing metadata to trust it - see observe()
 
 # The rolling window the customer-facing entity reports over.
 DEFAULT_WINDOW_S = 86400
@@ -305,7 +306,29 @@ class ControlLedger:
         record = self.records.get(entity_id)
         return record["owned_value"] if record else None
 
-    def record_write(self, entity_id, control, read_back, fuzzy=0, now=0.0, generation=None):
+    def owns(self, entity_id):
+        """Return True when Predbat has a confirmed value for this entity."""
+        return entity_id in self.records
+
+    def record_ownership_from_read(self, entity_id, control, read_back, fuzzy=0, now=0.0, generation=None):
+        """Confer ownership from a read that ALREADY holds what Predbat wanted.
+
+        Weaker evidence than record_write() and marked as such - nobody watched this value being
+        set, so all it proves is that Predbat and the inverter currently agree. It exists because
+        the alternative is permanent blindness: once an EXTERNAL event has popped the record, or a
+        clear() has dropped it, a control already sitting at Predbat's target takes the write
+        helpers' no-write-needed early return on every subsequent cycle, so record_write() is
+        never reached again and that control is silently unwatched for the rest of the process.
+
+        Structurally refuses to touch a record that already exists. Re-arming is the only job, and
+        anything that refreshed a live record would revive the ownership age-out this feature has
+        already been burnt by once.
+        """
+        if entity_id in self.records:
+            return
+        self.record_write(entity_id, control, read_back, fuzzy=fuzzy, now=now, generation=generation, confirmed_by="read")
+
+    def record_write(self, entity_id, control, read_back, fuzzy=0, now=0.0, generation=None, confirmed_by="write"):
         """Record a VERIFIED read-back, conferring ownership.
 
         Only ever called with a read-back the write helper has already checked against the
@@ -328,6 +351,9 @@ class ControlLedger:
             "confirmed_at": now,
             "confirmed_generation": generation,
             "wrote_cycle": self.cycle,
+            "confirmed_by": confirmed_by,
+            # The cycle a divergence was first seen, for the persistence rule in observe().
+            "diverged_cycle": None,
         }
 
     def note_write_attempt(self, entity_id):
@@ -357,6 +383,9 @@ class ControlLedger:
             return UNAVAILABLE
 
         if values_match(value, record["owned_value"], record["fuzzy"]):
+            # Agreement resets the persistence rule below: a divergence that came back on its own
+            # was a cached read, not somebody holding the control at a different value.
+            record["diverged_cycle"] = None
             return OWNED
 
         # The read must be newer than the confirmation, by cycle and - where the entity
@@ -381,6 +410,17 @@ class ControlLedger:
         if record["wrote_cycle"] > record["confirmed_cycle"]:
             return SETTLING
 
+        # The freshness gate above FAILS OPEN: where either side has no generation it is skipped
+        # entirely, so a timestamp-less entity plus a vendor serving a cached read of the
+        # pre-write value walks straight to EXTERNAL - the exact false accusation the gate exists
+        # to prevent. With no timing metadata to trust, trust repetition instead: a cached read
+        # resolves on the next poll, somebody genuinely holding the control at another value does
+        # not. Two DISTINCT cycles, because a second pass inside one cycle can be the same read.
+        if generation is None or record["confirmed_generation"] is None:
+            if record["diverged_cycle"] is None or record["diverged_cycle"] == self.cycle:
+                record["diverged_cycle"] = self.cycle
+                return PENDING
+
         event = {
             "at": now,
             "control": control,
@@ -388,6 +428,7 @@ class ControlLedger:
             "we_set": record["owned_value"],
             "now_reads": value,
             "confirmed_at": record["confirmed_at"],
+            "confirmed_by": record["confirmed_by"],
         }
         self.events.append(event)
         self.session_events.append(event)
@@ -444,12 +485,18 @@ class ControlLedger:
         Events detected by THIS process are therefore kept ahead of restored history, whatever
         their timestamp says, and the remaining room goes to the newest history by time.
         """
+        if limit <= 0:
+            # [-0:] is the WHOLE list, so a zero or negative cap published everything.
+            return []
         if len(self.events) <= limit:
             return sorted(self.events, key=_event_sort_key)
         detected = {id(event) for event in self.session_events}
         mine = [event for event in self.events if id(event) in detected]
         if len(mine) >= limit:
-            return self.session_events[-limit:]
+            # Same events as `mine`, since prune() keeps the two lists in step - but in DETECTION
+            # order, which is what "keep the most recent" means when their timestamps are the very
+            # thing in doubt. Sorted on the way out to honour the oldest-first contract.
+            return sorted(self.session_events[-limit:], key=_event_sort_key)
         history = sorted((event for event in self.events if id(event) not in detected), key=_event_sort_key)
         return sorted(history[len(history) - (limit - len(mine)) :] + mine, key=_event_sort_key)
 
@@ -462,8 +509,15 @@ class ControlLedger:
 
         Takes the windowed list rather than a `now`/`window_s` pair so there is exactly one
         place the window is applied - a signature accepting both silently ignored one of them.
+
+        Counted per ENTITY, reported per control NAME. Counting by name conflated inverters: on a
+        three-inverter site one single external change to each inverter's own charge window is
+        three events all named "charge_start_time", which tripped a threshold meant to say "this
+        one control keeps being changed back". Three different controls touched once each is not
+        the repeated tug-of-war the threshold exists to find.
         """
         counts = {}
+        names = {}
         for event in events:
             # restore() does not require "control" to be present, so a restored event can carry
             # control=None or a non-name. The result is written straight into a customer-facing
@@ -472,8 +526,14 @@ class ControlLedger:
             control = event.get("control") if isinstance(event, dict) else None
             if not isinstance(control, str) or not control.strip():
                 continue
-            counts[control] = counts.get(control, 0) + 1
-        return sorted(control for control, count in counts.items() if count >= threshold)
+            # Keyed on the entity where there is one, falling back to the name for an event
+            # restored from a version that did not record it. An entity id always contains a dot
+            # and a control name never does, so the two key spaces cannot collide.
+            entity_id = event.get("entity_id")
+            key = entity_id if isinstance(entity_id, str) and entity_id.strip() else control
+            counts[key] = counts.get(key, 0) + 1
+            names[key] = control
+        return sorted({names[key] for key, count in counts.items() if count >= threshold})
 
     def prune(self, now, window_s=DEFAULT_WINDOW_S):
         """WRITE path: drop only what has genuinely aged out, so the list cannot grow unbounded.
@@ -485,6 +545,19 @@ class ControlLedger:
         real 24 hours of history irrecoverably on the very next publish. The clock corrects; the
         events have to still be there when it does.
         """
+        # A timestamp further ahead than the jitter allowance is CLAMPED to now rather than kept
+        # as it was. The detection was real; the timestamp was not - a pod that boots with its
+        # clock ahead stamps events in the future, and after the clock steps back they can never
+        # age out, because ageing out is exactly what keeping future-dated events prevents. They
+        # then squat every publish slot for the life of the process. Clamping brings them back inside the window
+        # so they count once and age out on schedule, and does the same good turn to the
+        # slow-clock restore case.
+        for event in self.events:
+            if not isinstance(event, dict):
+                continue
+            at = _event_time(event)
+            if at is not None and at > now + CLOCK_JITTER_S:
+                event["at"] = now
         self.events = self._in_window(now, window_s, drop_future=False)
         # Keep the protected set in step, or it grows for the life of the process and can protect
         # events that have already aged out of the store.

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -105,14 +105,26 @@ class Execute:
     adjustment, and multi-inverter balancing.
     """
 
-    def clear_control_ledger(self):
+    def clear_control_ledger(self, reason):
         """Drop every control ownership record, if the ledger is configured.
 
-        Called wherever PredBat stops controlling the inverter - read-only mode and
-        calibration.
+        Called wherever PredBat stops controlling the inverter - read-only mode and calibration.
+
+        Deliberately global, and both callers are genuinely fleet-wide even though they read as
+        though they were per-inverter. set_read_only is one config flag for the whole install. And
+        the calibration branch, on finding ANY inverter in calibration, writes charge rate,
+        discharge rate, battery target and reserve to EVERY inverter through the ordinary helpers
+        before breaking out - so every inverter's ownership is conferred there and every
+        inverter's has to go. Scoping this to the inverter that happened to trigger it would leave
+        the others owning values calibration itself had just written.
+
+        Logged because a user whose detection reports nothing needs to be able to find out why.
         """
-        if self.control_ledger is not None:
-            self.control_ledger.clear()
+        if self.control_ledger is None:
+            return
+        if self.control_ledger.records:
+            self.log("Control ledger: dropping ownership of {} control(s) - {}".format(len(self.control_ledger.records), reason))
+        self.control_ledger.clear()
 
     def execute_plan(self):
         # Per-inverter detail segments, assembled into the status text after the headline status is
@@ -143,7 +155,7 @@ class Execute:
         # PredBat is no longer controlling anything, so it is not ours to claim. set_read_only
         # is a global flag, so this is decided once rather than re-decided per inverter.
         if self.set_read_only:
-            self.clear_control_ledger()
+            self.clear_control_ledger("read-only mode is enabled, so Predbat is not setting anything")
 
         isCharging = False
         isExporting = False
@@ -171,7 +183,7 @@ class Execute:
                 # exactly the mode where the inverter's own firmware is driving its settings.
                 # A value found moved next cycle is the inverter calibrating, not a third
                 # party, so ownership is dropped after the writes rather than before them.
-                self.clear_control_ledger()
+                self.clear_control_ledger("inverter {} is calibrating, so its own firmware is driving the settings".format(inverter.id))
                 break
 
             resetDischarge = self.set_charge_window or self.set_export_window
@@ -1020,6 +1032,13 @@ class Execute:
         """
         if self.inverters is None:
             return False
+        # Its own control-ledger cycle. This runs every 120s and reaches update_status(), which
+        # writes scheduled_charge_enable through write_and_poll_switch - so it both observes and
+        # confirms. Without advancing the cycle, every observation here was unconditionally STALE
+        # (cycle <= confirmed_cycle) and its confirmations collided with the plan run's. Every
+        # entry point that can observe or confirm gets its own cycle.
+        if self.control_ledger is not None:
+            self.control_ledger.begin_cycle()
         if self.fetch_inverter_data(create=False):
             self.publish_inverter_data()
             return True

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2030,8 +2030,8 @@ class Inverter:
         observe()'s verdict is otherwise discarded at all three call sites, which makes the
         whole suppression ladder invisible. When a customer reports interference and the
         entity reads 0 there is then no way to tell whether the ledger owned nothing,
-        suppressed on the freshness gate, refused the read as implausible, saw a dropout, or
-        had been wiped by a service template - four completely different problems that look
+        suppressed on the freshness gate, refused the read as implausible, saw a dropout, or is
+        holding a divergence pending a repeat - five completely different problems that look
         identical from outside. This line is the feature's only diagnostic.
         """
         owned = ledger.owned_value(entity_id)
@@ -2068,6 +2068,14 @@ class Inverter:
 
         if current_state == new_value:
             self.base.log("Inverter {} write_and_poll_switch: No write needed for {} as {} == {}".format(self.id, name, new_value, current_state))
+            # Re-arm. Once an EXTERNAL event (or a clear) has dropped ownership, a control already
+            # sitting at Predbat's target reaches this early return on every cycle from now on, so
+            # record_write() below is never called again and the control is silently unwatched for
+            # the rest of the process. record_ownership_from_read() refuses to touch a live record,
+            # so this only ever fills that gap - see its docstring for why a matching read is
+            # weaker but sufficient evidence.
+            if ledger is not None:
+                ledger.record_ownership_from_read(entity_id, name, raw_state, now=time.time(), generation=self._ledger_generation(entity_id))
             return True
 
         retry = 0
@@ -2173,6 +2181,10 @@ class Inverter:
 
         if retry == 0:
             self.base.log(f"Inverter {self.id} write_and_poll_value: No write needed for {name}: {new_value} == {current_state} fuzzy {fuzzy}")
+            # Re-arm - see write_and_poll_switch() for why this early return would otherwise leave
+            # the control unwatched for good once ownership had been dropped.
+            if ledger is not None:
+                ledger.record_ownership_from_read(entity_id, name, raw_state, fuzzy=fuzzy, now=time.time(), generation=self._ledger_generation(entity_id))
             return True
         elif matched:
             self.base.log(f"Inverter {self.id} write_and_poll_value: Wrote {new_value} to {name}, successfully now {current_state}")

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -1119,10 +1119,11 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
                 "state_class": "measurement",
                 "unit_of_measurement": "changes",
                 "icon": "mdi:account-alert",
-                # Newest 20 BY TIME. The stored list is sorted by restore(), so on a pod whose clock
-                # is behind, this run's real event carries a small "at", sorts to index 0, and a
-                # plain [-20:] tail discarded the very event just detected - from the attribute that
-                # IS the durable store.
+                # Newest 20, but explicitly NOT purely by time - see newest_events(). This
+                # attribute is the durable store restore() reads back, and on a pod whose clock is
+                # behind, the event just detected carries a small "at" and looks like the oldest
+                # thing here, so any by-time cap would discard exactly the one that cannot be
+                # recovered from anywhere else.
                 "events": self.control_ledger.newest_events(20),
                 "sustained": sustained,
             },

--- a/apps/predbat/tests/test_control_ledger.py
+++ b/apps/predbat/tests/test_control_ledger.py
@@ -25,6 +25,7 @@ from control_ledger import (
     SETTLING,
     EXTERNAL,
     UNAVAILABLE,
+    PENDING,
 )
 from const import INVERTER_MAX_RETRY
 
@@ -460,8 +461,11 @@ class _RecordingLedger:
     def note_write_attempt(self, entity_id):
         self.calls.append(("note_write_attempt", entity_id))
 
-    def record_write(self, entity_id, control, read_back, fuzzy=0, now=0.0, generation=None):
+    def record_write(self, entity_id, control, read_back, fuzzy=0, now=0.0, generation=None, confirmed_by="write"):
         self.calls.append(("record_write", entity_id, control, read_back))
+
+    def record_ownership_from_read(self, entity_id, control, read_back, fuzzy=0, now=0.0, generation=None):
+        self.calls.append(("record_ownership_from_read", entity_id, control, read_back))
 
     def clear(self, entity_id=None):
         self.calls.append(("clear", entity_id))
@@ -550,7 +554,7 @@ def _stub_inverter(state_sequence, ledger=None, generation=1000.0):
 
 
 def test_wiring_no_write_needed_skips_note_and_record():
-    """A read that already matches must not be treated as a write attempt.
+    """A read that already matches must not be treated as a write attempt - but must re-arm.
 
     This is the property that matters most: if note_write_attempt fired here with no matching
     record_write, the control would be stuck reporting SETTLING forever (correction 2 in the
@@ -564,7 +568,7 @@ def test_wiring_no_write_needed_skips_note_and_record():
     if not stub.write_and_poll_switch("enable", "switch.charge_enable", True):
         print("ERROR: write_and_poll_switch should report success with nothing to do")
         failed = True
-    if ledger.calls != [("observe", "switch.charge_enable", "enable", True)]:
+    if ledger.calls != [("observe", "switch.charge_enable", "enable", True), ("record_ownership_from_read", "switch.charge_enable", "enable", True)]:
         print(f"ERROR: write_and_poll_switch no-write-needed call list was {ledger.calls}")
         failed = True
 
@@ -573,7 +577,7 @@ def test_wiring_no_write_needed_skips_note_and_record():
     if not stub.write_and_poll_value("charge_limit", "number.charge_limit", 50.0, fuzzy=0):
         print("ERROR: write_and_poll_value should report success with nothing to do")
         failed = True
-    if ledger.calls != [("observe", "number.charge_limit", "charge_limit", 50.0)]:
+    if ledger.calls != [("observe", "number.charge_limit", "charge_limit", 50.0), ("record_ownership_from_read", "number.charge_limit", "charge_limit", 50.0)]:
         print(f"ERROR: write_and_poll_value no-write-needed call list was {ledger.calls}")
         failed = True
 
@@ -1094,6 +1098,31 @@ def test_sustained_lists_repeat_offenders():
     if sustained != ["charge_start_time"]:
         print(f"ERROR: expected only charge_start_time sustained, got {sustained}")
         failed = True
+
+    # ...on ONE control, meaning one ENTITY. On a three-inverter site, one single external change
+    # to each inverter's own charge window is three events all named "charge_start_time", which is
+    # three controls touched once each - not the repeated tug-of-war the threshold exists to find.
+    ledger = ControlLedger()
+    ledger.events = [{"at": 1000.0 + n, "control": "charge_start_time", "entity_id": f"select.inverter{n}_charge_start", "we_set": "23:30", "now_reads": "19:42", "confirmed_at": 900.0} for n in range(3)]
+    sustained = ledger.sustained_controls(ledger.recent_events(now=1100.0), threshold=3)
+    if sustained:
+        print(f"ERROR: one change per inverter was reported as a sustained control: {sustained}")
+        failed = True
+
+    # An event restored from a version that did not record entity_id still counts, keyed by name,
+    # rather than being silently dropped.
+    ledger = ControlLedger()
+    ledger.events = [{"at": 1000.0 + n, "control": "reserve"} for n in range(3)]
+    if ledger.sustained_controls(ledger.recent_events(now=1100.0), threshold=3) != ["reserve"]:
+        print("ERROR: legacy events with no entity_id were dropped instead of counted by name")
+        failed = True
+
+    # A control name is reported once however many of its entities are sustained.
+    ledger = ControlLedger()
+    ledger.events = [{"at": 1000.0 + n, "control": "reserve", "entity_id": f"number.inverter{n // 3}_reserve"} for n in range(6)]
+    if ledger.sustained_controls(ledger.recent_events(now=1100.0), threshold=3) != ["reserve"]:
+        print(f"ERROR: a control sustained on two entities was not reported once: {ledger.sustained_controls(ledger.recent_events(now=1100.0))}")
+        failed = True
     assert not failed, "test_sustained_lists_repeat_offenders"
 
 
@@ -1362,31 +1391,59 @@ def test_steady_control_stays_owned_indefinitely():
     assert not failed, "test_steady_control_stays_owned_indefinitely"
 
 
-def test_prune_keeps_future_dated_events():
-    """prune() maintains the DURABLE store, so it must not delete what it merely cannot judge.
+def test_prune_clamps_future_dated_events():
+    """prune() maintains the DURABLE store, so it must neither delete nor immortalise.
 
-    The publisher writes the pruned list back to the entity attribute restore() reads, so
-    anything prune() drops is gone for good. A pod that starts before NTP sync with a slow clock
-    makes every restored event compute as future-dated - pruning on that basis deletes a real 24
-    hours of history irrecoverably on the very first publish. The clock corrects; the events have
-    to still be there when it does.
+    The publisher writes the pruned list back to the attribute restore() reads, so anything
+    prune() drops is gone for good - a pod starting before NTP sync with a slow clock makes every
+    restored event compute as future-dated, and deleting on that basis loses a real 24 hours of
+    history on the first publish.
+
+    But KEEPING them beyond judgement was its own trap in the other clock direction: a pod that boots
+    with its clock ahead stamps events in the future, and once the clock steps back those events
+    can never age out, because not ageing out is precisely what "keep future-dated events" means.
+    They then squat every publish slot for the life of the process. The timestamp was wrong; the
+    detection was real. So the timestamp is clamped, which keeps the event and lets it age out.
     """
     failed = False
+
+    # Clock AHEAD: events stamped in the future must be clamped, not immortal.
+    ledger = ControlLedger()
+    ledger.restore([{"at": 9_000_000.0, "control": "reserve", "entity_id": "e1"}, {"at": 950.0, "control": "reserve", "entity_id": "e2"}])
+    ledger.prune(now=1000.0)
+    if len(ledger.events) != 2:
+        print(f"ERROR: prune() deleted a future-dated event instead of clamping it: {ledger.events}")
+        failed = True
+    if any(event["at"] > 1000.0 for event in ledger.events):
+        print(f"ERROR: a future-dated event was not clamped: {[e['at'] for e in ledger.events]}")
+        failed = True
+    if len(ledger.recent_events(now=1000.0)) != 2:
+        print("ERROR: a clamped event still cannot be judged, so it can never age out")
+        failed = True
+    # And having been clamped it ages out on schedule rather than living for ever.
+    ledger.prune(now=1000.0 + 2 * 86400.0)
+    if ledger.events:
+        print(f"ERROR: a clamped event did not age out: {ledger.events}")
+        failed = True
+
+    # Clock BEHIND: restored history must survive, and can be judged straight away.
     ledger = ControlLedger()
     ledger.restore([{"at": 5000.0, "control": "reserve"}, {"at": 5100.0, "control": "reserve"}])
-    # A clock ten minutes slow makes both look future-dated.
     slow_clock = 4400.0
     ledger.prune(now=slow_clock)
     if len(ledger.events) != 2:
         print(f"ERROR: prune() on a slow clock deleted real history: {ledger.events}")
         failed = True
-    # They are still not COUNTED while they cannot be judged - the count is a claim, the store is not.
-    if ledger.recent_events(now=slow_clock):
-        print("ERROR: future-dated events were counted as if they could be judged")
+    if len(ledger.recent_events(now=slow_clock)) != 2:
+        print("ERROR: clamping did not bring slow-clock history back into the window")
         failed = True
-    # Once the clock corrects they come back.
-    if len(ledger.recent_events(now=5200.0)) != 2:
-        print("ERROR: events were not judged again once the clock corrected")
+
+    # Ordinary forward jitter is inside the allowance, so it is left exactly as it was.
+    ledger = ControlLedger()
+    ledger.events = [{"at": 1030.0, "control": "reserve"}]
+    ledger.prune(now=1000.0)
+    if [event["at"] for event in ledger.events] != [1030.0]:
+        print(f"ERROR: prune() clamped ordinary clock jitter: {ledger.events}")
         failed = True
 
     # What HAS genuinely aged out still goes, or the list grows without bound.
@@ -1404,7 +1461,7 @@ def test_prune_keeps_future_dated_events():
     if [event["at"] for event in ledger.events] != [950.0]:
         print(f"ERROR: prune() kept unparseable events: {ledger.events}")
         failed = True
-    assert not failed, "test_prune_keeps_future_dated_events"
+    assert not failed, "test_prune_clamps_future_dated_events"
 
 
 def test_minute_control_rejects_a_wall_clock_on_an_integer_entity():
@@ -1579,6 +1636,242 @@ def test_begin_cycle_precedes_every_inverter_read():
     assert not failed, "test_begin_cycle_precedes_every_inverter_read"
 
 
+def test_newest_events_honours_its_contract():
+    """The publish cap must be oldest-first, and must respect a zero cap.
+
+    Two defects in one method. The "session events alone exceed the cap" branch returned
+    self.session_events[-limit:] unsorted, breaking the oldest-first contract it documents - and
+    reading a different list from the `mine` it had just computed. And newest_events(0) returned
+    EVERYTHING, because [-0:] is the whole list, not the empty one.
+    """
+    failed = False
+
+    def _detect(ledger, at, entity_id):
+        """Drive a real detection, so events are shaped the way production shapes them."""
+        ledger.begin_cycle()
+        ledger.record_write(entity_id, "reserve", 4.0, now=at - 1.0, generation=at - 1.0)
+        ledger.begin_cycle()
+        ledger.observe(entity_id, "reserve", 50.0, now=at, generation=at)
+
+    # More session events than the cap: keep the most recently DETECTED, output oldest-first.
+    ledger = ControlLedger()
+    for n in range(5):
+        _detect(ledger, 1000.0 - n, f"number.e{n}")  # detected in DESCENDING time order
+    published = ledger.newest_events(3)
+    if len(published) != 3:
+        print(f"ERROR: expected 3 published events, got {len(published)}")
+        failed = True
+    if [event["at"] for event in published] != sorted(event["at"] for event in published):
+        print(f"ERROR: published events are not oldest-first: {[e['at'] for e in published]}")
+        failed = True
+    if {event["entity_id"] for event in published} != {"number.e2", "number.e3", "number.e4"}:
+        print(f"ERROR: the most recently detected events were not the ones kept: {[e['entity_id'] for e in published]}")
+        failed = True
+
+    for limit in (0, -1):
+        if ledger.newest_events(limit) != []:
+            print(f"ERROR: newest_events({limit}) published {len(ledger.newest_events(limit))} events instead of none")
+            failed = True
+
+    # Under the cap, everything, still oldest-first.
+    ledger = ControlLedger()
+    _detect(ledger, 1000.0, "number.only")
+    ledger.restore([{"at": 900.0, "control": "reserve", "entity_id": "history"}])
+    published = ledger.newest_events(20)
+    if [event["entity_id"] for event in published] != ["history", "number.only"]:
+        print(f"ERROR: an under-cap publish was not the whole store oldest-first: {[e['entity_id'] for e in published]}")
+        failed = True
+
+    # And a just-detected event still beats restored history when the cap bites, even though its
+    # small timestamp makes it look like the oldest thing in the store.
+    ledger = ControlLedger()
+    _detect(ledger, 1000.0, "number.detected_now")
+    ledger.restore([{"at": 5000.0 + n, "control": "reserve", "entity_id": f"h{n}"} for n in range(25)])
+    published = ledger.newest_events(20)
+    if not any(event["entity_id"] == "number.detected_now" for event in published):
+        print("ERROR: the just-detected event was dropped by the publish cap")
+        failed = True
+    assert not failed, "test_newest_events_honours_its_contract"
+
+
+def test_ownership_re_arms_when_no_write_is_needed():
+    """A control already at Predbat's target must not stay unwatched once ownership is dropped.
+
+    read-only and calibration clear the ledger, and an EXTERNAL event pops one record. When
+    Predbat resumes, any control already sitting at its target takes write_and_poll_*'s
+    no-write-needed early return, so record_write() is never reached and that control is silently
+    unwatched for the rest of the process. A read that already holds what Predbat wanted is weaker
+    evidence than a verified write - nobody watched it being set - but it is evidence of
+    agreement, and the alternative is permanent blindness.
+    """
+    failed = False
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter([2000.0, 2950.0], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+    ledger.clear()  # read-only or calibration
+
+    ledger.begin_cycle()
+    stub = _stub_inverter([2950.0], ledger=ledger, generation=2000.0)  # already at target, no write
+    stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+    if not ledger.owns("number.charge_rate"):
+        print("ERROR: a control already at target was never re-armed after a clear")
+        failed = True
+    elif ledger.records["number.charge_rate"]["confirmed_by"] != "read":
+        print("ERROR: re-armed ownership was not marked as the weaker read-confirmed evidence")
+        failed = True
+
+    # Having re-armed, a genuine later change reports.
+    ledger.begin_cycle()
+    stub = _stub_inverter([500.0, 2950.0], ledger=ledger, generation=3000.0)
+    stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+    if len(ledger.events) != 1:
+        print(f"ERROR: a change after re-arming produced {len(ledger.events)} events, expected 1")
+        failed = True
+
+    # The same for a switch already in position.
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter(["on"], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_switch("enable", "switch.charge_enable", True)
+    if not ledger.owns("switch.charge_enable"):
+        print("ERROR: a switch already at target was never armed")
+        failed = True
+
+    # write_and_poll_option needs no such path: it always issues at least one write and confirms
+    # from the read-back, so record_write() is reached even when the value already matched.
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter(["Eco"], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_option("inverter_mode", "select.inverter_mode", "Eco")
+    if not ledger.owns("select.inverter_mode"):
+        print("ERROR: write_and_poll_option did not confer ownership on an already-matching value")
+        failed = True
+
+    # And re-arming must NEVER touch a live record - that is how the ownership age-out crept in.
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    stub = _stub_inverter([2000.0, 2950.0], ledger=ledger, generation=1000.0)
+    stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+    before = dict(ledger.records["number.charge_rate"])
+    ledger.begin_cycle()
+    stub = _stub_inverter([2950.0], ledger=ledger, generation=9999.0)
+    stub.write_and_poll_value("charge_rate", "number.charge_rate", 3000, fuzzy=130)
+    after = ledger.records["number.charge_rate"]
+    if after["confirmed_cycle"] != before["confirmed_cycle"] or after["confirmed_generation"] != before["confirmed_generation"] or after["confirmed_by"] != "write":
+        print(f"ERROR: a no-write-needed read modified a live record: {before} -> {after}")
+        failed = True
+    assert not failed, "test_ownership_re_arms_when_no_write_is_needed"
+
+
+def test_divergence_without_timing_metadata_must_repeat():
+    """The freshness gate FAILS OPEN, so without it a divergence has to prove itself by repeating.
+
+    Where either side has no generation the gate is skipped entirely - so a timestamp-less entity
+    plus a vendor serving a cached read of the pre-write value walks straight to EXTERNAL, the
+    exact false accusation the gate exists to prevent. With no timing metadata to trust, trust
+    repetition: a cached read resolves on the next poll, somebody holding the control at another
+    value does not.
+    """
+    failed = False
+    for label, confirmed_generation, read_generation in (
+        ("neither side has a generation", None, None),
+        ("the record has none", None, 400.0),
+        ("the read has none", 100.0, None),
+    ):
+        ledger = ControlLedger()
+        ledger.begin_cycle()
+        ledger.record_write("number.reserve", "reserve", 4.0, now=100.0, generation=confirmed_generation)
+        ledger.begin_cycle()
+        if ledger.observe("number.reserve", "reserve", 50.0, now=200.0, generation=read_generation) != PENDING:
+            print(f"ERROR: a first divergence with no gate ({label}) was not held pending")
+            failed = True
+        if ledger.events:
+            print(f"ERROR: a first divergence with no gate ({label}) was reported: {ledger.events}")
+            failed = True
+        # A second look in the SAME cycle is the same possibly-cached read, so it proves nothing.
+        if ledger.observe("number.reserve", "reserve", 50.0, now=210.0, generation=read_generation) != PENDING:
+            print(f"ERROR: a repeat within one cycle ({label}) was treated as persistence")
+            failed = True
+        # A distinct cycle does.
+        ledger.begin_cycle()
+        if ledger.observe("number.reserve", "reserve", 50.0, now=300.0, generation=read_generation) != EXTERNAL:
+            print(f"ERROR: a divergence persisting across cycles ({label}) was not reported")
+            failed = True
+        if len(ledger.events) != 1:
+            print(f"ERROR: expected exactly one event for {label}, got {len(ledger.events)}")
+            failed = True
+
+    # A divergence that resolves on its own is a cached read, and must not count toward the next.
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("number.reserve", "reserve", 4.0, now=100.0, generation=None)
+    ledger.begin_cycle()
+    ledger.observe("number.reserve", "reserve", 50.0, now=200.0, generation=None)  # pending
+    ledger.begin_cycle()
+    if ledger.observe("number.reserve", "reserve", 4.0, now=300.0, generation=None) != OWNED:
+        print("ERROR: the value coming back was not treated as agreement")
+        failed = True
+    ledger.begin_cycle()
+    if ledger.observe("number.reserve", "reserve", 50.0, now=400.0, generation=None) != PENDING:
+        print("ERROR: a stale pending divergence survived the value coming back")
+        failed = True
+    if ledger.events:
+        print(f"ERROR: a resolved-then-new divergence was reported immediately: {ledger.events}")
+        failed = True
+
+    # With generation on BOTH sides the gate does its job and behaviour is unchanged.
+    ledger = ControlLedger()
+    ledger.begin_cycle()
+    ledger.record_write("number.reserve", "reserve", 4.0, now=100.0, generation=100.0)
+    ledger.begin_cycle()
+    if ledger.observe("number.reserve", "reserve", 50.0, now=200.0, generation=200.0) != EXTERNAL:
+        print("ERROR: a divergence with a working freshness gate was delayed")
+        failed = True
+    assert not failed, "test_divergence_without_timing_metadata_must_repeat"
+
+
+def test_every_entry_point_opens_its_own_cycle():
+    """Anything that can observe or confirm needs its own cycle number.
+
+    quick_inverter_data_update() runs every 120s and reaches update_status(), which writes
+    scheduled_charge_enable through write_and_poll_switch - so it both observes and confirms.
+    Without advancing the cycle its observations were unconditionally STALE and its confirmations
+    collided with the plan run's.
+    """
+    failed = False
+    from execute import Execute
+
+    stub = Execute.__new__(Execute)
+    ledger = ControlLedger()
+    stub.control_ledger = ledger
+    stub.inverters = []
+    stub.fetch_inverter_data = lambda create=True: False
+    before = ledger.cycle
+    stub.quick_inverter_data_update()
+    if ledger.cycle != before + 1:
+        print(f"ERROR: quick_inverter_data_update did not open a cycle ({before} -> {ledger.cycle})")
+        failed = True
+
+    # No inverters at all cannot observe or confirm, so it must not burn a cycle.
+    stub.inverters = None
+    before = ledger.cycle
+    stub.quick_inverter_data_update()
+    if ledger.cycle != before:
+        print("ERROR: quick_inverter_data_update opened a cycle with no inverters to read")
+        failed = True
+
+    # A missing ledger must not take the path out.
+    stub.inverters = []
+    stub.control_ledger = None
+    try:
+        stub.quick_inverter_data_update()
+    except Exception as e:
+        print(f"ERROR: quick_inverter_data_update raised with no ledger configured: {e}")
+        failed = True
+    assert not failed, "test_every_entry_point_opens_its_own_cycle"
+
+
 def run_control_ledger_tests(my_predbat):
     """Run all control ledger tests."""
     failed = False
@@ -1620,6 +1913,10 @@ def run_control_ledger_tests(my_predbat):
         ("restore_rehydrates", test_restore_rehydrates_and_filters),
         ("restore_ignores_non_list", test_restore_ignores_non_list_attribute),
         ("sustained_controls", test_sustained_lists_repeat_offenders),
+        ("newest_events_contract", test_newest_events_honours_its_contract),
+        ("cycle_per_entry_point", test_every_entry_point_opens_its_own_cycle),
+        ("re_arms_no_write_needed", test_ownership_re_arms_when_no_write_is_needed),
+        ("divergence_must_repeat", test_divergence_without_timing_metadata_must_repeat),
         ("restore_string_at_safe", test_restored_event_with_string_at_does_not_raise),
         ("sustained_survives_missing_control", test_sustained_controls_survives_event_missing_control_key),
         ("future_dated_events_not_counted", test_future_dated_events_are_not_counted),
@@ -1627,7 +1924,7 @@ def run_control_ledger_tests(my_predbat):
         ("is_plausible_hour_minute", test_is_plausible_validates_hour_and_minute_components),
         ("implausible_hour_logged", test_implausible_hour_read_is_suppressed_and_logged),
         ("steady_control_stays_owned", test_steady_control_stays_owned_indefinitely),
-        ("prune_keeps_future_events", test_prune_keeps_future_dated_events),
+        ("prune_clamps_future_events", test_prune_clamps_future_dated_events),
         ("minute_rejects_wall_clock", test_minute_control_rejects_a_wall_clock_on_an_integer_entity),
         ("plausibility_both_directions", test_plausibility_is_owned_aware_in_both_directions),
         ("publish_cap_keeps_detected", test_publish_cap_never_drops_an_event_we_just_detected),


### PR DESCRIPTION
## What

Follow-up to #4638: continued review of the merged code found eight defects in the control ownership ledger. This fixes them, with **no change to the ledger API** the Metrics dashboard (fb8120f6) consumes — `test_metrics_dashboard_control_conflicts` passes unmodified, and is the acceptance test for that claim.

(An earlier revision of this PR proposed replacing the event window with a bare counter; withdrawn — the dashboard's event/sustained detail is exactly what a bare count can't provide, as its own docstring says.)

## The fixes

**False-accusation paths closed:**

- **The freshness gate failed open.** When either side had no timing metadata the gate was skipped entirely, so a timestamp-less entity plus a vendor serving a cached pre-write read produced exactly the false accusation the gate exists to prevent. Without timing metadata, a divergence must now persist across two distinct cycles before it is reported (a new `PENDING` verdict) — a cached read resolves on the next poll; somebody genuinely holding the control does not. Costs one cycle of latency on timestamp-less entities only.
- **`sustained_controls()` conflated inverters.** It counted by control *name*, so on a three-inverter install one external change per inverter tripped the sustained threshold. It now counts per entity and reports the control name.

**Silent-blindness paths closed:**

- **`quick_inverter_data_update()` observed outside any ledger cycle.** It runs every 120s between plan runs and confirms through `update_status()`, so all of its observations were unconditionally classified stale — a third-party change between plan runs was silently reverted without ever being reported. Every entry point that can observe now opens its own cycle.
- **A control at Predbat's target was never re-owned after an event or a clear.** The no-write-needed early return skipped `record_write()`, so once ownership was dropped the control became permanently undetectable. A matching read now re-arms ownership when no record exists, recorded as `confirmed_by: "read"` rather than `"write"` — weaker evidence, accepted because the alternative is permanent blindness on any control Predbat has no reason to rewrite. (`write_and_poll_option` needed no change — it always writes at least once — and a test pins that.)

**Robustness:**

- **Clock-ahead poisoning.** A process booting with its clock ahead stamps events in the future; once the clock corrects, those events were never pruned and permanently occupied the 20-event publish cap, evicting all real history. `prune()` now clamps a future-dated timestamp to the current time — the detection was real, the timestamp was not — so the event ages out naturally instead of becoming immortal.
- **`newest_events()`**: one branch returned an unsorted slice violating its own oldest-first contract, and `limit=0` returned the entire list (`[-0:]`). Both fixed and pinned.
- **Calibration/read-only ledger clears now log**, and the docstring records why the clear is deliberately global (the calibration branch writes rates, target and reserve to *every* inverter through the ordinary helpers before breaking out).
- **Doc/test sweeps**: a docstring still describing a deleted suppression path, and a source-order test that string-scraped for one spelling of `fetch_inverter_data()` — replaced with a behavioural pin.

Two review findings are deliberately *not* addressed here because they are design questions about the event window rather than defects — raised separately with our findings so they can be decided rather than patched around.

## Testing

Full quick suite (what CI runs): 268 passed, 0 failed, including `test_metrics_dashboard_control_conflicts` unmodified. Each behavioural fix was verified by reverting it and watching its test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
