### PR TITLE
Widen triage bot permissions and add a debug journal

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: issue-triage
 description: Investigate a newly opened batpred GitHub issue against current main, classify it, assign labels and priority, and post a first-pass triage comment.
-allowed-tools: You can view and edit files in this repo, run local tests, access the issue in github with 'gh' and use git commands to check history etc. Do not go outside this sandbox or push any changes back to git.
+allowed-tools: You can view and edit files in this repo, run local tests, download and grep issue attachments, access the issue in github with 'gh' and use git commands to check history and re-sync the clone. Do not go outside this sandbox or push any changes back to git.
 ---
 
 # Issue Triage
 
-You are triaging one GitHub issue on `springfall2008/batpred`. The issue number is given as an argument to this skill invocation. The working directory is a dedicated local clone already synced to the current `main` branch — investigate using it directly.
+You are triaging one GitHub issue on `springfall2008/batpred`. The working directory is a dedicated local clone of the repo — investigate using it directly.
+
+Arguments: `<issue-number> [scratch=<dir>]`. The scratch directory is a writable place to download attachments to; it is emptied before each run. If no `scratch=` is given (an interactive invocation), use `/tmp/predbat-triage/<issue-number>` and `mkdir -p` it yourself.
 
 ## 1. Read the issue
 
@@ -14,7 +16,23 @@ Fetch it with `gh issue view <number> --json title,body,labels,comments`. Note a
 
 ## 2. Fetch attachments
 
-If the body links a log file or `predbat_debug.yaml`, fetch and read them. Use the log for error/traceback context and the debug yaml for the reporter's actual configuration.
+If the body links a log file, a `predbat_debug.yaml`, or a zip of either, download it into the scratch directory rather than pulling it through WebFetch — a `predbat.log` is routinely tens of MB, well past what WebFetch will return.
+
+```bash
+curl -sL "<url>" -o <scratch>/predbat.log
+```
+
+Never `cat` or read a whole log into context. Size it up first, then extract only what matters:
+
+```bash
+wc -l <scratch>/predbat.log
+grep -n "Traceback\|ERROR\|Exception\|Warn" <scratch>/predbat.log | tail -50
+sed -n '<start>,<end>p' <scratch>/predbat.log     # context around an interesting line
+```
+
+The log gives you error/traceback context; the debug yaml gives you the reporter's actual configuration (grep it for the specific keys you care about if it is large). The reporter's Predbat version is usually in the first few lines of the log — quote the version you actually confirmed, not the one in the issue template.
+
+A `predbat_debug.yaml` can also be replayed against current main to reproduce their plan and list every setting they have changed from default — see [references/debug-journal.md](references/debug-journal.md).
 
 ## 3. Classify the type
 
@@ -29,12 +47,27 @@ Search existing issues (`gh issue list --search ...`, both open and closed) for 
 
 ## 5. Investigate against current main
 
-- This clone copy should be sync'ed to main, but you should sync to latest and you can discard any local changes left over from previous runs.
+- Sync the clone first and discard anything left over from a previous run, so you are reading the code you think you are:
+
+  ```bash
+  git fetch origin main && git reset --hard origin/main && git clean -fd
+  git describe --tags        # the version you are investigating against
+  ```
+
+- Read [references/debug-journal.md](references/debug-journal.md) before forming a hypothesis. It maps common symptoms to modules, records known per-integration behaviour from past investigations, and lists the traps that have wasted time before. Its entries are dated observations, not current truth — confirm anything you rely on against the working tree.
 - Read the relevant source area for the reported symptom (e.g. `apps/predbat/fetch.py` for rate issues, `apps/predbat/inverter.py` for a named inverter).
 - Check `git log` / `git blame` on that area for recent related changes — the issue may already be fixed on main since the version the reporter is using.
-- If the issue clearly maps to an existing test module (`apps/predbat/tests/test_<feature>.py`, listed in `TEST_REGISTRY` in `unit_test.py`), run just that test: `cd coverage && ./run_all --test <name>`. Skip this step if there's no clean mapping — never run the full suite.
+- If the issue clearly maps to an existing test module (`apps/predbat/tests/test_<feature>.py`, listed in `TEST_REGISTRY` in `unit_test.py`), run just that test. Save the output and grep it rather than reading it all back — the run is verbose:
+
+  ```bash
+  cd coverage && ./run_all --test <name> > <scratch>/test.log 2>&1; echo "exit=$?"
+  tail -30 <scratch>/test.log
+  ```
+
+  Skip this step if there's no clean mapping — never run the full suite. A test only settles questions about code behaviour; it can't settle what real hardware did, so don't run one to look thorough.
+
 - Form a root-cause hypothesis with a `file:line` pointer if the investigation supports one. It's fine to say the cause needs maintainer review if it doesn't.
-- You may edit files locally to test a hypothesis (e.g. a temporary debug print, a tweaked test fixture) — this clone is hard-reset before the next run, so nothing here persists. Never `git commit` or `git push`.
+- You may edit files locally to test a hypothesis (e.g. a temporary debug print, a tweaked test fixture) — this clone is hard-reset and cleaned before the next run, so nothing here persists. Never `git commit` or `git push`.
 
 ## 6. Apply component labels
 
@@ -65,3 +98,4 @@ Post exactly one comment via `gh issue comment <number> --body "..."`, opening w
 - Analysis only: no commits, no pushes, no PRs, no code changes that leave this clone.
 - Never remove a label a human applied.
 - Never close an issue except a confident duplicate.
+- If a command you needed was blocked by permissions, say plainly in the comment what you could not do — never word it so a step you skipped reads as one you completed.

--- a/.claude/skills/issue-triage/references/debug-journal.md
+++ b/.claude/skills/issue-triage/references/debug-journal.md
@@ -1,0 +1,82 @@
+# Debug journal
+
+Notes distilled from maintainer debugging sessions on this repo (roughly June–August 2026), written for whoever is triaging an issue next.
+
+Every entry is an observation from a past investigation, not a statement about current main. The code moves. Use these as "look here first", confirm against the working tree before you put anything in a comment, and say what you actually confirmed rather than what this file says.
+
+## Replay the reporter's debug file
+
+The most useful attachment on a bug report is `predbat_debug.yaml` — a full state dump the test harness can replay against current main:
+
+```bash
+cd coverage
+./run_all --debug_file <scratch>/predbat_debug.yaml > <scratch>/replay.log 2>&1
+```
+
+What you get out of it:
+
+- **Every config item the reporter has changed from default**, printed as `- <item> = <value> (default <value>)`. Grep the replay log for that block before reading their yaml — it is where most "the plan is wrong" reports get settled.
+- A recalculated plan with a metric before and after, written to `plan_orig.html` and `plan_final.json` in `coverage/`. Both are gitignored, and `git clean -fd` clears them.
+- `--redo` recomputes rates, load model and Octopus slots instead of reusing the ones in the dump. Without it you are replaying the exact state they had, which is normally what you want.
+
+Committed examples of the same format live in `coverage/cases/*.yaml`; they run as golden regressions under `./run_all --test debug_cases`.
+
+Two lines in that output are normal and are not the reporter's bug:
+
+- `Prediction kernel stale binary ... - using Python engine` — the local C++ kernel is older than the Python side expects, so the pure-Python engine runs instead. The plan is still correct, just slower.
+- `Config item ... is below the minimum ... - clamping to ...` — routine clamping of an out-of-range setting.
+
+## Check configuration before code
+
+"The plan is wrong" has repeatedly turned out to be settings rather than a defect:
+
+- **GH#4222** (odd freeze-export windows) — traced to the reporter's own `combine_export_slots: True` plus a high `metric_min_improvement_export`, not a code regression. A stale local test file also produced a false kernel regression partway through that investigation.
+- **GH#4478** (exports scheduled late) — there *was* a real ordering bug (`optimise_swap_export` ran before the later plan passes, fixed in PR #4513), but the user-visible difference was dominated by `best_soc_keep: 4.0` in their config.
+
+So pull the non-default config list out of the replay first and look at `combine_export_slots`, `metric_min_improvement_export`, `best_soc_keep`, `metric_battery_value_export_scaling` and the `load_scaling*` family before concluding "code bug". Saying "this is configuration" is a legitimate triage outcome — that is what the `configuration` label is for.
+
+## Per-integration notes
+
+Grep for the named symbol rather than trusting a line number.
+
+| Area | What past debugging found | Targeted test |
+|------|---------------------------|---------------|
+| Fox (`fox.py`) | The cloud API returns errno 42015/44096 for settings a given device does not support (`FOX_SETTINGS_UNSUPPORTED_ERRNO`); those are marked unavailable and never polled or written again. Entity type matters — WorkMode is a select, ExportLimit a number. | `fox_api`, `fox_oauth` |
+| Solis (`solis.py`) | `SOLIS_CID_STORAGE_MODE = 636`. The inverter only retains the TOU bit on CID 636 while a charge or discharge window is configured; with slots disabled the bit silently drops and the verification warning repeats. A log full of CID 636 verification warnings is usually this, not a failed write. | `solis` |
+| SolaX (`solax.py`) | Code `10402` is a token/auth failure, retried in-request rather than waiting for the next cycle. SolaX clamps battery minimum SOC at 10% (`SOLAX_MIN_RESERVE_PERCENT`), so `battery_min_soc` is auto-configured to stop Predbat writing limits the inverter will reject. | `solax` |
+| Sigenergy (`sigenergy.py`) | Lifetime/history totals are cumulative server-side and reset around EU midnight, which showed up as an overnight dip; `fetch_history_totals` applies a monotonic clamp. "Energy totals went backwards overnight" starts here. | `sigenergy` |
+| GE Cloud (`gecloud.py`) | Gateway fields can come back null. `merge_non_null` stops nulls overwriting good values, and the publish path guards null containers — GH#4656 was a null crash in that area. | `ge_cloud` |
+| Teslemetry / Powerwall (`teslemetry.py`) | Battery model is inferred from site `nameplate_power / battery_count`. A nameplate fallback combined with `inverter_hybrid: True` once produced a false 5 kW inverter limit and spurious morning export. Tariff writes push a whole TOU schedule every cycle, so a setting changed by hand in the Tesla app is reverted on the next cycle (GH#4600, GH#4610). | `teslemetry` |
+| Sunsynk / DEYE (`sunsynk.py`, `deye.py`) | Freeze export is gated by the per-slot power register (`sellTime{n}Pac` on Sunsynk), confirmed on live hardware — setting the energy mode alone had no effect, and with slot power at zero the battery still charged. `read_only` was ignored by the reconcile loops until `_is_read_only()` gated `_reconcile_control()` (GH#4436). | `sunsynk_control`, `deye_control` |
+| Grid sign / arrow direction | `grid_power_invert` is owned by some integrations and not others. With two systems configured, one integration setting it `True` bleeds into the other's entities and inverts the arrows. The fix is an explicit `False` in the automatic config of both. | `sunsynk_config`, `teslemetry` |
+| Enphase (`enphase.py`) | Unofficial Enlighten endpoints. Accounts with MFA cannot log in at all. Discharge-to-grid schedules are required for export control. Writes need a double-submit CSRF token or return 403. Using the Enphase app at the same time can trip session limits. | `enphase_api` |
+| Octopus (`octopus.py`, `fetch.py`) | Intelligent Go tariffs are detected via `is_intelligent_go_tariff()`, and IOG-prefixed tariffs must be skipped when updating intelligent devices. Saving-session auto-join rebinding regressed when `joined_events` was empty (GH#4573). `octopus_slots_signature()` deliberately omits the time-drifting fields of active dispatch slots so a replan is not forced every cycle. | `octopus_*`, `saving_session*` |
+| Axle (`axle.py`) | Export sessions have to boost the import rate as well as the export rate. State is published unconditionally from `run()` so a fetch failure does not freeze the sensor at a stale value. | `axle` |
+| History fetch / memory (`ha.py`) | History is fetched in `HISTORY_CHUNK_DAYS`-sized chunks with boundary dedup — records landing exactly on a chunk start inside a data gap corrupted smoothing before that was fixed. The largest memory peak in a run is ML load-predictor training (`load_predictor.py`), not the plan. | `history_chunking` |
+| Charge/discharge curve (`inverter.py`) | The curve is evaluated per target minute; tapering near ~93% SOC is expected behaviour, not a fault. | `find_charge_curve`, `battery_curve_keys` |
+| Standalone / Docker (non-HA) | GH#4601: a callback returning `None` instead of `True` broke the Octopus saving-session fallback in standalone mode. Anything that works under HA but not standalone is worth checking along the `ha.py` websocket and `userinterface.py` callback paths. | `trigger_callback_success_signal` |
+| Predheat (`predheat.py`) | GH#4670: with `predheat_enable` set, Predheat still did not activate after startup because of lazy flag initialisation. There is no registered Predheat test module, so there is nothing to run here — investigate by reading. | none |
+
+## Symptom → first place to look
+
+| Report | Start here |
+|--------|-----------|
+| Plan tab blank / no plan shown in HA | `predbat.cost_today` missing from HA recorder history — a recorder configuration problem (GH#3936). Test: `faq_recorder_config`, and see `docs/faq.md`. |
+| Exports happen at the wrong time | `plan.py` export optimisation order, plus `combine_export_slots` and `metric_min_improvement_export` in their config. |
+| Battery charges or freezes when it shouldn't | Freeze paths in `prediction.py` and the inverter component's control write; check `best_soc_keep` and the freeze-related config in the replay. |
+| Rates wrong, missing or not updating | `fetch.py` rate scanning, then the provider component (`octopus.py`, `kraken.py`, `energydataservice.py`). |
+| Inverter setting not applied | `execute.py` into the component's reconcile loop; check whether `read_only` is set. |
+| Energy totals jump or reset | Provider-side cumulative counters and any monotonic clamping. |
+| Works in HA, broken in Docker/standalone | `ha.py` websocket and `userinterface.py` callback return values. |
+
+## Traps when investigating
+
+- **Stale kernel binary.** The `prediction_kernel_lib_*.so` binaries are committed and CI has a job for them. The warning above means the checkout falls back to the Python engine, which is fine for triage. Never rebuild or commit binaries while triaging.
+- **Test ordering.** Some tests share a `PredBat` instance, which is exactly why `run_debug_cases` builds a fresh one per case. A test that fails in a full run but passes alone is usually pollution, not the reporter's bug — another reason to run only the targeted test.
+- **Version drift.** Compare `git describe --tags` against the version in the first few lines of their log. A fair number of reports are already fixed on main, and that is a useful triage answer on its own.
+- **Log noise.** `predbat.log` carries routine `Warn:` lines (config clamps, kernel status, unsupported settings). Don't quote a warning as the root cause unless it lines up with the time the reporter describes.
+- **Hardware questions.** A unit test settles what the code does, not what an inverter did. Several findings here were only confirmed on live hardware. If the question is hardware behaviour, say the maintainer needs to confirm it rather than running a test to look thorough.
+
+## Adding to this file
+
+When an investigation turns up something a future triage run would have wanted to know — a config item that explains a class of report, an API quirk, a symptom that maps to a module — add a row. Keep it short, name the symbol rather than the line number, and cite the issue number so the next reader can check the original.

--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -176,6 +176,7 @@ Enpower
 entrez
 epod
 epvtoday
+errno
 ESSAPI
 etoday
 etok
@@ -649,4 +650,5 @@ YOURSERIAL
 yuanzhi
 zappi
 zappis
+zcat
 zigbee

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,21 @@ source setup.csh
 
 The `run_all` script is a thin wrapper; you can run `unit_test.py` directly from the `coverage/` directory (it needs to be the working directory so relative paths resolve).
 
+### Replaying a debug dump
+
+`predbat_debug_*.yaml` is a full state dump, written to `debug/` when `switch.predbat_debug_enable` is on and normally what users attach to bug reports. Replay one against the current tree with:
+
+```bash
+cd coverage
+./run_all --debug_file <path-to-predbat_debug.yaml>
+```
+
+It lists every config item that differs from its default, recalculates the plan, and writes `plan_orig.html` / `plan_final.json` into `coverage/`. Add `--redo` to recompute rates, load model and Octopus slots instead of reusing the ones in the dump. Committed examples live in `coverage/cases/*.yaml` and run as golden regressions under `./run_all --test debug_cases`.
+
+### Debugging notes
+
+`.claude/skills/issue-triage/references/debug-journal.md` records what past investigations found: per-integration API quirks, symptom-to-module pointers, and traps such as stale kernel binaries and test-order pollution. Read it before debugging an integration or a "the plan is wrong" report, and add to it when you learn something a future session would want.
+
 ## Code Quality
 
 All checks are enforced via pre-commit and must pass before merging:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,21 @@ source setup.csh
 
 The `run_all` script is a thin wrapper; you can run `unit_test.py` directly from the `coverage/` directory (it needs to be the working directory so relative paths resolve).
 
+### Replaying a debug dump
+
+`predbat_debug_*.yaml` is a full state dump, written to `debug/` when `switch.predbat_debug_enable` is on and normally what users attach to bug reports. Replay one against the current tree with:
+
+```bash
+cd coverage
+./run_all --debug_file <path-to-predbat_debug.yaml>
+```
+
+It lists every config item that differs from its default, recalculates the plan, and writes `plan_orig.html` / `plan_final.json` into `coverage/`. Add `--redo` to recompute rates, load model and Octopus slots instead of reusing the ones in the dump. Committed examples live in `coverage/cases/*.yaml` and run as golden regressions under `./run_all --test debug_cases`.
+
+### Debugging notes
+
+`.claude/skills/issue-triage/references/debug-journal.md` records what past investigations found: per-integration API quirks, symptom-to-module pointers, and traps such as stale kernel binaries and test-order pollution. Read it before debugging an integration or a "the plan is wrong" report, and add to it when you learn something a future session would want.
+
 ## Code Quality
 
 All checks are enforced via pre-commit and must pass before merging:

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -164,6 +164,7 @@ DISALLOWED_TOOLS = ",".join(
         "Bash(gh workflow*)",
         "Bash(gh auth*)",
         "Bash(gh secret*)",
+        "Bash(gh api*)",
     ]
 )
 

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -49,6 +49,13 @@ DISALLOWED_TOOLS blocks all MCP tools plus the git/gh commands that
 would publish something, and --max-turns/--max-budget-usd cap a single
 invocation from running away.
 
+Everything Claude prints for an issue is captured to
+~/predbat-triage-bot/logs/issue-<number>.log - appended, not truncated, so a
+run that failed and got retried keeps the failed attempt too. The daemon's own
+console output just says which issue it is working on and where that log is;
+`tail -f` it to watch a triage in progress. Logs are never pruned, so clear the
+directory out yourself if it grows.
+
 The allowlist deliberately includes general-purpose tools (python3,
 curl, ./run_all), which together amount to arbitrary code execution
 inside the clone - the triage skill needs to open a reporter's log,
@@ -69,6 +76,7 @@ REPO = "springfall2008/batpred"
 BASE_DIR = Path.home() / "predbat-triage-bot"
 CLONE_DIR = BASE_DIR / "batpred"
 SCRATCH_DIR = BASE_DIR / "scratch"
+LOG_DIR = BASE_DIR / "logs"
 STATE_FILE = BASE_DIR / "state.json"
 POLL_SECONDS = 300
 
@@ -212,6 +220,9 @@ def triage(issue_number):
         ALLOWED_TOOLS,
         "--disallowedTools",
         DISALLOWED_TOOLS,
+        # Turn-by-turn trace rather than just the final message, so the per-issue
+        # log below shows which tool calls ran and which were denied.
+        "--verbose",
         # Downloads land outside the clone, so the session needs the scratch
         # directory in scope for Read/Grep as well as for the Bash rules above.
         "--add-dir",
@@ -225,8 +236,16 @@ def triage(issue_number):
         "--max-budget-usd",
         "10.00",
     ]
-    print(f"[triage] issue #{issue_number}: starting", flush=True)
-    result = subprocess.run(cmd, cwd=str(CLONE_DIR))
+    log_path = LOG_DIR / f"issue-{issue_number}.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"[triage] issue #{issue_number}: starting, logging to {log_path}", flush=True)
+    # Append rather than truncate: a failed run leaves the issue unprocessed, so the
+    # next poll retries it - and the failed attempt's output is the part worth keeping.
+    with log_path.open("a") as log_handle:
+        log_handle.write(f"\n==== issue #{issue_number} started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
+        log_handle.flush()
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        log_handle.write(f"==== issue #{issue_number} exited {result.returncode} ====\n")
     if result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd)
     print(f"[triage] issue #{issue_number}: exited {result.returncode}", flush=True)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -38,16 +38,29 @@ Setup (one-time, on whichever always-on machine will run this):
        python3 tools/triage_daemon.py
 
 What it does per new issue: syncs the dedicated clone to origin/main,
-then runs `claude -p "/issue-triage <number>"` (the skill at
-.claude/skills/issue-triage/SKILL.md) with a permission mode that
-denies anything not explicitly listed below - git/gh read commands,
-running one targeted test, editing files only inside this dedicated
-clone, and fetching issue attachments. All MCP tools are explicitly
-denied (--disallowedTools "mcp__*"), and --max-turns/--max-budget-usd
-cap a single invocation from running away.
+empties the scratch directory used for issue attachments, then runs
+`claude -p "/issue-triage <number> scratch=<dir>"` (the skill at
+.claude/skills/issue-triage/SKILL.md) with a permission mode that denies
+anything not explicitly listed in ALLOWED_TOOLS: gh, git history and
+re-sync, running one targeted test, downloading and grepping issue
+attachments (logs are routinely far larger than WebFetch will return),
+and editing files inside the clone or the scratch directory.
+DISALLOWED_TOOLS blocks all MCP tools plus the git/gh commands that
+would publish something, and --max-turns/--max-budget-usd cap a single
+invocation from running away.
+
+The allowlist deliberately includes general-purpose tools (python3,
+curl, ./run_all), which together amount to arbitrary code execution
+inside the clone - the triage skill needs to open a reporter's log,
+parse their debug yaml and run a test. That is what the dedicated
+throwaway clone in step 2 is protecting: treat this checkout as
+disposable, and don't run the daemon on a machine holding credentials
+you wouldn't hand to an issue reporter. DISALLOWED_TOOLS is a backstop
+against the obvious mistakes, not a sandbox boundary.
 """
 
 import json
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -55,25 +68,94 @@ from pathlib import Path
 REPO = "springfall2008/batpred"
 BASE_DIR = Path.home() / "predbat-triage-bot"
 CLONE_DIR = BASE_DIR / "batpred"
+SCRATCH_DIR = BASE_DIR / "scratch"
 STATE_FILE = BASE_DIR / "state.json"
 POLL_SECONDS = 300
 
 EDIT_SCOPE = f"//{CLONE_DIR.relative_to('/')}/**"
+SCRATCH_SCOPE = f"//{SCRATCH_DIR.relative_to('/')}/**"
 ALLOWED_TOOLS = ",".join(
     [
+        # Read the issue, search for duplicates, post the triage comment
         "Bash(gh *)",
+        # Git history, and the re-sync/discard the skill does before investigating
         "Bash(git log*)",
         "Bash(git diff*)",
         "Bash(git show*)",
         "Bash(git blame*)",
         "Bash(git grep*)",
+        "Bash(git status*)",
+        "Bash(git branch*)",
+        "Bash(git tag*)",
+        "Bash(git describe*)",
+        "Bash(git rev-parse*)",
+        "Bash(git remote -v*)",
+        "Bash(git remote show*)",
+        "Bash(git fetch*)",
+        "Bash(git reset*)",
+        "Bash(git checkout*)",
+        "Bash(git restore*)",
+        "Bash(git clean*)",
+        "Bash(git stash*)",
+        # Running one targeted test, from coverage/ or from the repo root
         "Bash(cd *)",
         "Bash(./run_all*)",
+        "Bash(coverage/run_all*)",
+        "Bash(./coverage/run_all*)",
+        "Bash(python3 *)",
+        # Pulling issue attachments down and picking them apart. A predbat.log
+        # is often tens of MB - too big for WebFetch and too big to read into
+        # context, so it gets downloaded and grepped instead.
+        "Bash(curl *)",
+        "Bash(mkdir *)",
+        "Bash(unzip *)",
+        "Bash(gunzip *)",
+        "Bash(zcat *)",
+        "Bash(tar *)",
+        "Bash(file *)",
+        "Bash(ls *)",
+        "Bash(find *)",
+        "Bash(wc *)",
+        "Bash(head *)",
+        "Bash(tail *)",
+        "Bash(cat *)",
+        "Bash(grep *)",
+        "Bash(rg *)",
+        "Bash(sed *)",
+        "Bash(awk *)",
+        "Bash(sort *)",
+        "Bash(uniq *)",
+        "Bash(cut *)",
+        "Bash(tr *)",
+        "Bash(tee *)",
+        "Bash(echo *)",
         f"Edit({EDIT_SCOPE})",
+        f"Edit({SCRATCH_SCOPE})",
+        f"Write({EDIT_SCOPE})",
+        f"Write({SCRATCH_SCOPE})",
         "WebFetch",
         "Read",
         "Grep",
         "Glob",
+    ]
+)
+# Deny wins over allow, so these carve the publishing commands back out of
+# the broad "Bash(gh *)" / "Bash(git ...)" entries above.
+DISALLOWED_TOOLS = ",".join(
+    [
+        "mcp__*",
+        "Bash(git push*)",
+        "Bash(git commit*)",
+        "Bash(git remote add*)",
+        "Bash(git remote set-url*)",
+        "Bash(gh pr create*)",
+        "Bash(gh pr merge*)",
+        "Bash(gh pr close*)",
+        "Bash(gh repo*)",
+        "Bash(gh release*)",
+        "Bash(gh workflow*)",
+        "Bash(gh auth*)",
+        "Bash(gh secret*)",
     ]
 )
 
@@ -109,21 +191,33 @@ def fetch_new_issues(since_number):
 def sync_repo():
     subprocess.run(["git", "-C", str(CLONE_DIR), "fetch", "origin", "main"], check=True)
     subprocess.run(["git", "-C", str(CLONE_DIR), "reset", "--hard", "origin/main"], check=True)
+    # Drop untracked leftovers from the previous run's investigation. Not -x:
+    # coverage/venv/ is gitignored and expensive to rebuild every issue.
+    subprocess.run(["git", "-C", str(CLONE_DIR), "clean", "-fd"], check=True)
+
+
+def reset_scratch():
+    shutil.rmtree(SCRATCH_DIR, ignore_errors=True)
+    SCRATCH_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def triage(issue_number):
     cmd = [
         "claude",
         "-p",
-        f"/issue-triage {issue_number}",
+        f"/issue-triage {issue_number} scratch={SCRATCH_DIR}",
         "--permission-mode",
         "dontAsk",
         "--allowedTools",
         ALLOWED_TOOLS,
         "--disallowedTools",
-        "mcp__*",
+        DISALLOWED_TOOLS,
+        # Downloads land outside the clone, so the session needs the scratch
+        # directory in scope for Read/Grep as well as for the Bash rules above.
+        "--add-dir",
+        str(SCRATCH_DIR),
         "--max-turns",
-        "40",
+        "60",
         # Client-side token-usage estimate, not a real spend cap under subscription
         # auth (see agent-sdk/cost-tracking) - just a circuit-breaker against a
         # runaway invocation, sized generously since one issue can need several
@@ -147,6 +241,7 @@ def main():
         try:
             for issue in fetch_new_issues(state["last_processed"]):
                 sync_repo()
+                reset_scratch()
                 triage(issue["number"])
                 state["last_processed"] = issue["number"]
                 save_state(state)


### PR DESCRIPTION
## Why

The auto-triage bot was hitting permission denials on three things the `issue-triage` skill actually asks it to do:

1. **Downloading a reporter's log** — `curl` and `python3` were not allowed, and a `predbat.log` is routinely tens of MB, past what WebFetch returns.
2. **Re-syncing the clone** — `git fetch` / `git reset --hard` were denied, so a run investigated whatever the checkout happened to be at.
3. **Running one targeted test** — `./run_all --test <name>` was denied despite the rule being present, most likely because of the shape of the command (compound with a redirect to an out-of-scope path).

## What changed

**`tools/triage_daemon.py`**

- Allowlist now covers `curl`, `python3` and the text-slicing commands needed to grep a large log, plus `git fetch`/`reset`/`checkout`/`clean` for the in-session re-sync, and `coverage/run_all` variants for running the test from the repo root.
- New scratch directory (`~/predbat-triage-bot/scratch`), emptied per issue and passed via `--add-dir`, so downloads and redirect targets land somewhere in scope for `Read`/`Grep` as well as Bash.
- New `DISALLOWED_TOOLS`: `git push`/`commit` and the publishing `gh` commands are now denied by the harness rather than only by the skill's prose guardrails — the broad `Bash(gh *)` entry had been leaving `gh pr create`, `gh release`, `gh auth` and friends open.
- `sync_repo()` runs `git clean -fd` (not `-x`, so `coverage/venv/` survives), making the "hard-reset before the next run" claim in the docstring true for untracked leftovers.
- `--max-turns` 40 → 60, since downloading and grepping a log costs turns.

**`.claude/skills/issue-triage/SKILL.md`**

- Documents the download-and-grep recipe for attachments, the sync command, and the save-output-then-grep form for the targeted test run (per the CLAUDE.md testing rule).
- New guardrail: when a permission block stops a step, say so plainly in the triage comment rather than wording it so a skipped step reads as a completed one.

**`.claude/skills/issue-triage/references/debug-journal.md` (new)**

Distilled from maintainer debugging sessions, June–August 2026:

- **Replaying a reporter's `predbat_debug.yaml`** — `./run_all --debug_file <file>` reproduces their plan and lists every config item they have changed from default. Verified by running it against `coverage/cases/predbat_debug_agile1.yaml`.
- **Check configuration before code**, with GH#4222 and GH#4478 as worked examples.
- **Per-integration table** — Fox unsupported-setting errno, Solis CID 636 TOU bit, SolaX 10402 and the 10% SOC clamp, Sigenergy midnight counter reset, GE Cloud nulls, Teslemetry nameplate inference and per-cycle TOU rewrite, Sunsynk/DEYE per-slot power register and `read_only`, `grid_power_invert` bleeding between two configured systems, Enphase MFA/DTG/CSRF, Octopus IOG and saving sessions, and more — each with the symbol to grep and the registered test name.
- **Symptom → module table** and the traps that have wasted time before (stale kernel binaries, test-order pollution, version drift, log noise).

Every symbol cited was checked against the current tree. Three notes did not survive that check and were corrected or dropped: Fox's unsupported errno is now `(42015, 44096)`; `load_power_statistics_enable` no longer exists; and there is no registered Predheat test, so that row says so explicitly.

**`CLAUDE.md` / `AGENTS.md`**

Gain the `--debug_file` replay recipe, which was missing from the testing docs entirely, and a pointer to the journal. No pointer to the skill itself — skills are auto-listed to the model each session, so that would be redundant.

## Testing

`pre-commit` passes on all changed files (`zcat` and `errno` added to the workspace dictionary). The debug replay was run end to end to confirm the command and flag names before documenting them. No production code is touched — this is bot tooling and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
