### PR TITLE
test(execute): stop freeze capability flags leaking between test scenarios

### DIFF
--- a/apps/predbat/tests/test_execute.py
+++ b/apps/predbat/tests/test_execute.py
@@ -287,6 +287,17 @@ def run_execute_test(
         inverter.reserve_max = reserve_max_array[inverter.id] if reserve_max_array else reserve_max
         inverter.battery_temperature = battery_temperature
 
+    # fetch_inverter_data() only ever narrows the freeze capability flags (it sets them False for an
+    # inverter that doesn't support freeze, and never widens them back), matching production where
+    # fetch_config_options() re-derives them from raw config every cycle before fetch_inverter_data()
+    # runs. This helper calls fetch_inverter_data() directly and is reused across many scenarios in
+    # one process, so re-derive them here too - otherwise a narrowing from an earlier scenario (e.g.
+    # one using an inverter with no freeze support) leaks forward into every later scenario, making
+    # results depend on test ordering.
+    my_predbat.set_charge_freeze = my_predbat.get_arg("set_charge_freeze")
+    my_predbat.set_export_freeze = my_predbat.get_arg("set_export_freeze")
+    my_predbat.set_export_freeze_only = my_predbat.get_arg("set_export_freeze_only")
+
     my_predbat.fetch_inverter_data(create=False)
 
     if my_predbat.soc_kw != soc_kw:
@@ -3062,5 +3073,39 @@ def run_execute_tests(my_predbat):
         failed = True
     if failed:
         return failed
+
+    failed |= test_freeze_flags_do_not_leak_between_scenarios(my_predbat)
+
+    return failed
+
+
+def test_freeze_flags_do_not_leak_between_scenarios(my_predbat):
+    """
+    fetch_inverter_data() narrows the freeze capability flags for an inverter that doesn't support
+    freeze and never widens them back. In production fetch_config_options() re-derives them from raw
+    config every cycle, so the narrowing lasts one cycle; run_execute_test() calls
+    fetch_inverter_data() directly, so without re-deriving them the narrowing would persist for the
+    rest of the process and silently disable freeze in every later scenario.
+    """
+    print("**** Running test_freeze_flags_do_not_leak_between_scenarios ****")
+    failed = False
+    saved = [(inverter.inv_support_charge_freeze, inverter.inv_support_discharge_freeze) for inverter in my_predbat.inverters]
+
+    for inverter in my_predbat.inverters:
+        inverter.inv_support_charge_freeze = False
+        inverter.inv_support_discharge_freeze = False
+    run_execute_test(my_predbat, "freeze_unsupported_inverter", set_charge_window=True, set_export_window=True)
+
+    for inverter, (support_charge, support_discharge) in zip(my_predbat.inverters, saved):
+        inverter.inv_support_charge_freeze = support_charge
+        inverter.inv_support_discharge_freeze = support_discharge
+    run_execute_test(my_predbat, "freeze_supported_inverter_after", set_charge_window=True, set_export_window=True)
+
+    for name in ("set_charge_freeze", "set_export_freeze", "set_export_freeze_only"):
+        expected = my_predbat.get_arg(name)
+        actual = getattr(my_predbat, name)
+        if actual != expected:
+            print("ERROR: {} leaked from the previous scenario - is {} but config says {}".format(name, actual, expected))
+            failed = True
 
     return failed


### PR DESCRIPTION
## Summary

Test-isolation bug found while reworking #4435 - independent of that ticket, so raising separately.

`fetch_inverter_data()` narrows `set_charge_freeze` / `set_export_freeze` / `set_export_freeze_only` when an inverter doesn't support freeze (`execute.py:913-921`), and never widens them back. In production that's correct: `fetch_config_options()` re-derives them from raw config every cycle before `fetch_inverter_data()` runs, so a narrowing lasts exactly one cycle.

`run_execute_test()` calls `fetch_inverter_data()` directly and is reused across many scenarios in a single process, so nothing re-derives them there. A single scenario using a freeze-unsupported inverter would silently disable freeze for **every later scenario in the run** - making test results depend on ordering.

Nothing in the suite currently trips it, so this is preventive rather than a fix to a visibly-failing test - but it's a live trap for anyone adding a freeze-capability scenario later.

## Changes

- Re-derive all three flags from config in `run_execute_test()` before calling `fetch_inverter_data()`.
- New regression test `test_freeze_flags_do_not_leak_between_scenarios`: runs a freeze-unsupported scenario, then a supported one, and asserts all three flags still match config.

## Test plan

- [x] Verified the new test **fails** without the fix (`set_charge_freeze leaked from the previous scenario - is False but config says True`) and passes with it
- [x] `./run_all --test execute` passes
- [x] `./run_pre_commit` passes (full suite, ruff, black, cspell, markdownlint)

No production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)