### PR TITLE
fix(predheat): say in the log when Predheat is disabled (#4670)

### DIFF
--- a/apps/predbat/predheat.py
+++ b/apps/predbat/predheat.py
@@ -177,6 +177,7 @@ class PredHeat:
         self.had_errors = False
         self.prediction_started = False
         self.update_pending = False
+        self.enabled_logged = None
         self.prefix = self.get_arg("prefix", "predheat", domain="predheat")
         self.days_previous = [7]
         self.days_previous_weight = [1]
@@ -633,11 +634,34 @@ class PredHeat:
         self.run_every(self.run_time_loop, next_time, run_every, random_start=0, random_end=0)
         self.run_every(self.update_time_loop, datetime.now(), 5, random_start=0, random_end=0)
 
+    def is_enabled(self):
+        """
+        Report whether Predheat is turned on, logging each change of state
+
+        Both timer callbacks below simply return when Predheat is off, so without this a
+        disabled Predheat logs its startup banner and then goes completely silent forever -
+        indistinguishable in the log from a scheduler that never fires (#4670). Log the state
+        once per transition so the log always says which of the two is happening.
+        """
+        enabled = True if self.get_arg("predheat_enable") else False
+
+        if enabled != self.enabled_logged:
+            if enabled:
+                self.log("Predheat: Enabled via switch.{}_predheat_enable, will update every {} minutes".format(self.base.prefix, self.get_arg("run_every", 5, domain="predheat")))
+                # Coming back from disabled the scheduled run can be up to run_every away, so ask
+                # for an immediate one - otherwise turning the switch on looks like it did nothing.
+                self.update_pending = True
+            else:
+                self.log("Predheat: Disabled - turn on switch.{}_predheat_enable to run it".format(self.base.prefix))
+            self.enabled_logged = enabled
+
+        return enabled
+
     def update_time_loop(self, cb_args):
         """
         Called every 15 seconds
         """
-        if not self.get_arg("predheat_enable"):
+        if not self.is_enabled():
             return
 
         if self.update_pending and not self.prediction_started:
@@ -657,7 +681,7 @@ class PredHeat:
         """
         Called every N minutes
         """
-        if not self.get_arg("predheat_enable"):
+        if not self.is_enabled():
             return
 
         if not self.prediction_started:

--- a/apps/predbat/tests/test_predheat.py
+++ b/apps/predbat/tests/test_predheat.py
@@ -1,0 +1,151 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""Tests for the Predheat scheduler and its predheat_enable gate (#4670)."""
+
+import asyncio
+from datetime import datetime, timedelta
+
+from predheat import PredHeat
+
+
+class FakeComponents:
+    """Minimal stand-in for the component registry so switch_event can be driven in tests."""
+
+    async def switch_event(self, entity_id, service):
+        """Swallow the component-level switch routing, which is not under test here."""
+        return None
+
+
+def _make_predheat(my_predbat, captured):
+    """Build a PredHeat bound to my_predbat with its log captured and update_pred stubbed."""
+    my_predbat.args["predheat"] = {"forecast_days": 2, "run_every": 5, "mode": "pump"}
+    my_predbat.log = lambda msg, quiet=True: captured.append(msg)
+    predheat = PredHeat(my_predbat)
+    predheat.initialize()
+    predheat.runs = []
+    predheat.update_pred = lambda scheduled: predheat.runs.append(scheduled)
+    return predheat
+
+
+async def _turn_switch(my_predbat, service):
+    """Drive the real HA switch-event path for switch.predbat_predheat_enable."""
+    await my_predbat.switch_event(service, {"service": service, "service_data": {"entity_id": "switch.predbat_predheat_enable"}}, None)
+
+
+def _run_due_now(my_predbat, predheat):
+    """Make every registered timer due and run one timer tick."""
+    for item in my_predbat.run_list:
+        item["next_time"] = datetime.now()
+    asyncio.get_event_loop().run_until_complete(my_predbat.timer_tick())
+
+
+def test_predheat(my_predbat):
+    """Predheat scheduler registration and the predheat_enable gate."""
+    failed = False
+
+    original_log = my_predbat.log
+    original_components = my_predbat.components
+    original_run_list = my_predbat.run_list
+    original_predheat_args = my_predbat.args.get("predheat", None)
+    original_enable = my_predbat.config_index["predheat_enable"].get("value", None)
+
+    try:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        my_predbat.components = FakeComponents()
+
+        print("**** Running Predheat tests ****")
+
+        # ------------------------------------------------------------------
+        print("Test: initialize registers both Predheat timers")
+        my_predbat.run_list = []
+        my_predbat.expose_config("predheat_enable", False)
+        captured = []
+        predheat = _make_predheat(my_predbat, captured)
+
+        registered = {item["callback"].__name__: item for item in my_predbat.run_list}
+        if "run_time_loop" not in registered or "update_time_loop" not in registered:
+            print("  ERROR: expected both Predheat timers to be registered, got {}".format(list(registered)))
+            failed = True
+        elif registered["run_time_loop"]["run_every"] != 300:
+            print("  ERROR: expected run_time_loop every 300 seconds, got {}".format(registered["run_time_loop"]["run_every"]))
+            failed = True
+
+        # ------------------------------------------------------------------
+        print("Test: while disabled Predheat does not run but says so in the log (#4670)")
+        _run_due_now(my_predbat, predheat)
+        if predheat.runs:
+            print("  ERROR: Predheat ran while predheat_enable was off: {}".format(predheat.runs))
+            failed = True
+        disabled_logs = [msg for msg in captured if "Predheat" in msg and "disabled" in msg.lower()]
+        if len(disabled_logs) != 1:
+            print("  ERROR: expected exactly one 'disabled' log line explaining why Predheat is idle, captured: {}".format(captured))
+            failed = True
+        elif "predheat_enable" not in disabled_logs[0]:
+            print("  ERROR: expected the disabled log line to name the switch to turn on, got: {}".format(disabled_logs[0]))
+            failed = True
+
+        # The pending first run must survive the disabled ticks, or enabling Predheat later
+        # would silently wait for the next 5 minute boundary instead of running promptly.
+        if not predheat.update_pending:
+            print("  ERROR: expected update_pending to survive while disabled")
+            failed = True
+
+        print("Test: the disabled message is not repeated on every tick")
+        _run_due_now(my_predbat, predheat)
+        _run_due_now(my_predbat, predheat)
+        if len([msg for msg in captured if "Predheat" in msg and "disabled" in msg.lower()]) != 1:
+            print("  ERROR: expected the disabled log line to be logged once, captured: {}".format(captured))
+            failed = True
+
+        # ------------------------------------------------------------------
+        print("Test: turning switch.predbat_predheat_enable on starts Predheat")
+        asyncio.get_event_loop().run_until_complete(_turn_switch(my_predbat, "turn_on"))
+        if not my_predbat.get_arg("predheat_enable"):
+            print("  ERROR: the switch event did not enable predheat_enable")
+            failed = True
+        _run_due_now(my_predbat, predheat)
+        if not predheat.runs:
+            print("  ERROR: Predheat did not run after being enabled")
+            failed = True
+        enabled_logs = [msg for msg in captured if "Predheat" in msg and "enabled" in msg.lower()]
+        if len(enabled_logs) != 1:
+            print("  ERROR: expected exactly one 'enabled' log line, captured: {}".format(captured))
+            failed = True
+
+        # ------------------------------------------------------------------
+        print("Test: re-enabling after a run schedules a prompt update rather than waiting 5 minutes")
+        predheat.update_pending = False
+        asyncio.get_event_loop().run_until_complete(_turn_switch(my_predbat, "turn_off"))
+        _run_due_now(my_predbat, predheat)
+        runs_while_off = len(predheat.runs)
+
+        asyncio.get_event_loop().run_until_complete(_turn_switch(my_predbat, "turn_on"))
+
+        # Only the fast 5 second update loop is due here, so a run proves re-enabling asked for
+        # an immediate update rather than leaving the user waiting for the next 5 minute boundary
+        for item in my_predbat.run_list:
+            item["next_time"] = datetime.now() if item["callback"].__name__ == "update_time_loop" else datetime.now() + timedelta(minutes=5)
+        asyncio.get_event_loop().run_until_complete(my_predbat.timer_tick())
+        if len(predheat.runs) <= runs_while_off:
+            print("  ERROR: Predheat did not run promptly after being re-enabled")
+            failed = True
+
+    finally:
+        my_predbat.log = original_log
+        my_predbat.components = original_components
+        my_predbat.run_list = original_run_list
+        my_predbat.config_index["predheat_enable"]["value"] = original_enable
+        if original_predheat_args is None:
+            my_predbat.args.pop("predheat", None)
+        else:
+            my_predbat.args["predheat"] = original_predheat_args
+
+    return failed

--- a/apps/predbat/tests/test_predheat.py
+++ b/apps/predbat/tests/test_predheat.py
@@ -43,7 +43,7 @@ async def _turn_switch(my_predbat, service):
 def _run_due_now(my_predbat, predheat):
     """Make every registered timer due and run one timer tick."""
     for item in my_predbat.run_list:
-        item["next_time"] = datetime.now()
+        item["next_time"] = datetime.now() - timedelta(seconds=1)
     asyncio.get_event_loop().run_until_complete(my_predbat.timer_tick())
 
 

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -35,6 +35,7 @@ from tests.test_kernel_static_cache import run_kernel_static_cache_tests
 from tests.test_execute import run_execute_tests
 from tests.test_execute_multi_inverter_status import test_multi_inverter_status
 from tests.test_load_car_energy import test_load_car_energy_warns_when_configured_entity_has_no_data
+from tests.test_predheat import test_predheat
 from tests.test_debug_enable_auto_scope import test_debug_enable_auto_scope
 from tests.test_octopus_slots import run_load_octopus_slots_tests
 from tests.test_multi_car_iog import run_multi_car_iog_tests
@@ -373,6 +374,7 @@ def main():
         ("execute", run_execute_tests, "Execute tests", False),
         ("multi_inverter_status", test_multi_inverter_status, "Multi-inverter headline status resolution tests (#4446)", False),
         ("load_car_energy", test_load_car_energy_warns_when_configured_entity_has_no_data, "car_charging_energy configured-but-empty warning tests (#4458 follow-up)", False),
+        ("predheat", test_predheat, "Predheat scheduler and predheat_enable gate tests (#4670)", False),
         ("debug_enable_auto_scope", test_debug_enable_auto_scope, "debug_enable auto-disable-after-N-hours tests (#4438 review)", False),
         ("basic_rates", test_basic_rates, "Basic rates tests", False),
         ("rate_min_forward_calc", test_rate_min_forward_calc, "Rate min forward calc tests", False),

--- a/docs/predheat.md
+++ b/docs/predheat.md
@@ -29,6 +29,14 @@ Future versions will also offer Predbat to run in master mode, controlling your 
 
 Predheat is now part of Predbat, you will need to configure it using `apps.yaml` and then enable it by turning on **switch.predbat_predheat_enable**
 
+Configuring the `predheat` section of `apps.yaml` on its own only makes Predheat start up, it does not make it run.
+Until the switch is turned on you will see `Predheat: Startup` and `Predheat: Next run time will be ...` in the log
+followed by `Predheat: Disabled - turn on switch.predbat_predheat_enable to run it`, and no `predheat.*` entities
+will be created. Once the switch is on the log shows `Predheat: Enabled via switch.predbat_predheat_enable ...` and
+then a `Predheat: update at ...` line for each run. If you turn the switch on in Home Assistant but the log still
+says Predheat is disabled, then Predbat did not receive the switch change - toggle it from Predbat's own web
+interface instead and check the log for a `switch_event: switch.predbat_predheat_enable` line.
+
 ### Weather install
 
 You will need a weather forecast service available in Home Assistant for Predbat to be able to forecast heating demand based on the weather forecast.


### PR DESCRIPTION
Fixes #4670

## Problem

Predheat initialises, logs `Predheat: Startup` and `Predheat: Next run time will be ... and then every 300 seconds`, and is then completely silent forever — no `Predheat: update at ...`, no `predheat.*` entities.

Both timer callbacks open with a silent early return:

```python
if not self.get_arg("predheat_enable"):
    return
```

So "Predheat is switched off" and "Predheat's scheduler is broken" produce byte-for-byte identical logs. There is no way to tell them apart from a log, which is why #4670 could not be resolved from the reporter's evidence.

## Root cause of #4670 itself

Every other link in the chain checks out, verified against the real code and on a live add-on instance:

| Link | Result |
|---|---|
| `initialize()` registers both timers in `run_list` | ✅ both, `run_every` 300s |
| `Hass.timer_tick()` dispatches them | ✅ |
| HA switch event → config value → gate | ✅ Predheat ran 3s after the toggle |
| `predheat_enable` restored from `predbat_config.json` across a restart | ✅ |

That leaves the gate as the only thing that can produce total silence, i.e. Predbat's stored `predheat_enable` is `False` while Home Assistant's entity displays `on` — the HA toggle never reached Predbat. When it does arrive, the log already records it (`switch_event: switch.predbat_predheat_enable = True`) and Predheat runs seconds later. The reporter's "restarting returns the switch to OFF" note is the same desync seen from the other side.

Not a v8.52.0 regression: `predheat.py` has had no functional change since April, the only commit since being an `ERROR:`→`Error:` string tidy.

## Change

`is_enabled()` logs each change of state once (not per tick), naming the switch:

```
Predheat: Disabled - turn on switch.predbat_predheat_enable to run it
Predheat: Enabled via switch.predbat_predheat_enable, will update every 5 minutes
```

Re-enabling also sets `update_pending`, so turning the switch on runs Predheat immediately instead of appearing dead for up to `run_every` minutes.

## Tests

First Predheat tests in the repo (`./run_all --test predheat`) — timer registration, the silent-gate regression, enabling via the real `switch_event` path, and the prompt re-enable. Confirmed RED before the fix.

- `./run_all --quick` — 816 passed, 0 failed
- `./run_pre_commit` — all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
