### PR TITLE
fix(solis): record a fatal status when no inverter has a battery

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1399,6 +1399,11 @@ class SolisAPI(ComponentBase, OAuthMixin):
             self.log("Warn: Solis API automatic_config: No inverters to configure")
             return
 
+        # Fatal only when every inverter explicitly declares no battery attached - this must match
+        # NO_BATTERY_STATUS and the SaaS block predicate exactly, not the (wider) batteryHealthSoh
+        # gate below, which also excludes inverters with a real battery but an unparseable SoH.
+        self._no_battery_fatal = all(self._reports_no_battery(self.inverter_details.get(sn, {})) for sn in self.inverter_sn)
+
         # Count inverters with batteries
         batteries = []
         for inverter_sn in self.inverter_sn:
@@ -1419,13 +1424,13 @@ class SolisAPI(ComponentBase, OAuthMixin):
         num_inverters = len(batteries)
         self.log(f"Solis API: Configuring Predbat for {num_inverters} inverter(s) with batteries")
         if num_inverters == 0:
-            # Fatal: PredBat optimises battery charging and there is no battery to optimise.
-            # Re-asserted every run() tick because had_errors (and so the status) resets each
-            # plan cycle - see _assert_no_battery_status().
-            self._no_battery_fatal = True
+            # No inverter has a usable batteryHealthSoh (missing/unparseable field, or every
+            # inverter explicitly has no battery). self._no_battery_fatal was already computed
+            # above from the explicit declaration only - see _assert_no_battery_status(), which
+            # re-asserts it every run() tick because had_errors (and so the status) resets each
+            # plan cycle.
             self.log("Warn: Solis API automatic_config: No inverters with batteries found, skipping configuration")
             return
-        self._no_battery_fatal = False
 
         # Convert SNs to lowercase for entity naming
         devices = [sn.lower() for sn in batteries]

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -28,6 +28,12 @@ SOLIS_BASE_URL = "https://www.soliscloud.com:13333"
 # different namespace, so paths are translated via SOLIS_OAUTH_ENDPOINTS below. (Design #366
 # approach 1 assumed path parity here; that was verified false against the live gateway.)
 SOLIS_OAUTH_BASE_URL = "https://api-oauth2.soliscloud.com"
+
+# Recorded as predbat.status when an account has inverters but none with a battery.
+# The SaaS instance-health sweep matches the "No battery found on any inverter"
+# substring to escalate this specific case, so keep that wording stable and ASCII.
+NO_BATTERY_STATUS = "Error: No battery found on any inverter - PredBat requires a battery to optimise"
+
 SOLIS_READ_ENDPOINT = "/v2/api/atRead"
 SOLIS_READ_BATCH_ENDPOINT = "/v2/api/atReadBatch"
 SOLIS_CONTROL_ENDPOINT = "/v2/api/control"
@@ -382,6 +388,8 @@ class SolisAPI(ComponentBase, OAuthMixin):
         self.slots_reset = set()  # Track which inverters had slots reset
         self.capacity_voltage_warned = set()  # Inverters already warned about an estimated capacity voltage
         self.tou_bit_refused = {}  # Inverter -> when it was seen to reject the TOU bit on CID 636 (issue #4707)
+        # Set by automatic_config() when no discovered inverter has a battery.
+        self._no_battery_fatal = False
 
         self.log(f"Solis API: Initialised with inverter_sn={self.configured_inverter_sn}, automatic={automatic}")
 
@@ -1411,8 +1419,13 @@ class SolisAPI(ComponentBase, OAuthMixin):
         num_inverters = len(batteries)
         self.log(f"Solis API: Configuring Predbat for {num_inverters} inverter(s) with batteries")
         if num_inverters == 0:
+            # Fatal: PredBat optimises battery charging and there is no battery to optimise.
+            # Re-asserted every run() tick because had_errors (and so the status) resets each
+            # plan cycle - see _assert_no_battery_status().
+            self._no_battery_fatal = True
             self.log("Warn: Solis API automatic_config: No inverters with batteries found, skipping configuration")
             return
+        self._no_battery_fatal = False
 
         # Convert SNs to lowercase for entity naming
         devices = [sn.lower() for sn in batteries]
@@ -1469,6 +1482,20 @@ class SolisAPI(ComponentBase, OAuthMixin):
         self.set_arg_auto("export_limit", [f"number.{self.prefix}_solis_{device}_max_export_power" for device in devices])
 
         self.log("Solis API: Automatic configuration complete")
+
+    async def _assert_no_battery_status(self):
+        """Keep the fatal no-battery status current.
+
+        predbat.py resets had_errors at the start of every plan cycle and the completion
+        path may write a fresh status, so a status recorded once at startup would not
+        survive. Called from run() on every tick; the current_status check keeps it to one
+        write per overwrite rather than one per tick.
+        """
+        if not self._no_battery_fatal:
+            return
+        if getattr(self.base, "current_status", None) == NO_BATTERY_STATUS:
+            return
+        self.base.record_status(NO_BATTERY_STATUS, had_errors=True)
 
     async def poll_inverter_data(self, inverter_sn, cid_list, batch=True):
         """Poll CID values for specific inverter"""
@@ -3298,6 +3325,9 @@ class SolisAPI(ComponentBase, OAuthMixin):
         # Auto-configure Predbat if enabled
         if first and self.automatic and self.inverter_sn:
             await self.automatic_config()
+
+        # Keep the fatal no-battery status current (no-op unless it applies)
+        await self._assert_no_battery_status()
 
         # Return status. A refused control write must not refresh the success timestamp:
         # components.is_alive() treats a stale timestamp as unhealthy, which surfaces as

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -29,12 +29,19 @@ class MockBase:
 
     def __init__(self, prefix="predbat"):
         self.prefix = prefix
+        self.current_status = ""
+        self.record_status_calls = []
 
     def get_arg(self, key, default=None):
         """Mock get_arg method"""
         if key == "prefix":
             return self.prefix
         return default
+
+    def record_status(self, message, debug="", had_errors=False, notify=False, extra=""):
+        """Mock record_status - track calls and mirror output.py's current_status write."""
+        self.record_status_calls.append({"message": message, "had_errors": had_errors})
+        self.current_status = message + extra
 
 
 class MockSolisAPI(SolisAPI):
@@ -60,6 +67,8 @@ class MockSolisAPI(SolisAPI):
         self.tou_bit_refused = {}
         self.control_enable = True
         self.inverter_sn = []
+        # Set by automatic_config() when no discovered inverter has a battery.
+        self._no_battery_fatal = False
 
         # Mock base object for get_arg calls
         self.base = MockBase(prefix)
@@ -1294,6 +1303,87 @@ async def test_automatic_config_keeps_real_battery_reporting_zero_soh():
     return failed
 
 
+async def test_run_records_fatal_status_when_no_inverter_has_a_battery():
+    """An account where no inverter has a battery is fatal - PredBat cannot do its job.
+
+    Recorded with had_errors=True so predbat.py's run-completion path leaves it alone
+    (it logs without calling record_status when had_errors is set), which makes the
+    status terminal for the cycle and visible to the hourly instance-health sweep.
+    """
+    failed = False
+    print("**** Testing run() records a fatal status when no inverter has a battery ****")
+
+    api = MockSolisAPI()
+    api.inverter_sn = ["6031042245160206"]
+    api.inverter_details = {"6031042245160206": _DETAIL_NO_BATTERY}
+    api.set_arg_auto = lambda key, value: None
+    await api.automatic_config()
+
+    if not api._no_battery_fatal:
+        print("ERROR: expected _no_battery_fatal to be set when no inverter has a battery")
+        failed = True
+
+    api.base.record_status_calls = []
+    await api._assert_no_battery_status()
+    if len(api.base.record_status_calls) != 1:
+        print("ERROR: expected exactly one record_status call, got {}".format(api.base.record_status_calls))
+        failed = True
+    else:
+        call = api.base.record_status_calls[0]
+        if "No battery found on any inverter" not in call["message"]:
+            print("ERROR: status must contain the cross-repo contract substring, got {!r}".format(call["message"]))
+            failed = True
+        if call["had_errors"] is not True:
+            print("ERROR: status must be recorded with had_errors=True or it will be overwritten")
+            failed = True
+
+    # Idempotent: already our status, so no repeat write on the next 5s tick.
+    await api._assert_no_battery_status()
+    if len(api.base.record_status_calls) != 1:
+        print("ERROR: expected no repeat write while the status is already ours, got {} calls".format(len(api.base.record_status_calls)))
+        failed = True
+
+    # Something else overwrote it (a new plan cycle) - we must re-assert.
+    api.base.current_status = "Demand"
+    await api._assert_no_battery_status()
+    if len(api.base.record_status_calls) != 2:
+        print("ERROR: expected a re-assert after the status was overwritten, got {} calls".format(len(api.base.record_status_calls)))
+        failed = True
+
+    if not failed:
+        print("PASSED: run() records a fatal status when no inverter has a battery")
+    return failed
+
+
+async def test_no_fatal_status_when_some_inverter_has_a_battery():
+    """A mixed account is NOT fatal - the customer has a working battery and must not be paused."""
+    failed = False
+    print("**** Testing no fatal status when at least one inverter has a battery ****")
+
+    api = MockSolisAPI()
+    api.inverter_sn = ["1031260253072197", "6031042245160206"]
+    api.inverter_details = {
+        "1031260253072197": _DETAIL_WITH_BATTERY,
+        "6031042245160206": _DETAIL_NO_BATTERY,
+    }
+    api.set_arg_auto = lambda key, value: None
+    await api.automatic_config()
+
+    if api._no_battery_fatal:
+        print("ERROR: a mixed account must not be fatal - the customer has a working battery")
+        failed = True
+
+    api.base.record_status_calls = []
+    await api._assert_no_battery_status()
+    if api.base.record_status_calls:
+        print("ERROR: expected no status recorded for a mixed account, got {}".format(api.base.record_status_calls))
+        failed = True
+
+    if not failed:
+        print("PASSED: no fatal status when at least one inverter has a battery")
+    return failed
+
+
 def run_solis_tests(my_predbat):
     """
     Run all Solis API tests
@@ -1316,6 +1406,8 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_automatic_config_skips_no_battery_on_alt_firmware())
         failed |= asyncio.run(test_automatic_config_skips_no_battery_named_only_in_battery_list())
         failed |= asyncio.run(test_automatic_config_keeps_real_battery_reporting_zero_soh())
+        failed |= asyncio.run(test_run_records_fatal_status_when_no_inverter_has_a_battery())
+        failed |= asyncio.run(test_no_fatal_status_when_some_inverter_has_a_battery())
         failed |= asyncio.run(test_read_cid())
         failed |= asyncio.run(test_read_batch())
         failed |= asyncio.run(test_read_and_write_cid())

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -1175,6 +1175,18 @@ _DETAIL_WITH_BATTERY_ALT_FIRMWARE = {
     "batteryList": [{"batteryType": 99, "batteryTypeName": "Lithium Battery LV", "battSn": "", "noBattery": None, "batteryVoltage": 54.83}],
 }
 
+# A real pack whose firmware simply omits batteryHealthSoh. It still names a real battery type, so
+# _reports_no_battery says False - only the (separate, wider) SoH gate in automatic_config excludes
+# it from num_inverters. _no_battery_fatal must not follow num_inverters here.
+_DETAIL_WITH_BATTERY_MISSING_SOH = {
+    "batteryType": "PYLON_LV",
+    "batteryTypeCode": "0001",
+    "batteryVoltage": 51.28,
+    "batteryCDEnableSet": 1,
+    "batteryJump": {"canJump": True, "batteryCount": 1, "batterySn": "1031260253072197BAT01"},
+    "batteryList": [{"batteryTypeName": "PYLON_LV", "battSn": "PYLON", "batteryVoltage": 51.28}],
+}
+
 # A real pack that happens to report SoH 0 - a documented, valid SolisCloud response. It must stay
 # enrolled; SoH alone can never be the reason to drop an inverter.
 _DETAIL_REAL_BATTERY_ZERO_SOH = {
@@ -1384,6 +1396,57 @@ async def test_no_fatal_status_when_some_inverter_has_a_battery():
     return failed
 
 
+async def test_no_fatal_status_when_single_inverter_has_battery_but_no_soh():
+    """A single real battery whose firmware omits/mis-reports batteryHealthSoh must not be fatal.
+
+    num_inverters is 0 here (the SoH gate in automatic_config still excludes the inverter, exactly
+    as before this change), but _no_battery_fatal must stay False: the inverter never declared "No
+    Battery" - see _reports_no_battery - so treating this like the fatal case would auto-pause a
+    paying customer whose battery is fine (day-3 alert, day-7 pause).
+    """
+    failed = False
+    print("**** Testing no fatal status for a real battery with missing/unparseable batteryHealthSoh ****")
+
+    sn = "1031260253072197"
+
+    api = MockSolisAPI()
+    api.inverter_sn = [sn]
+    api.inverter_details = {sn: _DETAIL_WITH_BATTERY_MISSING_SOH}
+    api.set_arg_auto = lambda key, value: None
+    await api.automatic_config()
+
+    if api._no_battery_fatal:
+        print("ERROR: a real battery with missing batteryHealthSoh must not be fatal")
+        failed = True
+
+    await api._assert_no_battery_status()
+    if api.base.record_status_calls:
+        print("ERROR: expected no status recorded for a real battery with missing SoH, got {}".format(api.base.record_status_calls))
+        failed = True
+
+    # Same again with a non-numeric batteryHealthSoh (some firmware reports a placeholder string).
+    detail_non_numeric = dict(_DETAIL_WITH_BATTERY_MISSING_SOH)
+    detail_non_numeric["batteryHealthSoh"] = "N/A"
+    api2 = MockSolisAPI()
+    api2.inverter_sn = [sn]
+    api2.inverter_details = {sn: detail_non_numeric}
+    api2.set_arg_auto = lambda key, value: None
+    await api2.automatic_config()
+
+    if api2._no_battery_fatal:
+        print("ERROR: a real battery with non-numeric batteryHealthSoh must not be fatal")
+        failed = True
+
+    await api2._assert_no_battery_status()
+    if api2.base.record_status_calls:
+        print("ERROR: expected no status recorded for a real battery with non-numeric SoH, got {}".format(api2.base.record_status_calls))
+        failed = True
+
+    if not failed:
+        print("PASSED: no fatal status for a real battery with missing/unparseable batteryHealthSoh")
+    return failed
+
+
 def run_solis_tests(my_predbat):
     """
     Run all Solis API tests
@@ -1408,6 +1471,7 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_automatic_config_keeps_real_battery_reporting_zero_soh())
         failed |= asyncio.run(test_run_records_fatal_status_when_no_inverter_has_a_battery())
         failed |= asyncio.run(test_no_fatal_status_when_some_inverter_has_a_battery())
+        failed |= asyncio.run(test_no_fatal_status_when_single_inverter_has_battery_but_no_soh())
         failed |= asyncio.run(test_read_cid())
         failed |= asyncio.run(test_read_batch())
         failed |= asyncio.run(test_read_and_write_cid())


### PR DESCRIPTION
## Problem

PredBat optimises battery charging. An account where **no** inverter has a battery cannot be
optimised at all — but #4643 only skips those inverters and logs it, so nothing downstream can
tell "no battery anywhere" apart from "running fine".

## Fix

Record a fatal status when every discovered inverter explicitly declares no battery:

```
Error: No battery found on any inverter - PredBat requires a battery to optimise
```

Recorded with `had_errors=True`, which also makes it terminal for the cycle: `record_status()`
sets `self.had_errors` as its last statement, and `record_final_run_status()`'s `if self.had_errors:`
branch logs **without** calling `record_status`, so the run-completion path does not overwrite it.

Re-asserted from `run()` rather than `automatic_config()`, because `automatic_config()` runs only
when `first` is true while `had_errors` resets every plan cycle — a status written once at startup
would be silently overwritten. The `current_status` check keeps that to one write per overwrite
rather than one per tick.

### The predicate is deliberately narrow

`_no_battery_fatal` is computed from `_reports_no_battery()` alone, **not** from
`num_inverters == 0`. Those differ: an inverter only reaches `num_inverters` if it also has a
parseable `batteryHealthSoh`, so keying off that count would make a single-inverter account with a
real, connected battery whose firmware omits SoH report "no battery found" — and, on the SaaS side,
eventually auto-pause a customer whose battery is fine. That is exactly the inference
`_reports_no_battery`'s own comments forbid, and it is covered by a regression test here.

A **mixed** account (some inverters with batteries, some without) is deliberately not fatal — the
customer has a working battery and nothing is broken for them.

## Testing

Three new tests in `test_solis.py`, reusing the live `inverterDetail` fixtures from #4643:
fatal status for a wholly battery-less account (recorded once, idempotent, re-asserted after an
overwrite); no status for a mixed account; and no status for a real battery with a
missing/non-numeric `batteryHealthSoh`. `MockBase` gains `record_status`/`current_status` mirroring
`output.py`, and `MockSolisAPI` gains the `_no_battery_fatal` default that `initialize()` sets.

Full suite `--quick`: no new failures (`data_age_metrics` fails identically on unmodified `main`).
`black --check` clean.
