### PR TITLE
Fix the triage bot's blocked test runs, and drop the dead Write() rules

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -57,12 +57,13 @@ Search existing issues (`gh issue list --search ...`, both open and closed) for 
 - Read [references/debug-journal.md](references/debug-journal.md) before forming a hypothesis. It maps common symptoms to modules, records known per-integration behaviour from past investigations, and lists the traps that have wasted time before. Its entries are dated observations, not current truth — confirm anything you rely on against the working tree.
 - Read the relevant source area for the reported symptom (e.g. `apps/predbat/fetch.py` for rate issues, `apps/predbat/inverter.py` for a named inverter).
 - Check `git log` / `git blame` on that area for recent related changes — the issue may already be fixed on main since the version the reporter is using.
-- If the issue clearly maps to an existing test module (`apps/predbat/tests/test_<feature>.py`, listed in `TEST_REGISTRY` in `unit_test.py`), run just that test. Save the output and grep it rather than reading it all back — the run is verbose:
+- If the issue clearly maps to an existing test module (`apps/predbat/tests/test_<feature>.py`, listed in `TEST_REGISTRY` in `unit_test.py`), run just that test with the wrapper, from the repo root:
 
   ```bash
-  cd coverage && ./run_all --test <name> > <scratch>/test.log 2>&1; echo "exit=$?"
-  tail -30 <scratch>/test.log
+  tools/triage_test.sh <name> <scratch>/test.log
   ```
+
+  It prints the exit status and the last 30 lines; grep the log file for anything more. Use the wrapper rather than composing your own `cd coverage && ./run_all ... > log` — a `cd` combined with an output redirect is refused outright in this session's permission mode, which is why the wrapper exists.
 
   Skip this step if there's no clean mapping — never run the full suite. A test only settles questions about code behaviour; it can't settle what real hardware did, so don't run one to look thorough.
 

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -105,11 +105,16 @@ ALLOWED_TOOLS = ",".join(
         "Bash(git restore*)",
         "Bash(git clean*)",
         "Bash(git stash*)",
-        # Running one targeted test, from coverage/ or from the repo root
+        # Running one targeted test. tools/triage_test.sh keeps the cd into
+        # coverage/ and the output redirect inside the script, because Claude Code
+        # prompts on a cd combined with an output redirect - which is what the
+        # obvious "cd coverage && ./run_all --test X > log 2>&1" form is, so it is
+        # denied outright under dontAsk no matter what rules are listed here.
+        "Bash(tools/triage_test.sh *)",
+        "Bash(./tools/triage_test.sh *)",
         "Bash(cd *)",
-        "Bash(./run_all*)",
-        "Bash(coverage/run_all*)",
-        "Bash(./coverage/run_all*)",
+        "Bash(./run_all *)",
+        "Bash(./run_all)",
         "Bash(python3 *)",
         # Pulling issue attachments down and picking them apart. A predbat.log
         # is often tens of MB - too big for WebFetch and too big to read into

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -137,10 +137,10 @@ ALLOWED_TOOLS = ",".join(
         "Bash(tr *)",
         "Bash(tee *)",
         "Bash(echo *)",
+        # Edit rules cover every file-editing tool (Write included) - a Write(path)
+        # rule is not matched by the file permission check, so don't add one.
         f"Edit({EDIT_SCOPE})",
         f"Edit({SCRATCH_SCOPE})",
-        f"Write({EDIT_SCOPE})",
-        f"Write({SCRATCH_SCOPE})",
         "WebFetch",
         "Read",
         "Grep",

--- a/tools/triage_test.sh
+++ b/tools/triage_test.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Run one Predbat test module and save the full output to a log file.
+#
+# usage: tools/triage_test.sh <test-name> [log-file]
+#
+# This exists for the triage bot (tools/triage_daemon.py). run_all has to
+# execute with coverage/ as the working directory, and the obvious way to write
+# that - `cd coverage && ./run_all --test X > out.log 2>&1` - is denied under a
+# non-interactive permission mode: Claude Code prompts on a `cd` combined with
+# an output redirect, because it can't tell which directory the redirect target
+# resolves against once the `cd` has run. Keeping the cd and the redirect inside
+# this script leaves a single plain command for the permission check to match.
+#
+# Prints the exit status and the tail of the log; grep the log file for the rest.
+# Exits with the test run's own status.
+
+set -u
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <test-name> [log-file]" >&2
+    exit 2
+fi
+
+test_name=$1
+log_file=${2:-${TMPDIR:-/tmp}/triage-test-$1.log}
+
+cd "$(dirname "$0")/../coverage" || exit 1
+
+./run_all --test "$test_name" > "$log_file" 2>&1
+status=$?
+
+echo "test=$test_name exit=$status log=$log_file"
+echo "---- last 30 lines ----"
+tail -n 30 "$log_file"
+
+exit $status


### PR DESCRIPTION
Follow-up to #4703, two fixes to the triage bot's permissions.

## Test runs were still being denied

The bot reported `./run_all --test solis` denied even though `Bash(./run_all*)` was allowed. The rule was never the problem. Per the [permissions docs](https://code.claude.com/docs/en/permissions#read-only-commands), a `cd` combined with an output redirect prompts, "because Claude Code can't determine which directory the redirect target resolves against after the `cd` runs" — and the skill's recipe was exactly that shape:

```bash
cd coverage && ./run_all --test <name> > <scratch>/test.log 2>&1
```

So it was refused under `dontAsk` regardless of what was in the allowlist. `run_all` has to execute with `coverage/` as the working directory, so the `cd` can't simply be dropped.

**`tools/triage_test.sh`** (new) keeps both the `cd` and the redirect inside the script, leaving one plain command for the permission check to match:

```bash
tools/triage_test.sh solis <scratch>/test.log
```

It prints the exit status and the last 30 lines of the log, and exits with the test run's own status. The skill now tells the bot to use it and says why, so it doesn't improvise the denied form again.

Also drops the `coverage/run_all` rules added in #4703 — those forms can't work at runtime anyway, since `run_all` sources `setup.csh` and resolves `unit_test.py` relative to `coverage/` — and switches the remaining `run_all` rules to the word-boundary form (`Bash(./run_all *)` rather than `Bash(./run_all*)`, which would also match `./run_all_anything`).

## Dead Write() rules

`Write(path)` rules are not matched by the file permission check — only `Edit(path)` rules are, and an `Edit` rule covers every file-editing tool, `Write` included. The two `Write(...)` entries granted nothing; the `Edit(...)` rules beside them already cover the clone and the scratch directory. Removed, with a comment so they don't come back.

## Testing

Ran the wrapper end to end against a real test module (`tools/triage_test.sh units <log>`): exit 0, log written, pass/fail summary in the printed tail. `pre-commit` passes on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
