### PR TITLE
fix(inverter): don't press the update button on idle non-export cycles

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2543,6 +2543,11 @@ class Inverter:
             self.log("Warn: Inverter {} unable read discharge window as neither REST, discharge_start_time or discharge_start_hour are set".format(self.id))
             return False
 
+        # Whether the caller asked us to manage the export times at all this cycle. execute.py calls
+        # adjust_force_export(False) with no times whenever nothing is being exported, which is a
+        # different thing from the GE branch below deliberately clearing them.
+        times_supplied = (new_start_time is not None) or (new_end_time is not None)
+
         # Start time to correct format
         if new_start_time:
             new_start_time += timedelta(seconds=self.base.inverter_clock_skew_discharge_start * 60)
@@ -2707,12 +2712,18 @@ class Inverter:
         # press zeroes the timed current registers (#4709), and it also triggers the 30s GivTCP sleep in
         # adjust_inverter_mode. Tracking what we last committed keeps a stable window quiet while still
         # committing once after a restart, when nothing has been committed yet (#4000).
+        # When the caller supplied no times at all we are not managing the export window this cycle, so
+        # neither time can have "changed". Comparing None against the time the inverter still reports is
+        # never equal, which pressed the update button on every idle cycle for the rest of the day (#2328).
+        # A genuine transition out of export is still caught by force_export != old_discharge_enable below.
+        start_changed = times_supplied and new_start != old_start
+        end_changed = times_supplied and new_end != old_end
         export_schedule = (new_start, new_end, force_export)
         # Separately, whether the start/end times themselves actually moved - used below to gate the
         # GivTCP settle sleep, which exists for the window write specifically ("start/end of discharge
         # window was just adjusted"). schedule_changed alone is too broad for that: it also goes True on
         # a bare scheduled_discharge_enable flip with the window untouched, which doesn't need settling.
-        times_changed = (new_end != old_end) or (new_start != old_start)
+        times_changed = start_changed or end_changed
         schedule_changed = times_changed or (force_export != old_discharge_enable)
         if is_hm_format and export_schedule != self.last_export_schedule_committed:
             # Only the H M path rewrites unconditionally, so only it needs the extra commit-once-per-run

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -2577,6 +2577,59 @@ def test_force_export_enable_only_flip_skips_settle_sleep(test_name, ha, inv):
     return failed
 
 
+def test_force_export_off_does_not_press_every_cycle(test_name, ha, my_predbat):
+    """
+    Regression test for issue #2328: with no export scheduled the update button must not be pressed on
+    every cycle.
+
+    execute.py calls adjust_force_export(False) with no times whenever nothing is being exported. On an
+    inverter with has_discharge_enable_time set (GS_fb00, and the FoxCloud/TESLA/Enphase/Deye/Sunsynk/
+    AlphaESS cloud types) the midnight override is skipped, so new_start/new_end stay None while the
+    inverter still reports a real time - and None never compares equal, so every cycle looked like a
+    change and pressed the button. That is most of the day, not just export windows.
+
+    Plain GS takes the midnight-override path and was never affected, so it is checked here too to pin
+    the difference down.
+    """
+    failed = False
+    print("Test: {}".format(test_name))
+
+    saved_type = my_predbat.args.get("inverter_type")
+
+    try:
+        for inverter_type, expected_presses in (("GS_fb00", 1), ("GS", 1)):
+            my_predbat.args["inverter_type"] = [inverter_type]
+            inv = Inverter(my_predbat, 0, quiet=True)
+            inv.rest_data = None
+
+            ha.dummy_items["select.discharge_start_time"] = "00:00:00"
+            ha.dummy_items["select.discharge_end_time"] = "00:00:00"
+            ha.dummy_items["switch.scheduled_discharge_enable"] = "off"
+            ha.dummy_items["select.inverter_mode"] = "Eco"
+            my_predbat.args["discharge_start_time"] = "select.discharge_start_time"
+            my_predbat.args["discharge_end_time"] = "select.discharge_end_time"
+            my_predbat.args["scheduled_discharge_enable"] = "switch.scheduled_discharge_enable"
+
+            presses = []
+            # Must report success, as a real press does - a falsy return means "not committed, retry"
+            inv.press_and_poll_button = lambda side="both", _p=presses: (_p.append(side), True)[1]
+
+            # Several cycles with nothing to export - the first may commit, the rest must be silent
+            for _ in range(4):
+                inv.adjust_force_export(False)
+
+            if len(presses) > expected_presses:
+                print(f"ERROR: {test_name}: {inverter_type} pressed the button {len(presses)} times over 4 idle cycles, expected at most {expected_presses}")
+                failed = True
+    finally:
+        if saved_type is None:
+            my_predbat.args.pop("inverter_type", None)
+        else:
+            my_predbat.args["inverter_type"] = saved_type
+
+    return failed
+
+
 def test_time_entity_hour_write(test_name, ha, inv, dummy_rest, direction, new_start, new_end):
     """
     Test that when *_start_hour / *_end_hour args resolve to time.* entities the full
@@ -3713,6 +3766,9 @@ charge_start_service:
 
     # Regression test: an enable-only flip (times unchanged) must not trigger the GivTCP settle sleep
     failed |= test_force_export_enable_only_flip_skips_settle_sleep("force_export_enable_only_flip_skips_settle_sleep", ha, inv)
+
+    # Regression test for issue #2328: idle (non-export) cycles must not press the button every time
+    failed |= test_force_export_off_does_not_press_every_cycle("force_export_off_no_repeat_press", ha, my_predbat)
     if failed:
         return failed
 

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -2588,13 +2588,20 @@ def test_force_export_off_does_not_press_every_cycle(test_name, ha, my_predbat):
     inverter still reports a real time - and None never compares equal, so every cycle looked like a
     change and pressed the button. That is most of the day, not just export windows.
 
-    Plain GS takes the midnight-override path and was never affected, so it is checked here too to pin
-    the difference down.
+    Plain GS takes the midnight-override path and is not affected by this None-comparison route, so it
+    is checked here too to pin the difference down. (GS was affected by a separate bug - #4711's
+    unconditional H M register rewrite, which GS also uses - but that is a different code path to the
+    one this test targets.)
     """
     failed = False
     print("Test: {}".format(test_name))
 
-    saved_type = my_predbat.args.get("inverter_type")
+    # my_predbat/ha are shared across the whole test run - save everything this test touches so it
+    # can be restored exactly, rather than leaking a changed/missing arg or dummy entity value into
+    # later tests and making results order-dependent.
+    unset = object()
+    saved_args = {key: my_predbat.args.get(key, unset) for key in ("inverter_type", "discharge_start_time", "discharge_end_time", "scheduled_discharge_enable")}
+    saved_items = {key: ha.dummy_items.get(key, unset) for key in ("select.discharge_start_time", "select.discharge_end_time", "switch.scheduled_discharge_enable", "select.inverter_mode")}
 
     try:
         for inverter_type, expected_presses in (("GS_fb00", 1), ("GS", 1)):
@@ -2622,10 +2629,16 @@ def test_force_export_off_does_not_press_every_cycle(test_name, ha, my_predbat):
                 print(f"ERROR: {test_name}: {inverter_type} pressed the button {len(presses)} times over 4 idle cycles, expected at most {expected_presses}")
                 failed = True
     finally:
-        if saved_type is None:
-            my_predbat.args.pop("inverter_type", None)
-        else:
-            my_predbat.args["inverter_type"] = saved_type
+        for key, value in saved_args.items():
+            if value is unset:
+                my_predbat.args.pop(key, None)
+            else:
+                my_predbat.args[key] = value
+        for key, value in saved_items.items():
+            if value is unset:
+                ha.dummy_items.pop(key, None)
+            else:
+                ha.dummy_items[key] = value
 
     return failed
 


### PR DESCRIPTION
Fixes #4712

**Draft — stacked on #4711, and not yet confirmed against a live install.**

Base is `fix/solis-redundant-button-press-4709`, so this PR shows only its own commit. Retarget to `main` once #4711 lands.

## Problem

`execute.py` calls `adjust_force_export(False)` with no times at all whenever nothing is being exported. On an inverter with `has_discharge_enable_time` set, the midnight-override branch is skipped, so `new_start` / `new_end` stay `None` while the inverter still reports a real time — and `None` never compares equal, so every idle cycle looks like a schedule change and presses the update button.

That is most of the day, not just export windows: roughly 288 presses/day rather than a handful. On Solis each press is a non-volatile register write (#2328) and also zeroes the timed current registers (#4415 / #4709).

## This PR is necessary but not sufficient on its own

There are **two** independent routes from an idle cycle to the button press, and this PR closes one of them. Measured on unmodified `main` (`b08b7716`), four idle `adjust_force_export(False)` calls:

```
             GS      GS_fb00
main         4/4     4/4
+#4711       1       4/4     <- #4711 closes the is_hm_format / changed_start_end route
+#4713       1       1       <- this PR closes the None-comparison route
```

- `GS` is `charge_time_format: "H M"`, so on `main` it presses every idle cycle via `changed_start_end`. **#4711 fixes that** — a wider benefit than #4711's own description claims.
- `GS_fb00` and the cloud types (`FoxCloud`, `TESLA`, `EnphaseCloud`, `DeyeCloud`, `SunsynkCloud`, `AlphaESSCloud`) additionally hit the `None` comparison. Their `old_start` / `old_end` are never overwritten — nothing is written when `new_start` is `None` — so that route stays true forever past #4711, and needs this PR.

An earlier revision of this description said plain `GS` "was never affected". That was measured with #4711 already applied rather than against `main`, and was wrong; corrected above. Thanks to the automated triage on #4712 for catching it.

## Fix

Only compare times the caller actually asked us to set.

The distinction matters: the GE branch *deliberately* clears the times to signal "we're using immediate controls", which is a different thing from the caller never supplying any. So the check keys off whether the caller supplied times, captured before either override runs — not off the times being `None` by the time we reach the comparison. That keeps the GE path's behaviour byte-for-byte unchanged, and is what `adjust_force_export1` in the existing suite pins down.

A genuine transition out of export is still caught by `force_export != old_discharge_enable`.

## Testing

New regression test covering both types, verified to fail without the fix:

```
ERROR: GS_fb00 pressed the button 4 times over 4 idle cycles, expected at most 1
```

Full `--quick` suite green.

## Why draft

Unit-level reproduction only; no live confirmation yet, and six of the eight affected types are cloud inverters that are hard to test here. Logs requested on #4712 and #4709 — the specific question is whether presses continue at the same 5-minute cadence when no export is scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)