### PR TITLE
fix(inverter): never degrade an explicit freeze into a real charge or export

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2948,7 +2948,17 @@ class Inverter:
                 self.call_service_template("charge_stop_service", service_data_stop, domain="discharge")
 
             # Start charge or charge freeze
-            if target_soc == self.soc_percent or freeze:
+            if freeze:
+                # An explicit freeze request must never degrade into a real charge. When no
+                # charge_freeze_service is configured, fall back to a plain charge stop: the passive
+                # hold is already established by the caller before we get here (target SoC written to
+                # the current SoC, plus pause_discharge / discharge rate 0 / reserve), so stopping is
+                # a genuine hold. Falling back to charge_start_service instead issued a fresh active
+                # charge command, which some inverters briefly ramp to full power every cycle,
+                # producing repeated short full-rate import bursts (batpred#4424/#4432).
+                if not self.call_service_template("charge_freeze_service", service_data, domain="charge", extra_data=extra_data):
+                    self.call_service_template("charge_stop_service", service_data_stop, domain="charge")
+            elif target_soc == self.soc_percent:
                 if not self.call_service_template("charge_freeze_service", service_data, domain="charge", extra_data=extra_data):
                     self.call_service_template("charge_start_service", service_data, domain="charge", extra_data=extra_data)
             elif not self.inv_has_target_soc and target_soc < self.soc_percent:
@@ -2987,8 +2997,14 @@ class Inverter:
             # to it) whenever export naturally reached its target, regardless of set_export_freeze
             # (batpred#4464).
             if freeze:
+                # As in adjust_charge_immediate(): an explicit freeze request must never degrade into
+                # a real export. Without a discharge_freeze_service configured, fall back to a plain
+                # discharge stop - combined with the charge_stop_service issued just above, that is
+                # neither charging nor force-discharging, i.e. a genuine freeze export. Falling back
+                # to discharge_start_service instead began a real timed export the caller never asked
+                # for (batpred#4424/#4432).
                 if not self.call_service_template("discharge_freeze_service", service_data, domain="discharge", extra_data=extra_data):
-                    self.call_service_template("discharge_start_service", service_data, domain="discharge", extra_data=extra_data)
+                    self.call_service_template("discharge_stop_service", service_data_stop, domain="discharge")
             elif target_soc >= self.soc_percent:
                 self.call_service_template("discharge_stop_service", service_data_stop, domain="discharge")
             else:

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1235,6 +1235,11 @@ def test_call_adjust_charge_immediate(test_name, my_predbat, ha, inv, dummy_item
     ha.service_store_enable = True
     if clear:
         ha.service_store = []
+        # Also drop the charge-domain dedup memory so this call is judged fresh rather than against
+        # whatever the previous sub-test happened to send - mirrors the discharge-domain reset in
+        # test_call_adjust_export_immediate(), and is needed now the freeze fallback collapses onto
+        # the same charge_stop call other sub-tests make (batpred#4424/#4432).
+        my_predbat.last_service_hash.pop("charge", None)
 
     print("**** Running Test: {} ****".format(test_name))
 
@@ -1264,10 +1269,20 @@ def test_call_adjust_charge_immediate(test_name, my_predbat, ha, inv, dummy_item
 
     if repeat:
         pass
-    elif soc == inv.soc_percent or freeze:
+    elif freeze:
         if stop_discharge:
             expected.append(["discharge_stop", {"device_id": "DID0"}])
-        expected.append(["charge_freeze", {"device_id": "DID0", "target_soc": int(soc), "power": power}])
+        if no_freeze:
+            # An explicit freeze with no charge_freeze_service configured must fall back to a plain
+            # charge stop, never a real charge_start_service (batpred#4424/#4432)
+            expected.append(["charge_stop", {"device_id": "DID0"}])
+        else:
+            expected.append(["charge_freeze", {"device_id": "DID0", "target_soc": int(soc), "power": power}])
+    elif soc == inv.soc_percent:
+        if stop_discharge:
+            expected.append(["discharge_stop", {"device_id": "DID0"}])
+        # Reaching the target without an explicit freeze request keeps its existing behaviour
+        expected.append(["charge_freeze" if not no_freeze else "charge_start", {"device_id": "DID0", "target_soc": int(soc), "power": power}])
     elif soc > 0 and (inv.has_target_soc or soc > inv.soc_percent):
         if stop_discharge:
             expected.append(["discharge_stop", {"device_id": "DID0"}])
@@ -1327,7 +1342,12 @@ def test_call_adjust_export_immediate(test_name, my_predbat, ha, inv, dummy_item
     elif freeze:
         if charge_stop:
             expected.append(["charge_stop", {"device_id": "DID0"}])
-        expected.append(["discharge_freeze", {"device_id": "DID0", "target_soc": int(soc), "power": power}])
+        if no_freeze:
+            # An explicit freeze with no discharge_freeze_service configured must fall back to a
+            # plain discharge stop, never a real discharge_start_service (batpred#4424/#4432)
+            expected.append(["discharge_stop", {"device_id": "DID0"}])
+        else:
+            expected.append(["discharge_freeze", {"device_id": "DID0", "target_soc": int(soc), "power": power}])
     elif soc < inv.soc_percent:
         if charge_stop:
             expected.append(["charge_stop", {"device_id": "DID0"}])
@@ -3241,6 +3261,16 @@ charge_start_service:
     failed |= test_call_adjust_export_immediate("export_immediate7", my_predbat, ha, inv, dummy_items, 50, freeze=True)
     failed |= test_call_adjust_export_immediate("export_immediate8", my_predbat, ha, inv, dummy_items, 50, freeze=False, no_freeze=True)
     failed |= test_call_adjust_export_immediate("export_immediate9", my_predbat, ha, inv, dummy_items, 30.0)
+    # batpred#4424/#4432: an explicit freeze request must never degrade into a real charge/export
+    # when the corresponding freeze service isn't configured - it must fall back to a plain stop.
+    # Kept at the end of this group: the fallback emits charge_stop/discharge_stop, which would
+    # otherwise be deduplicated against the identical calls the earlier sub-tests expect to make.
+    # The freeze branch ignores target_soc, so each second call takes the same path and is
+    # deduplicated as a repeat - confirming the fallback isn't re-issued every cycle.
+    failed |= test_call_adjust_charge_immediate("charge_immediate_freeze_no_service", my_predbat, ha, inv, dummy_items, 50, freeze=True, no_freeze=True, clear=True, stop_discharge=True)
+    failed |= test_call_adjust_charge_immediate("charge_immediate_freeze_no_service_repeat", my_predbat, ha, inv, dummy_items, 75, freeze=True, no_freeze=True, repeat=True)
+    failed |= test_call_adjust_export_immediate("export_immediate_freeze_no_service", my_predbat, ha, inv, dummy_items, 50, freeze=True, no_freeze=True, clear=True)
+    failed |= test_call_adjust_export_immediate("export_immediate_freeze_no_service_repeat", my_predbat, ha, inv, dummy_items, 30, freeze=True, no_freeze=True, repeat=True)
     if failed:
         return failed
 


### PR DESCRIPTION
## Summary

Replaces #4435, which took the wrong approach - see below.

`adjust_charge_immediate()` / `adjust_export_immediate()` try the configured freeze service and, when none is configured, fall back to a real `charge_start_service` / `discharge_start_service`. That's a fresh *active* command rather than a passive hold, and some inverters treat it as a new instruction each cycle and briefly ramp to full power - the repeated short full-rate import bursts reported in #4424 / #4432.

Fall back to a plain `charge_stop` / `discharge_stop` instead. The hold is already established by the caller before these are reached (target SoC written to the current SoC, plus `pause_discharge` / discharge rate 0 / reserve on the charge side; the `charge_stop` issued at the top of `adjust_export_immediate` on the export side), so stopping *is* the hold - starting is not.

Only the explicit `freeze=True` path changes. Reaching the target without a freeze request (`target_soc == soc_percent`) keeps its existing behaviour, so this stays scoped to the reported fault and doesn't drag in the charge-side equivalent of #4464.

## Why not #4435

#4435 treated this as "which inverters may *plan* freeze windows" and switched off the global `set_charge_freeze` / `set_export_freeze` flags, scoping which inverters by inferring capability from config. Three commits went into refining that condition. @springfall2008 pushed back on it twice, and the second version would have disabled export freeze for stock GivEnergy/GivTCP (`GE`/`GEC`/`GEE`, plus `GS_fb00` and `SA`) - all of which reach freeze export through the safe local rate=0/pause path in `execute.py` and never touch a service at all.

The failure was never about planning; it's about how one command is delivered. Fixing it at the point of failure makes the capability question disappear, so no inverter-capability inference is needed. That also answers "why not just add an inverter capability setting?" - we don't need one for *this*.

## Known limitation

For an inverter whose only freeze mechanism was that service (no target SoC, no pause), falling back to stop gives "don't charge" rather than a true hold, while the planner still believes it froze. That's strictly better than a full-power burst, but it's a residual model/execution mismatch of the same family as #4690. If it needs closing, that's where a *real* capability declaration in `INVERTER_DEF` belongs - declared, not inferred from whether a config key happens to be set - and it's separable from this safety fix.

## Test plan

- [x] Four new cases (both sides, plus a repeat call each), **verified failing first** - they show `charge_start` / `discharge_start` issued at full rate where a stop was required, and re-issued rather than deduplicated on the next cycle, which is the reported burst symptom
- [x] `./run_all --test inverter --test execute` passes
- [x] `./run_pre_commit` passes (full suite, ruff, black, cspell, markdownlint)

Also gave `test_call_adjust_charge_immediate`'s `clear=` the same dedup reset `test_call_adjust_export_immediate` already had, so the new cases are judged fresh rather than against whatever the previous sub-test sent.

Fixes #4424. Fixes #4432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)