### PR TITLE
fix(plan): honour set_export_freeze_only for manual export overrides

### DIFF
--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -4243,7 +4243,20 @@ class Plan:
                 if self.export_window_best[window_n]["start"] in self.manual_demand_times:
                     self.export_limits_best[window_n] = EXPORT_LIMIT_IDLE
                 elif self.export_window_best[window_n]["start"] in self.manual_export_times:
-                    self.export_limits_best[window_n] = 0.0
+                    if self.set_export_freeze_only:
+                        # A manual "export now" request can't be honoured as an active export when
+                        # the user has said Predbat may only ever freeze export, never force it - the
+                        # optimiser's own search already respects this (optimise_export's loop_options
+                        # excludes every active target when set_export_freeze_only is set), so a
+                        # manual override doing the same silently was the one path where the plan
+                        # ended up assuming charging was disabled (Freeze Export) while execution left
+                        # it enabled (Hold Export) - see #4690. Clamp to freeze instead of dropping the
+                        # override entirely, since freeze is the closest available approximation of
+                        # "export what you can right now".
+                        self.log("Warn: Manual export time {} clamped to freeze export as set_export_freeze_only is enabled".format(self.time_abs_str(self.export_window_best[window_n]["start"])))
+                        self.export_limits_best[window_n] = EXPORT_LIMIT_FREEZE
+                    else:
+                        self.export_limits_best[window_n] = 0.0
                 elif self.export_window_best[window_n]["start"] in self.manual_freeze_export_times:
                     self.export_limits_best[window_n] = EXPORT_LIMIT_FREEZE
 

--- a/apps/predbat/tests/test_manual_overrides.py
+++ b/apps/predbat/tests/test_manual_overrides.py
@@ -1,0 +1,104 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+from const import EXPORT_LIMIT_FREEZE, EXPORT_LIMIT_IDLE
+from tests.test_infra import reset_inverter
+
+
+def run_manual_overrides_tests(my_predbat):
+    """
+    Tests for optimise_charge_windows_manual method
+    """
+    failed = False
+    failed |= test_manual_export_forces_active_export(my_predbat)
+    failed |= test_manual_export_clamped_when_export_freeze_only(my_predbat)
+    failed |= test_manual_freeze_export_unaffected_by_export_freeze_only(my_predbat)
+    failed |= test_manual_demand_unaffected_by_export_freeze_only(my_predbat)
+    return failed
+
+
+def setup(my_predbat, set_export_freeze_only):
+    """Put the plan into a known state with a single charge and export window covering the same slot"""
+    reset_inverter(my_predbat)
+    my_predbat.soc_max = 10.0
+    my_predbat.reserve = 1.0
+    my_predbat.debug_enable = False
+    my_predbat.calculate_best_charge = True
+    my_predbat.calculate_best_export = True
+    my_predbat.set_export_freeze_only = set_export_freeze_only
+
+    my_predbat.manual_demand_times = []
+    my_predbat.manual_export_times = []
+    my_predbat.manual_freeze_export_times = []
+    my_predbat.manual_charge_times = []
+    my_predbat.manual_freeze_charge_times = []
+
+    my_predbat.charge_window_best = [{"start": 720, "end": 750, "average": 10.0}]
+    my_predbat.charge_limit_best = [5.0]
+    my_predbat.export_window_best = [{"start": 720, "end": 750, "average": 10.0}]
+    my_predbat.export_limits_best = [EXPORT_LIMIT_IDLE]
+
+
+def check_export_limit(name, my_predbat, expected):
+    """Assert the single export window ended up at the expected limit"""
+    actual = my_predbat.export_limits_best[0]
+    if actual != expected:
+        print("ERROR: {} - export limit should be {} got {}".format(name, expected, actual))
+        return True
+    return False
+
+
+def test_manual_export_forces_active_export(my_predbat):
+    """Baseline: with set_export_freeze_only off, a manual export override forces a real export"""
+    print("**** test_manual_export_forces_active_export ****")
+    setup(my_predbat, set_export_freeze_only=False)
+    my_predbat.manual_export_times = [720]
+
+    my_predbat.optimise_charge_windows_manual()
+
+    return check_export_limit("test_manual_export_forces_active_export", my_predbat, 0.0)
+
+
+def test_manual_export_clamped_when_export_freeze_only(my_predbat):
+    """
+    #4690: set_export_freeze_only means Predbat may only ever freeze export, never force one -
+    optimise_export's own search already honours that, but a manual export override wrote an active
+    limit straight into the plan regardless. The model then treats any active limit as a freeze when
+    the switch is set, while execution saw a non-freeze limit and left charging enabled, so the plan
+    assumed a hold that never happened. Clamp the override to freeze instead.
+    """
+    print("**** test_manual_export_clamped_when_export_freeze_only ****")
+    setup(my_predbat, set_export_freeze_only=True)
+    my_predbat.manual_export_times = [720]
+
+    my_predbat.optimise_charge_windows_manual()
+
+    return check_export_limit("test_manual_export_clamped_when_export_freeze_only", my_predbat, EXPORT_LIMIT_FREEZE)
+
+
+def test_manual_freeze_export_unaffected_by_export_freeze_only(my_predbat):
+    """A manual freeze export override is already a freeze, so the switch must not change it"""
+    print("**** test_manual_freeze_export_unaffected_by_export_freeze_only ****")
+    setup(my_predbat, set_export_freeze_only=True)
+    my_predbat.manual_freeze_export_times = [720]
+
+    my_predbat.optimise_charge_windows_manual()
+
+    return check_export_limit("test_manual_freeze_export_unaffected_by_export_freeze_only", my_predbat, EXPORT_LIMIT_FREEZE)
+
+
+def test_manual_demand_unaffected_by_export_freeze_only(my_predbat):
+    """A manual demand override disables the export window entirely and must stay that way"""
+    print("**** test_manual_demand_unaffected_by_export_freeze_only ****")
+    setup(my_predbat, set_export_freeze_only=True)
+    my_predbat.manual_demand_times = [720]
+
+    my_predbat.optimise_charge_windows_manual()
+
+    return check_export_limit("test_manual_demand_unaffected_by_export_freeze_only", my_predbat, EXPORT_LIMIT_IDLE)

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -249,6 +249,7 @@ from tests.test_band_rate_text import test_band_rate_text
 from tests.test_kraken import run_kraken_tests
 from tests.test_kraken_auth_mixin import run_kraken_auth_mixin_tests
 from tests.test_clip_export_slots import run_clip_export_slots_tests
+from tests.test_manual_overrides import run_manual_overrides_tests
 from tests.test_prune_dead_slots import run_prune_dead_slots_tests
 from tests.test_clip_charge_slots import run_clip_charge_slots_tests
 from tests.test_discard_unused_charge_slots import run_discard_unused_charge_slots_tests
@@ -604,6 +605,7 @@ def main():
         ("kraken", run_kraken_tests, "Kraken API tests (init, GraphQL, tariff discovery, rate fetching, run lifecycle)", False),
         ("kraken_auth", run_kraken_auth_mixin_tests, "Kraken auth mixin tests (API key, email, refresh, 401 handling)", False),
         ("clip_export_slots", run_clip_export_slots_tests, "Clip export slots tests", False),
+        ("manual_overrides", run_manual_overrides_tests, "Manual window override tests", False),
         ("prune_dead_slots", run_prune_dead_slots_tests, "Prune dead plan slots tests", False),
         ("clip_charge_slots", run_clip_charge_slots_tests, "Clip charge slots tests", False),
         ("discard_unused_charge_slots", run_discard_unused_charge_slots_tests, "Discard unused charge slots tests", False),


### PR DESCRIPTION
## Summary

Fixes the export-side instance of #4690 (the charge-side instance on that issue is separate and not touched here).

`set_export_freeze_only` means Predbat may only ever freeze export, never force an active one. `optimise_export`'s own search honours that - its `loop_options` exclude every active target when the switch is set (`plan.py:2181`) - but `optimise_charge_windows_manual` wrote `0.0` straight into `export_limits_best` for any slot in `manual_export_times`, with no check of the switch at all.

That was the one path by which an active export limit could reach the plan while the switch was on, and it's what produced the reported mismatch: `prediction.py` treats *any* active limit as a freeze when the switch is set (charging disabled, SoC held), while `execute.py`'s freeze/hold split tests for the exact `99` sentinel - so it saw a non-freeze limit, took `"Hold exporting"`, and left charging enabled. The plan assumed a hold that never happened.

## Approach

Clamp the manual override to `EXPORT_LIMIT_FREEZE` rather than dropping it, since freeze is the closest available approximation of "export what you can right now", and log it as a `Warn` so the clamp is visible rather than silent.

I initially also had `execute.py` re-derive the model's full condition as belt-and-braces, then dropped it: fixing this at the source keeps the value genuinely `99` everywhere downstream, so the model, execution **and the HTML plan** all agree with no further special-casing. Teaching `execute.py` to re-derive would have left the plan display still showing `Exp` while execution froze - moving the mismatch rather than closing it.

Checked the other `export_limits_best` writers cannot manufacture an active limit under the switch: `clip_export_slots` explicitly skips freeze windows (`plan.py:2938`) and only ever narrows an already-active one, and the swap passes move existing limits between windows rather than creating them. So the manual override really was the only hole.

## Test plan

- [x] New `test_manual_overrides` module - the clamp case **verified failing first** (`export limit should be 99.0 got 0.0`)
- [x] Also covers the switch-off baseline (manual export still forces a real export) and the freeze/demand overrides that must not change
- [x] `./run_pre_commit` passes (full suite, ruff, black, cspell, markdownlint)

Addresses the export-side instance of #4690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)