### PR TITLE
Show car charging on the web power flow diagram

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -80,6 +80,8 @@ Chrg
 citem
 cloudfront
 cobat
+codepoint
+codepoints
 Codespaces
 COEFF
 collaps

--- a/apps/predbat/alphaess.py
+++ b/apps/predbat/alphaess.py
@@ -794,6 +794,9 @@ class AlphaESSAPI(ComponentBase):
         if ev_devices:
             self.set_arg_auto("car_charging_energy", [self._sensor_name(sn, "ev_energy_today") for sn in ev_devices])
             self.log("Info: AlphaESS mapped car_charging_energy to the EV charger energy of {} inverter(s): {}. It only affects the plan once car_charging_hold is enabled.".format(len(ev_devices), ev_devices))
+            # The live power reading of the same chargers. Display only - it feeds the web power
+            # flow diagram and the predbat.car_charging_power sensor, never the plan.
+            self.set_arg_auto("car_charging_power", [self._sensor_name(sn, "ev_power") for sn in ev_devices])
         else:
             self.log("Info: AlphaESS found no EV charger on any inverter, so car_charging_energy is left unset")
 

--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -2562,7 +2562,7 @@ APPS_SCHEMA = {
     "pv_forecast_d3": {"type": "sensor", "sensor_type": "float"},
     "pv_forecast_d4": {"type": "sensor", "sensor_type": "float"},
     "car_charging_energy": {"type": "sensor", "sensor_type": "float"},
-    "car_charging_power": {"type": "sensor|sensor_list", "sensor_type": "float"},
+    "car_charging_power": {"type": "sensor|sensor_list", "sensor_type": "float", "transient_ok": True},
     "num_cars": {"type": "integer", "zero": True},
     "car_charging_planned": {"type": "sensor|sensor_list", "sensor_type": "string|boolean", "entries": "num_cars"},
     "car_charging_planned_response": {"type": "string_list"},

--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -2561,7 +2561,7 @@ APPS_SCHEMA = {
     "pv_forecast_tomorrow": {"type": "sensor", "sensor_type": "float"},
     "pv_forecast_d3": {"type": "sensor", "sensor_type": "float"},
     "pv_forecast_d4": {"type": "sensor", "sensor_type": "float"},
-    "car_charging_energy": {"type": "sensor", "sensor_type": "float"},
+    "car_charging_energy": {"type": "sensor", "sensor_type": "float", "transient_ok": True},
     "car_charging_power": {"type": "sensor|sensor_list", "sensor_type": "float", "transient_ok": True},
     "num_cars": {"type": "integer", "zero": True},
     "car_charging_planned": {"type": "sensor|sensor_list", "sensor_type": "string|boolean", "entries": "num_cars"},

--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -2562,6 +2562,7 @@ APPS_SCHEMA = {
     "pv_forecast_d3": {"type": "sensor", "sensor_type": "float"},
     "pv_forecast_d4": {"type": "sensor", "sensor_type": "float"},
     "car_charging_energy": {"type": "sensor", "sensor_type": "float"},
+    "car_charging_power": {"type": "sensor|sensor_list", "sensor_type": "float"},
     "num_cars": {"type": "integer", "zero": True},
     "car_charging_planned": {"type": "sensor|sensor_list", "sensor_type": "string|boolean", "entries": "num_cars"},
     "car_charging_planned_response": {"type": "string_list"},

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -996,6 +996,8 @@ class Execute:
                     except (TypeError, ValueError):
                         self.log("Warn: Invalid PV power value for sensor {}".format(pv_power_sensors[idx]))
 
+        self.update_car_charging_power()
+
         self.soc_percent = calc_percent_limit(self.soc_kw, self.soc_max)
         self.reserve_percent = calc_percent_limit(self.reserve, self.soc_max)
         self.reserve_current_percent = calc_percent_limit(self.reserve_current, self.soc_max)
@@ -1043,6 +1045,49 @@ class Execute:
             self.publish_inverter_data()
             return True
         return False
+
+    def update_car_charging_power(self):
+        """
+        Read the live car charging power (W) from the optional car_charging_power sensors
+
+        This is a monitoring input only - the plan still models car charging from
+        car_charging_energy - so it is kept apart from the inverter totals above. Several
+        chargers can be listed and are summed, as car_charging_energy allows. A charger that
+        is configured but reading zero is not the same as no charger at all, so whether the
+        key is set at all is recorded separately: that is what decides if the car appears on
+        the power flow diagram and is published as a sensor.
+        """
+        sensors = self.get_arg("car_charging_power", None, indirect=False)
+        if not isinstance(sensors, list):
+            sensors = [sensors] if sensors else []
+
+        # The apps.yaml templates ship this as a regular expression matching the common chargers.
+        # auto_config(final=True) deletes the key when nothing matched, but until it has run the
+        # literal "re:" string is still here - treat it as unconfigured so a household with no
+        # charger never gets a car drawn on the power flow diagram.
+        sensors = [sensor for sensor in sensors if sensor and not (isinstance(sensor, str) and sensor.startswith("re:"))]
+
+        if not sensors:
+            self.car_charging_power_configured = False
+            self.car_charging_power = 0
+            return
+
+        self.car_charging_power_configured = True
+        car_charging_power = 0.0
+        for sensor in sensors:
+            # Resolved one entity at a time rather than by index, as auto_config() leaves a None
+            # in place of a list entry whose regular expression found nothing and an index-based
+            # read would then stop at the hole instead of the chargers after it.
+            #
+            # No numeric default is passed, and the conversion happens here, because get_arg would
+            # report a charger sitting at 'unavailable' with nothing plugged in as an error and
+            # leave the whole run flagged with errors - which is normal for a charger, not a fault.
+            value = self.resolve_arg("car_charging_power", sensor, default=None, required_unit="W")
+            try:
+                car_charging_power += float(value)
+            except (ValueError, TypeError):
+                pass
+        self.car_charging_power = car_charging_power
 
     def publish_inverter_data(self):
         """
@@ -1092,6 +1137,21 @@ class Execute:
                 "icon": "mdi:battery",
             },
         )
+        if self.car_charging_power_configured:
+            # Only published when a charger sensor is actually configured - a sensor pinned at
+            # zero for everyone else is noise, and its absence is how upstream consumers tell
+            # "no car charger" from "car charger idle"
+            self.dashboard_item(
+                self.prefix + ".car_charging_power",
+                state=dp3(self.car_charging_power / 1000.0),
+                attributes={
+                    "friendly_name": "Current Car Charging Power",
+                    "state_class": "measurement",
+                    "unit_of_measurement": "kW",
+                    "device_class": "power",
+                    "icon": "mdi:ev-station",
+                },
+            )
 
     def publish_inverter_config(self):
         """

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -1072,7 +1072,6 @@ class Execute:
             self.car_charging_power = 0
             return
 
-        self.car_charging_power_configured = True
         car_charging_power = 0.0
         for sensor in sensors:
             # Resolved one entity at a time rather than by index, as auto_config() leaves a None
@@ -1087,7 +1086,13 @@ class Execute:
                 car_charging_power += float(value)
             except (ValueError, TypeError):
                 pass
+
+        # Published together, after every sensor has been read, so the web server - which runs in
+        # its own thread and reads the pair independently - can never see a car declared but its
+        # power still left over from the previous cycle. Same reason fetch_inverter_data publishes
+        # its accumulated totals in one go rather than as it sums them.
         self.car_charging_power = car_charging_power
+        self.car_charging_power_configured = True
 
     def publish_inverter_data(self):
         """

--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -1368,6 +1368,8 @@ class GatewayMQTT(ComponentBase):
             self.set_arg("car_charging_now", [f"binary_sensor.{pfx}_session_active"])
         self.set_arg("car_charging_soc", [f"sensor.{pfx}_soc"])
         self.set_arg("car_charging_energy", f"sensor.{pfx}_session_energy")
+        # Live charge power - display only, for the web power flow diagram
+        self.set_arg("car_charging_power", f"sensor.{pfx}_power")
         # car_charging_rate is a UI config item (input_number), so update it via
         # expose_config. get_arg() consults HA/UI config before args, so set_arg() would
         # be ignored (and indirect entity resolution would never run).

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -1449,10 +1449,11 @@ class GECloudDirect(ComponentBase):
         devices in a different order. car_charging_energy lets car_charging_hold subtract
         the charging precisely instead of falling back to the car_charging_threshold
         heuristic; car_charging_planned tells Predbat when there is actually a car to plan
-        for. Both go through set_arg_auto so an apps.yaml entry that auto-discovery is
+        for; car_charging_power is display-only and drives the web power flow diagram. Both go through set_arg_auto so an apps.yaml entry that auto-discovery is
         about to override is logged rather than silently discarded.
         """
         energy_entities = []
+        power_entities = []
         connected_entities = []
         for uuid in sorted(self.evc_device_list, key=lambda item: str(self.evc_device.get(item, {}).get("serial_number", "") or "")):
             serial = self.evc_device.get(uuid, {}).get("serial_number", None)
@@ -1464,6 +1465,7 @@ class GECloudDirect(ComponentBase):
                 continue
             entity_name = "{}_gecloud_{}".format(self.prefix, serial).lower()
             energy_entities.append("sensor." + entity_name + "_evc_energy_active_import_register")
+            power_entities.append("sensor." + entity_name + "_evc_power_active_import")
             connected_entities.append("binary_sensor." + entity_name + "_evc_car_connected")
 
         if not energy_entities:
@@ -1479,6 +1481,8 @@ class GECloudDirect(ComponentBase):
         self.set_arg_auto("car_charging_energy", energy_entities)
         self.log("GECloud: Setting car_charging_planned to {}".format(connected_entities))
         self.set_arg_auto("car_charging_planned", connected_entities)
+        self.log("GECloud: Setting car_charging_power to {}".format(power_entities))
+        self.set_arg_auto("car_charging_power", power_entities)
 
     async def run(self, seconds, first):
         """

--- a/apps/predbat/myenergi.py
+++ b/apps/predbat/myenergi.py
@@ -835,14 +835,19 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
         An intervening zero reading does not rescue it, because the dip is smoothed away
         first. That loss is in the shared cumulative series, so it affects
         car_charging_energy and iboost_today alike. Documented in docs/components.md.
+
+        The Zappi live power sensors go to car_charging_power, which is display-only: it feeds
+        the web power flow diagram and the predbat.car_charging_power sensor, never the plan.
         """
         zappi_energy_entities = []
+        zappi_power_entities = []
         zappi_plug_entities = []
         eddi_entity = None
         for device in sorted(self.devices.values(), key=lambda item: item.serial):
             prefix = self.entity_prefix(device)
             if device.kind == DEVICE_KIND_ZAPPI:
                 zappi_energy_entities.append("sensor.{}_session_energy".format(prefix))
+                zappi_power_entities.append("sensor.{}_power".format(prefix))
                 zappi_plug_entities.append("sensor.{}_plug_status".format(prefix))
             elif device.kind == DEVICE_KIND_EDDI and eddi_entity is None:
                 eddi_entity = "sensor.{}_session_energy".format(prefix)
@@ -852,6 +857,8 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
             self.set_arg_auto("car_charging_energy", zappi_energy_entities)
             self.log("Info: myenergi: setting car_charging_planned to {}".format(zappi_plug_entities))
             self.set_arg_auto("car_charging_planned", zappi_plug_entities)
+            self.log("Info: myenergi: setting car_charging_power to {}".format(zappi_power_entities))
+            self.set_arg_auto("car_charging_power", zappi_power_entities)
         if eddi_entity:
             self.log("Info: myenergi: setting iboost_energy_today to {}".format(eddi_entity))
             self.set_arg_auto("iboost_energy_today", eddi_entity)

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -61,6 +61,7 @@ ohme_attribute_table = {
 # Delivered-energy sensor built by OhmeAPI.update_energy_today() - see that method for why
 # Ohme's own energy figure cannot be used for this
 ENERGY_TODAY_ENTITY = "sensor.predbat_ohme_energy_today"
+POWER_WATTS_ENTITY = "sensor.predbat_ohme_power_watts"
 
 # How often the Predbat-led control loop re-evaluates the plan. The plan is minute-granular so a
 # finer cadence buys nothing, and this matches the gateway EV charger control loop
@@ -478,6 +479,11 @@ class OhmeAPI(ComponentBase):
         existing = self.get_arg("car_charging_energy", default=None, indirect=False)
         if (not existing) or (isinstance(existing, str) and existing.startswith("re:")):
             self.set_arg_auto("car_charging_energy", ENERGY_TODAY_ENTITY)
+            # Live charge power, for the web power flow diagram and the predbat.car_charging_power
+            # sensor. Deliberately tied to the same decision as the energy sensor above: the two
+            # have to describe the same charger, so when another charger owns the energy figure
+            # Ohme's own power reading is left out rather than reported beside it.
+            self.set_arg_auto("car_charging_power", POWER_WATTS_ENTITY)
         else:
             self.log("Info: Ohme API: Leaving car_charging_energy set to {} rather than using {}".format(existing, ENERGY_TODAY_ENTITY))
 
@@ -607,7 +613,7 @@ class OhmeAPI(ComponentBase):
 
         # Publish power data
         if power:
-            self.dashboard_item(entity_name_sensor + "_power_watts", state=power.watts, attributes=ohme_attribute_table.get("power_watts", {}), app="ohme")
+            self.dashboard_item(POWER_WATTS_ENTITY, state=power.watts, attributes=ohme_attribute_table.get("power_watts", {}), app="ohme")
             self.dashboard_item(entity_name_sensor + "_power_amps", state=power.amps, attributes=ohme_attribute_table.get("power_amps", {}), app="ohme")
             self.dashboard_item(entity_name_sensor + "_power_volts", state=power.volts, attributes=ohme_attribute_table.get("power_volts", {}), app="ohme")
             # self.dashboard_item(entity_name_sensor + "_ct_amps", state=power.ct_amps, attributes=ohme_attribute_table.get("ct_amps", {}), app="ohme")

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -476,8 +476,14 @@ class OhmeAPI(ComponentBase):
         # before auto_config(final=True), so an unmatched regex from the apps.yaml default is
         # still present as its literal "re:" string rather than having been removed yet - treat
         # that as unconfigured, but leave a real charger (Zappi, Wallbox, hand-set sensor) alone.
+        # A list of one is how several components hand over a single entity, so unwrap it before
+        # comparing - otherwise an explicit ["sensor.predbat_ohme_energy_today"] looks third-party
         existing = self.get_arg("car_charging_energy", default=None, indirect=False)
-        if (not existing) or (isinstance(existing, str) and existing.startswith("re:")):
+        if isinstance(existing, list) and len(existing) == 1:
+            existing = existing[0]
+        # Ohme already owns the energy figure when the entity configured is its own, whether that
+        # was set here on a previous run or written into apps.yaml by hand (#4715 review)
+        if (not existing) or (isinstance(existing, str) and existing.startswith("re:")) or existing == ENERGY_TODAY_ENTITY:
             self.set_arg_auto("car_charging_energy", ENERGY_TODAY_ENTITY)
             # Live charge power, for the web power flow diagram and the predbat.car_charging_power
             # sensor. Deliberately tied to the same decision as the energy sensor above: the two

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -1644,6 +1644,15 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
                                         errors += 1
                                         break
 
+                                if spec.get("transient_ok", False) and isinstance(state, str) and state.strip().lower() in ["unavailable", "unknown", "none", ""]:
+                                    # Home Assistant reports these while an entity is offline or has
+                                    # not produced a reading yet. For a sensor that legitimately drops
+                                    # out - an EV charger with nothing plugged into it - that is normal
+                                    # rather than a misconfiguration, and flagging it leaves the whole
+                                    # run reporting errors. A missing entity is still an error above,
+                                    # so a typo in the name is still caught.
+                                    continue
+
                                 validated = False
                                 if "float" in sensor_types and self.validate_is_float(state):
                                     validated = True

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -448,6 +448,8 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.load_power = 0
         self.battery_power = 0
         self.grid_power = 0
+        self.car_charging_power = 0
+        self.car_charging_power_configured = False
         self.io_adjusted = {}
         self.current_charge_limit = 0.0
         self.current_charge_limit_kwh = 0.0

--- a/apps/predbat/tests/test_alphaess_publish.py
+++ b/apps/predbat/tests/test_alphaess_publish.py
@@ -319,6 +319,35 @@ def test_alphaess_car_charging_energy_unmapped_without_a_charger():
     assert not failed, "test_alphaess_car_charging_energy_unmapped_without_a_charger"
 
 
+def test_alphaess_car_charging_power_mapped_for_serials_with_a_charger():
+    """The live EV power sensor follows the same charger detection as the energy one.
+
+    car_charging_power is display-only - it drives the web power flow diagram and the
+    predbat.car_charging_power sensor - so it must cover exactly the serials that actually
+    have a charger, never the permanent zero a charger-less system reports."""
+    failed = False
+    client = _ready_client()
+    for sn in client.device_list:
+        client.device_energy[sn]["ev_energy_today"] = 4.2
+    client._ev_present = {client.device_list[0]: True, client.device_list[1]: False}
+    run_async_local(client.automatic_config())
+    mapped = client.base.args.get("car_charging_power")
+    expected = [f"sensor.predbat_alphaess_{client.device_list[0].lower()}_ev_power"]
+    if mapped != expected:
+        print(f"ERROR: car_charging_power {mapped} != {expected}")
+        failed = True
+
+    no_charger = _ready_client()
+    for sn in no_charger.device_list:
+        no_charger._ev_present[sn] = False
+        no_charger.device_energy[sn]["ev_energy_today"] = 0.0
+    run_async_local(no_charger.automatic_config())
+    if "car_charging_power" in no_charger.base.args:
+        print(f"ERROR: car_charging_power mapped with no charger: {no_charger.base.args.get('car_charging_power')}")
+        failed = True
+    assert not failed, "test_alphaess_car_charging_power_mapped_for_serials_with_a_charger"
+
+
 def test_alphaess_ev_sensors_are_published():
     """ev_power (W) and ev_energy_today (kWh) both reach the dashboard."""
     failed = False
@@ -353,6 +382,7 @@ def run_alphaess_publish_tests(my_predbat):
         ("ev_charger_detection", test_alphaess_ev_charger_detected_from_pev_detail),
         ("car_charging_energy_mapping", test_alphaess_car_charging_energy_mapped_only_for_serials_with_a_charger),
         ("car_charging_energy_unmapped", test_alphaess_car_charging_energy_unmapped_without_a_charger),
+        ("car_charging_power_mapping", test_alphaess_car_charging_power_mapped_for_serials_with_a_charger),
         ("ev_sensors_published", test_alphaess_ev_sensors_are_published),
     ]:
         try:

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -4178,6 +4178,8 @@ class TestEvAutoConfig:
         gw.base.expose_config.assert_called_once_with("car_charging_rate", 7.68)  # 32A * 240V / 1000
         # Session energy sensor for subtracting EV load from history
         assert gw._args["car_charging_energy"] == "sensor.predbat_gateway_ev_cp1_session_energy"
+        # Live charge power, display-only: drives the web power flow diagram
+        assert gw._args["car_charging_power"] == "sensor.predbat_gateway_ev_cp1_power"
         # Battery size and target limit are left to the existing car_charging_* settings
         assert "car_charging_battery_size" not in gw._args
         assert "car_charging_limit" not in gw._args

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -4283,6 +4283,11 @@ def _test_async_automatic_config_evc(my_predbat):
             "binary_sensor.predbat_gecloud_evc100_evc_car_connected",
             "binary_sensor.predbat_gecloud_evc200_evc_car_connected",
         ], "car_charging_planned should list both chargers in serial order, got {}".format(ge.config_args.get("car_charging_planned"))
+        # Display-only live power, wired in the same serial order so it describes the same chargers
+        assert ge.config_args.get("car_charging_power") == [
+            "sensor.predbat_gecloud_evc100_evc_power_active_import",
+            "sensor.predbat_gecloud_evc200_evc_power_active_import",
+        ], "car_charging_power should list both chargers in serial order, got {}".format(ge.config_args.get("car_charging_power"))
         assert ge.config_args.get("num_cars") == 2, "num_cars should be raised to the number of chargers"
 
         # Test 2: an existing larger num_cars is left alone - another component may own those cars
@@ -4297,6 +4302,7 @@ def _test_async_automatic_config_evc(my_predbat):
         await ge.async_automatic_config_evc()
         assert ge.config_args.get("car_charging_energy") is None, "car_charging_energy should be left alone with no chargers"
         assert ge.config_args.get("car_charging_planned") is None, "car_charging_planned should be left alone with no chargers"
+        assert ge.config_args.get("car_charging_power") is None, "car_charging_power should be left alone with no chargers"
         assert ge.config_args.get("num_cars") is None, "num_cars should be left alone with no chargers"
 
         # Test 4: a charger whose serial has not been read yet is skipped rather than

--- a/apps/predbat/tests/test_myenergi.py
+++ b/apps/predbat/tests/test_myenergi.py
@@ -1582,6 +1582,37 @@ def test_automatic_config():
     print("  ✓ Automatic configuration wires both energy inputs, deterministically by serial")
 
 
+def test_automatic_config_wires_car_charging_power():
+    """Zappi live power sensors wire into car_charging_power in the same serial order.
+
+    The power sensors are display-only (the plan runs off car_charging_energy), but they have to
+    line up with the energy list so both describe the same chargers.
+    """
+    component = _make_component()
+    second_zappi = dict(MOCK_DIRECT_ZAPPI, sno=22223333)
+    component.devices = {
+        "Z22223333": normalise_direct_device(second_zappi, DEVICE_KIND_ZAPPI),
+        "E87654321": normalise_direct_device(MOCK_DIRECT_EDDI, DEVICE_KIND_EDDI),
+        "Z12345678": normalise_direct_device(MOCK_DIRECT_ZAPPI, DEVICE_KIND_ZAPPI),
+    }
+    component.automatic_config()
+
+    assert component.base.args["car_charging_power"] == [
+        "sensor.predbat_myenergi_zappi_12345678_power",
+        "sensor.predbat_myenergi_zappi_22223333_power",
+    ], component.base.args["car_charging_power"]
+    print("  ✓ Automatic configuration wires the Zappi power sensors for the flow diagram")
+
+
+def test_automatic_config_eddi_only_leaves_car_charging_power_alone():
+    """An Eddi is not a car charger, so it must not appear as car charging power."""
+    component = _make_component()
+    component.devices = {"E87654321": normalise_direct_device(MOCK_DIRECT_EDDI, DEVICE_KIND_EDDI)}
+    component.automatic_config()
+    assert "car_charging_power" not in component.base.args
+    print("  ✓ Eddi-only site leaves car_charging_power unset")
+
+
 def test_automatic_config_single_zappi_is_still_a_list():
     """A single Zappi still produces a list, so adding a second changes nothing else."""
     component = _make_component()
@@ -2416,6 +2447,8 @@ def test_myenergi(my_predbat=None):
     test_component_direct_auth_error_never_refreshes()
     test_component_registration()
     test_automatic_config()
+    test_automatic_config_wires_car_charging_power()
+    test_automatic_config_eddi_only_leaves_car_charging_power_alone()
     test_automatic_config_single_zappi_is_still_a_list()
     test_automatic_config_eddi_only()
     test_automatic_config_uses_set_arg_auto()

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -22,6 +22,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ohme import (
     ENERGY_TODAY_ENTITY,
     MAX_ENERGY_GAP_SECONDS,
+    POWER_WATTS_ENTITY,
     OhmeAPI,
     OhmeApiClient,
     ChargerStatus,
@@ -289,6 +290,7 @@ def test_ohme(my_predbat=None):
         ("control_read_only_src", _test_ohme_control_read_only_effective, "read only uses the effective state"),
         ("control_target_restore", _test_ohme_control_restores_target, "release restores the charger target"),
         ("auto_config_keeps", _test_ohme_auto_config_keeps_existing_car_charging_energy, "auto config keeps a real charger sensor"),
+        ("auto_config_power", _test_ohme_auto_config_wires_car_charging_power, "auto config wires car_charging_power"),
         ("publish_data", _test_ohme_publish_data, "OhmeAPI publish_data"),
         ("publish_disconnected", _test_ohme_publish_data_disconnected, "OhmeAPI publish_data disconnected"),
         ("run_first", _test_ohme_run_first_call, "OhmeAPI run first call"),
@@ -2305,6 +2307,25 @@ def _test_ohme_auto_config_keeps_existing_car_charging_energy(my_predbat=None):
     assert any("Leaving car_charging_energy" in msg for msg in api.log_messages), f"Expected a note about keeping it, got {api.log_messages}"
 
     print("PASS: auto config kept the existing car_charging_energy sensor")
+    return 0
+
+
+def _test_ohme_auto_config_wires_car_charging_power(my_predbat=None):
+    """Test car registration points car_charging_power at the live charge power sensor"""
+    print("**** Running test_ohme_auto_config_wires_car_charging_power ****")
+
+    api = MockOhmeAPI()
+    run_async(api.automatic_config())
+    assert api.args.get("car_charging_power") == POWER_WATTS_ENTITY, f"Expected {POWER_WATTS_ENTITY}, got {api.args.get('car_charging_power')}"
+
+    # The energy and power sensors have to describe the same charger, so when a real third-party
+    # energy sensor is kept, Ohme's own power figure must not be wired in beside it
+    api = MockOhmeAPI()
+    api.args["car_charging_energy"] = "sensor.myenergi_zappi_1234_charge_added_session"
+    run_async(api.automatic_config())
+    assert api.args.get("car_charging_power") is None, f"Expected no power wiring when another charger owns the energy sensor, got {api.args.get('car_charging_power')}"
+
+    print("PASS: auto config wired car_charging_power")
     return 0
 
 

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -2325,6 +2325,19 @@ def _test_ohme_auto_config_wires_car_charging_power(my_predbat=None):
     run_async(api.automatic_config())
     assert api.args.get("car_charging_power") is None, f"Expected no power wiring when another charger owns the energy sensor, got {api.args.get('car_charging_power')}"
 
+    # ...but Ohme's own energy entity, set explicitly in apps.yaml or left behind by an earlier
+    # run, is still Ohme's charger, so the power sensor belongs with it (#4715 review)
+    api = MockOhmeAPI()
+    api.args["car_charging_energy"] = ENERGY_TODAY_ENTITY
+    run_async(api.automatic_config())
+    assert api.args.get("car_charging_power") == POWER_WATTS_ENTITY, f"Expected power wiring alongside Ohme's own energy entity, got {api.args.get('car_charging_power')}"
+
+    # The same entity handed over as a single-item list, which is how it round-trips through apps.yaml
+    api = MockOhmeAPI()
+    api.args["car_charging_energy"] = [ENERGY_TODAY_ENTITY]
+    run_async(api.automatic_config())
+    assert api.args.get("car_charging_power") == POWER_WATTS_ENTITY, f"Expected power wiring for the list form, got {api.args.get('car_charging_power')}"
+
     print("PASS: auto config wired car_charging_power")
     return 0
 

--- a/apps/predbat/tests/test_validate_config.py
+++ b/apps/predbat/tests/test_validate_config.py
@@ -362,6 +362,34 @@ def test_validate_config(my_predbat):
         expect_clean=["car_charging_now"],
     )
 
+    # ==========================================================================
+    # transient_ok  (car_charging_energy, car_charging_power)
+    #
+    # An EV charger routinely reports 'unavailable' or 'unknown' with nothing
+    # plugged into it. minute_data() already skips those samples (utils.py), and
+    # update_car_charging_power() reads them as zero, so the reading being absent
+    # right now is normal rather than a misconfiguration - but validate_config
+    # reads the same entity by its own path and required the state to parse as a
+    # float, leaving the whole run reporting errors for a car sitting on the
+    # driveway. transient_ok on those two schema entries allows the placeholder
+    # states without loosening anything else.
+    # ==========================================================================
+    for name in ("car_charging_energy", "car_charging_power"):
+        print(f"  [transient_ok] {name} reading 'unavailable' passes")
+        _run(my_predbat, {name: "sensor.test_charger_energy"}, extra_states={"sensor.test_charger_energy": "unavailable"}, expect_clean=[name])
+
+        print(f"  [transient_ok] {name} reading 'unknown' passes")
+        _run(my_predbat, {name: "sensor.test_charger_energy"}, extra_states={"sensor.test_charger_energy": "unknown"}, expect_clean=[name])
+
+        print(f"  [transient_ok] {name} reading a real number still passes")
+        _run(my_predbat, {name: "sensor.test_charger_energy"}, extra_states={"sensor.test_charger_energy": 4.2}, expect_clean=[name])
+
+        print(f"  [transient_ok] {name} reading a non-numeric value still fails")
+        _run(my_predbat, {name: "sensor.test_charger_energy"}, extra_states={"sensor.test_charger_energy": "banana"}, expect_errors=[name])
+
+        print(f"  [transient_ok] {name} pointing at an entity that does not exist still fails")
+        _run(my_predbat, {name: "sensor.test_charger_typo"}, expect_errors=[name])
+
     print("**** test_validate_config PASSED ****")
     return False
 

--- a/apps/predbat/tests/test_web_power_flow.py
+++ b/apps/predbat/tests/test_web_power_flow.py
@@ -1,0 +1,227 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+from config import APPS_SCHEMA
+from web import WebInterface
+
+
+def make_web(my_predbat):
+    """Create a WebInterface instance bound to the given predbat."""
+    return WebInterface(my_predbat, web_port=5053)
+
+
+def set_power_sensor(my_predbat, entity_id, watts):
+    """Publish a power sensor into the HA mock for get_arg() to resolve."""
+    my_predbat.ha_interface.dummy_items[entity_id] = {"state": watts, "unit_of_measurement": "W"}
+
+
+def run_web_power_flow_tests(my_predbat):
+    """Car charging power input, published sensor and its arm of the power flow diagram."""
+    failed = 0
+    print("**** Running web power flow car charging tests ****")
+
+    original_args = my_predbat.args.copy()
+    original_load_power = my_predbat.load_power
+    web = make_web(my_predbat)
+
+    # -------------------------------------------------------------------------
+    print("Test: car_charging_power is a known apps.yaml key")
+    if "car_charging_power" not in APPS_SCHEMA:
+        print("  ERROR: car_charging_power missing from APPS_SCHEMA, apps.yaml validation would reject it")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: no car_charging_power configured leaves the reading at zero and unconfigured")
+    my_predbat.args.pop("car_charging_power", None)
+    my_predbat.update_car_charging_power()
+    if my_predbat.car_charging_power != 0:
+        print(f"  ERROR: expected 0 W with nothing configured, got {my_predbat.car_charging_power}")
+        failed += 1
+    if my_predbat.car_charging_power_configured:
+        print("  ERROR: car_charging_power_configured should be False when the key is not set")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    # The apps.yaml templates ship car_charging_power as a regular expression matching the
+    # common chargers. auto_config(final=True) deletes it when nothing matches, but until then
+    # the literal "re:" string is still sitting in args - and a household with no car charger
+    # must not get a Car node drawn from it
+    print("Test: an unmatched regular expression default counts as not configured")
+    my_predbat.args["car_charging_power"] = "re:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)"
+    my_predbat.update_car_charging_power()
+    if my_predbat.car_charging_power_configured:
+        print("  ERROR: an unresolved 're:' expression should not count as a configured charger")
+        failed += 1
+    if my_predbat.car_charging_power != 0:
+        print(f"  ERROR: expected 0 W from an unresolved 're:' expression, got {my_predbat.car_charging_power}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: a single car_charging_power sensor is read")
+    set_power_sensor(my_predbat, "sensor.car_charger_power", 3200)
+    my_predbat.args["car_charging_power"] = "sensor.car_charger_power"
+    my_predbat.update_car_charging_power()
+    if my_predbat.car_charging_power != 3200:
+        print(f"  ERROR: expected 3200 W from the configured sensor, got {my_predbat.car_charging_power}")
+        failed += 1
+    if not my_predbat.car_charging_power_configured:
+        print("  ERROR: car_charging_power_configured should be True once the key is set")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: multiple chargers are summed")
+    set_power_sensor(my_predbat, "sensor.car_charger_power_2", 1500)
+    my_predbat.args["car_charging_power"] = ["sensor.car_charger_power", "sensor.car_charger_power_2"]
+    my_predbat.update_car_charging_power()
+    if my_predbat.car_charging_power != 4700:
+        print(f"  ERROR: expected 3200 + 1500 = 4700 W summed over both chargers, got {my_predbat.car_charging_power}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    # auto_config() replaces a list entry whose regular expression found nothing with None,
+    # leaving holes in the middle of the list rather than shortening it
+    print("Test: a hole in the sensor list does not hide the chargers after it")
+    my_predbat.args["car_charging_power"] = [None, "sensor.car_charger_power_2"]
+    my_predbat.update_car_charging_power()
+    if my_predbat.car_charging_power != 1500:
+        print(f"  ERROR: expected the second charger's 1500 W to still be read past the hole, got {my_predbat.car_charging_power}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: kW sensors are converted to W")
+    my_predbat.ha_interface.dummy_items["sensor.car_charger_power_kw"] = {"state": 7.2, "unit_of_measurement": "kW"}
+    my_predbat.args["car_charging_power"] = "sensor.car_charger_power_kw"
+    my_predbat.update_car_charging_power()
+    if my_predbat.car_charging_power != 7200:
+        print(f"  ERROR: expected 7.2 kW to be read as 7200 W, got {my_predbat.car_charging_power}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: an unavailable sensor reads as zero rather than breaking the total")
+    my_predbat.ha_interface.dummy_items["sensor.car_charger_offline"] = {"state": "unavailable", "unit_of_measurement": "W"}
+    my_predbat.args["car_charging_power"] = ["sensor.car_charger_power", "sensor.car_charger_offline"]
+    original_had_errors = my_predbat.had_errors
+    my_predbat.had_errors = False
+    my_predbat.update_car_charging_power()
+    if my_predbat.car_charging_power != 3200:
+        print(f"  ERROR: expected the good charger's 3200 W with the other unavailable, got {my_predbat.car_charging_power}")
+        failed += 1
+    if not my_predbat.car_charging_power_configured:
+        print("  ERROR: an unavailable sensor should still count as configured")
+        failed += 1
+    # A charger reporting 'unavailable' while nothing is plugged in is normal, so it must not
+    # flag the run as errored - that would leave Predbat sitting in "with Errors" all day
+    if my_predbat.had_errors:
+        print("  ERROR: an unavailable car charger sensor should not put the run into an error state")
+        failed += 1
+    my_predbat.had_errors = original_had_errors
+
+    # -------------------------------------------------------------------------
+    print("Test: car charging power is published as a sensor for upstream consumers")
+    my_predbat.args["car_charging_power"] = "sensor.car_charger_power"
+    my_predbat.update_car_charging_power()
+    my_predbat.publish_inverter_data()
+    entity = my_predbat.prefix + ".car_charging_power"
+    attrs = my_predbat.ha_interface.dummy_items.get(entity)
+    if not attrs:
+        print(f"  ERROR: {entity} was not published")
+        failed += 1
+    else:
+        if attrs.get("state") != 3.2:
+            print(f"  ERROR: expected {entity} to publish 3.2 kW, got {attrs.get('state')}")
+            failed += 1
+        if attrs.get("unit_of_measurement") != "kW":
+            print(f"  ERROR: expected {entity} in kW like the other power sensors, got {attrs.get('unit_of_measurement')}")
+            failed += 1
+        if attrs.get("device_class") != "power":
+            print(f"  ERROR: expected {entity} to carry device_class power, got {attrs.get('device_class')}")
+            failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: the sensor is not published when no charger is configured")
+    my_predbat.ha_interface.dummy_items.pop(entity, None)
+    my_predbat.args.pop("car_charging_power", None)
+    my_predbat.update_car_charging_power()
+    my_predbat.publish_inverter_data()
+    if entity in my_predbat.ha_interface.dummy_items:
+        print(f"  ERROR: {entity} should not be published when no car charging power sensor is configured")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: the flow diagram is unchanged when no car charging power is configured")
+    my_predbat.load_power = 3000
+    my_predbat.car_charging_power = 0
+    my_predbat.car_charging_power_configured = False
+    html = web.get_power_flow_diagram()
+    if ">Car<" in html:
+        print("  ERROR: the Car node should not be drawn when no car charging power sensor is configured")
+        failed += 1
+    if ">3000 W<" not in html:
+        print("  ERROR: the House circle should show the full load power when there is no car to subtract")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: a charging car is drawn with its own arm and subtracted from the house load")
+    my_predbat.load_power = 3000
+    my_predbat.car_charging_power = 2000
+    my_predbat.car_charging_power_configured = True
+    html = web.get_power_flow_diagram()
+    if ">Car<" not in html:
+        print("  ERROR: expected a Car node in the diagram once a car charging power sensor is configured")
+        failed += 1
+    if ">2000 W<" not in html:
+        print("  ERROR: expected the car charging power to be labelled on its arrow")
+        failed += 1
+    if ">1000 W<" not in html:
+        print("  ERROR: expected the House circle to show the load remainder (3000 - 2000) once the car is drawn separately")
+        failed += 1
+    if "car-house-path" in html and "house-car-path" not in html:
+        print("  ERROR: the car arm should flow from the house to the car, not the other way")
+        failed += 1
+    if "animateMotion" not in html:
+        print("  ERROR: expected animated flow dots on the car arm while it is charging")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: a configured but idle charger keeps its node with a dashed arm")
+    my_predbat.car_charging_power = 0
+    my_predbat.car_charging_power_configured = True
+    html = web.get_power_flow_diagram()
+    if ">Car<" not in html:
+        print("  ERROR: a configured charger should stay on the diagram when it is not charging")
+        failed += 1
+    car_arm = html[html.find("<!-- House to Car") :] if "<!-- House to Car" in html else ""
+    if "stroke-dasharray" not in car_arm:
+        print("  ERROR: expected the idle car arm to be dashed, as the PV arm is when not generating")
+        failed += 1
+    if ">3000 W<" not in html:
+        print("  ERROR: the House circle should show the full load power when the car is drawing nothing")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    print("Test: a car reading above the house load clamps the house remainder at zero")
+    my_predbat.load_power = 1000
+    my_predbat.car_charging_power = 3000
+    my_predbat.car_charging_power_configured = True
+    html = web.get_power_flow_diagram()
+    if ">0 W<" not in html:
+        print("  ERROR: expected the House remainder to clamp at 0 W rather than go negative")
+        failed += 1
+    if "-2000 W" in html:
+        print("  ERROR: the House circle must never show a negative load")
+        failed += 1
+
+    my_predbat.args = original_args
+    my_predbat.load_power = original_load_power
+    my_predbat.car_charging_power = 0
+    my_predbat.car_charging_power_configured = False
+
+    print("**** Web power flow car charging tests completed ****")
+    return failed

--- a/apps/predbat/tests/test_web_power_flow.py
+++ b/apps/predbat/tests/test_web_power_flow.py
@@ -406,6 +406,30 @@ def run_web_power_flow_tests(my_predbat):
     my_predbat.had_errors = original_had_errors
 
     # -------------------------------------------------------------------------
+    # update_car_charging_power() tolerates an unavailable charger, but apps.yaml validation is a
+    # separate path that reads the same entity and checks its state is a float. A charger sitting
+    # at 'unavailable' with nothing plugged in is normal, so it must not end the run in an error
+    # state through that route either (#4715 review)
+    print("Test: an unavailable charger does not fail apps.yaml validation")
+    my_predbat.args.pop("car_charging_power", None)
+    baseline_errors = my_predbat.validate_config()
+    my_predbat.args["car_charging_power"] = "sensor.car_charger_offline"
+    errors_with_unavailable = my_predbat.validate_config()
+    if errors_with_unavailable != baseline_errors:
+        print(f"  ERROR: an unavailable car charger added {errors_with_unavailable - baseline_errors} validation error(s): {my_predbat.arg_errors.get('car_charging_power')}")
+        failed += 1
+
+    print("Test: a genuinely wrong car charging power sensor is still rejected")
+    my_predbat.ha_interface.dummy_items["sensor.car_charger_nonsense"] = {"state": "banana", "unit_of_measurement": "W"}
+    my_predbat.args["car_charging_power"] = "sensor.car_charger_nonsense"
+    errors_with_nonsense = my_predbat.validate_config()
+    if errors_with_nonsense <= baseline_errors:
+        print("  ERROR: a non-numeric, non-transient state should still be reported as a configuration error")
+        failed += 1
+    my_predbat.args.pop("car_charging_power", None)
+    my_predbat.validate_config()
+
+    # -------------------------------------------------------------------------
     print("Test: car charging power is published as a sensor for upstream consumers")
     my_predbat.args["car_charging_power"] = "sensor.car_charger_power"
     my_predbat.update_car_charging_power()
@@ -427,13 +451,22 @@ def run_web_power_flow_tests(my_predbat):
             failed += 1
 
     # -------------------------------------------------------------------------
+    # Checked from a clean slate rather than by deleting what the test above published, so this
+    # cannot pass just because the entity was removed by hand a moment earlier (#4715 review)
     print("Test: the sensor is not published when no charger is configured")
-    my_predbat.ha_interface.dummy_items.pop(entity, None)
+    for store in (my_predbat.ha_interface.dummy_items, my_predbat.dashboard_values, my_predbat.dashboard_index_app):
+        store.pop(entity, None)
+    if entity in my_predbat.dashboard_index:
+        my_predbat.dashboard_index.remove(entity)
     my_predbat.args.pop("car_charging_power", None)
     my_predbat.update_car_charging_power()
     my_predbat.publish_inverter_data()
-    if entity in my_predbat.ha_interface.dummy_items:
-        print(f"  ERROR: {entity} should not be published when no car charging power sensor is configured")
+    for name, store in (("the HA state", my_predbat.ha_interface.dummy_items), ("dashboard_values", my_predbat.dashboard_values), ("dashboard_index_app", my_predbat.dashboard_index_app)):
+        if entity in store:
+            print(f"  ERROR: {entity} should not reach {name} when no car charging power sensor is configured")
+            failed += 1
+    if entity in my_predbat.dashboard_index:
+        print(f"  ERROR: {entity} should not reach dashboard_index when no car charging power sensor is configured")
         failed += 1
 
     # -------------------------------------------------------------------------
@@ -499,6 +532,13 @@ def run_web_power_flow_tests(my_predbat):
     if "-2000 W" in html:
         print("  ERROR: the House circle must never show a negative load")
         failed += 1
+
+    # dashboard_item() records an entity in four separate stores, and a lingering
+    # predbat.car_charging_power would show up in any later test that enumerates them
+    for store in (my_predbat.ha_interface.dummy_items, my_predbat.dashboard_values, my_predbat.dashboard_index_app):
+        store.pop(my_predbat.prefix + ".car_charging_power", None)
+    if (my_predbat.prefix + ".car_charging_power") in my_predbat.dashboard_index:
+        my_predbat.dashboard_index.remove(my_predbat.prefix + ".car_charging_power")
 
     failed += run_power_flow_icon_tests(my_predbat, web)
     failed += run_power_flow_colour_tests(my_predbat, web)

--- a/apps/predbat/tests/test_web_power_flow.py
+++ b/apps/predbat/tests/test_web_power_flow.py
@@ -18,10 +18,10 @@ from web import WebInterface
 HOUSE_CENTRE = (300, 200)
 NODE_RADIUS = 50
 NODE_BY_COLOUR = {
-    "#2196F3": ("PV", (150, 100)),
-    "#FF9800": ("Battery", (150, 300)),
-    "#4CAF50": ("Grid", (450, 300)),
-    "#00BCD4": ("Car", (450, 100)),
+    "#F9A825": ("PV", (150, 100)),
+    "#43A047": ("Battery", (150, 300)),
+    "#757575": ("Grid", (450, 300)),
+    "#E53935": ("Car", (450, 100)),
 }
 
 # The arrowhead is drawn beyond the end of the line, not on it. The markers use the default
@@ -161,6 +161,114 @@ def check_label_clearance(html, state_description):
                 print(f"  ERROR [{state_description}]: the {name} label '{text}' at ({x:.0f},{y:.0f}) is printed across an arm")
                 failed += 1
                 break
+    return failed
+
+
+def run_power_flow_icon_tests(my_predbat, web):
+    """Each circle is labelled by its Material Design Icon, with the name kept as a tooltip."""
+    failed = 0
+    print("Test: every node in the diagram is drawn as an icon, named by a tooltip")
+
+    saved = (my_predbat.car_charging_power_configured, my_predbat.car_charging_power, my_predbat.load_power)
+    my_predbat.car_charging_power_configured = True
+    my_predbat.car_charging_power = 0
+    my_predbat.load_power = 1372
+    html = web.get_power_flow_diagram()
+
+    # Codepoints taken from the @mdi/font stylesheet the web interface already loads. The battery
+    # is the one node whose icon changes with its state, so it is covered by its own test.
+    icons = {
+        "PV": "&#xF0D9B;",  # solar-panel
+        "Grid": "&#xF0D3E;",  # transmission-tower
+        "House": "&#xF02DC;",  # home
+        "Car": "&#xF010B;",  # car
+    }
+    for name, codepoint in icons.items():
+        if codepoint not in html:
+            print(f"  ERROR: the {name} circle has no {name} icon ({codepoint}) in it")
+            failed += 1
+    for name in list(icons) + ["Battery"]:
+        if f"<title>{name}</title>" not in html:
+            print(f"  ERROR: the {name} circle has no tooltip naming it, so an unrecognised icon cannot be identified")
+            failed += 1
+
+    if 'font-family="Material Design Icons"' not in html:
+        print("  ERROR: the icon glyphs need the Material Design Icons font, or they render as empty boxes")
+        failed += 1
+
+    # The reading the House circle carries is the point of the diagram - an icon must not cost it
+    if ">1372 W<" not in html:
+        print("  ERROR: the House circle should still show its power reading alongside the icon")
+        failed += 1
+
+    (my_predbat.car_charging_power_configured, my_predbat.car_charging_power, my_predbat.load_power) = saved
+    return failed
+
+
+def run_battery_icon_tests(my_predbat, web):
+    """The battery icon shows how full the battery is, and whether it is charging.
+
+    battery_power is positive for DISCHARGE in Predbat (gateway.py negates the firmware's sign
+    for exactly this reason), so the charging icon has to key off a negative reading. Getting
+    that backwards would show a battery charging while it empties.
+    """
+    failed = 0
+    print("Test: the battery icon follows the state of charge and the direction of flow")
+
+    saved = (my_predbat.soc_percent, my_predbat.battery_power)
+    cases = [
+        (10, 1500, "&#xF12A1;", "10% discharging", "battery-low"),
+        (50, 1500, "&#xF12A2;", "50% discharging", "battery-medium"),
+        (90, 1500, "&#xF12A3;", "90% discharging", "battery-high"),
+        (0, 0, "&#xF12A1;", "empty and idle", "battery-low"),
+        (50, 0, "&#xF12A2;", "50% idle", "battery-medium"),
+        (100, 0, "&#xF12A3;", "full and idle", "battery-high"),
+        (10, -1500, "&#xF12A4;", "10% charging", "battery-charging-low"),
+        (50, -1500, "&#xF12A5;", "50% charging", "battery-charging-medium"),
+        (90, -1500, "&#xF12A6;", "90% charging", "battery-charging-high"),
+    ]
+    for soc, battery_power, codepoint, description, icon_name in cases:
+        my_predbat.soc_percent = soc
+        my_predbat.battery_power = battery_power
+        html = web.get_power_flow_diagram()
+        if codepoint not in html:
+            print(f"  ERROR: at {description} the battery should be drawn as {icon_name} ({codepoint})")
+            failed += 1
+
+    (my_predbat.soc_percent, my_predbat.battery_power) = saved
+    return failed
+
+
+def run_power_flow_colour_tests(my_predbat, web):
+    """Each node carries its own colour, on the circle and on the arm that reaches it."""
+    failed = 0
+    print("Test: each node is drawn in its own colour")
+
+    saved = my_predbat.car_charging_power_configured
+    my_predbat.car_charging_power_configured = True
+    html = web.get_power_flow_diagram()
+
+    # Each node carries the colour of the thing it is, on the circle and on its arm
+    for name, fill in (("PV", "#FDD835"), ("Battery", "#43A047"), ("Grid", "#757575"), ("House", "#6D4C41"), ("Car", "#E53935")):
+        if f'fill="{fill}"><title>{name}</title>' not in html:
+            print(f"  ERROR: the {name} circle should be filled {fill}")
+            failed += 1
+
+    # Every icon is white, whatever it sits on
+    for name, codepoint, size in (("solar panel", "&#xF0D9B;", 44), ("pylon", "&#xF0D3E;", 44), ("car", "&#xF010B;", 44), ("house", "&#xF02DC;", 34)):
+        if f'font-size="{size}" fill="#fff">{codepoint}' not in html:
+            print(f"  ERROR: the {name} icon should be white")
+            failed += 1
+    if 'font-size="44" fill="#fff">&#xF12A' not in html:
+        print("  ERROR: the battery icon should be white")
+        failed += 1
+
+    # A #FDD835 line is close to invisible against the page, so the PV arm takes a deeper shade
+    if "#F9A825" not in html:
+        print("  ERROR: the PV arm should use a deeper yellow than its circle so it reads against the page")
+        failed += 1
+
+    my_predbat.car_charging_power_configured = saved
     return failed
 
 
@@ -392,6 +500,9 @@ def run_web_power_flow_tests(my_predbat):
         print("  ERROR: the House circle must never show a negative load")
         failed += 1
 
+    failed += run_power_flow_icon_tests(my_predbat, web)
+    failed += run_power_flow_colour_tests(my_predbat, web)
+    failed += run_battery_icon_tests(my_predbat, web)
     failed += run_power_flow_geometry_tests(my_predbat, web)
 
     my_predbat.args = original_args

--- a/apps/predbat/tests/test_web_power_flow.py
+++ b/apps/predbat/tests/test_web_power_flow.py
@@ -8,8 +8,26 @@
 # pylint: disable=line-too-long
 # pylint: disable=attribute-defined-outside-init
 
+import math
+import re
+
 from config import APPS_SCHEMA
 from web import WebInterface
+
+# Where each node is drawn in the diagram's SVG, keyed by the colour of the arm that reaches it
+HOUSE_CENTRE = (300, 200)
+NODE_RADIUS = 50
+NODE_BY_COLOUR = {
+    "#2196F3": ("PV", (150, 100)),
+    "#FF9800": ("Battery", (150, 300)),
+    "#4CAF50": ("Grid", (450, 300)),
+    "#00BCD4": ("Car", (450, 100)),
+}
+
+# The arrowhead is drawn beyond the end of the line, not on it. The markers use the default
+# markerUnits of "strokeWidth", so markerWidth="10" on a stroke-width="2" line is 20 user units
+# of arrowhead past the line's end vertex - which is where the point of the arrow actually lands.
+ARROW_HEAD_LENGTH = 20
 
 
 def make_web(my_predbat):
@@ -20,6 +38,162 @@ def make_web(my_predbat):
 def set_power_sensor(my_predbat, entity_id, watts):
     """Publish a power sensor into the HA mock for get_arg() to resolve."""
     my_predbat.ha_interface.dummy_items[entity_id] = {"state": watts, "unit_of_measurement": "W"}
+
+
+def arrow_lines(html):
+    """Return (colour, (x1, y1, x2, y2)) for every arrow drawn in the diagram."""
+    found = []
+    for match in re.finditer(r'<line x1="([-\d.]+)" y1="([-\d.]+)" x2="([-\d.]+)" y2="([-\d.]+)" stroke="(#[0-9A-Fa-f]{6})"', html):
+        found.append((match.group(5), tuple(float(match.group(index)) for index in range(1, 5))))
+    return found
+
+
+def distance(point_a, point_b):
+    """Distance between two (x, y) points."""
+    return math.hypot(point_a[0] - point_b[0], point_a[1] - point_b[1])
+
+
+def distance_from_line(point, line_start, line_end):
+    """Perpendicular distance of a point from the infinite line through two points."""
+    run_x = line_end[0] - line_start[0]
+    run_y = line_end[1] - line_start[1]
+    cross = (point[0] - line_start[0]) * run_y - (point[1] - line_start[1]) * run_x
+    return abs(cross) / math.hypot(run_x, run_y)
+
+
+def check_arm_geometry(html, state_description):
+    """Every arm runs along the line joining the two circles, tail on one edge and point on the other.
+
+    Drawn at any other angle the arrow leaves its circle off-centre and its head stops in open
+    space short of the House, which is what the PV, battery and grid arms did (all three were
+    drawn at 45 degrees when the true angle between the circles is 33.7).
+
+    The point of the arrow is ARROW_HEAD_LENGTH beyond the line's end vertex, so the line has to
+    stop short by exactly that much. Ending it on the circle edge instead drives the arrowhead
+    inside the circle it is pointing at.
+    """
+    failed = 0
+    for colour, (x1, y1, x2, y2) in arrow_lines(html):
+        name, node_centre = NODE_BY_COLOUR[colour]
+        start, end = (x1, y1), (x2, y2)
+
+        # marker-end puts the arrowhead on (x2, y2), so the line is always drawn tail first and
+        # an arm reversed by the flow direction swaps which circle each end belongs to
+        tail, head = start, end
+        tail_at_node = distance(tail, node_centre) < distance(tail, HOUSE_CENTRE)
+        tail_centre, head_centre = (node_centre, HOUSE_CENTRE) if tail_at_node else (HOUSE_CENTRE, node_centre)
+        tail_name, head_name = (name, "House") if tail_at_node else ("House", name)
+
+        tail_gap = distance(tail, tail_centre) - NODE_RADIUS
+        if abs(tail_gap) > 1.5:
+            print(f"  ERROR [{state_description}]: the {name} arm starts {tail_gap:+.1f}px off the {tail_name} circle edge, it should touch it")
+            failed += 1
+
+        # Where the point of the arrow actually lands, once the marker past the line end is counted
+        length = distance(tail, head)
+        if length > 0:
+            direction = ((head[0] - tail[0]) / length, (head[1] - tail[1]) / length)
+            tip = (head[0] + direction[0] * ARROW_HEAD_LENGTH, head[1] + direction[1] * ARROW_HEAD_LENGTH)
+            tip_gap = distance(tip, head_centre) - NODE_RADIUS
+            if tip_gap < -1.5:
+                print(f"  ERROR [{state_description}]: the {name} arrowhead reaches {abs(tip_gap):.1f}px inside the {head_name} circle, it should stop on the edge")
+                failed += 1
+            elif tip_gap > 1.5:
+                print(f"  ERROR [{state_description}]: the {name} arrowhead stops {tip_gap:.1f}px short of the {head_name} circle, leaving it pointing at nothing")
+                failed += 1
+
+        for point in (tail, head):
+            offset = distance_from_line(point, node_centre, HOUSE_CENTRE)
+            if offset > 1.5:
+                print(f"  ERROR [{state_description}]: the {name} arm is {offset:.1f}px off the line joining {name} to the House, so it points the wrong way")
+                failed += 1
+    return failed
+
+
+def power_labels(html):
+    """Return (colour, text, x, y) for each 'NNN W' label on an arm."""
+    found = []
+    for match in re.finditer(r'<text x="([-\d.]+)" y="([-\d.]+)" text-anchor="middle" fill="(#[0-9A-Fa-f]{6})">([^<]*)</text>', html):
+        if match.group(3) in NODE_BY_COLOUR:
+            found.append((match.group(3), match.group(4), float(match.group(1)), float(match.group(2))))
+    return found
+
+
+def segment_hits_box(segment, box):
+    """True if a line segment crosses (or ends inside) an axis-aligned box."""
+    (x1, y1), (x2, y2) = segment
+    left, top, right, bottom = box
+
+    def inside(x, y):
+        return left <= x <= right and top <= y <= bottom
+
+    if inside(x1, y1) or inside(x2, y2):
+        return True
+
+    def segments_cross(p1, p2, p3, p4):
+        def orientation(a, b, c):
+            value = (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+            return (value > 0) - (value < 0)
+
+        return orientation(p1, p2, p3) != orientation(p1, p2, p4) and orientation(p3, p4, p1) != orientation(p3, p4, p2)
+
+    corners = [(left, top), (right, top), (right, bottom), (left, bottom)]
+    for index in range(4):
+        if segments_cross((x1, y1), (x2, y2), corners[index], corners[(index + 1) % 4]):
+            return True
+    return False
+
+
+def check_label_clearance(html, state_description):
+    """A power reading must sit beside its arm, not printed across it.
+
+    The text is rendered at the browser default of 16px with no font-size set, so it is estimated
+    generously here - a label that only just clears at this width is too close to be readable.
+    """
+    failed = 0
+    lines = [((x1, y1), (x2, y2)) for _, (x1, y1, x2, y2) in arrow_lines(html)]
+    for colour, text, x, y in power_labels(html):
+        name = NODE_BY_COLOUR[colour][0]
+        half_width = len(text) * 9 / 2.0
+        box = (x - half_width, y - 12, x + half_width, y + 4)
+        for line in lines:
+            if segment_hits_box(line, box):
+                print(f"  ERROR [{state_description}]: the {name} label '{text}' at ({x:.0f},{y:.0f}) is printed across an arm")
+                failed += 1
+                break
+    return failed
+
+
+def run_power_flow_geometry_tests(my_predbat, web):
+    """The arms line up with the circles they join, in every flow direction."""
+    failed = 0
+    print("Test: every arm runs circle edge to circle edge, whichever way the power is flowing")
+
+    saved = (my_predbat.pv_power, my_predbat.load_power, my_predbat.battery_power, my_predbat.grid_power, my_predbat.car_charging_power, my_predbat.car_charging_power_configured)
+
+    my_predbat.car_charging_power_configured = True
+
+    # Importing, battery discharging, PV generating, car charging
+    my_predbat.pv_power = 2000
+    my_predbat.load_power = 4000
+    my_predbat.battery_power = 1500
+    my_predbat.grid_power = -1000
+    my_predbat.car_charging_power = 2000
+    html = web.get_power_flow_diagram()
+    failed += check_arm_geometry(html, "importing, battery discharging")
+    failed += check_label_clearance(html, "importing, battery discharging")
+
+    # The opposite of every branch: exporting, battery charging, PV idle, car idle
+    my_predbat.pv_power = 0
+    my_predbat.battery_power = -1500
+    my_predbat.grid_power = 1000
+    my_predbat.car_charging_power = 0
+    html = web.get_power_flow_diagram()
+    failed += check_arm_geometry(html, "exporting, battery charging")
+    failed += check_label_clearance(html, "exporting, battery charging")
+
+    (my_predbat.pv_power, my_predbat.load_power, my_predbat.battery_power, my_predbat.grid_power, my_predbat.car_charging_power, my_predbat.car_charging_power_configured) = saved
+    return failed
 
 
 def run_web_power_flow_tests(my_predbat):
@@ -217,6 +391,8 @@ def run_web_power_flow_tests(my_predbat):
     if "-2000 W" in html:
         print("  ERROR: the House circle must never show a negative load")
         failed += 1
+
+    failed += run_power_flow_geometry_tests(my_predbat, web)
 
     my_predbat.args = original_args
     my_predbat.load_power = original_load_power

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -110,6 +110,7 @@ from tests.test_web_debug_history_routes import test_web_debug_history_routes
 from tests.test_debug_history_client_js import test_debug_history_client_js
 from tests.test_metrics_dashboard_soc_refresh import test_soc_chart_center_text_reads_live_data
 from tests.test_web_functions import run_web_functions_tests, run_web_logo_image_tests
+from tests.test_web_power_flow import run_web_power_flow_tests
 from tests.test_web_history_table import run_web_history_table_tests
 from tests.test_web_charts import run_web_charts_tests
 from tests.test_web_chart_grouping import run_web_chart_grouping_tests
@@ -452,6 +453,7 @@ def main():
         ("debug_history_client_js", test_debug_history_client_js, "Debug-history client-side JS structure tests (#4438 review item 22)", False),
         ("metrics_dashboard_soc_refresh", test_soc_chart_center_text_reads_live_data, "Metrics dashboard SoC chart live-refresh tests", False),
         ("web_functions", run_web_functions_tests, "Web function unit tests", False),
+        ("web_power_flow", run_web_power_flow_tests, "Power flow diagram car charging tests", False),
         ("web_logo_image", run_web_logo_image_tests, "Local logo image route tests (issue #4562)", False),
         ("web_annual", test_web_annual, "Annual web tab prefill tests", False),
         ("web_annual_form", test_web_annual_form, "Annual web tab form tests", False),

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -626,17 +626,17 @@ class WebInterface(ComponentBase):
                 <!-- Define animation paths -->
                 <defs>
                     <!-- PV to House path -->
-                    <path id="pv-house-path" d="M200,100 L250,150" stroke="transparent" fill="none" />
+                    <path id="pv-house-path" d="M192,128 L241,161" stroke="transparent" fill="none" />
                     <!-- House to PV path -->
-                    <path id="house-pv-path" d="M250,150 L200,100" stroke="transparent" fill="none" />
+                    <path id="house-pv-path" d="M241,161 L192,128" stroke="transparent" fill="none" />
                     <!-- Battery to House path -->
-                    <path id="battery-house-path" d="M200,300 L250,250" stroke="transparent" fill="none" />
+                    <path id="battery-house-path" d="M192,272 L241,239" stroke="transparent" fill="none" />
                     <!-- House to Battery path -->
-                    <path id="house-battery-path" d="M265,235 L215,275" stroke="transparent" fill="none" />
+                    <path id="house-battery-path" d="M258,228 L209,261" stroke="transparent" fill="none" />
                     <!-- Grid to House path -->
-                    <path id="grid-house-path" d="M410,290 L355,240" stroke="transparent" fill="none" />
+                    <path id="grid-house-path" d="M408,272 L359,239" stroke="transparent" fill="none" />
                     <!-- House to Grid path -->
-                    <path id="house-grid-path" d="M340,230 L390,270" stroke="transparent" fill="none" />
+                    <path id="house-grid-path" d="M342,228 L391,261" stroke="transparent" fill="none" />
                 </defs>
         """.format(
             dp0(house_power)
@@ -652,7 +652,7 @@ class WebInterface(ComponentBase):
 
                 <defs>
                     <!-- House to Car path -->
-                    <path id="house-car-path" d="M342,172 L408,128" stroke="transparent" fill="none" />
+                    <path id="house-car-path" d="M342,172 L391,139" stroke="transparent" fill="none" />
                     <marker id="car-arrow" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
                     <polygon points="0 0, 10 3.5, 0 7" fill="#00BCD4"/>
                     </marker>
@@ -664,18 +664,18 @@ class WebInterface(ComponentBase):
 
                 html += """
                 <!-- House to Car Arrow -->
-                <line x1="342" y1="172" x2="408" y2="128" stroke="#00BCD4" stroke-width="2" marker-end="url(#car-arrow)" />
-                <text x="370" y="135" text-anchor="middle" fill="#00BCD4">{} W</text>
+                <line x1="342" y1="172" x2="391" y2="139" stroke="#00BCD4" stroke-width="2" marker-end="url(#car-arrow)" />
+                <text x="356" y="122" text-anchor="middle" fill="#00BCD4">{} W</text>
 
                 <!-- Moving dots for House to Car -->
                 <circle r="4" fill="#00BCD4" opacity="0.8">
-                    <animateMotion dur="{}s" repeatCount="indefinite" path="M342,172 L408,128" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" path="M342,172 L391,139" />
                 </circle>
                 <circle r="3" fill="#00BCD4" opacity="0.6">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M342,172 L408,128" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M342,172 L391,139" />
                 </circle>
                 <circle r="2" fill="#00BCD4" opacity="0.4">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M342,172 L408,128" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M342,172 L391,139" />
                 </circle>
                 """.format(
                     dp0(car_power), car_speed, car_speed, car_speed
@@ -683,8 +683,8 @@ class WebInterface(ComponentBase):
             else:
                 html += """
                 <!-- House to Car Arrow (dashed) -->
-                <line x1="342" y1="172" x2="408" y2="128" stroke="#00BCD4" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#car-arrow)" />
-                <text x="370" y="135" text-anchor="middle" fill="#00BCD4">{} W</text>
+                <line x1="342" y1="172" x2="391" y2="139" stroke="#00BCD4" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#car-arrow)" />
+                <text x="356" y="122" text-anchor="middle" fill="#00BCD4">{} W</text>
                 <!-- No moving dot when the car is not charging -->
                 """.format(
                     dp0(car_power)
@@ -697,18 +697,18 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- PV to House Arrow -->
-                <line x1="200" y1="100" x2="250" y2="150" stroke="#2196F3" stroke-width="2" marker-end="url(#pv-arrow)" />
-                <text x="250" y="120" text-anchor="middle" fill="#2196F3">{} W</text>
+                <line x1="192" y1="128" x2="241" y2="161" stroke="#2196F3" stroke-width="2" marker-end="url(#pv-arrow)" />
+                <text x="244" y="122" text-anchor="middle" fill="#2196F3">{} W</text>
 
                 <!-- Moving dots for PV to House -->
                 <circle r="4" fill="#2196F3" opacity="0.8">
-                    <animateMotion dur="{}s" repeatCount="indefinite" path="M200,100 L250,150" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" path="M192,128 L241,161" />
                 </circle>
                 <circle r="3" fill="#2196F3" opacity="0.6">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M200,100 L250,150" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M192,128 L241,161" />
                 </circle>
                 <circle r="2" fill="#2196F3" opacity="0.4">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M200,100 L250,150" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M192,128 L241,161" />
                 </circle>
             """.format(
                 dp0(pv_power), pv_speed, pv_speed, pv_speed
@@ -717,8 +717,8 @@ class WebInterface(ComponentBase):
             # Make the PV to House line dashed if not generating
             html += """
                 <!-- PV to House Arrow (dashed) -->
-                <line x1="200" y1="100" x2="250" y2="150" stroke="#2196F3" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#pv-arrow)" />
-                <text x="250" y="120" text-anchor="middle" fill="#2196F3">{} W</text>
+                <line x1="192" y1="128" x2="241" y2="161" stroke="#2196F3" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#pv-arrow)" />
+                <text x="244" y="122" text-anchor="middle" fill="#2196F3">{} W</text>
                 <!-- No moving dot when PV is not generating -->
             """.format(
                 dp0(pv_power)
@@ -729,18 +729,18 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- Battery to House Arrow -->
-                <line x1="200" y1="300" x2="250" y2="250" stroke="#FF9800" stroke-width="2" marker-end="url(#battery-arrow)" />
-                <text x="260" y="280" text-anchor="middle" fill="#FF9800">{} W</text>
+                <line x1="192" y1="272" x2="241" y2="239" stroke="#FF9800" stroke-width="2" marker-end="url(#battery-arrow)" />
+                <text x="244" y="278" text-anchor="middle" fill="#FF9800">{} W</text>
 
                 <!-- Moving dots for Battery to House -->
                 <circle r="4" fill="#FF9800" opacity="0.8">
-                    <animateMotion dur="{}s" repeatCount="indefinite" path="M200,300 L250,250" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" path="M192,272 L241,239" />
                 </circle>
                 <circle r="3" fill="#FF9800" opacity="0.6">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M200,300 L250,250" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M192,272 L241,239" />
                 </circle>
                 <circle r="2" fill="#FF9800" opacity="0.4">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M200,300 L250,250" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M192,272 L241,239" />
                 </circle>
             """.format(
                 dp0(battery_power), battery_speed, battery_speed, battery_speed
@@ -751,18 +751,18 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- House to Battery Arrow -->
-                <line x1="265" y1="235" x2="215" y2="275" stroke="#FF9800" stroke-width="2" marker-end="url(#battery-arrow)" />
-                <text x="260" y="280" text-anchor="middle" fill="#FF9800">{} W</text>
+                <line x1="258" y1="228" x2="209" y2="261" stroke="#FF9800" stroke-width="2" marker-end="url(#battery-arrow)" />
+                <text x="244" y="278" text-anchor="middle" fill="#FF9800">{} W</text>
 
                 <!-- Moving dots for House to Battery -->
                 <circle r="4" fill="#FF9800" opacity="0.8">
-                    <animateMotion dur="{}s" repeatCount="indefinite" path="M265,235 L215,275" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" path="M258,228 L209,261" />
                 </circle>
                 <circle r="3" fill="#FF9800" opacity="0.6">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M265,235 L215,275" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M258,228 L209,261" />
                 </circle>
                 <circle r="2" fill="#FF9800" opacity="0.4">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M265,235 L215,275" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M258,228 L209,261" />
                 </circle>
             """.format(
                 dp0(battery_power), battery_speed, battery_speed, battery_speed
@@ -774,18 +774,18 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- Grid to House Arrow -->
-                <line x1="410" y1="290" x2="355" y2="240" stroke="#4CAF50" stroke-width="2" marker-end="url(#grid-arrow)" />
-                <text x="350" y="280" text-anchor="middle" fill="#4CAF50">{} W</text>
+                <line x1="408" y1="272" x2="359" y2="239" stroke="#4CAF50" stroke-width="2" marker-end="url(#grid-arrow)" />
+                <text x="356" y="278" text-anchor="middle" fill="#4CAF50">{} W</text>
 
                 <!-- Moving dots for Grid to House -->
                 <circle r="4" fill="#4CAF50" opacity="0.8">
-                    <animateMotion dur="{}s" repeatCount="indefinite" path="M410,290 L355,240" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" path="M408,272 L359,239" />
                 </circle>
                 <circle r="3" fill="#4CAF50" opacity="0.6">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M410,290 L355,240" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M408,272 L359,239" />
                 </circle>
                 <circle r="2" fill="#4CAF50" opacity="0.4">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M410,290 L355,240" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M408,272 L359,239" />
                 </circle>
             """.format(
                 dp0(grid_power), grid_speed, grid_speed, grid_speed
@@ -796,18 +796,18 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- House to Grid Arrow -->
-                <line x1="340" y1="230" x2="390" y2="270" stroke="#4CAF50" stroke-width="2" marker-end="url(#grid-arrow)" />
-                <text x="340" y="280" text-anchor="middle" fill="#4CAF50">{} W</text>
+                <line x1="342" y1="228" x2="391" y2="261" stroke="#4CAF50" stroke-width="2" marker-end="url(#grid-arrow)" />
+                <text x="356" y="278" text-anchor="middle" fill="#4CAF50">{} W</text>
 
                 <!-- Moving dots for House to Grid -->
                 <circle r="4" fill="#4CAF50" opacity="0.8">
-                    <animateMotion dur="{}s" repeatCount="indefinite" path="M340,230 L390,270" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" path="M342,228 L391,261" />
                 </circle>
                 <circle r="3" fill="#4CAF50" opacity="0.6">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M340,230 L390,270" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M342,228 L391,261" />
                 </circle>
                 <circle r="2" fill="#4CAF50" opacity="0.4">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M340,230 L390,270" />
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M342,228 L391,261" />
                 </circle>
             """.format(
                 dp0(grid_power), grid_speed, grid_speed, grid_speed

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -583,6 +583,15 @@ class WebInterface(ComponentBase):
         pv_power = self.base.pv_power
         load_power = self.base.load_power
 
+        # Car charging only appears when a car_charging_power sensor is configured (execute.py
+        # update_car_charging_power). The charger sits on the house side of the meter, so its power
+        # is already inside load_power - subtract it so the House circle reads as the rest of the
+        # house rather than counting the car twice. Clamped at zero because the two readings come
+        # from different meters and a slow-updating load sensor can briefly read below the car.
+        car_configured = self.base.car_charging_power_configured
+        car_power = self.base.car_charging_power
+        house_power = max(0, load_power - car_power) if car_configured else load_power
+
         # Determine flow directions
         grid_importing = grid_power <= -10  # Grid is importing power (negative value)
         grid_exporting = grid_power >= 10  # Grid is exporting power (positive value)
@@ -630,8 +639,57 @@ class WebInterface(ComponentBase):
                     <path id="house-grid-path" d="M340,230 L390,270" stroke="transparent" fill="none" />
                 </defs>
         """.format(
-            dp0(load_power)
+            dp0(house_power)
         )
+
+        # Car charging arm - drawn top right, the corner left free by PV/battery/grid
+        if car_configured:
+            car_charging = car_power >= 10
+            html += """
+                <!-- Car Circle -->
+                <circle cx="450" cy="100" r="50" fill="#00BCD4" />
+                <text x="450" y="100" text-anchor="middle" dy=".3em" fill="#fff">Car</text>
+
+                <defs>
+                    <!-- House to Car path -->
+                    <path id="house-car-path" d="M342,172 L408,128" stroke="transparent" fill="none" />
+                    <marker id="car-arrow" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
+                    <polygon points="0 0, 10 3.5, 0 7" fill="#00BCD4"/>
+                    </marker>
+                </defs>
+            """
+            if car_charging:
+                # Calculate animation speed based on power flow - faster for higher power
+                car_speed = max(0.5, min(3.0, 2.0 - (abs(car_power) / 3000)))
+
+                html += """
+                <!-- House to Car Arrow -->
+                <line x1="342" y1="172" x2="408" y2="128" stroke="#00BCD4" stroke-width="2" marker-end="url(#car-arrow)" />
+                <text x="370" y="135" text-anchor="middle" fill="#00BCD4">{} W</text>
+
+                <!-- Moving dots for House to Car -->
+                <circle r="4" fill="#00BCD4" opacity="0.8">
+                    <animateMotion dur="{}s" repeatCount="indefinite" path="M342,172 L408,128" />
+                </circle>
+                <circle r="3" fill="#00BCD4" opacity="0.6">
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M342,172 L408,128" />
+                </circle>
+                <circle r="2" fill="#00BCD4" opacity="0.4">
+                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M342,172 L408,128" />
+                </circle>
+                """.format(
+                    dp0(car_power), car_speed, car_speed, car_speed
+                )
+            else:
+                html += """
+                <!-- House to Car Arrow (dashed) -->
+                <line x1="342" y1="172" x2="408" y2="128" stroke="#00BCD4" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#car-arrow)" />
+                <text x="370" y="135" text-anchor="middle" fill="#00BCD4">{} W</text>
+                <!-- No moving dot when the car is not charging -->
+                """.format(
+                    dp0(car_power)
+                )
+
         # Draw arrows and labels
         if pv_generating:
             # Calculate animation speed based on power flow - faster for higher power

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -564,6 +564,24 @@ class WebInterface(ComponentBase):
             icon = '<span class="mdi mdi-{}"></span>'.format(icon.replace("mdi:", ""))
         return icon
 
+    def get_battery_icon(self, soc_percent, charging):
+        """
+        Pick the Material Design Icon showing how full the battery is and whether it is charging
+
+        The charging variants carry the same three levels plus a bolt, so the level survives in
+        both directions. battery-plus and battery-minus exist but have no level in them, so they
+        would trade the state of charge away for the sign.
+        """
+        if soc_percent < 30:
+            level = 0
+        elif soc_percent < 70:
+            level = 1
+        else:
+            level = 2
+        if charging:
+            return ["&#xF12A4;", "&#xF12A5;", "&#xF12A6;"][level]  # battery-charging low/medium/high
+        return ["&#xF12A1;", "&#xF12A2;", "&#xF12A3;"][level]  # battery low/medium/high
+
     def get_power_flow_diagram(self):
         """
         Generate a graphical power flow diagram showing energy movement between grid, battery, PV, and house load
@@ -592,14 +610,16 @@ class WebInterface(ComponentBase):
         car_power = self.base.car_charging_power
         house_power = max(0, load_power - car_power) if car_configured else load_power
 
-        # Determine flow directions
+        # Determine flow directions. battery_power is positive when the battery is DISCHARGING
+        # (gateway.py negates the firmware's sign for exactly this reason) and grid_power is
+        # negative when importing, so the reading and the arrow run opposite ways round.
         grid_importing = grid_power <= -10  # Grid is importing power (negative value)
-        grid_exporting = grid_power >= 10  # Grid is exporting power (positive value)
 
-        battery_charging = battery_power >= 10  # Battery is charging (positive value)
-        battery_discharging = battery_power <= -10  # Battery is discharging (negative value)
+        battery_to_house = battery_power >= 10  # Battery is discharging into the house
+        battery_charging = battery_power <= -10  # Power is flowing into the battery
 
         pv_generating = pv_power > 0  # PV is generating power
+        battery_icon = self.get_battery_icon(self.base.soc_percent, battery_charging)
         html = ""
 
         html += """
@@ -607,20 +627,20 @@ class WebInterface(ComponentBase):
             <svg width="600" height="400" viewBox="0 0 600 400" xmlns="http://www.w3.org/2000/svg">
 
                 <!-- Grid Circle -->
-                <circle cx="450" cy="300" r="50" fill="#4CAF50" />
-                <text x="450" y="300" text-anchor="middle" dy=".3em" fill="#fff">Grid</text>
+                <circle cx="450" cy="300" r="50" fill="#757575"><title>Grid</title></circle>
+                <text x="450" y="300" text-anchor="middle" dy=".35em" font-family="Material Design Icons" font-size="44" fill="#fff">&#xF0D3E;</text>
 
                 <!-- Battery Circle -->
-                <circle cx="150" cy="300" r="50" fill="#FF9800" />
-                <text x="150" y="300" text-anchor="middle" dy=".3em" fill="#fff">Battery</text>
+                <circle cx="150" cy="300" r="50" fill="#43A047"><title>Battery</title></circle>
+                <text x="150" y="300" text-anchor="middle" dy=".35em" font-family="Material Design Icons" font-size="44" fill="#fff">{}</text>
 
                 <!-- PV Circle -->
-                <circle cx="150" cy="100" r="50" fill="#2196F3" />
-                <text x="150" y="100" text-anchor="middle" dy=".3em" fill="#fff">PV</text>
+                <circle cx="150" cy="100" r="50" fill="#FDD835"><title>PV</title></circle>
+                <text x="150" y="100" text-anchor="middle" dy=".35em" font-family="Material Design Icons" font-size="44" fill="#fff">&#xF0D9B;</text>
 
                 <!-- House Circle -->
-                <circle cx="300" cy="200" r="50" fill="#9C27B0" />
-                <text x="300" y="190" text-anchor="middle" dy=".3em" fill="#fff">House</text>
+                <circle cx="300" cy="200" r="50" fill="#6D4C41"><title>House</title></circle>
+                <text x="300" y="186" text-anchor="middle" dy=".35em" font-family="Material Design Icons" font-size="34" fill="#fff">&#xF02DC;</text>
                 <text x="300" y="215" text-anchor="middle" dy=".3em" fill="#fff">{} W</text>
 
                 <!-- Define animation paths -->
@@ -639,7 +659,7 @@ class WebInterface(ComponentBase):
                     <path id="house-grid-path" d="M342,228 L391,261" stroke="transparent" fill="none" />
                 </defs>
         """.format(
-            dp0(house_power)
+            battery_icon, dp0(house_power)
         )
 
         # Car charging arm - drawn top right, the corner left free by PV/battery/grid
@@ -647,14 +667,14 @@ class WebInterface(ComponentBase):
             car_charging = car_power >= 10
             html += """
                 <!-- Car Circle -->
-                <circle cx="450" cy="100" r="50" fill="#00BCD4" />
-                <text x="450" y="100" text-anchor="middle" dy=".3em" fill="#fff">Car</text>
+                <circle cx="450" cy="100" r="50" fill="#E53935"><title>Car</title></circle>
+                <text x="450" y="100" text-anchor="middle" dy=".35em" font-family="Material Design Icons" font-size="44" fill="#fff">&#xF010B;</text>
 
                 <defs>
                     <!-- House to Car path -->
                     <path id="house-car-path" d="M342,172 L391,139" stroke="transparent" fill="none" />
                     <marker id="car-arrow" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
-                    <polygon points="0 0, 10 3.5, 0 7" fill="#00BCD4"/>
+                    <polygon points="0 0, 10 3.5, 0 7" fill="#E53935"/>
                     </marker>
                 </defs>
             """
@@ -664,17 +684,17 @@ class WebInterface(ComponentBase):
 
                 html += """
                 <!-- House to Car Arrow -->
-                <line x1="342" y1="172" x2="391" y2="139" stroke="#00BCD4" stroke-width="2" marker-end="url(#car-arrow)" />
-                <text x="356" y="122" text-anchor="middle" fill="#00BCD4">{} W</text>
+                <line x1="342" y1="172" x2="391" y2="139" stroke="#E53935" stroke-width="2" marker-end="url(#car-arrow)" />
+                <text x="356" y="122" text-anchor="middle" fill="#E53935">{} W</text>
 
                 <!-- Moving dots for House to Car -->
-                <circle r="4" fill="#00BCD4" opacity="0.8">
+                <circle r="4" fill="#E53935" opacity="0.8">
                     <animateMotion dur="{}s" repeatCount="indefinite" path="M342,172 L391,139" />
                 </circle>
-                <circle r="3" fill="#00BCD4" opacity="0.6">
+                <circle r="3" fill="#E53935" opacity="0.6">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M342,172 L391,139" />
                 </circle>
-                <circle r="2" fill="#00BCD4" opacity="0.4">
+                <circle r="2" fill="#E53935" opacity="0.4">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M342,172 L391,139" />
                 </circle>
                 """.format(
@@ -683,8 +703,8 @@ class WebInterface(ComponentBase):
             else:
                 html += """
                 <!-- House to Car Arrow (dashed) -->
-                <line x1="342" y1="172" x2="391" y2="139" stroke="#00BCD4" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#car-arrow)" />
-                <text x="356" y="122" text-anchor="middle" fill="#00BCD4">{} W</text>
+                <line x1="342" y1="172" x2="391" y2="139" stroke="#E53935" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#car-arrow)" />
+                <text x="356" y="122" text-anchor="middle" fill="#E53935">{} W</text>
                 <!-- No moving dot when the car is not charging -->
                 """.format(
                     dp0(car_power)
@@ -697,17 +717,17 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- PV to House Arrow -->
-                <line x1="192" y1="128" x2="241" y2="161" stroke="#2196F3" stroke-width="2" marker-end="url(#pv-arrow)" />
-                <text x="244" y="122" text-anchor="middle" fill="#2196F3">{} W</text>
+                <line x1="192" y1="128" x2="241" y2="161" stroke="#F9A825" stroke-width="2" marker-end="url(#pv-arrow)" />
+                <text x="244" y="122" text-anchor="middle" fill="#F9A825">{} W</text>
 
                 <!-- Moving dots for PV to House -->
-                <circle r="4" fill="#2196F3" opacity="0.8">
+                <circle r="4" fill="#F9A825" opacity="0.8">
                     <animateMotion dur="{}s" repeatCount="indefinite" path="M192,128 L241,161" />
                 </circle>
-                <circle r="3" fill="#2196F3" opacity="0.6">
+                <circle r="3" fill="#F9A825" opacity="0.6">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M192,128 L241,161" />
                 </circle>
-                <circle r="2" fill="#2196F3" opacity="0.4">
+                <circle r="2" fill="#F9A825" opacity="0.4">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M192,128 L241,161" />
                 </circle>
             """.format(
@@ -717,29 +737,29 @@ class WebInterface(ComponentBase):
             # Make the PV to House line dashed if not generating
             html += """
                 <!-- PV to House Arrow (dashed) -->
-                <line x1="192" y1="128" x2="241" y2="161" stroke="#2196F3" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#pv-arrow)" />
-                <text x="244" y="122" text-anchor="middle" fill="#2196F3">{} W</text>
+                <line x1="192" y1="128" x2="241" y2="161" stroke="#F9A825" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#pv-arrow)" />
+                <text x="244" y="122" text-anchor="middle" fill="#F9A825">{} W</text>
                 <!-- No moving dot when PV is not generating -->
             """.format(
                 dp0(pv_power)
             )
-        if battery_charging:
+        if battery_to_house:
             # Calculate animation speed based on power flow - faster for higher power
             battery_speed = max(0.5, min(3.0, 2.0 - (abs(battery_power) / 3000)))
 
             html += """
                 <!-- Battery to House Arrow -->
-                <line x1="192" y1="272" x2="241" y2="239" stroke="#FF9800" stroke-width="2" marker-end="url(#battery-arrow)" />
-                <text x="244" y="278" text-anchor="middle" fill="#FF9800">{} W</text>
+                <line x1="192" y1="272" x2="241" y2="239" stroke="#43A047" stroke-width="2" marker-end="url(#battery-arrow)" />
+                <text x="244" y="278" text-anchor="middle" fill="#43A047">{} W</text>
 
                 <!-- Moving dots for Battery to House -->
-                <circle r="4" fill="#FF9800" opacity="0.8">
+                <circle r="4" fill="#43A047" opacity="0.8">
                     <animateMotion dur="{}s" repeatCount="indefinite" path="M192,272 L241,239" />
                 </circle>
-                <circle r="3" fill="#FF9800" opacity="0.6">
+                <circle r="3" fill="#43A047" opacity="0.6">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M192,272 L241,239" />
                 </circle>
-                <circle r="2" fill="#FF9800" opacity="0.4">
+                <circle r="2" fill="#43A047" opacity="0.4">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M192,272 L241,239" />
                 </circle>
             """.format(
@@ -751,17 +771,17 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- House to Battery Arrow -->
-                <line x1="258" y1="228" x2="209" y2="261" stroke="#FF9800" stroke-width="2" marker-end="url(#battery-arrow)" />
-                <text x="244" y="278" text-anchor="middle" fill="#FF9800">{} W</text>
+                <line x1="258" y1="228" x2="209" y2="261" stroke="#43A047" stroke-width="2" marker-end="url(#battery-arrow)" />
+                <text x="244" y="278" text-anchor="middle" fill="#43A047">{} W</text>
 
                 <!-- Moving dots for House to Battery -->
-                <circle r="4" fill="#FF9800" opacity="0.8">
+                <circle r="4" fill="#43A047" opacity="0.8">
                     <animateMotion dur="{}s" repeatCount="indefinite" path="M258,228 L209,261" />
                 </circle>
-                <circle r="3" fill="#FF9800" opacity="0.6">
+                <circle r="3" fill="#43A047" opacity="0.6">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M258,228 L209,261" />
                 </circle>
-                <circle r="2" fill="#FF9800" opacity="0.4">
+                <circle r="2" fill="#43A047" opacity="0.4">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M258,228 L209,261" />
                 </circle>
             """.format(
@@ -774,17 +794,17 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- Grid to House Arrow -->
-                <line x1="408" y1="272" x2="359" y2="239" stroke="#4CAF50" stroke-width="2" marker-end="url(#grid-arrow)" />
-                <text x="356" y="278" text-anchor="middle" fill="#4CAF50">{} W</text>
+                <line x1="408" y1="272" x2="359" y2="239" stroke="#757575" stroke-width="2" marker-end="url(#grid-arrow)" />
+                <text x="356" y="278" text-anchor="middle" fill="#757575">{} W</text>
 
                 <!-- Moving dots for Grid to House -->
-                <circle r="4" fill="#4CAF50" opacity="0.8">
+                <circle r="4" fill="#757575" opacity="0.8">
                     <animateMotion dur="{}s" repeatCount="indefinite" path="M408,272 L359,239" />
                 </circle>
-                <circle r="3" fill="#4CAF50" opacity="0.6">
+                <circle r="3" fill="#757575" opacity="0.6">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M408,272 L359,239" />
                 </circle>
-                <circle r="2" fill="#4CAF50" opacity="0.4">
+                <circle r="2" fill="#757575" opacity="0.4">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M408,272 L359,239" />
                 </circle>
             """.format(
@@ -796,17 +816,17 @@ class WebInterface(ComponentBase):
 
             html += """
                 <!-- House to Grid Arrow -->
-                <line x1="342" y1="228" x2="391" y2="261" stroke="#4CAF50" stroke-width="2" marker-end="url(#grid-arrow)" />
-                <text x="356" y="278" text-anchor="middle" fill="#4CAF50">{} W</text>
+                <line x1="342" y1="228" x2="391" y2="261" stroke="#757575" stroke-width="2" marker-end="url(#grid-arrow)" />
+                <text x="356" y="278" text-anchor="middle" fill="#757575">{} W</text>
 
                 <!-- Moving dots for House to Grid -->
-                <circle r="4" fill="#4CAF50" opacity="0.8">
+                <circle r="4" fill="#757575" opacity="0.8">
                     <animateMotion dur="{}s" repeatCount="indefinite" path="M342,228 L391,261" />
                 </circle>
-                <circle r="3" fill="#4CAF50" opacity="0.6">
+                <circle r="3" fill="#757575" opacity="0.6">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M342,228 L391,261" />
                 </circle>
-                <circle r="2" fill="#4CAF50" opacity="0.4">
+                <circle r="2" fill="#757575" opacity="0.4">
                     <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M342,228 L391,261" />
                 </circle>
             """.format(
@@ -816,13 +836,13 @@ class WebInterface(ComponentBase):
                 <!-- Arrowhead Marker -->
                 <defs>
                     <marker id="pv-arrow" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
-                    <polygon points="0 0, 10 3.5, 0 7" fill="#2196F3"/>
+                    <polygon points="0 0, 10 3.5, 0 7" fill="#F9A825"/>
                     </marker>
                     <marker id="battery-arrow" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
-                    <polygon points="0 0, 10 3.5, 0 7" fill="#FF9800"/>
+                    <polygon points="0 0, 10 3.5, 0 7" fill="#43A047"/>
                     </marker>
                     <marker id="grid-arrow" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
-                    <polygon points="0 0, 10 3.5, 0 7" fill="#4CAF50"/>
+                    <polygon points="0 0, 10 3.5, 0 7" fill="#757575"/>
                     </marker>
                 </defs>
             </svg>

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -1896,6 +1896,7 @@ Details of configuring `apps.yaml` for EV charging are described in [Configure a
 - **car_charging_exclusive** for multiple EV's to indicate if they can be charged independently or not
 - **car_energy_reported_load** - Set to False if your EV charger is wired outside the inverter's CT clamp (see [car charging documentation](car-charging.md#filtering-car-charging-energy-from-house-load))
 - **car_charging_energy** - Energy consumed by your EV charger
+- **car_charging_power** - Live power drawn by your EV charger, used for display only
 - **octopus_intelligent_slot** - Octopus Energy integration 'intelligent dispatching' sensor that indicates
 whether you are within an Octopus Energy "smart charge" slot
 - **octopus_ready_time** - Octopus Energy integration sensor for when the car charging will be completed by

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -83,6 +83,24 @@ car_charging_energy can be set to a list of energy sensors, one per line if you 
 - **input_number.predbat_car_charging_energy_scale** - Used to define a scaling factor (in the range of 0 to 1.0)
 to multiply the **car_charging_energy** sensor data by if required (e.g. set to 0.001 to convert Watts to kW). Default 1.0, i.e. no scaling.
 
+- **car_charging_power** - Set in `apps.yaml` to point to an entity giving the **live charging power** of your car charger (in Watts, or any unit Predbat can convert such as kW).
+This has been pre-defined as a regular expression that should auto-detect the appropriate Wallbox and Zappi car charger sensors, or edit as necessary in `apps.yaml` for your charger sensor.<BR>
+Unlike **car_charging_energy** this is display only - it has no effect at all on the Predbat plan. When it is set:
+
+- the [web interface](web-interface.md) power flow diagram gains a Car showing what the charger is drawing, and the House figure becomes the household load with the car charging subtracted from it
+- Predbat publishes a **predbat.car_charging_power** sensor (in kW) which you can graph or use in your own automations
+
+Like car_charging_energy it can be a list of sensors, one per line, if you have more than one charger - they are added together:
+
+```yaml
+  car_charging_power:
+    - sensor.zappi_charge_power
+    - sensor.wallbox_charging_power
+```
+
+If your car charger has no live power sensor, leave **car_charging_power** commented out in `apps.yaml`; the power flow diagram then shows the same four items it always has, and no **predbat.car_charging_power** sensor is published.<BR>
+If you use one of the supported charger integrations (Ohme, myenergi Zappi, GivEnergy EV charger, AlphaESS EV charger or the Predbat gateway) then this is configured automatically and you do not need an `apps.yaml` entry of your own.
+
 If you do not have a suitable car charging energy kWh sensor in Home Assistant then comment the **car_charging_energy** line out of `apps.yaml` and configure **input_number.predbat_car_charging_threshold**
 
 - **input_number.predbat_car_charging_threshold** (default 6 = 6kW)- Sets the kW power threshold above which home consumption is assumed to be car charging

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -62,12 +62,13 @@ Note that this must be configured to point to an 'energy today' sensor in kWh no
 your car charging energy sensor does not accurately report your car charging data (e.g. it falsely reports charging data when not actually charging), or your house load sensor already excludes car charging,
 then this will really mess up your predbat plan as Predbat will exclude all car_charging_energy from your load predictions and you could end up with erroneous or zero house load predictions.  Do check the entity!<BR><BR>
 *NOTE:* The car charging energy sensor must be a daily incrementing kWh sensor. Check the history of your sensor in Home Assistant, that it increments through the day when your car is charging, resets to zero at midnight,
-and does not dip down in value or reset to zero other than at midnight. Some car charger energy sensors do not behave as Predbat requires them to do; for example, they may show cumulative energy per charge, not cumulative charge energy today, or may show 'unavailable' or 'unknown' when the car isn't plugged in.<BR>
-You may need to wrap the car charger energy sensor into a daily resetting utility meter to create a sensor that increments through the day and only changes to zero at midnight, or if your car energy sensor reports unknown/unavailable then create a helper template sensor, e.g.:
+and does not dip down in value or reset to zero other than at midnight. Some car charger energy sensors do not behave as Predbat requires them to do; for example, they may show cumulative energy per charge, not cumulative charge energy today.<BR>
+You may need to wrap the car charger energy sensor into a daily resetting utility meter to create a sensor that increments through the day and only changes to zero at midnight.<BR><BR>
 
-```yaml
-    {{ states('sensor.car_charger_energy') | float(0) }}
-```
+*NOTE:* A charger that reports 'unavailable' or 'unknown' when the car isn't plugged in needs no special handling. Predbat skips those readings when it loads the sensor history,
+and does not treat them as a configuration error, so the sensor can be used exactly as it is.<BR>
+Do **not** wrap such a sensor in a template that substitutes zero (for example `| float(0)`). For a daily incrementing sensor, a zero part way through the day looks exactly like the midnight reset,
+so Predbat starts counting the day's energy again from that point and the charging before it is counted twice.
 
 *TIP:* You can also use **car_charging_energy** to remove other house load kWh from the data Predbat uses for the forecast,
 e.g. if you want to remove Mixergy hot water tank heating data from the forecast such as if you sometimes heat on gas, and sometimes electric depending upon import rates.<BR>

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -287,6 +287,7 @@ Predbat outputs the values it read from your inverters as totals, this gives the
 - predbat.battery_power - The current power of your battery (charging or discharging) in Watts
 - predbat.pv_power - The current power of your PV system in Watts
 - predbat.grid_power - The current grid power flow (import or export) in Watts
+- predbat.car_charging_power - The current power drawn by your car charger in kW, only published when **car_charging_power** is set in `apps.yaml` (see [car charging](car-charging.md#configure-appsyaml-for-your-car-charging))
 
 ## Baseline data
 

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -287,7 +287,7 @@ Predbat outputs the values it read from your inverters as totals, this gives the
 - predbat.battery_power - The current power of your battery (charging or discharging) in Watts
 - predbat.pv_power - The current power of your PV system in Watts
 - predbat.grid_power - The current grid power flow (import or export) in Watts
-- predbat.car_charging_power - The current power drawn by your car charger in kW, only published when **car_charging_power** is set in `apps.yaml` (see [car charging](car-charging.md#configure-appsyaml-for-your-car-charging))
+- predbat.car_charging_power - The current power drawn by your car charger in kW. Only published when **car_charging_power** is set in `apps.yaml`, or wired up automatically by a supported charger integration (Ohme, myenergi Zappi, GivEnergy EV charger, AlphaESS or the Predbat gateway) - see [car charging](car-charging.md#configure-appsyaml-for-your-car-charging)
 
 ## Baseline data
 

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -37,6 +37,10 @@ The initial view is the Dash view which gives a summary of Predbat's status and 
 
 ![image](images/web-interface-dash-view.png)
 
+The power flow diagram shows the PV, battery, grid and house, with animated arrows whose speed reflects how much power is flowing.
+A car is also shown if you have set [car_charging_power](car-charging.md#configure-appsyaml-for-your-car-charging) in `apps.yaml` (this is automatic for the supported charger integrations);
+the car charging power is then subtracted from the House figure so that it shows the rest of your household load rather than counting the car twice.
+
 The Debug panel provides easy access to a number of files that are useful in diagnosing a problem and are usually required if you raise a [Predbat GitHub issue](https://github.com/springfall2008/batpred/issues):
 
 - **Download apps.yaml** - provides a link to download your [apps.yaml file](apps-yaml.md). This is useful to identify issues with your Predbat configuration

--- a/templates/alphaess_cloud.yaml
+++ b/templates/alphaess_cloud.yaml
@@ -124,6 +124,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/enphase_cloud.yaml
+++ b/templates/enphase_cloud.yaml
@@ -106,6 +106,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/ep_cube_cloud.yaml
+++ b/templates/ep_cube_cloud.yaml
@@ -160,6 +160,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/fox.yaml
+++ b/templates/fox.yaml
@@ -257,6 +257,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 0
 

--- a/templates/fox_cloud.yaml
+++ b/templates/fox_cloud.yaml
@@ -97,6 +97,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/fronius.yaml
+++ b/templates/fronius.yaml
@@ -268,6 +268,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kWh to fix the units
   #car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 0
 

--- a/templates/ge_cloud_octopus_standalone.yaml
+++ b/templates/ge_cloud_octopus_standalone.yaml
@@ -118,6 +118,12 @@ pred_bat:
   # If using PredAI you will need to subtract this inside PredAI also
   #car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/ginlong_solis.yaml
+++ b/templates/ginlong_solis.yaml
@@ -202,6 +202,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   num_cars: 0
 
   # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots

--- a/templates/givenergy_cloud.yaml
+++ b/templates/givenergy_cloud.yaml
@@ -214,6 +214,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/givenergy_ems.yaml
+++ b/templates/givenergy_ems.yaml
@@ -128,6 +128,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/givenergy_givtcp.yaml
+++ b/templates/givenergy_givtcp.yaml
@@ -257,6 +257,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/hanchu_cloud.yaml
+++ b/templates/hanchu_cloud.yaml
@@ -149,6 +149,12 @@ pred_bat:
   pv_forecast_d4: re:(sensor.(solcast_|)(pv_forecast_|)forecast_(day_4|d4))
   # ─── Car charging ─────────────────────────────────────────────────────────
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
+
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
   num_cars: 1
   car_charging_planned:
     - 're:(sensor.wallbox_portal_status_description|sensor.myenergi_zappi_[0-9a-z]+_plug_status)'

--- a/templates/huawei.yaml
+++ b/templates/huawei.yaml
@@ -226,6 +226,12 @@ pred_bat:
   car_charging_energy:
   - sensor.go_echarger_energy_kwh
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  #car_charging_power:
+  #- sensor.go_echarger_nrg_12
+
   num_cars: 1
 
   car_charging_planned:

--- a/templates/kostal.yaml
+++ b/templates/kostal.yaml
@@ -220,6 +220,12 @@ pred_bat:
   #car_charging_energy:
   #  - sensor.evvc3efe773bc_active_energy_conn1
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  #car_charging_power:
+  #  - sensor.evvc3efe773bc_power_conn1
+
   #car_charging_planned:
   #- binary_sensor.evcc_garage_connected
 

--- a/templates/luxpower.yaml
+++ b/templates/luxpower.yaml
@@ -226,6 +226,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 0
 

--- a/templates/sigenergy_cloud.yaml
+++ b/templates/sigenergy_cloud.yaml
@@ -126,6 +126,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/sigenergy_sigenstor.yaml
+++ b/templates/sigenergy_sigenstor.yaml
@@ -172,6 +172,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   num_cars: 0
 
   # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots

--- a/templates/sofar.yaml
+++ b/templates/sofar.yaml
@@ -155,6 +155,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 0
 

--- a/templates/sofar_modbus.yaml
+++ b/templates/sofar_modbus.yaml
@@ -172,6 +172,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 0
 

--- a/templates/solar_assistant_growatt_spa.yaml
+++ b/templates/solar_assistant_growatt_spa.yaml
@@ -172,6 +172,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   num_cars: 0
 
   # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots

--- a/templates/solar_assistant_growatt_sph.yaml
+++ b/templates/solar_assistant_growatt_sph.yaml
@@ -169,6 +169,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   num_cars: 0
 
   # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots

--- a/templates/solaredge.yaml
+++ b/templates/solaredge.yaml
@@ -173,6 +173,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   num_cars: 1
 
   # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots

--- a/templates/solax_cloud.yaml
+++ b/templates/solax_cloud.yaml
@@ -100,6 +100,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/solax_sx4.yaml
+++ b/templates/solax_sx4.yaml
@@ -229,6 +229,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   num_cars: 0
 
   # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots

--- a/templates/solis_cloud.yaml
+++ b/templates/solis_cloud.yaml
@@ -129,6 +129,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 1
 

--- a/templates/sunsynk.yaml
+++ b/templates/sunsynk.yaml
@@ -264,6 +264,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
 #  car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+# car_charging_power is the live charging power of your car charger, in Watts
+# It is display only - it drives the car shown on the web interface power flow diagram
+# and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+# Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+# car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   # Defines the number of cars modelled by the system, set to 0 for no car
   num_cars: 0
 

--- a/templates/tesla_powerwall.yaml
+++ b/templates/tesla_powerwall.yaml
@@ -202,6 +202,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   num_cars: 0
 
   # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots

--- a/templates/teslemetry.yaml
+++ b/templates/teslemetry.yaml
@@ -74,6 +74,12 @@ pred_bat:
   # Also adjust car_charging_energy_scale if it's not in kwH to fix the units
   # car_charging_energy: 're:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)'
 
+  # car_charging_power is the live charging power of your car charger, in Watts
+  # It is display only - it drives the car shown on the web interface power flow diagram
+  # and the predbat.car_charging_power sensor. The plan itself is unaffected by it.
+  # Automatically set to detect Wallbox and Zappi, if it doesn't match manually enter your sensor name
+  # car_charging_power: 're:(sensor.myenergi_zappi_[0-9a-z]+_internal_load_ct1|sensor.wallbox_portal_charging_power)'
+
   num_cars: 0
 
   # car_charging_planned is set to a sensor which when positive indicates the car will charged in the upcoming low rate slots


### PR DESCRIPTION
Adds **`car_charging_power`**, an optional `apps.yaml` sensor giving the live power (W) drawn by an EV charger, and puts the car on the web interface power flow diagram.

It is **display only** — the plan still models car charging from `car_charging_energy` and is unaffected by this.

## What it does

When `car_charging_power` is set:

- the power flow diagram gains a **Car** alongside PV, battery and grid — animated while charging, dashed when configured but idle
- the **House** figure becomes `load_power - car_charging_power` (clamped at zero), so it reads as the rest of the household rather than counting the charger twice
- **`predbat.car_charging_power`** (kW, `device_class: power`) is published for upstream consumers. It is only published when a charger is configured, so its absence is how a consumer tells "no charger" from "charger idle"

When it is not set the diagram renders exactly as it does today and no sensor is published.

Several chargers can be listed and are summed, as `car_charging_energy` allows.

## Automatic configuration

All five components that already wire `car_charging_energy` now wire the matching power sensor from the same device list, so entry N is the same charger:

| Component | `car_charging_energy` | `car_charging_power` |
|---|---|---|
| Ohme | `sensor.predbat_ohme_energy_today` | `sensor.predbat_ohme_power_watts` |
| myenergi (Zappi) | `..._session_energy` | `..._power` |
| GECloud EV charger | `..._evc_energy_active_import_register` | `..._evc_power_active_import` |
| AlphaESS | `..._ev_energy_today` | `..._ev_power` |
| Gateway MQTT | `sensor.{pfx}_session_energy` | `sensor.{pfx}_power` |

Ohme's is tied to the same decision as its energy sensor: when a third-party charger owns the energy figure, Ohme's own power reading is left out rather than reported beside it.

The `apps.yaml` templates ship a regular expression matching Wallbox and Zappi, the same way `car_charging_energy` does. Huawei and Kostal ship charger-specific entries (go-eCharger, evcc) rather than the generic regex, so those get commented placeholders pointing at their own charger.

## Three cases handled deliberately

Each is covered by a test that failed first:

- a charger reporting `unavailable` with nothing plugged in (normal for an EV charger) reads as zero **without** flagging the run as errored — `get_arg`'s numeric path would otherwise leave Predbat sitting in "with Errors" all day
- an unresolved `re:` template default counts as **not configured**, so a household with no charger never gets a Car drawn in the window before `auto_config(final=True)` removes the key
- each entity is resolved individually rather than by index, because `auto_config()` leaves a `None` in place of a list entry whose expression found nothing, and an index walk would stop at the hole instead of the chargers after it

## Testing

- new `apps/predbat/tests/test_web_power_flow.py` (registered as `web_power_flow`) — 13 cases covering the reader, unit conversion, the published sensor, all three diagram states and the house-remainder clamp
- auto-map assertions added to `test_ohme.py`, `test_myenergi.py`, `test_alphaess_publish.py`, `test_ge_cloud.py` and `test_gateway.py`
- full suite passes with no skips (151.58s); all pre-commit hooks pass

## Docs

`car-charging.md`, `apps-yaml.md`, `web-interface.md` and `output-data.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)