### PR TITLE
Make the myenergi CLI harness run a real component cycle

### DIFF
--- a/apps/predbat/myenergi.py
+++ b/apps/predbat/myenergi.py
@@ -1225,6 +1225,37 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
                     self.dashboard_item("sensor.{}_temp_2".format(prefix), state=device.temp_2, attributes=myenergi_attribute_table["temp_2"], app="myenergi")
 
 
+# myenergi accepts a command before the device reports it, so a read-back fired straight
+# after one still shows the old state. Long enough for the change to land, short enough
+# that a boost/cancel test is not a chore to sit through.
+COMMAND_SETTLE_SECONDS = 8
+
+
+def print_device_table(devices):  # pragma: no cover
+    """Print the device summary table, for the poll and for a command read-back alike."""
+    print("{:<12} {:<10} {:<16} {:<10} {:>10} {:>12}".format("DEVICE", "KIND", "STATUS", "MODE", "POWER W", "SESSION kWh"))
+    for device in devices:
+        print("{:<12} {:<10} {:<16} {:<10} {:>10.0f} {:>12.2f}".format(device.device_id, device.kind, device.status, device.mode, device.power_w, device.session_energy_kwh))
+
+
+async def confirm_command(component, device_id):  # pragma: no cover
+    """Re-poll after a command and show the device's new state, so one run proves the effect.
+
+    Reads through the transport rather than run(), which would republish every entity and
+    bury the two lines that matter.
+    """
+    print("\nWaiting {}s for the device to report the change...".format(COMMAND_SETTLE_SECONDS))
+    await asyncio.sleep(COMMAND_SETTLE_SECONDS)
+    devices = await component.transport.fetch_devices()
+    device = next((item for item in devices if item.device_id == device_id), None)
+    if not device:
+        print("{} is no longer in the poll response".format(device_id))
+        return
+    print_device_table([device])
+    remaining = ", {} minutes remaining".format(device.boost_remaining_mins) if device.boost_remaining_mins else ""
+    print("Boost active: {}{}".format(device.boost_active, remaining))
+
+
 async def run_myenergi_cli(args):  # pragma: no cover
     """Run one myenergi poll, and optionally a boost command, against the live API."""
     mock_base = MockBase()
@@ -1234,7 +1265,10 @@ async def run_myenergi_cli(args):  # pragma: no cover
         "api_key": args.api_key,
         "key": args.token,
         "token_hash": args.token_hash,
-        "automatic": False,
+        # On by default, as it is in apps.yaml, so a harness run shows the car_charging_energy,
+        # car_charging_planned and iboost_energy_today wiring a real run would set up - that
+        # mapping is most of what there is to check before trusting the component with a car.
+        "automatic": not args.no_automatic,
         "enable_controls": True,
     }
     component = MyEnergiAPI(mock_base, **arg_dict)
@@ -1244,18 +1278,27 @@ async def run_myenergi_cli(args):  # pragma: no cover
 
     print("Connecting with the {} transport...".format(component.auth_method_config))
     await component.transport.connect()
-    devices = await component.transport.fetch_devices()
+
+    # One whole component cycle, as the other harnesses do, rather than a bare
+    # fetch_devices(): publishing is part of run(), so a raw fetch shows the readings but
+    # none of the sensors, switches and numbers a real run creates - which is exactly what
+    # this harness is used to check before wiring the component into apps.yaml.
+    print("Running one poll cycle...")
+    if not await component.run(0, True):
+        print("The poll cycle failed - see the messages above")
+        return
+    devices = sorted(component.devices.values(), key=lambda item: item.serial)
     if not devices:
         print("No Zappi or Eddi devices found")
         return
+
+    print("")
 
     if args.raw:
         for device in devices:
             print(device)
     else:
-        print("{:<12} {:<10} {:<16} {:<10} {:>10} {:>12}".format("DEVICE", "KIND", "STATUS", "MODE", "POWER W", "SESSION kWh"))
-        for device in devices:
-            print("{:<12} {:<10} {:<16} {:<10} {:>10.0f} {:>12.2f}".format(device.device_id, device.kind, device.status, device.mode, device.power_w, device.session_energy_kwh))
+        print_device_table(devices)
 
     # The three supply modes Predbat-led charge control drives a Zappi between, so the
     # same commands the component issues can be exercised by hand against a live charger.
@@ -1271,9 +1314,9 @@ async def run_myenergi_cli(args):  # pragma: no cover
         if not zappi:
             print("No Zappi found to control")
             return
-        print("Setting {} to {}...".format(zappi.name, mode))
+        print("\nSetting {} to {}...".format(zappi.name, mode))
         await component.transport.set_mode(zappi, mode)
-        print("Done - run again with no action to see the new mode")
+        await confirm_command(component, zappi.device_id)
         return
 
     target_kind = args.boost or args.cancel_boost
@@ -1283,12 +1326,12 @@ async def run_myenergi_cli(args):  # pragma: no cover
             print("No {} device found to control".format(target_kind))
             return
         if args.boost:
-            print("Boosting {} by {}...".format(device.name, args.amount))
+            print("\nBoosting {} by {}...".format(device.name, args.amount))
             await component.transport.send_boost(device, args.amount)
         else:
-            print("Cancelling boost on {}...".format(device.name))
+            print("\nCancelling boost on {}...".format(device.name))
             await component.transport.cancel_boost(device)
-        print("Done")
+        await confirm_command(component, device.device_id)
 
 
 def main():  # pragma: no cover
@@ -1307,6 +1350,7 @@ def main():  # pragma: no cover
     charge_group.add_argument("--start-charge", action="store_true", help="Put the first Zappi in {} to charge now, as a planned window does".format(ZAPPI_MODE_CHARGING))
     charge_group.add_argument("--stop-charge", action="store_true", help="Put the first Zappi in {}, as being outside a planned window does".format(ZAPPI_MODE_STOPPED))
     charge_group.add_argument("--release", action="store_true", help="Put the first Zappi back in {}, as releasing it does".format(ZAPPI_MODE_RELEASE))
+    parser.add_argument("--no-automatic", action="store_true", help="Skip the automatic configuration of car_charging_energy, car_charging_planned and iboost_energy_today")
     parser.add_argument("--raw", action="store_true", help="Print the full normalised device records")
 
     args = parser.parse_args()

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -1906,10 +1906,15 @@ The direct transport (the default) needs your hub serial number and an API key y
   myenergi_api_key: !secret myenergi_api_key
 ```
 
+The hub serial is the login for the direct API - it is sent as the HTTP digest username, with the API key as the password -
+and not a filter naming which device to read, so there is no 'all devices' value and it cannot be left out. One serial is all
+you need: Predbat asks for every device on the account in a single call and publishes each Zappi and Eddi it finds. If you have
+no hub, use the serial of the device acting as one, which is the Zappi or Eddi the API key was generated against.
+
 **Configuration options:**
 
 - **myenergi_auth_method** - `direct` (default, local digest API) or `oauth` (official cloud API)
-- **myenergi_hub_serial** - Hub serial number, printed on the hub and shown in the myenergi app - required when `myenergi_auth_method` is `direct`
+- **myenergi_hub_serial** - Hub serial number, printed on the hub and shown in the myenergi app - required when `myenergi_auth_method` is `direct`, and the serial of your Zappi or Eddi if you have no hub
 - **myenergi_api_key** - API key generated at [myaccount.myenergi.com](https://myaccount.myenergi.com) (Advanced → API Key) - required when `myenergi_auth_method` is `direct`
 - **myenergi_key** - OAuth access token, cloud transport
 - **myenergi_token_hash** - OAuth refresh token hash, used to refresh `myenergi_key` automatically - at least one of `myenergi_key` or `myenergi_token_hash` is required when `myenergi_auth_method` is `oauth`

--- a/docs/components.md
+++ b/docs/components.md
@@ -543,7 +543,7 @@ Predbat supports both of myenergi's APIs:
 | Option | Type | Required | Default | Config Key | Description |
 | ------ | ---- | -------- | ------- | ---------- | ----------- |
 | `auth_method` | String | No | `direct` | `myenergi_auth_method` | `direct` (local digest API) or `oauth` (official cloud API) |
-| `hub_serial` | String | No | - | `myenergi_hub_serial` | Hub serial number — required when `auth_method` is `direct` |
+| `hub_serial` | String | No | - | `myenergi_hub_serial` | Hub serial number — required when `auth_method` is `direct`. It is the API login rather than a device filter, so it cannot default to all devices; one serial reads every device on the account. With no hub, use the serial the API key was generated against |
 | `api_key` | String | No | - | `myenergi_api_key` | API key generated at myaccount.myenergi.com — required when `auth_method` is `direct` |
 | `key` | String | No | - | `myenergi_key` | OAuth access token, cloud transport |
 | `token_hash` | String | No | - | `myenergi_token_hash` | OAuth refresh token hash, used to refresh `key` automatically. At least one of `key` or `token_hash` is required when `auth_method` is `oauth` |
@@ -570,7 +570,9 @@ myenergi_api_key: !secret myenergi_api_key
 1. Sign in at <https://myaccount.myenergi.com>.
 2. Open **Advanced** then **API Key**.
 3. Generate a key for your hub and copy it.
-4. Your hub serial number is printed on the hub and shown in the myenergi app.
+4. Your hub serial number is printed on the hub and shown in the myenergi app. If you have no hub, use the serial of the device
+   acting as one — the Zappi or Eddi you generated the key against. Either way a single serial is enough, because it is the
+   login for the account rather than a choice of which device to read: Predbat discovers every Zappi and Eddi behind it.
 
 #### Published entities (myenergi)
 


### PR DESCRIPTION
## What

`myenergi.py`'s standalone harness called `transport.connect()` and `transport.fetch_devices()` directly, so it never reached `run()` — and publishing lives in `run()` → `publish_data()`. A live run printed the device readings but none of the sensors, switches and numbers the component actually creates, which is the main thing the harness is used to check before wiring the component into `apps.yaml`.

- One whole component cycle now, as the axle and gecloud harnesses do
- Automatic configuration on by default, matching `myenergi_automatic`'s apps.yaml default, so the `car_charging_energy`, `car_charging_planned` and `iboost_energy_today` wiring shows up too — `--no-automatic` skips it
- A boost, cancel or mode command used to print `Done` and exit, so proving it worked meant a second run. Commands now wait for the device to report the change and print its new state, so a boost/cancel test is one run
- Docs: the hub serial is the API login rather than a device filter, so it cannot default to all devices and one serial reads every device on the account; a setup with no hub uses the serial of the Zappi or Eddi the API key was generated against

## Example output

```
Connecting with the direct transport...
Running one poll cycle...
ENTITY: sensor.predbat_myenergi_eddi_XXXXXXXX_status = Paused
... 15 entities across a Zappi and an Eddi ...
Info: myenergi: setting car_charging_energy to ['sensor.predbat_myenergi_zappi_XXXXXXXX_session_energy']
Info: myenergi: setting car_charging_planned to ['sensor.predbat_myenergi_zappi_XXXXXXXX_plug_status']
Info: myenergi: setting iboost_energy_today to sensor.predbat_myenergi_eddi_XXXXXXXX_session_energy

DEVICE       KIND       STATUS           MODE          POWER W  SESSION kWh
EXXXXXXXX    eddi       Paused           Normal              0         0.00
ZXXXXXXXX    zappi      Paused           Eco+                0        48.94
```

and with `--boost eddi --amount 1`:

```
Boosting eddi-XXXXXXXX by 1...

Waiting 8s for the device to report the change...
DEVICE       KIND       STATUS           MODE          POWER W  SESSION kWh
EXXXXXXXX    eddi       Boosting         Normal           3000         0.00
Boost active: True, 1 minutes remaining
```

## Testing

The whole change sits inside the `# pragma: no cover` CLI harness, so no new unit tests — `publish_data()` and `automatic_config()` are already covered by `test_myenergi.py`.

- Verified against a stubbed transport (one Zappi, one Eddi): 15 entities published, auto-config lines emitted, and the read-back correctly showing `Boosting` / `Boost active: True` after a boost and `Boost active: False` after a cancel
- Verified against a live account for the poll path — the entities and the auto-config wiring appear as above
- `./run_all --test myenergi` passes; pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)