### PR TITLE
fix(solis): clamp discharge slot SOC to the inverter's recovery SOC floor, and surface refused control writes

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -3195,13 +3195,15 @@ class SolisAPI(ComponentBase, OAuthMixin):
                         await self.fetch_entity_data(sn)
 
         # Control mode
+        control_success = True
         if first or (seconds % 60 == 0):
             # Write to inverter using new function (handles both V1 and V2)
             is_readonly = self.get_state_wrapper(f'switch.{self.prefix}_set_read_only', default='off') == 'on'
             if self.control_enable and not is_readonly:
                 for sn in self.inverter_sn:
                     await self.reset_charge_windows_if_needed(sn)
-                    await self.write_time_windows_if_changed(sn)
+                    if not await self.write_time_windows_if_changed(sn):
+                        control_success = False
             else:
                 self.log("Solis API: Control disabled, skipping writing time windows")
 
@@ -3213,8 +3215,16 @@ class SolisAPI(ComponentBase, OAuthMixin):
         if first and self.automatic and self.inverter_sn:
             await self.automatic_config()
 
-        # Return status
-        if poll_success:
+        # Return status. A refused control write must not refresh the success timestamp:
+        # components.is_alive() treats a stale timestamp as unhealthy, which surfaces as
+        # "component errors: Solis" in the run status. Without this a register the inverter
+        # keeps rejecting is invisible outside the log (see issue #4702).
+        #
+        # The run itself is still reported as successful, so a control failure does not reach
+        # non_fatal_error_occurred(). That sets base.had_errors, and the had_errors branch in
+        # update_pred() skips record_status() entirely, which would freeze predbat.status on
+        # its last value rather than show an error.
+        if poll_success and control_success:
             self.update_success_timestamp()
 
         # Mark API as started after first successful run

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -113,7 +113,6 @@ SOLIS_CID_INFREQUENT = [
     SOLIS_CID_BATTERY_RESERVE_SOC,
     SOLIS_CID_BATTERY_OVER_DISCHARGE_SOC,
     SOLIS_CID_BATTERY_FORCE_CHARGE_SOC,
-    SOLIS_CID_BATTERY_RECOVERY_SOC,
     SOLIS_CID_BATTERY_MAX_CHARGE_SOC,
     # Battery max currents
     SOLIS_CID_BATTERY_MAX_CHARGE_CURRENT,
@@ -123,6 +122,14 @@ SOLIS_CID_INFREQUENT = [
     SOLIS_CID_MAX_OUTPUT_POWER,
     SOLIS_CID_MAX_EXPORT_POWER,
     SOLIS_CID_BATTERY_CAPACITY,
+]
+
+# Infrequent poll CIDs that must be read one at a time. The atReadBatch endpoint returns a
+# wrong value for these - CID 7229 comes back as "1" rather than the real recovery SOC, which
+# a single atRead reports correctly - so batching them silently poisons the cache and the
+# published entity. Polled alongside SOLIS_CID_INFREQUENT with batch=False.
+SOLIS_CID_INFREQUENT_SINGLE = [
+    SOLIS_CID_BATTERY_RECOVERY_SOC,
 ]
 
 SOLIS_CID_LIST_TOU_V2 = [
@@ -182,6 +189,23 @@ SOLIS_BIT_BACKUP_MODE = 4  # Battery reserve/backup mode
 SOLIS_BIT_GRID_CHARGING = 5  # Allow grid charging
 SOLIS_BIT_FEED_IN_PRIORITY = 6  # Feed-in priority mode
 SOLIS_BIT_PEAK_SHAVING = 11  # Peak-shaving mode
+
+def parse_cid_int(value, default=None):
+    """Convert a CID register value to an int, returning default when it is missing or not numeric.
+
+    Register reads arrive as strings and are None when a poll has not populated the cache yet,
+    so callers that need to compare them numerically go through here rather than guessing a value.
+
+    Args:
+        value: Raw register value, usually a string
+        default: Value to return when the conversion is not possible
+
+    Returns: The value as an int, or default
+    """
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
 
 def get_solis_mode_enum(value):
     """
@@ -668,6 +692,52 @@ class SolisAPI(ComponentBase, OAuthMixin):
             slot_data["charge_enable"] = 0
             slot_data["discharge_enable"] = 0
 
+    async def resolve_discharge_soc_floor(self, inverter_sn, target_soc):
+        """Return the lowest discharge slot cut-off SOC the inverter will actually accept.
+
+        The inverter refuses any discharge slot cut-off below the battery recovery SOC
+        (CID 7229), and refuses to take a recovery SOC below the over-discharge SOC
+        (CID 158) plus one. A refused write is silent - the control API answers with
+        code 0 and the register keeps its previous value - so a slot can sit at a stale
+        cut-off far above the target and never force export at all.
+
+        Where the recovery SOC is higher than the inverter's own minimum it is lowered
+        towards the target first, so only the unavoidable one percent is given up. The
+        over-discharge SOC is never written here, leaving the battery protection floor
+        where the user set it.
+
+        Args:
+            inverter_sn: Inverter serial number
+            target_soc: Cut-off SOC Predbat wants for the discharge slot, as a percentage
+
+        Returns: The cut-off SOC to write, which is target_soc or the lowest value above it the inverter will take
+        """
+        values = self.cached_values.get(inverter_sn, {})
+
+        # Cache only - the infrequent poll runs before the first control write, so a missing
+        # value means we cannot tell where the floor is and the target is left alone
+        recovery_soc = parse_cid_int(values.get(SOLIS_CID_BATTERY_RECOVERY_SOC))
+        if recovery_soc is None or target_soc >= recovery_soc:
+            return target_soc
+
+        # The inverter will not accept a recovery SOC at or below the over-discharge SOC
+        over_discharge_soc = parse_cid_int(values.get(SOLIS_CID_BATTERY_OVER_DISCHARGE_SOC))
+        hard_floor = (over_discharge_soc + 1) if over_discharge_soc is not None else recovery_soc
+
+        wanted_recovery = max(target_soc, hard_floor)
+        if wanted_recovery < recovery_soc:
+            self.log(f"Solis API: Discharge target {target_soc}% is below recovery SOC {recovery_soc}% on {inverter_sn}, lowering recovery SOC to {wanted_recovery}%")
+            if await self.read_and_write_cid(inverter_sn, SOLIS_CID_BATTERY_RECOVERY_SOC, wanted_recovery, field_description="battery recovery SOC"):
+                recovery_soc = wanted_recovery
+            else:
+                # Re-read rather than trust the requested value, the write may have been refused
+                recovery_soc = parse_cid_int(self.cached_values.get(inverter_sn, {}).get(SOLIS_CID_BATTERY_RECOVERY_SOC), recovery_soc)
+
+        if target_soc < recovery_soc:
+            self.log(f"Solis API: Clamping discharge slot SOC from {target_soc}% to {recovery_soc}% on {inverter_sn}, the inverter will not discharge below its recovery SOC")
+            return recovery_soc
+        return target_soc
+
     async def write_time_windows_if_changed(self, inverter_sn):
         """Write charge/discharge time windows, SOC, and current to inverter, only if values changed from cache.
         Automatically handles V1 vs V2 modes and only writes registers that have changed.
@@ -819,7 +889,10 @@ class SolisAPI(ComponentBase, OAuthMixin):
                         # Check and write discharge SOC if changed
                         if "discharge_soc" in slot_data:
                             soc_cid = SOLIS_CID_DISCHARGE_SOC[slot - 1]
-                            new_soc_str = str(int(slot_data['discharge_soc']))
+                            # The inverter silently discards a cut-off below its recovery SOC, leaving the
+                            # slot on a stale value that can stop it exporting at all (see issue #4702)
+                            new_soc = await self.resolve_discharge_soc_floor(inverter_sn, int(slot_data['discharge_soc']))
+                            new_soc_str = str(new_soc)
                             cached_soc = self.cached_values.get(inverter_sn, {}).get(soc_cid)
                             if cached_soc != new_soc_str:
                                 result = await self.read_and_write_cid(inverter_sn, soc_cid, new_soc_str, field_description=f"discharge slot {slot} SOC")
@@ -3091,6 +3164,8 @@ class SolisAPI(ComponentBase, OAuthMixin):
             for sn in self.inverter_sn:
                 self.log(f"Solis API: Performing infrequent data poll for inverter {sn}...")
                 await self.poll_inverter_data(sn, SOLIS_CID_INFREQUENT)
+                # Read separately, the batch endpoint mis-reports these (see SOLIS_CID_INFREQUENT_SINGLE)
+                await self.poll_inverter_data(sn, SOLIS_CID_INFREQUENT_SINGLE, batch=False)
                 # Recalculate max currents after polling infrequent data
                 self._calculate_max_currents(sn)
 

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -16,7 +16,7 @@ from solis import SolisAPI, SOLIS_CID_CHARGE_ENABLE_BASE, SOLIS_CID_CHARGE_TIME,
 from solis import SOLIS_CID_BATTERY_FORCE_CHARGE_SOC, SOLIS_CID_BATTERY_OVER_DISCHARGE_SOC, SOLIS_CID_CHARGE_DISCHARGE_SETTINGS
 from solis import SOLIS_CID_STORAGE_MODE, SOLIS_BIT_GRID_CHARGING, SOLIS_BIT_TOU_MODE
 from solis import SOLIS_CID_ALLOW_EXPORT, SOLIS_ALLOW_EXPORT_ON, SOLIS_ALLOW_EXPORT_OFF, SOLIS_CID_BATTERY_RESERVE_SOC
-from solis import SOLIS_CID_BATTERY_MAX_CHARGE_CURRENT
+from solis import SOLIS_CID_BATTERY_MAX_CHARGE_CURRENT, SOLIS_CID_BATTERY_RECOVERY_SOC, SOLIS_CID_DISCHARGE_SOC
 from solis import SOLIS_CID_POWER_LIMIT, SOLIS_BIT_BACKUP_MODE
 from solis import SOLIS_READ_ENDPOINT, SOLIS_READ_BATCH_ENDPOINT, SOLIS_CONTROL_ENDPOINT, SOLIS_INVERTER_LIST_ENDPOINT, SOLIS_INVERTER_DETAIL_ENDPOINT
 from solis import get_solis_mode_enum, compute_solis_mode_value
@@ -1244,6 +1244,13 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_write_time_windows_v2_no_changes())
         failed |= asyncio.run(test_write_time_windows_v2_stale_slot_clearing())
         failed |= asyncio.run(test_write_time_windows_v2_no_active_slot())
+        failed |= asyncio.run(test_discharge_soc_clamped_to_recovery_soc())
+        failed |= asyncio.run(test_recovery_soc_lowered_when_above_minimum())
+        failed |= asyncio.run(test_recovery_soc_lowered_to_target_when_reachable())
+        failed |= asyncio.run(test_discharge_soc_unchanged_above_recovery())
+        failed |= asyncio.run(test_discharge_soc_unclamped_when_recovery_unknown())
+        failed |= asyncio.run(test_recovery_soc_not_lowered_below_inverter_minimum())
+        failed |= asyncio.run(test_recovery_soc_polled_outside_batch())
         failed |= asyncio.run(test_write_time_windows_zero_charge_current())
         failed |= asyncio.run(test_write_time_windows_v1_slot_detection())
         failed |= asyncio.run(test_write_time_windows_v1_discharge_slot_detection())
@@ -2183,6 +2190,165 @@ async def test_write_time_windows_v2_stale_slot_clearing():
     assert slot2_time_idx < first_slot1_active, "Slot 2 time clear must precede slot 1 active write"
 
     print("PASSED: V2 mode two-pass clears stale disabled slots before writing active slot")
+    return False
+
+
+def _discharge_slot_api(discharge_soc, recovery_soc, over_discharge_soc, inverter_sn="TEST123"):
+    """Build a V2-mode MockSolisAPI with one enabled discharge slot and the given SOC limits.
+
+    Args:
+        discharge_soc: Cut-off SOC Predbat wants for the slot
+        recovery_soc: Value cached for CID 7229, or None to leave it absent
+        over_discharge_soc: Value cached for CID 158, or None to leave it absent
+        inverter_sn: Inverter serial number to use
+
+    Returns: The configured MockSolisAPI
+    """
+    api = MockSolisAPI()
+    api._test_v2_mode = True
+    api._mock_storage_mode = True
+    api.inverter_sn = [inverter_sn]
+    api.charge_discharge_time_windows[inverter_sn] = {
+        1: {
+            "charge_enable": 0,
+            "charge_start_time": "00:00",
+            "charge_end_time": "00:00",
+            "charge_soc": 100,
+            "charge_current": 50,
+            "discharge_enable": 1,
+            "discharge_start_time": "16:00",
+            "discharge_end_time": "19:00",
+            "discharge_soc": discharge_soc,
+            "discharge_current": 30,
+        }
+    }
+    cache = {}
+    if recovery_soc is not None:
+        cache[SOLIS_CID_BATTERY_RECOVERY_SOC] = str(recovery_soc)
+    if over_discharge_soc is not None:
+        cache[SOLIS_CID_BATTERY_OVER_DISCHARGE_SOC] = str(over_discharge_soc)
+    api.cached_values[inverter_sn] = cache
+    return api
+
+
+def _written_soc(api, inverter_sn="TEST123"):
+    """Return the value written to the discharge slot 1 cut-off SOC register, or None.
+
+    Args:
+        api: MockSolisAPI whose recorded calls should be searched
+        inverter_sn: Inverter serial number the write was made against
+
+    Returns: The written value as a string, or None if the register was not written
+    """
+    call = next((c for c in api.read_and_write_cid_calls if c["cid"] == SOLIS_CID_DISCHARGE_SOC[0]), None)
+    return call["value"] if call else None
+
+
+def _written_recovery(api):
+    """Return the value written to the battery recovery SOC register, or None.
+
+    Args:
+        api: MockSolisAPI whose recorded calls should be searched
+
+    Returns: The written value as a string, or None if the register was not written
+    """
+    call = next((c for c in api.read_and_write_cid_calls if c["cid"] == SOLIS_CID_BATTERY_RECOVERY_SOC), None)
+    return call["value"] if call else None
+
+
+async def test_discharge_soc_clamped_to_recovery_soc():
+    """A discharge target below the recovery SOC is raised to it when recovery cannot be lowered.
+
+    Reproduces issue #4702: with over-discharge at 20 the inverter holds recovery at 21 and
+    silently discards a write of 20, leaving the slot on a stale cut-off.
+    """
+    print("\n=== Test: discharge SOC clamped to recovery SOC ===")
+
+    api = _discharge_slot_api(discharge_soc=20, recovery_soc=21, over_discharge_soc=20)
+    assert await api.write_time_windows_if_changed("TEST123") is True, "write_time_windows_if_changed should succeed"
+
+    assert _written_soc(api) == "21", f"Discharge SOC should be clamped up to 21, got {_written_soc(api)}"
+    # Recovery is already at the inverter's minimum of over_discharge + 1, so must not be touched
+    assert _written_recovery(api) is None, "Recovery SOC must not be written when already at its minimum"
+    print("PASSED: Target of 20 clamped to recovery SOC of 21, recovery left alone")
+    return False
+
+
+async def test_recovery_soc_lowered_when_above_minimum():
+    """A recovery SOC above over-discharge + 1 is lowered towards the target before clamping."""
+    print("\n=== Test: recovery SOC lowered when above its minimum ===")
+
+    # Recovery sits at 50 but over-discharge is 20, so the inverter would accept 21
+    api = _discharge_slot_api(discharge_soc=20, recovery_soc=50, over_discharge_soc=20)
+    assert await api.write_time_windows_if_changed("TEST123") is True, "write_time_windows_if_changed should succeed"
+
+    assert _written_recovery(api) == "21", f"Recovery SOC should be lowered to 21, got {_written_recovery(api)}"
+    assert _written_soc(api) == "21", f"Discharge SOC should then be 21, got {_written_soc(api)}"
+    print("PASSED: Recovery lowered 50 -> 21 and discharge SOC written as 21 rather than a stale 50")
+    return False
+
+
+async def test_recovery_soc_lowered_to_target_when_reachable():
+    """When the target sits above over-discharge + 1 the recovery SOC drops to the target exactly."""
+    print("\n=== Test: recovery SOC lowered to the target itself ===")
+
+    # Target 30 is comfortably above the inverter minimum of 11, so no clamping is needed
+    api = _discharge_slot_api(discharge_soc=30, recovery_soc=45, over_discharge_soc=10)
+    assert await api.write_time_windows_if_changed("TEST123") is True, "write_time_windows_if_changed should succeed"
+
+    assert _written_recovery(api) == "30", f"Recovery SOC should be lowered to the target 30, got {_written_recovery(api)}"
+    assert _written_soc(api) == "30", f"Discharge SOC should be the unclamped target 30, got {_written_soc(api)}"
+    print("PASSED: Recovery lowered to the target so no capacity is given up")
+    return False
+
+
+async def test_discharge_soc_unchanged_above_recovery():
+    """A target already at or above the recovery SOC is written through untouched."""
+    print("\n=== Test: discharge SOC above recovery SOC is untouched ===")
+
+    api = _discharge_slot_api(discharge_soc=40, recovery_soc=21, over_discharge_soc=20)
+    assert await api.write_time_windows_if_changed("TEST123") is True, "write_time_windows_if_changed should succeed"
+
+    assert _written_soc(api) == "40", f"Discharge SOC should stay at 40, got {_written_soc(api)}"
+    assert _written_recovery(api) is None, "Recovery SOC must not be written when the target is already reachable"
+    print("PASSED: Reachable target written unchanged with no recovery write")
+    return False
+
+
+async def test_discharge_soc_unclamped_when_recovery_unknown():
+    """With no cached recovery SOC the target is written as-is rather than guessed at."""
+    print("\n=== Test: discharge SOC unclamped when recovery SOC is unknown ===")
+
+    api = _discharge_slot_api(discharge_soc=20, recovery_soc=None, over_discharge_soc=20)
+    assert await api.write_time_windows_if_changed("TEST123") is True, "write_time_windows_if_changed should succeed"
+
+    assert _written_soc(api) == "20", f"Discharge SOC should be the raw target 20, got {_written_soc(api)}"
+    assert _written_recovery(api) is None, "Recovery SOC must not be written when its value is unknown"
+    print("PASSED: Unknown recovery SOC leaves the target untouched")
+    return False
+
+
+async def test_recovery_soc_not_lowered_below_inverter_minimum():
+    """Recovery is never driven below over-discharge + 1, which the inverter refuses."""
+    print("\n=== Test: recovery SOC floored at over-discharge + 1 ===")
+
+    # Target of 5 is below the inverter minimum of 21, so recovery stops at 21 and the target clamps
+    api = _discharge_slot_api(discharge_soc=5, recovery_soc=40, over_discharge_soc=20)
+    assert await api.write_time_windows_if_changed("TEST123") is True, "write_time_windows_if_changed should succeed"
+
+    assert _written_recovery(api) == "21", f"Recovery SOC should stop at over-discharge + 1 = 21, got {_written_recovery(api)}"
+    assert _written_soc(api) == "21", f"Discharge SOC should be clamped to 21, got {_written_soc(api)}"
+    print("PASSED: Recovery floored at 21 and the target clamped to match")
+    return False
+
+
+async def test_recovery_soc_polled_outside_batch():
+    """CID 7229 is polled individually, the batch endpoint mis-reports it as 1."""
+    print("\n=== Test: recovery SOC excluded from the batch poll ===")
+
+    assert SOLIS_CID_BATTERY_RECOVERY_SOC not in solis_module.SOLIS_CID_INFREQUENT, "Recovery SOC must not be in the batched infrequent list"
+    assert SOLIS_CID_BATTERY_RECOVERY_SOC in solis_module.SOLIS_CID_INFREQUENT_SINGLE, "Recovery SOC must be in the single-read infrequent list"
+    print("PASSED: Recovery SOC is polled via the single-read list")
     return False
 
 

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -508,6 +508,8 @@ def _make_run_api(configured_sns=None, control_enable=True, automatic=False):
 
     async def mock_write_time_windows_if_changed(sn):
         api.write_time_windows_calls.append(sn)
+        # Mirror the real method, which reports whether every control register write verified
+        return getattr(api, "_test_write_result", True)
 
     api.write_time_windows_if_changed = mock_write_time_windows_if_changed
 
@@ -1250,6 +1252,9 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_discharge_soc_unchanged_above_recovery())
         failed |= asyncio.run(test_discharge_soc_unclamped_when_recovery_unknown())
         failed |= asyncio.run(test_recovery_soc_not_lowered_below_inverter_minimum())
+        failed |= asyncio.run(test_control_write_failure_withholds_success_timestamp())
+        failed |= asyncio.run(test_control_write_success_updates_success_timestamp())
+        failed |= asyncio.run(test_storage_mode_failure_does_not_fail_control_write())
         failed |= asyncio.run(test_recovery_soc_polled_outside_batch())
         failed |= asyncio.run(test_write_time_windows_zero_charge_current())
         failed |= asyncio.run(test_write_time_windows_v1_slot_detection())
@@ -2339,6 +2344,90 @@ async def test_recovery_soc_not_lowered_below_inverter_minimum():
     assert _written_recovery(api) == "21", f"Recovery SOC should stop at over-discharge + 1 = 21, got {_written_recovery(api)}"
     assert _written_soc(api) == "21", f"Discharge SOC should be clamped to 21, got {_written_soc(api)}"
     print("PASSED: Recovery floored at 21 and the target clamped to match")
+    return False
+
+
+async def test_control_write_failure_withholds_success_timestamp():
+    """A refused control register write stops the success timestamp advancing, so the component ages out.
+
+    components.is_alive() treats a timestamp older than an hour as unhealthy, which is what puts
+    "component errors: Solis" into the run status instead of the failure sitting only in the log.
+    """
+    print("\n=== Test: control write failure withholds the success timestamp ===")
+
+    sn = "INV001"
+    api = _make_run_api(configured_sns=[sn], control_enable=True)
+    api._test_write_result = False
+
+    async def mock_get_inverter_list():
+        return [{"sn": sn}]
+
+    api.get_inverter_list = mock_get_inverter_list
+
+    result = await api.run(seconds=0, first=True)
+
+    assert api.write_time_windows_calls == [sn], "The control write should still have been attempted"
+    assert api.update_success_timestamp_calls == 0, "A failed control write must not refresh the success timestamp"
+    # Still True: routing this through the return value would hit non_fatal_error_occurred(), whose
+    # had_errors flag makes update_pred() skip record_status() and freeze predbat.status
+    assert result is True, "The run itself should still be reported as successful"
+    print("PASSED: Failed control write withheld the timestamp without failing the run")
+    return False
+
+
+async def test_control_write_success_updates_success_timestamp():
+    """A clean control write refreshes the success timestamp as before."""
+    print("\n=== Test: successful control write updates the success timestamp ===")
+
+    sn = "INV001"
+    api = _make_run_api(configured_sns=[sn], control_enable=True)
+
+    async def mock_get_inverter_list():
+        return [{"sn": sn}]
+
+    api.get_inverter_list = mock_get_inverter_list
+
+    result = await api.run(seconds=0, first=True)
+
+    assert api.update_success_timestamp_calls == 1, "A successful control write should refresh the timestamp"
+    assert result is True, "Run should return True"
+    print("PASSED: Successful control write refreshed the timestamp")
+    return False
+
+
+async def test_storage_mode_failure_does_not_fail_control_write():
+    """A refused CID 636 write must not make write_time_windows_if_changed report failure.
+
+    The TOU bit on CID 636 is cleared by some inverters for reasons that are not understood, and it
+    fails verification on every cycle. Letting that count as a control failure would age those
+    systems out to unhealthy permanently, so the storage mode result is deliberately not folded
+    into the return value. This test pins that down.
+    """
+    print("\n=== Test: storage mode failure does not fail the control write ===")
+
+    inverter_sn = "TEST123"
+    api = _discharge_slot_api(discharge_soc=40, recovery_soc=21, over_discharge_soc=20, inverter_sn=inverter_sn)
+    api._mock_storage_mode = False  # Exercise the real set_storage_mode_if_needed path
+    # Force a mode change so the CID 636 write is actually attempted
+    api.cached_values[inverter_sn][SOLIS_CID_STORAGE_MODE] = "0"
+
+    async def failing_storage_mode_write(sn, cid, value, field_description=None):
+        api.read_and_write_cid_calls.append({"inverter_sn": sn, "cid": cid, "value": str(value), "field_description": field_description})
+        if cid == SOLIS_CID_STORAGE_MODE:
+            return False
+        if sn not in api.cached_values:
+            api.cached_values[sn] = {}
+        api.cached_values[sn][cid] = str(value)
+        return True
+
+    api.read_and_write_cid = failing_storage_mode_write
+
+    result = await api.write_time_windows_if_changed(inverter_sn)
+
+    storage_calls = [c for c in api.read_and_write_cid_calls if c["cid"] == SOLIS_CID_STORAGE_MODE]
+    assert len(storage_calls) > 0, "The storage mode write should have been attempted"
+    assert result is True, "A failed storage mode write must not fail the control write"
+    print("PASSED: CID 636 failure left the control write reporting success")
     return False
 
 


### PR DESCRIPTION
Fixes #4702.

## The bug

The inverter refuses any discharge slot cut-off SOC below the battery recovery SOC (CID 7229), and will not take a recovery SOC at or below the over-discharge SOC (CID 158). Predbat writes the reserve verbatim to *both* CID 158 and the slot cut-off, so the cut-off is always exactly one percent below the floor and can never be accepted.

The refusal is silent — the control API answers `code: 0` and the register keeps its previous value — so a slot sits on a stale cut-off that can be far above the target, and the battery never force exports, while `predbat.status` still reports `Exporting`. On one inverter the stale value was 50%, so no forced export ever ran below half charge.

## What this changes

**1. Clamp, and lower the recovery SOC where possible.** New `resolve_discharge_soc_floor()` lowers CID 7229 towards the target as far as the inverter allows (`over_discharge + 1`), then clamps the cut-off to whatever gap remains — usually the unavoidable one percent.

**CID 158 is deliberately never written**, so the battery protection floor stays where the user set it. Only the V2 path needs this; V1 doesn't write CID 5965 at all (it zeroes the discharge current instead), so it never meets the floor.

Side effect: this also settles the write-every-cycle retry loop. Previously cached `50` never matched the wanted `20`, so it rewrote forever; now the cached value matches what we ask for.

**2. Poll CID 7229 outside the batch read.** `atReadBatch` reports it as `1` while a single `atRead` returns the real value. That poisoned the cache and the published `recovery_soc` entity — and would have made the clamp a silent no-op, since it reads from the cache.

Moving the CID into `SOLIS_CID_SINGLE` would have been wrong: that list is only polled on the V1 path, so V2 inverters would never read recovery SOC at all. Added `SOLIS_CID_INFREQUENT_SINGLE` instead, polled with `batch=False` alongside `SOLIS_CID_INFREQUENT`, so both paths get a correct value.

**3. Surface a control register the inverter keeps refusing.** `read_and_write_cid()` detects the mismatch but only logs `Warn:`, so the whole failure mode above was invisible to the user — `predbat.status` carried on reporting `Exporting` while the battery did nothing.

`run()` now withholds the success timestamp when a control write fails verification. `components.is_alive()` already treats a timestamp older than an hour as unhealthy, so a persistent failure ages the component out into `Error: Complete run status ... with component errors: Solis`, and a transient one heals on the next cycle. No new counters or thresholds.

The run is still reported as successful, deliberately. Routing this through the return value reaches `non_fatal_error_occurred()`, and the `had_errors` branch in `update_pred()` skips `record_status()` altogether — which would *freeze* `predbat.status` on its last value rather than show an error, i.e. worse than the current behaviour.

Scope comes free from reusing what `write_time_windows_if_changed()` already reports: slot enable, time, SOC and current, plus CID 103 on V1. **The storage mode result is excluded**, so the CID 636 TOU bit that some inverters clear (see below) cannot age those systems out permanently. That exclusion is currently structural rather than explicit — `set_storage_mode_value()` keeps its result in a local and returns `None` — so there is a regression test pinning it down, because one future `success &= await self.set_storage_mode_if_needed(...)` would otherwise quietly mark every affected system unhealthy.

## Hardware validation

The design depends on CID 7229 being writable downwards, so that was checked against a live inverter before writing any of this:

```
recovery <- 30  read_back='30'  LANDED
recovery <- 25  read_back='25'  LANDED
recovery <- 21  read_back='21'  LANDED
recovery <- 20  read_back='21'  REJECTED    (over_discharge=20, so 21 is the minimum)
over_discharge(158) = '20' (was '20')       (untouched throughout)
```

The `recovery = over_discharge + 1` rule and the cut-off floor were confirmed on three inverters across two model families and both auth methods — full evidence in #4702.

## Design notes

`resolve_discharge_soc_floor()` reads from the cache only, with no live-read fallback. The `first=True` infrequent poll runs before the first control write, so the value is always populated by the time it is needed; if it somehow isn't, the target is written unclamped, i.e. exactly today's behaviour. That also keeps the helper out of the HTTP path on every slot write.

## Tests

Ten new tests in `test_solis.py`, registered in `run_solis_tests`:

- the #4702 case — target 20 with recovery 21 clamps to 21 and leaves recovery alone
- recovery at 50 with over-discharge 20 is lowered to 21, target written as 21 rather than a stale 50
- recovery lowered to the target itself when the target is above the inverter minimum
- a target already above recovery is written through untouched, with no recovery write
- unknown recovery SOC leaves the target unclamped
- recovery is never driven below `over_discharge + 1`
- CID 7229 is in the single-read poll list and not the batched one
- a failed control write withholds the success timestamp without failing the run
- a clean control write still refreshes it
- a refused CID 636 write does **not** fail the control write (the exclusion guard)

`./run_all --test solis` and `./run_all --quick` both pass, and `run_pre_commit` is clean.

Note `solis.py` carries `# fmt: off`, so black skips it; the new code follows the file's own one-blank-line convention between module-level functions.

## Still open from #4702

Not addressed here, happy to follow up separately:

- **CID 636 losing bit 1 (TOU)** — now tracked separately as #4707. Confirmed to happen while slot 1 is *active*, so it is not the known #4239 idle case, and it appears on the V1 path too. Deliberately excluded from the health escalation above until it is understood, so it cannot mark affected systems unhealthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
