### PR TITLE
fix(octopus): anchor Economy 7 night window to UTC and allow manual off-peak times

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -388,6 +388,7 @@ OCPP
 octo
 octoplus
 octopoints
+OFFPEAK
 Ofgem
 Ohme
 ohmepy

--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -2673,6 +2673,7 @@ APPS_SCHEMA = {
     "octopus_saving_session_min_octopoints_per_kwh": {"type": "float"},
     "octopus_saving_session_rate": {"type": "float"},
     "octopus_free_url": {"type": "string", "empty": False},
+    "octopus_night_times": {"type": "dict_list"},
     "metric_octopus_import": {"type": "sensor", "sensor_type": "float"},
     "metric_octopus_export": {"type": "sensor", "sensor_type": "float"},
     "octopus_api_key": {"type": "string", "empty": False},

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1920,6 +1920,17 @@ class Fetch:
                 if end_minutes <= start_minutes:
                     end_minutes += 24 * 60
 
+                # A window flagged utc is given in UTC rather than local wall-clock time, so shift it
+                # by the local offset. That keeps a UTC-fixed schedule - an Economy 7 smart meter, for
+                # instance - aligned with the meter through British Summer Time instead of running an
+                # hour early. The offset is taken at local midnight, which is the reference the
+                # returned minute keys are relative to.
+                if this_rate.get("utc", False):
+                    utc_offset = self.midnight_utc.utcoffset()
+                    offset_minutes = int(utc_offset.total_seconds() // 60) if utc_offset else 0
+                    start_minutes += offset_minutes
+                    end_minutes += offset_minutes
+
                 # Adjust for date if specified
                 if date:
                     delta_minutes = minutes_to_time(date, self.midnight)

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -434,6 +434,11 @@ def _slot_tou_label(node):
 def _night_time_to_minutes(value):
     """
     Parse an "HH:MM" or "HH:MM:SS" time into minutes from midnight, or None if it is not valid.
+
+    An hour of 24 is normalised to 0, matching how utils.time_string_to_stamp parses the same
+    strings, so that octopus_night_times really does accept the format the rate bands document. A
+    "24:00" end still closes out the day, since the caller pushes an end at or before the start
+    into the following day.
     """
     if not value:
         return None
@@ -445,6 +450,8 @@ def _night_time_to_minutes(value):
         return None
     if hour < 0 or hour > 24 or minute < 0 or minute > 59:
         return None
+    if hour == 24:
+        hour = 0
     return hour * 60 + minute
 
 

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -41,10 +41,15 @@ _ATTRIBUTE_UNSET = object()
 
 # Night-rate window definitions: start time, end time, whether the window crosses midnight.
 # Keys: "eco7" (Economy 7), "go" (Octopus GO / generic day-night), "iog" (Intelligent GO TOU).
+# "utc" says which clock the window is fixed to. Octopus documents the Economy 7 smart-meter window
+# as a fixed 00:30-07:30 UTC period, so it falls at 01:30-08:30 local during BST. The GO and
+# Intelligent GO windows are instead advertised as local wall-clock times and hold year-round.
+# These are only a fallback: the meter's real schedule is read from the measurements TOU labels
+# when those are available.
 OCTOPUS_NIGHT_RATE_WINDOWS = {
-    "eco7": {"start": (0, 30), "end": (7, 30), "cross_midnight": False},
-    "go": {"start": (0, 30), "end": (5, 30), "cross_midnight": False},
-    "iog": {"start": (23, 30), "end": (5, 30), "cross_midnight": True},
+    "eco7": {"start": (0, 30), "end": (7, 30), "cross_midnight": False, "utc": True},
+    "go": {"start": (0, 30), "end": (5, 30), "cross_midnight": False, "utc": False},
+    "iog": {"start": (23, 30), "end": (5, 30), "cross_midnight": True, "utc": False},
 }
 
 OCTOPUS_MAX_RETRIES = 5
@@ -412,6 +417,122 @@ class OctopusEnergyApiClient:
         return self.session
 
 
+def _slot_tou_label(node):
+    """
+    Return the time-of-use bucket label Octopus assigned to this slot, e.g. DAY_RATE or NIGHT_RATE.
+
+    This is the API stating which register the slot bills against, rather than us inferring it from
+    the cost, so it is available even for a slot with no consumption.
+    """
+    stats = (node.get("metaData") or {}).get("statistics") or []
+    for stat in stats:
+        if stat.get("type", None) == "TOU_BUCKET_COST" and stat.get("label", None):
+            return stat["label"]
+    return None
+
+
+def _night_time_to_minutes(value):
+    """
+    Parse an "HH:MM" or "HH:MM:SS" time into minutes from midnight, or None if it is not valid.
+    """
+    if not value:
+        return None
+    parts = str(value).split(":")
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1]) if len(parts) > 1 else 0
+    except (ValueError, IndexError):
+        return None
+    if hour < 0 or hour > 24 or minute < 0 or minute > 59:
+        return None
+    return hour * 60 + minute
+
+
+def _windows_from_night_times(night_times, log=None):
+    """
+    Parse octopus_night_times entries into (start_minute, end_minute, is_utc) off-peak windows.
+
+    Entries use the same start/end form as basic_rates, and may carry utc: true to be given in UTC
+    rather than local wall-clock time. Returns an empty list when nothing usable is configured, so
+    the caller falls through to the meter's own schedule.
+    """
+    windows = []
+    for entry in night_times or []:
+        if not isinstance(entry, dict):
+            if log:
+                log("Warn: OctopusAPI: octopus_night_times entry must be a dict with start/end, got {}".format(entry))
+            continue
+        start = _night_time_to_minutes(entry.get("start", None))
+        end = _night_time_to_minutes(entry.get("end", None))
+        if start is None or end is None:
+            if log:
+                log("Warn: OctopusAPI: Bad start/end in octopus_night_times entry {}".format(entry))
+            continue
+        if end <= start:
+            end += 24 * 60
+        windows.append((start, end, bool(entry.get("utc", False))))
+    return sorted(windows)
+
+
+def _off_peak_tou_label(labels):
+    """
+    Pick the off-peak bucket out of the TOU labels Octopus returned, by conventional naming.
+    """
+    for label in sorted(labels):
+        upper = label.upper()
+        if "NIGHT" in upper or "OFF_PEAK" in upper or "OFFPEAK" in upper:
+            return label
+    return None
+
+
+def _merge_minute_windows(minutes):
+    """
+    Merge a sorted list of half-hour slot starts into contiguous (start, end) minute windows.
+
+    A window running up to midnight is joined with one starting at midnight, so a schedule that
+    straddles the day boundary comes back as a single window whose end exceeds 1440.
+    """
+    windows = []
+    for minute in minutes:
+        if windows and windows[-1][1] == minute:
+            windows[-1][1] = minute + 30
+        else:
+            windows.append([minute, minute + 30])
+    if len(windows) > 1 and windows[0][0] == 0 and windows[-1][1] == 1440:
+        wrapped = [windows[-1][0], windows[0][1] + 1440]
+        windows = windows[1:-1] + [wrapped]
+    return sorted(tuple(window) for window in windows)
+
+
+def _tou_windows_from_measurements(response_data):
+    """
+    Derive the meter's off-peak windows from measurement TOU bucket labels.
+
+    Returns (start_minute, end_minute) offsets from UTC midnight, or None when the response carries
+    no labels or only a single bucket, in which case there is nothing to distinguish an off-peak
+    period and the caller should fall back to the hard-wired windows.
+    """
+    if not response_data:
+        return None
+    labels_by_slot = {}
+    for prop in (response_data.get("account", {}) or {}).get("properties", []) or []:
+        for edge in (prop.get("measurements", {}) or {}).get("edges", []) or []:
+            node = edge.get("node", {}) or {}
+            stamp = node.get("startAt", None)
+            label = _slot_tou_label(node)
+            if not stamp or not label:
+                continue
+            start = str2time(stamp).astimezone(timezone.utc)
+            labels_by_slot.setdefault(start.hour * 60 + start.minute, []).append(label)
+    if not labels_by_slot:
+        return None
+    dominant = {slot: max(set(values), key=values.count) for slot, values in labels_by_slot.items()}
+    off_peak = _off_peak_tou_label(set(dominant.values()))
+    if not off_peak or len(set(dominant.values())) < 2:
+        return None
+    return _merge_minute_windows(sorted(slot for slot, label in dominant.items() if label == off_peak))
+
+
 class OctopusAPI(ComponentBase):
     """Octopus Energy integration component.
 
@@ -443,6 +564,8 @@ class OctopusAPI(ComponentBase):
         self.automatic = automatic
         self.commands = []
         self.mpan = None
+        self.tou_windows = None
+        self.tou_windows_day = None
         self.free_electricity_events = []
 
         # API request metrics for monitoring
@@ -1393,6 +1516,55 @@ class OctopusAPI(ComponentBase):
         else:
             return ("INTELLI-" in tariff_code) or ("IOG-" in tariff_code)
 
+    async def async_get_tou_night_windows(self, days=7):
+        """
+        Read the meter's real off-peak windows from the measurements API's TOU bucket labels.
+
+        Octopus labels every half-hour interval with the time-of-use bucket it bills against, which
+        is the meter's actual switching schedule rather than something inferred from the tariff
+        code. Returns (start_minute, end_minute) offsets from UTC midnight, or None when the labels
+        are unavailable so the caller falls back to the hard-wired windows. The result is cached
+        for the day, since a meter's schedule does not change between polls.
+        """
+        if not self.mpan or not self.account_id:
+            return None
+        today = self.now_utc_exact.astimezone(timezone.utc).strftime(DATE_STR_FORMAT)
+        if self.tou_windows_day == today:
+            return self.tou_windows
+
+        end_at = self.now_utc_exact.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        start_at = end_at - timedelta(days=days)
+        query = MEASUREMENTS_QUERY.format(
+            account_id=self.account_id,
+            first=days * 48 + 48,
+            mpan=self.mpan,
+            frequency="THIRTY_MIN_INTERVAL",
+            start_at=start_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            end_at=end_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+        try:
+            response_data = await self.async_graphql_query(query, "get-tou-buckets", ignore_errors=True)
+        except Exception as error:  # noqa: BLE001 - a diagnostic lookup must never break rate fetching
+            self.log("Warn: OctopusAPI: TOU bucket lookup failed ({}), falling back to hard-wired windows".format(error))
+            response_data = None
+        windows = _tou_windows_from_measurements(response_data)
+        self.tou_windows_day = today
+        self.tou_windows = windows
+        return windows
+
+    def _fallback_night_window(self, tariff_code):
+        """
+        Pick the hard-wired off-peak window for a tariff code, used when nothing better is known.
+        """
+        if self.is_intelligent_go_tariff(tariff_code):
+            return OCTOPUS_NIGHT_RATE_WINDOWS["iog"]
+        if tariff_code and "GO-" in tariff_code:
+            return OCTOPUS_NIGHT_RATE_WINDOWS["go"]
+        if tariff_code and tariff_code.startswith("E-2R-"):
+            return OCTOPUS_NIGHT_RATE_WINDOWS["eco7"]
+        self.log("Warn: OctopusAPI: Unknown tariff code {}, defaulting to GO night rate window".format(tariff_code))
+        return OCTOPUS_NIGHT_RATE_WINDOWS["go"]
+
     async def async_get_day_night_rates(self, url, product_code="", tariff_code=""):
         """
         Get day and night rates from Octopus.
@@ -1410,43 +1582,63 @@ class OctopusAPI(ComponentBase):
         result_night = await self.fetch_url_cached(url_night)
         self.log("Info: OctopusAPI: Day rate entries: {} night rate entries: {}".format(len(result_day) if result_day else 0, len(result_night) if result_night else 0))
         if result_day and result_night:
-            # Select night window based on tariff type
-            if self.is_intelligent_go_tariff(tariff_code):
-                window = OCTOPUS_NIGHT_RATE_WINDOWS["iog"]
-            elif tariff_code and "GO-" in tariff_code:
-                window = OCTOPUS_NIGHT_RATE_WINDOWS["go"]
-            elif tariff_code and tariff_code.startswith("E-2R-"):
-                window = OCTOPUS_NIGHT_RATE_WINDOWS["eco7"]
+            # A hand-configured schedule wins outright: it exists precisely for a meter whose real
+            # bands the API does not report. Failing that, the meter's own labels beat any guess
+            # made from the tariff code, and the hard-wired window is the last resort.
+            windows = _windows_from_night_times(self.get_arg("octopus_night_times", [], indirect=False), log=self.log)
+            if windows:
+                self.log("Info: OctopusAPI: Using off-peak windows {} from octopus_night_times".format(windows))
             else:
-                self.log("Warn: OctopusAPI: Unknown tariff code {}, defaulting to GO night rate window".format(tariff_code))
-                window = OCTOPUS_NIGHT_RATE_WINDOWS["go"]
+                tou_windows = await self.async_get_tou_night_windows()
+                if tou_windows:
+                    windows = [(start_minute, end_minute, True) for start_minute, end_minute in tou_windows]
+                    self.log("Info: OctopusAPI: Using off-peak windows {} (UTC minutes from midnight) from measurement TOU labels".format(tou_windows))
+            if not windows:
+                window = self._fallback_night_window(tariff_code)
+                start_minute = window["start"][0] * 60 + window["start"][1]
+                end_minute = window["end"][0] * 60 + window["end"][1]
+                if window["cross_midnight"]:
+                    end_minute += 24 * 60
+                windows = [(start_minute, end_minute, window.get("utc", False))]
+                self.log("Info: OctopusAPI: Using hard-wired night rate window {} anchored to {} based on tariff code {}".format(window, "UTC" if window.get("utc", False) else "local time", tariff_code))
 
-            self.log("Info: OctopusAPI: Using night rate window {} based on tariff code {}".format(window, tariff_code))
-            night_start_hour, night_start_minute = window["start"]
-            night_end_hour, night_end_minute = window["end"]
-            cross_midnight = window["cross_midnight"]
+            # Anchor each window to whichever clock it is fixed to. Economy 7 and any TOU-derived
+            # schedule are UTC, so anchoring them locally would run them an hour early through
+            # British Summer Time; GO and Intelligent GO are local wall-clock windows and must not
+            # move with the seasons. A hand-configured schedule may mix the two.
+            utc_midnight = self.now_utc_exact.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+            local_midnight = self.now_utc_exact.replace(hour=0, minute=0, second=0, microsecond=0)
 
-            # Build synthetic 8-day schedule starting 2 days back
-            # Look up the correct rate for each individual day to handle mid-window rate changes
-            night_start_time = self.now_utc_exact.replace(hour=night_start_hour, minute=night_start_minute, second=0, microsecond=0) - timedelta(days=2)
-            if cross_midnight:
-                night_end_time = (night_start_time + timedelta(days=1)).replace(hour=night_end_hour, minute=night_end_minute)
-            else:
-                night_end_time = night_start_time.replace(hour=night_end_hour, minute=night_end_minute)
-            day_start_time = night_end_time
-            day_end_time = night_start_time + timedelta(days=1)
+            # Build the off-peak intervals over the 8-day schedule, starting 2 days back. A ninth
+            # day is generated so the last day-rate gap has a following off-peak window to end at.
+            night_intervals = []
+            for day in range(-2, 7):
+                utc_base = utc_midnight + timedelta(days=day)
+                local_base = local_midnight + timedelta(days=day)
+                # Re-normalise the local anchor so the wall-clock time holds across a DST change,
+                # since adding days to a localised datetime keeps the original UTC offset.
+                if hasattr(local_base.tzinfo, "normalize"):
+                    local_base = local_base.tzinfo.normalize(local_base).replace(hour=0, minute=0, second=0, microsecond=0)
+                for start_minute, end_minute, window_is_utc in windows:
+                    base = utc_base if window_is_utc else local_base
+                    night_intervals.append((base + timedelta(minutes=start_minute), base + timedelta(minutes=end_minute)))
+            night_intervals.sort()
+
+            # The day rate fills each gap between consecutive off-peak windows, which generalises to
+            # a meter with several off-peak blocks a day rather than assuming a single one.
+            intervals = []
+            for index in range(len(night_intervals) - 1):
+                night_start, night_end = night_intervals[index]
+                next_start = night_intervals[index + 1][0]
+                intervals.append((night_start, night_end, result_night))
+                if night_end < next_start:
+                    intervals.append((night_end, next_start, result_day))
+
             current_time = self.now_utc_exact
-            for day in range(8):
-                night_rate = self._get_rate_for_time(result_night, night_start_time, now=current_time)
-                day_rate = self._get_rate_for_time(result_day, day_start_time, now=current_time)
-                if night_rate is not None:
-                    mdata.append({"valid_from": night_start_time.strftime(DATE_TIME_STR_FORMAT), "valid_to": night_end_time.strftime(DATE_TIME_STR_FORMAT), "value_inc_vat": night_rate})
-                if day_rate is not None:
-                    mdata.append({"valid_from": day_start_time.strftime(DATE_TIME_STR_FORMAT), "valid_to": day_end_time.strftime(DATE_TIME_STR_FORMAT), "value_inc_vat": day_rate})
-                night_start_time += timedelta(days=1)
-                night_end_time += timedelta(days=1)
-                day_start_time += timedelta(days=1)
-                day_end_time += timedelta(days=1)
+            for interval_start, interval_end, rates in intervals:
+                rate = self._get_rate_for_time(rates, interval_start, now=current_time)
+                if rate is not None:
+                    mdata.append({"valid_from": interval_start.strftime(DATE_TIME_STR_FORMAT), "valid_to": interval_end.strftime(DATE_TIME_STR_FORMAT), "value_inc_vat": rate})
         return mdata
 
     async def async_download_octopus_url(self, url, json_only=False):
@@ -3372,6 +3564,423 @@ async def test_octopus_api(api_key, account_id):  # pragma: no cover
     print("Test completed")
 
 
+# Query for per-half-hour consumption plus the cost Octopus itself attributes to each slot.
+# Deriving rate = cost / consumption for every slot reveals the meter's real switching times,
+# which the day-unit-rates/night-unit-rates endpoints do not publish.
+MEASUREMENTS_QUERY = """query {{
+  account(accountNumber: "{account_id}") {{
+    properties {{
+      measurements(
+        first: {first}
+        utilityFilters: [{{electricityFilters: {{readingFrequencyType: {frequency}, marketSupplyPointId: "{mpan}"}}}}]
+        startAt: "{start_at}"
+        endAt: "{end_at}"
+        timezone: "Europe/London"
+      ) {{
+        edges {{
+          node {{
+            value
+            unit
+            ... on IntervalMeasurementType {{
+              startAt
+              endAt
+            }}
+            metaData {{
+              statistics {{
+                type
+                label
+                description
+                value
+                costInclTax {{ estimatedAmount costCurrency }}
+                costExclTax {{ estimatedAmount costCurrency }}
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
+  }}
+}}"""
+
+
+def _slot_cost_incl_tax(node):  # pragma: no cover
+    """
+    Pull the inc-VAT consumption cost out of a measurements node, in pence.
+
+    Skips standing-charge statistics, which are a flat daily amount landed on one slot and
+    would otherwise swamp that slot's derived unit rate.
+    """
+    meta = node.get("metaData") or {}
+    stats = meta.get("statistics") or []
+    total = None
+    for stat in stats:
+        label = "{} {} {}".format(stat.get("type") or "", stat.get("label") or "", stat.get("description") or "").lower()
+        if "standing" in label:
+            continue
+        cost = stat.get("costInclTax") or {}
+        amount = cost.get("estimatedAmount", None)
+        if amount is None:
+            continue
+        try:
+            total = (total or 0.0) + float(amount)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _parse_agreement_time(stamp):  # pragma: no cover
+    """
+    Parse an agreement validFrom/validTo stamp, returning None when it is absent or unparseable.
+    """
+    if not stamp:
+        return None
+    try:
+        return datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _active_tariff_code(meter_point, now):  # pragma: no cover
+    """
+    Return the tariff code of the agreement covering `now`, rather than the one left open-ended.
+
+    A fixed-term product carries a future validTo, so selecting on `validTo is None` finds nothing.
+    """
+    for agr in meter_point.get("agreements", []) or []:
+        valid_from = _parse_agreement_time(agr.get("validFrom", None))
+        valid_to = _parse_agreement_time(agr.get("validTo", None))
+        if valid_from is not None and valid_from > now:
+            continue
+        if valid_to is not None and valid_to <= now:
+            continue
+        code = (agr.get("tariff", {}) or {}).get("tariffCode", None)
+        if code:
+            return code
+    return None
+
+
+def _import_meter_details(account, at_time=None):  # pragma: no cover
+    """
+    Pick the import MPAN, meter serial and currently-active tariff code out of account data.
+
+    An account with an export meter point has two of everything, so the export side is skipped by
+    both its smartExportElectricityMeter marker and its OUTGOING tariff code. Pass at_time to get
+    the tariff that was active then, which matters when analysing a historic window.
+    """
+    now = at_time or datetime.now(timezone.utc)
+    fallback = (None, None, None)
+    for agreement in account.get("electricityAgreements", []) or []:
+        meter_point = agreement.get("meterPoint", {}) or {}
+        mpan = meter_point.get("mpan", None)
+        tariff_code = _active_tariff_code(meter_point, now)
+        for meter in meter_point.get("meters", []) or []:
+            serial = meter.get("serialNumber", None)
+            is_export = bool(meter.get("smartExportElectricityMeter", None)) or "OUTGOING" in (tariff_code or "")
+            if is_export:
+                if fallback == (None, None, None):
+                    fallback = (mpan, serial, tariff_code)
+                continue
+            return mpan, serial, tariff_code
+    return fallback
+
+
+def _cheapest_tou_label(dominant, medians):  # pragma: no cover
+    """
+    Pick which TOU bucket is the cheap one, by comparing each bucket's median derived rate.
+
+    Returns None when there are not at least two buckets to choose between, leaving the caller to
+    fall back to a plain rate threshold.
+    """
+    labels = set(dominant.values())
+    if len(labels) < 2:
+        return None
+    by_label = {}
+    for slot, label in dominant.items():
+        if slot in medians:
+            by_label.setdefault(label, []).append(medians[slot])
+    if len(by_label) < 2:
+        # Nothing to compare on price, so fall back to the conventional naming.
+        for label in labels:
+            if "NIGHT" in label.upper() or "OFF_PEAK" in label.upper():
+                return label
+        return None
+    return min(by_label, key=lambda label: sorted(by_label[label])[len(by_label[label]) // 2])
+
+
+def _print_slot_table(medians, dominant, cheap_slots, days):  # pragma: no cover
+    """
+    Print each half-hour of the day with its derived rate, its TOU bucket and whether it bills cheap.
+    """
+    print("Rate and TOU bucket by half-hour (median across {} days, inc VAT):".format(days))
+    print("{:<8} {:>10}  {:<12} {}".format("Time", "p/kWh", "bucket", "band"))
+    for hour in range(24):
+        for minute in (0, 30):
+            slot = (hour, minute)
+            label = "{:02d}:{:02d}".format(hour, minute)
+            rate = "{:>10.4f}".format(medians[slot]) if slot in medians else "{:>10}".format("-")
+            bucket = dominant.get(slot, "-")
+            band = "CHEAP" if slot in cheap_slots else ("day" if slot in dominant or slot in medians else "(no data)")
+            print("{:<8} {}  {:<12} {}".format(label, rate, bucket, band))
+
+
+def _merge_windows(slots):  # pragma: no cover
+    """
+    Collapse a set of (hour, minute) slots into contiguous windows, in minutes from midnight.
+    """
+    windows = []
+    for hour, minute in sorted(slots):
+        start_minutes = hour * 60 + minute
+        if windows and windows[-1][1] == start_minutes:
+            windows[-1][1] = start_minutes + 30
+        else:
+            windows.append([start_minutes, start_minutes + 30])
+    return windows
+
+
+def _scale_to_pence(raw_by_slot):  # pragma: no cover
+    """
+    Convert raw cost/consumption ratios to pence per kWh, deciding the unit once for the whole set.
+
+    Choosing per slot would let the same tariff land in different units depending on how much was
+    used in that half hour, so a single dataset-wide decision is made from the median ratio: a
+    genuine p/kWh unit rate is of order 1-100, so a median below 1 means the amounts are pounds.
+    """
+    ratios = sorted(ratio for values in raw_by_slot.values() for ratio in values)
+    typical = ratios[len(ratios) // 2]
+    scale = 100.0 if typical < 1.0 else 1.0
+    return {slot: [ratio * scale for ratio in values] for slot, values in raw_by_slot.items()}, scale
+
+
+async def _graphql_post(octopus_api, query, context):  # pragma: no cover
+    """
+    Send one GraphQL request and return (data, errors) without the retry loop.
+
+    A schema error is a 400 that will never succeed on retry, so the diagnostic reads the error
+    body directly instead of hammering the endpoint five times for the same rejection.
+    """
+    token = await octopus_api.async_refresh_token()
+    if token is None:
+        return None, [{"message": "token refresh failed"}]
+    client = await octopus_api.api.async_create_client_session()
+    url = "{}/v1/graphql/".format(octopus_api.api.base_url)
+    headers = {"Authorization": "JWT {}".format(octopus_api.graphql_token), integration_context_header: context}
+    async with client.post(url, json={"query": query}, headers=headers) as response:
+        body = await response.text()
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            return None, [{"message": "non-JSON response {}: {}".format(response.status, body[:300])}]
+    return parsed.get("data", None), parsed.get("errors", None)
+
+
+async def _discover_reading_frequency(octopus_api):  # pragma: no cover
+    """
+    Introspect the ReadingFrequencyType enum and return its half-hourly member.
+
+    The enum member name has changed across Kraken versions, so it is read from the live schema
+    rather than hard-coded.
+    """
+    query = '{ __type(name: "ReadingFrequencyType") { enumValues { name } } }'
+    data, errors = await _graphql_post(octopus_api, query, "night-window-introspect")
+    if errors or not data:
+        print("Introspection of ReadingFrequencyType failed: {}".format(errors))
+        return None
+    values = [value["name"] for value in ((data.get("__type", {}) or {}).get("enumValues", []) or [])]
+    print("ReadingFrequencyType accepts: {}".format(values))
+    # Kraken has spelled the half-hourly member several ways across versions, so try the known
+    # names in preference order before falling back to any member that reads as a 30-minute one.
+    for preferred in ["HALF_HOURLY", "HALF_HOUR", "THIRTY_MIN_INTERVAL", "THIRTY_MINUTE_INTERVAL"]:
+        if preferred in values:
+            return preferred
+    for value in values:
+        if "HALF" in value.upper() or "THIRTY_MIN" in value.upper():
+            return value
+    return None
+
+
+async def _describe_measurement_types(octopus_api):  # pragma: no cover
+    """
+    Print the concrete types behind MeasurementInterface and the fields each exposes.
+
+    A different reading frequency can return a different concrete type, so this shows which inline
+    fragment the query needs before guessing at one.
+    """
+    query = '{ __type(name: "MeasurementInterface") { possibleTypes { name fields { name } } } }'
+    data, errors = await _graphql_post(octopus_api, query, "night-window-types")
+    if errors or not data:
+        print("Introspection of MeasurementInterface failed: {}".format(errors))
+        return
+    for possible in (data.get("__type", {}) or {}).get("possibleTypes", []) or []:
+        names = [field["name"] for field in possible.get("fields", []) or []]
+        print("MeasurementInterface type {}: {}".format(possible.get("name"), names))
+    print("")
+
+
+def _collect_slot_data(response_data, timezone_local):  # pragma: no cover
+    """
+    Walk the measurements edges, collecting per-slot cost ratios and TOU bucket labels.
+
+    Returns (raw_by_slot, labels_by_slot, all_nodes, node_count, sample) where sample is the first
+    slot carrying both a cost and a consumption, for unit sanity checking.
+    """
+    raw_by_slot = {}
+    labels_by_slot = {}
+    all_nodes = []
+    node_count = 0
+    sample = None
+    for prop in (response_data.get("account", {}) or {}).get("properties", []) or []:
+        for edge in (prop.get("measurements", {}) or {}).get("edges", []) or []:
+            node = edge.get("node", {}) or {}
+            node_count += 1
+            all_nodes.append(node)
+            if not node.get("startAt", None):
+                continue
+            start = str2time(node["startAt"]).astimezone(timezone_local)
+            slot = (start.hour, start.minute)
+            # The TOU bucket label is Octopus's own classification of the slot, so it is recorded
+            # for every node - including ones with no consumption, where no rate can be derived.
+            label = _slot_tou_label(node)
+            if label:
+                labels_by_slot.setdefault(slot, []).append(label)
+            try:
+                value = float(node.get("value", 0.0))
+            except (TypeError, ValueError):
+                continue
+            cost = _slot_cost_incl_tax(node)
+            if cost is None or value <= 0.0:
+                continue
+            if sample is None:
+                sample = (start, cost, value)
+            raw_by_slot.setdefault(slot, []).append(cost / value)
+    return raw_by_slot, labels_by_slot, all_nodes, node_count, sample
+
+
+def _dump_nodes(all_nodes):  # pragma: no cover
+    """
+    Print the first few measurement nodes and write the complete set to a file for inspection.
+    """
+    for index, node in enumerate(all_nodes[:3]):
+        print("Node {} payload:\n{}\n".format(index + 1, json.dumps(node, indent=2)[:2500]))
+    dump_path = "measurements_dump.json"
+    with open(dump_path, "w") as handle:
+        json.dump(all_nodes, handle, indent=2)
+    print("Wrote all {} raw nodes to {}\n".format(len(all_nodes), dump_path))
+
+
+async def test_night_window(api_key, account_id, days, frequency=None, dump=False, end_date=None):  # pragma: no cover
+    """
+    Work out a two-register meter's real day/night switching times from live account data.
+
+    For E-2R tariffs Octopus publishes only two prices and no times, so Predbat currently guesses
+    the window from the tariff code prefix. The measurements API instead states a TOU_BUCKET_COST
+    label (DAY_RATE / NIGHT_RATE) against every half-hour interval, which is the switching schedule
+    itself rather than an inference from it, so the windows are read straight off those labels.
+
+    Cost and consumption are still read, but only to report each bucket's actual p/kWh alongside
+    the schedule; they play no part in deciding which half-hours are cheap.
+    """
+    print("Testing night rate window detection for account: {}".format(account_id))
+
+    mock_base = MockBase()
+    os.makedirs(mock_base.config_root, exist_ok=True)
+    octopus_api = OctopusAPI(mock_base, key=api_key, account_id=account_id, automatic=True)
+
+    account_data = await octopus_api.async_get_account(account_id)
+    account = (account_data or {}).get("account", {}) or {}
+
+    timezone_local = pytz.timezone("Europe/London")
+    if end_date:
+        try:
+            end_at = timezone_local.localize(datetime.strptime(end_date, DATE_STR_FORMAT))
+        except ValueError:
+            print("ERROR: --end-date must be YYYY-MM-DD, got {}".format(end_date))
+            await octopus_api.final()
+            return
+    else:
+        end_at = datetime.now(timezone_local).replace(hour=0, minute=0, second=0, microsecond=0)
+    start_at = end_at - timedelta(days=days)
+
+    mpan, serial, tariff_code = _import_meter_details(account, at_time=start_at)
+
+    print("MPAN {} serial {} import tariff {}".format(mpan, serial, tariff_code))
+    if not mpan or not serial:
+        print("ERROR: could not determine MPAN/serial from the account, cannot continue")
+        await octopus_api.final()
+        return
+
+    print("Analysing {} -> {} ({} days, UTC offset {})\n".format(start_at, end_at, days, start_at.strftime("%z")))
+
+    if dump:
+        await _describe_measurement_types(octopus_api)
+    if not frequency:
+        frequency = await _discover_reading_frequency(octopus_api)
+    else:
+        print("Using caller-supplied ReadingFrequencyType {}".format(frequency))
+    if not frequency:
+        print("ERROR: could not determine the half-hourly ReadingFrequencyType value, cannot continue")
+        await octopus_api.final()
+        return
+    query = MEASUREMENTS_QUERY.format(
+        account_id=account_id, first=days * 48 + 48, mpan=mpan, frequency=frequency, start_at=start_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), end_at=end_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    response_data, errors = await _graphql_post(octopus_api, query, "night-window-probe")
+    if errors:
+        print("Measurements query errors: {}".format(json.dumps(errors, indent=2)[:2000]))
+    if not response_data:
+        print("ERROR: measurements query returned no data.")
+        await octopus_api.final()
+        return
+
+    raw_by_slot, labels_by_slot, all_nodes, node_count, sample = _collect_slot_data(response_data, timezone_local)
+    print("Measurements nodes returned: {}, slots with a rate: {}, slots with a TOU label: {}".format(node_count, len(raw_by_slot), len(labels_by_slot)))
+    if dump:
+        _dump_nodes(all_nodes)
+    if not raw_by_slot and not labels_by_slot:
+        print("No slot carried either a TOU label or a derivable rate.")
+        print("Raw response for inspection: {}".format(json.dumps(response_data, indent=2)[:2000]))
+        await octopus_api.final()
+        return
+
+    medians = {}
+    if raw_by_slot:
+        print("Sample slot {}: cost {} / consumption {} kWh".format(sample[0].strftime("%Y-%m-%d %H:%M"), sample[1], sample[2]))
+        rates_by_slot, scale = _scale_to_pence(raw_by_slot)
+        print("Cost amounts read as {} (scale x{:g})\n".format("pounds" if scale != 1.0 else "pence", scale))
+        for slot, values in rates_by_slot.items():
+            values = sorted(values)
+            medians[slot] = values[len(values) // 2]
+
+    # 3. Band each half-hour by its TOU bucket label where present, since that is stated by the API
+    # rather than inferred, and falls back to the derived rate only if no label was returned.
+    dominant = {slot: max(set(values), key=values.count) for slot, values in labels_by_slot.items()}
+    cheap_label = _cheapest_tou_label(dominant, medians)
+    if cheap_label:
+        print("TOU buckets seen: {}".format(sorted(set(dominant.values()))))
+        print("Treating '{}' as the cheap bucket\n".format(cheap_label))
+        cheap_slots = {slot for slot, label in dominant.items() if label == cheap_label}
+    else:
+        threshold = (min(medians.values()) + max(medians.values())) / 2.0
+        print("No TOU labels returned, falling back to a rate threshold of {:.4f}p\n".format(threshold))
+        cheap_slots = {slot for slot, rate in medians.items() if rate < threshold}
+
+    _print_slot_table(medians, dominant, cheap_slots, days)
+    windows = _merge_windows(cheap_slots)
+    if medians:
+        cheap_rates = [medians[slot] for slot in cheap_slots if slot in medians]
+        day_rates = [medians[slot] for slot in medians if slot not in cheap_slots]
+        if cheap_rates and day_rates:
+            print("\nCheap rate {:.4f}p, day rate {:.4f}p".format(min(cheap_rates), max(day_rates)))
+    print("Detected cheap windows (local time):")
+    for start_minutes, end_minutes in windows:
+        print("  {:02d}:{:02d} -> {:02d}:{:02d}".format(start_minutes // 60, start_minutes % 60, (end_minutes // 60) % 24, end_minutes % 60))
+
+    predbat_window = OCTOPUS_NIGHT_RATE_WINDOWS["eco7"] if (tariff_code or "").startswith("E-2R-") else OCTOPUS_NIGHT_RATE_WINDOWS["go"]
+    print("\nPredbat currently assumes: {:02d}:{:02d} -> {:02d}:{:02d}".format(predbat_window["start"][0], predbat_window["start"][1], predbat_window["end"][0], predbat_window["end"][1]))
+
+    await octopus_api.final()
+    print("\nTest completed")
+
+
 def main():  # pragma: no cover
     """
     Main function for command line execution to test Octopus API
@@ -3383,10 +3992,19 @@ def main():  # pragma: no cover
     parser.add_argument("--account", default="", help="Octopus account ID")
     parser.add_argument("--product-code", help="Product code for tariff rate test (e.g. AGILE-FLEX-22-11-25)")
     parser.add_argument("--tariff-code", help="Tariff code for tariff rate test (e.g. E-1R-AGILE-FLEX-22-11-25-C)")
+    parser.add_argument("--night-window", action="store_true", help="Detect the meter's real day/night switching times from billed half-hourly costs")
+    parser.add_argument("--days", type=int, default=7, help="Days of history to analyse for --night-window (default 7)")
+    parser.add_argument("--frequency", default=None, help="Override the ReadingFrequencyType enum value (e.g. RAW_INTERVAL) instead of auto-discovering it")
+    parser.add_argument("--dump", action="store_true", help="Print the measurement type schema and the first raw node payload")
+    parser.add_argument("--end-date", default=None, help="End the analysed window on this date (YYYY-MM-DD) instead of today, e.g. to probe a winter GMT period")
 
     args = parser.parse_args()
 
-    if args.product_code and args.tariff_code:
+    if args.night_window:
+        if not (args.api_key and args.account):
+            parser.error("--night-window requires --api-key and --account")
+        asyncio.run(test_night_window(args.api_key, args.account, args.days, args.frequency, args.dump, args.end_date))
+    elif args.product_code and args.tariff_code:
         # Tariff rate fetch test — no API key required (uses public Octopus REST API)
         asyncio.run(test_fetch_tariffs(args.product_code, args.tariff_code))
     elif args.api_key and args.account:

--- a/apps/predbat/tests/test_basic_rates_utc.py
+++ b/apps/predbat/tests/test_basic_rates_utc.py
@@ -1,0 +1,112 @@
+# fmt: off
+# pylint: disable=line-too-long
+"""
+Tests for the `utc: true` option on basic_rates entries.
+
+Manual rate windows are normally given in local wall-clock time. A meter whose schedule is fixed to
+UTC - an Economy 7 smart meter, for instance - needs its windows entered in UTC instead, so that
+they track the clocks changing rather than drifting an hour through British Summer Time.
+"""
+
+from datetime import datetime
+
+import pytz
+
+
+LONDON = pytz.timezone("Europe/London")
+
+
+def _pin_clock(my_predbat, when):
+    """Pin the predbat clock to local midnight on the given date, returning the UTC offset in minutes."""
+    local_midnight = LONDON.localize(datetime(when.year, when.month, when.day, 0, 0, 0))
+    my_predbat.midnight_utc = local_midnight
+    my_predbat.midnight = datetime(when.year, when.month, when.day, 0, 0, 0)
+    return int(local_midnight.utcoffset().total_seconds() // 60)
+
+
+def _window_of(rates, rate_value):
+    """Return the (first, last) minute of the day carrying the given rate."""
+    minutes = [minute for minute in range(24 * 60) if abs(rates.get(minute, 0) - rate_value) < 0.0001]
+    if not minutes:
+        return None
+    return min(minutes), max(minutes)
+
+
+def test_basic_rates_utc(my_predbat):
+    """
+    Test the utc flag on basic_rates windows.
+
+    Tests:
+    - Test 1: utc:true during BST shifts a 00:30-07:30 window to 01:30-08:30 local
+    - Test 2: utc:true during GMT leaves the window at 00:30-07:30 local
+    - Test 3: without the flag the window stays at local wall-clock time in BST
+    - Test 4: a window crossing midnight in UTC is shifted correctly
+    """
+    print("\n**** Running basic_rates utc option tests ****")
+    failed = False
+
+    # ------------------------------------------------------------------
+    # Test 1: utc:true in BST -> 01:30-08:30 local
+    # ------------------------------------------------------------------
+    print("\n*** Test 1: utc:true during BST ***")
+    offset = _pin_clock(my_predbat, datetime(2026, 8, 20))
+    rates = my_predbat.basic_rates([{"start": "00:30:00", "end": "07:30:00", "rate": 13.0, "utc": True}], "rates_import", include_manual_api=False)
+    window = _window_of(rates, 13.0)
+
+    if offset != 60:
+        print("ERROR: expected a +60 minute BST offset, got {}".format(offset))
+        failed = True
+    elif window != (90, 509):
+        print("ERROR: BST utc window should cover 01:30-08:30 (minutes 90-509), got {}".format(window))
+        failed = True
+    else:
+        print("PASS: utc:true window lands at 01:30-08:30 local during BST")
+
+    # ------------------------------------------------------------------
+    # Test 2: utc:true in GMT -> unchanged
+    # ------------------------------------------------------------------
+    print("\n*** Test 2: utc:true during GMT ***")
+    offset = _pin_clock(my_predbat, datetime(2026, 1, 20))
+    rates = my_predbat.basic_rates([{"start": "00:30:00", "end": "07:30:00", "rate": 13.0, "utc": True}], "rates_import", include_manual_api=False)
+    window = _window_of(rates, 13.0)
+
+    if offset != 0:
+        print("ERROR: expected a 0 minute GMT offset, got {}".format(offset))
+        failed = True
+    elif window != (30, 449):
+        print("ERROR: GMT utc window should cover 00:30-07:30 (minutes 30-449), got {}".format(window))
+        failed = True
+    else:
+        print("PASS: utc:true window stays at 00:30-07:30 local during GMT")
+
+    # ------------------------------------------------------------------
+    # Test 3: no flag -> local wall-clock, unshifted, even in BST
+    # ------------------------------------------------------------------
+    print("\n*** Test 3: no utc flag during BST ***")
+    _pin_clock(my_predbat, datetime(2026, 8, 20))
+    rates = my_predbat.basic_rates([{"start": "00:30:00", "end": "07:30:00", "rate": 13.0}], "rates_import", include_manual_api=False)
+    window = _window_of(rates, 13.0)
+
+    if window != (30, 449):
+        print("ERROR: unflagged window should stay at 00:30-07:30 local, got {}".format(window))
+        failed = True
+    else:
+        print("PASS: unflagged window keeps local wall-clock time")
+
+    # ------------------------------------------------------------------
+    # Test 4: a UTC window crossing midnight
+    # ------------------------------------------------------------------
+    print("\n*** Test 4: utc:true window crossing midnight in BST ***")
+    _pin_clock(my_predbat, datetime(2026, 8, 20))
+    rates = my_predbat.basic_rates([{"start": "23:30:00", "end": "05:30:00", "rate": 7.0, "utc": True}], "rates_import", include_manual_api=False)
+    # 23:30 UTC is 00:30 local, so the window runs 00:30-06:30 local on the same day
+    if abs(rates.get(30, 0) - 7.0) > 0.0001 or abs(rates.get(389, 0) - 7.0) > 0.0001:
+        print("ERROR: cross-midnight utc window should cover 00:30-06:30 local, got minute 30={} minute 389={}".format(rates.get(30), rates.get(389)))
+        failed = True
+    elif abs(rates.get(29, 0)) > 0.0001 or abs(rates.get(390, 0)) > 0.0001:
+        print("ERROR: cross-midnight utc window leaked outside 00:30-06:30, minute 29={} minute 390={}".format(rates.get(29), rates.get(390)))
+        failed = True
+    else:
+        print("PASS: cross-midnight utc window shifted correctly")
+
+    return failed

--- a/apps/predbat/tests/test_basic_rates_utc.py
+++ b/apps/predbat/tests/test_basic_rates_utc.py
@@ -34,7 +34,23 @@ def _window_of(rates, rate_value):
 
 def test_basic_rates_utc(my_predbat):
     """
-    Test the utc flag on basic_rates windows.
+    Test the utc flag on basic_rates windows, restoring the shared clock afterwards.
+
+    The whole suite runs against one PredBat instance, so the pinned clock these tests need must be
+    put back or every later test inherits a date five days in the past and becomes order-dependent.
+    """
+    original_midnight_utc = my_predbat.midnight_utc
+    original_midnight = my_predbat.midnight
+    try:
+        return _run_basic_rates_utc_tests(my_predbat)
+    finally:
+        my_predbat.midnight_utc = original_midnight_utc
+        my_predbat.midnight = original_midnight
+
+
+def _run_basic_rates_utc_tests(my_predbat):
+    """
+    Run the utc flag test cases against a clock the caller is responsible for restoring.
 
     Tests:
     - Test 1: utc:true during BST shifts a 00:30-07:30 window to 01:30-08:30 local

--- a/apps/predbat/tests/test_octopus_tou_windows.py
+++ b/apps/predbat/tests/test_octopus_tou_windows.py
@@ -19,7 +19,7 @@ from unittest.mock import patch, PropertyMock
 
 import pytz
 
-from octopus import OctopusAPI, DATE_TIME_STR_FORMAT
+from octopus import OctopusAPI, DATE_TIME_STR_FORMAT, _night_time_to_minutes, _windows_from_night_times
 
 
 LONDON = pytz.timezone("Europe/London")
@@ -152,6 +152,7 @@ async def test_octopus_tou_windows(my_predbat):
     - Test 8: octopus_night_times configures the windows manually, in local time
     - Test 9: a manually configured window may be given in UTC with utc: true
     - Test 10: manual configuration beats the meter's own TOU labels
+    - Test 11: an hour of 24 is normalised to 0, matching how basic_rates parses times
     """
     print("\n**** Running Octopus TOU window tests ****")
     failed = False
@@ -348,5 +349,21 @@ async def test_octopus_tou_windows(my_predbat):
         failed = True
     else:
         print("PASS: manual configuration takes precedence over the meter's TOU labels")
+
+    # ------------------------------------------------------------------
+    # Test 11: hour 24 normalises to hour 0, as time_string_to_stamp does
+    # ------------------------------------------------------------------
+    print("\n*** Test 11: 24:xx is normalised to 00:xx ***")
+    if _night_time_to_minutes("24:00:00") != 0 or _night_time_to_minutes("24:30:00") != 30:
+        print("ERROR: 24:00 should parse as 0 and 24:30 as 30, got {} and {}".format(_night_time_to_minutes("24:00:00"), _night_time_to_minutes("24:30:00")))
+        failed = True
+    elif _windows_from_night_times([{"start": "24:30:00", "end": "05:00:00"}]) != [(30, 300, False)]:
+        print("ERROR: a 24:30 start should behave as 00:30, got {}".format(_windows_from_night_times([{"start": "24:30:00", "end": "05:00:00"}])))
+        failed = True
+    elif _windows_from_night_times([{"start": "20:00:00", "end": "24:00:00"}]) != [(1200, 1440, False)]:
+        print("ERROR: a 24:00 end should still close the day at 1440, got {}".format(_windows_from_night_times([{"start": "20:00:00", "end": "24:00:00"}])))
+        failed = True
+    else:
+        print("PASS: hour 24 normalised to hour 0, and a 24:00 end still closes the day")
 
     return failed

--- a/apps/predbat/tests/test_octopus_tou_windows.py
+++ b/apps/predbat/tests/test_octopus_tou_windows.py
@@ -1,0 +1,352 @@
+# fmt: off
+# pylint: disable=line-too-long
+"""
+Tests for off-peak window determination in OctopusAPI.
+
+Two behaviours are covered:
+
+  1. The hard-wired fallback windows in OCTOPUS_NIGHT_RATE_WINDOWS are UTC ("Z") times, so they
+     must be anchored to UTC midnight rather than local midnight. Octopus documents the Economy 7
+     smart-meter window as a fixed 00:30-07:30 UTC period, which lands at 01:30-08:30 during BST.
+
+  2. The meter's real windows are read from the measurements API's TOU_BUCKET_COST labels when
+     they are available, and the hard-wired times are used only when that lookup fails.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import patch, PropertyMock
+
+import pytz
+
+from octopus import OctopusAPI, DATE_TIME_STR_FORMAT
+
+
+LONDON = pytz.timezone("Europe/London")
+
+# Midday during British Summer Time. now_utc_exact is local-timezone aware in production, so this
+# is what the production code actually receives - and it is what makes a local-anchored window wrong.
+_NOW_BST = LONDON.localize(datetime(2026, 8, 20, 12, 0, 0))
+# Midday during GMT, when local and UTC coincide and either anchor gives the same answer.
+_NOW_GMT = LONDON.localize(datetime(2026, 1, 20, 12, 0, 0))
+
+
+def _make_api(my_predbat, day_rate, night_rate, now):
+    """Create an OctopusAPI whose rate fetches are stubbed and whose clock is pinned to `now`."""
+    api = OctopusAPI(my_predbat, key="test-key", account_id="test-account", automatic=False)
+
+    day_entry = [{"valid_from": "2026-01-01T00:00:00+0000", "valid_to": None, "value_inc_vat": day_rate}]
+    night_entry = [{"valid_from": "2026-01-01T00:00:00+0000", "valid_to": None, "value_inc_vat": night_rate}]
+
+    async def mock_fetch(url, **kwargs):
+        """Return the stubbed day or night unit rates for the requested endpoint."""
+        if "day-unit-rates" in url:
+            return day_entry
+        if "night-unit-rates" in url:
+            return night_entry
+        return []
+
+    api.fetch_url_cached = mock_fetch
+    api.mpan = "1100014811702"
+    return api, now
+
+
+async def _run(api_and_now, base_url, tariff_code):
+    """Call async_get_day_night_rates with now_utc_exact pinned, since it is a read-only property."""
+    api, now = api_and_now
+    with patch.object(type(api), "now_utc_exact", new_callable=PropertyMock) as mock_now:
+        mock_now.return_value = now
+        return await api.async_get_day_night_rates(base_url, tariff_code=tariff_code)
+
+
+def _night_slots_utc(mdata, night_rate):
+    """Return (start, end) datetimes in UTC for every night-rate slot in mdata."""
+    slots = []
+    for entry in mdata:
+        if abs(entry["value_inc_vat"] - night_rate) > 0.001:
+            continue
+        start = datetime.strptime(entry["valid_from"], DATE_TIME_STR_FORMAT).astimezone(timezone.utc)
+        end = datetime.strptime(entry["valid_to"], DATE_TIME_STR_FORMAT).astimezone(timezone.utc)
+        slots.append((start, end))
+    return slots
+
+
+def _night_slots_local(mdata, night_rate):
+    """Return (start, end) datetimes in Europe/London for every night-rate slot in mdata."""
+    slots = []
+    for entry in mdata:
+        if abs(entry["value_inc_vat"] - night_rate) > 0.001:
+            continue
+        start = datetime.strptime(entry["valid_from"], DATE_TIME_STR_FORMAT).astimezone(LONDON)
+        end = datetime.strptime(entry["valid_to"], DATE_TIME_STR_FORMAT).astimezone(LONDON)
+        slots.append((start, end))
+    return slots
+
+
+def _stub_tou(api_and_now, labelled_windows_utc):
+    """
+    Stub the measurements GraphQL query so the given UTC windows come back labelled NIGHT_RATE.
+
+    labelled_windows_utc is a list of (start_minute, end_minute) from UTC midnight.
+    """
+    api = api_and_now[0]
+
+    def label_for(minute_of_day):
+        """Return the TOU bucket label for a given minute offset from UTC midnight."""
+        for start, end in labelled_windows_utc:
+            if start <= minute_of_day < end:
+                return "NIGHT_RATE"
+        return "DAY_RATE"
+
+    async def mock_query(query, context, **kwargs):
+        """Return a stubbed measurements response carrying one TOU label per half-hour slot."""
+        if "measurements" not in query:
+            return None
+        edges = []
+        base = datetime(2026, 8, 18, 0, 0, 0, tzinfo=timezone.utc)
+        for slot in range(48):
+            start = base.replace(hour=slot // 2, minute=(slot % 2) * 30)
+            edges.append(
+                {
+                    "node": {
+                        "value": "0.100000",
+                        "unit": "kwh",
+                        "startAt": start.strftime(DATE_TIME_STR_FORMAT),
+                        "metaData": {"statistics": [{"type": "TOU_BUCKET_COST", "label": label_for(slot * 30), "costInclTax": {"estimatedAmount": "1.0"}}]},
+                    }
+                }
+            )
+        return {"account": {"properties": [{"measurements": {"edges": edges}}]}}
+
+    api.async_graphql_query = mock_query
+
+
+def _stub_tou_unavailable(api_and_now):
+    """Stub the measurements query so it returns nothing, as it would for a meter with no history."""
+    api = api_and_now[0]
+
+    async def mock_query(query, context, **kwargs):
+        """Return nothing, as the measurements query would for a meter with no billed history."""
+        return None
+
+    api.async_graphql_query = mock_query
+
+
+def test_octopus_tou_windows_wrapper(my_predbat):
+    """Synchronous wrapper for the unit_test.py runner."""
+    return asyncio.run(test_octopus_tou_windows(my_predbat))
+
+
+async def test_octopus_tou_windows(my_predbat):
+    """
+    Test UTC anchoring of the fallback windows and TOU-label based window detection.
+
+    Tests:
+    - Test 1: Economy 7 during BST uses 00:30-07:30 UTC (01:30-08:30 local), not 00:30 local
+    - Test 2: Economy 7 during GMT still uses 00:30-07:30 UTC
+    - Test 3: A non-standard TOU window from the measurements API overrides the hard-wired one
+    - Test 4: A multi-block TOU schedule produces multiple night windows per day
+    - Test 5: GO falls back to a hard-wired window anchored to local time, not UTC
+    - Test 6: IOG likewise keeps its local wall-clock window through BST
+    - Test 7: Economy 7 is UTC-anchored and GO is local-anchored at the same instant
+    - Test 8: octopus_night_times configures the windows manually, in local time
+    - Test 9: a manually configured window may be given in UTC with utc: true
+    - Test 10: manual configuration beats the meter's own TOU labels
+    """
+    print("\n**** Running Octopus TOU window tests ****")
+    failed = False
+
+    base_url = "https://api.octopus.energy/v1/products/PROD/electricity-tariffs/TARIFF/standard-unit-rates/"
+    eco7 = "E-2R-OE-FIX-12M-26-06-11-B"
+
+    # ------------------------------------------------------------------
+    # Test 1: Economy 7 in BST must anchor the 00:30-07:30 window to UTC
+    # ------------------------------------------------------------------
+    print("\n*** Test 1: Economy 7 during BST -> 00:30-07:30 UTC ***")
+    api1 = _make_api(my_predbat, day_rate=29.26, night_rate=13.04, now=_NOW_BST)
+    _stub_tou_unavailable(api1)
+    mdata1 = await _run(api1, base_url, eco7)
+    slots1 = _night_slots_utc(mdata1, 13.04)
+
+    if not slots1:
+        print("ERROR: no night slots produced for Economy 7 in BST")
+        failed = True
+    else:
+        bad = [(s, e) for s, e in slots1 if (s.hour, s.minute) != (0, 30) or (e.hour, e.minute) != (7, 30)]
+        if bad:
+            print("ERROR: BST night slots are not 00:30-07:30 UTC - got {}".format([(s.strftime("%H:%M"), e.strftime("%H:%M")) for s, e in bad[:3]]))
+            failed = True
+        else:
+            local_start = slots1[0][0].astimezone(LONDON)
+            print("PASS: BST night window is 00:30-07:30 UTC ({} local)".format(local_start.strftime("%H:%M")))
+
+    # ------------------------------------------------------------------
+    # Test 2: Economy 7 in GMT must give the same UTC window
+    # ------------------------------------------------------------------
+    print("\n*** Test 2: Economy 7 during GMT -> 00:30-07:30 UTC ***")
+    api2 = _make_api(my_predbat, day_rate=30.16, night_rate=13.44, now=_NOW_GMT)
+    _stub_tou_unavailable(api2)
+    mdata2 = await _run(api2, base_url, eco7)
+    slots2 = _night_slots_utc(mdata2, 13.44)
+
+    if not slots2 or any((s.hour, s.minute) != (0, 30) or (e.hour, e.minute) != (7, 30) for s, e in slots2):
+        print("ERROR: GMT night slots are not 00:30-07:30 UTC - got {}".format([(s.strftime("%H:%M"), e.strftime("%H:%M")) for s, e in slots2[:3]]))
+        failed = True
+    else:
+        print("PASS: GMT night window is 00:30-07:30 UTC")
+
+    # ------------------------------------------------------------------
+    # Test 3: a real TOU schedule from the API overrides the hard-wired window
+    # ------------------------------------------------------------------
+    print("\n*** Test 3: TOU labels override the hard-wired window ***")
+    api3 = _make_api(my_predbat, day_rate=29.26, night_rate=13.04, now=_NOW_BST)
+    _stub_tou(api3, [(120, 360)])  # 02:00-06:00 UTC, deliberately not the Economy 7 default
+    mdata3 = await _run(api3, base_url, eco7)
+    slots3 = _night_slots_utc(mdata3, 13.04)
+
+    if not slots3:
+        print("ERROR: no night slots produced when TOU labels were available")
+        failed = True
+    elif any((s.hour, s.minute) != (2, 0) or (e.hour, e.minute) != (6, 0) for s, e in slots3):
+        print("ERROR: TOU window not honoured - got {}".format([(s.strftime("%H:%M"), e.strftime("%H:%M")) for s, e in slots3[:3]]))
+        failed = True
+    else:
+        print("PASS: TOU-detected 02:00-06:00 UTC window overrides the Economy 7 default")
+
+    # ------------------------------------------------------------------
+    # Test 4: a multi-block TOU schedule yields several night windows per day
+    # ------------------------------------------------------------------
+    print("\n*** Test 4: multi-block TOU schedule ***")
+    api4 = _make_api(my_predbat, day_rate=29.26, night_rate=13.04, now=_NOW_BST)
+    _stub_tou(api4, [(60, 300), (780, 960), (1200, 1320)])  # 01:00-05:00, 13:00-16:00, 20:00-22:00 UTC
+    mdata4 = await _run(api4, base_url, eco7)
+    slots4 = _night_slots_utc(mdata4, 13.04)
+
+    starts = sorted({(s.hour, s.minute) for s, _ in slots4})
+    expected_starts = [(1, 0), (13, 0), (20, 0)]
+    if starts != expected_starts:
+        print("ERROR: multi-block TOU windows not reproduced - expected {} got {}".format(expected_starts, starts))
+        failed = True
+    else:
+        print("PASS: all three TOU blocks reproduced")
+
+    # ------------------------------------------------------------------
+    # Test 5: GO falls back to a hard-wired window anchored to LOCAL time
+    # ------------------------------------------------------------------
+    print("\n*** Test 5: GO fallback window is local, not UTC ***")
+    api5 = _make_api(my_predbat, day_rate=29.14, night_rate=7.00, now=_NOW_BST)
+    _stub_tou_unavailable(api5)
+    mdata5 = await _run(api5, base_url, "E-1R-GO-VAR-22-10-14-M")
+    slots5 = _night_slots_local(mdata5, 7.00)
+
+    if not slots5:
+        print("ERROR: no night slots produced for the GO fallback")
+        failed = True
+    elif any((s.hour, s.minute) != (0, 30) or (e.hour, e.minute) != (5, 30) for s, e in slots5):
+        print("ERROR: GO window is not 00:30-05:30 local - got {}".format([(s.strftime("%H:%M"), e.strftime("%H:%M")) for s, e in slots5[:3]]))
+        failed = True
+    else:
+        utc_start = slots5[0][0].astimezone(timezone.utc)
+        print("PASS: GO window is 00:30-05:30 local during BST ({} UTC)".format(utc_start.strftime("%H:%M")))
+
+    # ------------------------------------------------------------------
+    # Test 6: IOG keeps its local wall-clock window through BST too
+    # ------------------------------------------------------------------
+    print("\n*** Test 6: IOG fallback window is local, not UTC ***")
+    api6 = _make_api(my_predbat, day_rate=29.14, night_rate=7.00, now=_NOW_BST)
+    _stub_tou_unavailable(api6)
+    mdata6 = await _run(api6, base_url, "E-1R-IOG-SMB-TOU-25-12-12-H")
+    slots6 = _night_slots_local(mdata6, 7.00)
+
+    if not slots6 or any((s.hour, s.minute) != (23, 30) or (e.hour, e.minute) != (5, 30) for s, e in slots6):
+        print("ERROR: IOG window is not 23:30-05:30 local - got {}".format([(s.strftime("%H:%M"), e.strftime("%H:%M")) for s, e in slots6[:3]]))
+        failed = True
+    else:
+        print("PASS: IOG window is 23:30-05:30 local during BST")
+
+    # ------------------------------------------------------------------
+    # Test 7: Economy 7 stays UTC-anchored while GO stays local, same clock
+    # ------------------------------------------------------------------
+    print("\n*** Test 7: E7 is UTC and GO is local at the same moment ***")
+    api7 = _make_api(my_predbat, day_rate=29.26, night_rate=13.04, now=_NOW_BST)
+    _stub_tou_unavailable(api7)
+    e7_local = _night_slots_local(await _run(api7, base_url, eco7), 13.04)
+    api8 = _make_api(my_predbat, day_rate=29.26, night_rate=13.04, now=_NOW_BST)
+    _stub_tou_unavailable(api8)
+    go_local = _night_slots_local(await _run(api8, base_url, "E-1R-GO-VAR-22-10-14-M"), 13.04)
+
+    if not e7_local or not go_local:
+        print("ERROR: missing slots when comparing E7 and GO anchoring")
+        failed = True
+    elif (e7_local[0][0].hour, e7_local[0][0].minute) != (1, 30):
+        print("ERROR: E7 should start 01:30 local in BST - got {}".format(e7_local[0][0].strftime("%H:%M")))
+        failed = True
+    elif (go_local[0][0].hour, go_local[0][0].minute) != (0, 30):
+        print("ERROR: GO should start 00:30 local in BST - got {}".format(go_local[0][0].strftime("%H:%M")))
+        failed = True
+    else:
+        print("PASS: E7 shifts to 01:30 local while GO stays at 00:30 local")
+
+    # ------------------------------------------------------------------
+    # Test 8: octopus_night_times sets the windows by hand, in local time
+    # ------------------------------------------------------------------
+    print("\n*** Test 8: octopus_night_times configures windows manually ***")
+    api9 = _make_api(my_predbat, day_rate=29.26, night_rate=13.04, now=_NOW_BST)
+    _stub_tou_unavailable(api9)
+    my_predbat.args["octopus_night_times"] = [
+        {"start": "01:00:00", "end": "05:00:00"},
+        {"start": "13:00:00", "end": "16:00:00"},
+        {"start": "20:00:00", "end": "22:00:00"},
+    ]
+    try:
+        slots9 = _night_slots_local(await _run(api9, base_url, eco7), 13.04)
+    finally:
+        del my_predbat.args["octopus_night_times"]
+
+    starts9 = sorted({(s.hour, s.minute) for s, _ in slots9})
+    if starts9 != [(1, 0), (13, 0), (20, 0)]:
+        print("ERROR: manual windows not applied - expected 01:00/13:00/20:00 local, got {}".format(starts9))
+        failed = True
+    elif sorted({(e.hour, e.minute) for _, e in slots9}) != [(5, 0), (16, 0), (22, 0)]:
+        print("ERROR: manual window ends wrong - got {}".format(sorted({(e.hour, e.minute) for _, e in slots9})))
+        failed = True
+    else:
+        print("PASS: three manually configured off-peak bands applied in local time")
+
+    # ------------------------------------------------------------------
+    # Test 9: a manually configured window given in UTC
+    # ------------------------------------------------------------------
+    print("\n*** Test 9: octopus_night_times with utc: true ***")
+    api10 = _make_api(my_predbat, day_rate=29.26, night_rate=13.04, now=_NOW_BST)
+    _stub_tou_unavailable(api10)
+    my_predbat.args["octopus_night_times"] = [{"start": "02:30:00", "end": "06:30:00", "utc": True}]
+    try:
+        slots10 = _night_slots_utc(await _run(api10, base_url, eco7), 13.04)
+    finally:
+        del my_predbat.args["octopus_night_times"]
+
+    if not slots10 or any((s.hour, s.minute) != (2, 30) or (e.hour, e.minute) != (6, 30) for s, e in slots10):
+        print("ERROR: utc-flagged manual window is not 02:30-06:30 UTC - got {}".format([(s.strftime("%H:%M"), e.strftime("%H:%M")) for s, e in slots10[:3]]))
+        failed = True
+    else:
+        print("PASS: utc-flagged manual window is 02:30-06:30 UTC (03:30 local in BST)")
+
+    # ------------------------------------------------------------------
+    # Test 10: manual configuration wins over the meter's TOU labels
+    # ------------------------------------------------------------------
+    print("\n*** Test 10: manual configuration overrides TOU labels ***")
+    api11 = _make_api(my_predbat, day_rate=29.26, night_rate=13.04, now=_NOW_BST)
+    _stub_tou(api11, [(120, 360)])  # the meter reports 02:00-06:00 UTC
+    my_predbat.args["octopus_night_times"] = [{"start": "01:00:00", "end": "05:00:00"}]
+    try:
+        slots11 = _night_slots_local(await _run(api11, base_url, eco7), 13.04)
+    finally:
+        del my_predbat.args["octopus_night_times"]
+
+    if not slots11 or any((s.hour, s.minute) != (1, 0) for s, _ in slots11):
+        print("ERROR: manual window did not override the TOU labels - got {}".format([(s.strftime("%H:%M")) for s, _ in slots11[:3]]))
+        failed = True
+    else:
+        print("PASS: manual configuration takes precedence over the meter's TOU labels")
+
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -171,6 +171,8 @@ from tests.test_octopus_fetch_previous_dispatch import test_octopus_fetch_previo
 from tests.test_octopus_intelligent_devices import test_octopus_intelligent_devices_wrapper
 from tests.test_octopus_sensor_due import test_octopus_sensor_due_wrapper
 from tests.test_octopus_day_night_rates import test_octopus_day_night_rates_wrapper
+from tests.test_octopus_tou_windows import test_octopus_tou_windows_wrapper
+from tests.test_basic_rates_utc import test_basic_rates_utc
 from tests.test_fetch_octopus_rates import test_fetch_octopus_rates
 from tests.test_fetch_tariffs import test_fetch_tariffs
 from tests.test_fetch_url_cached import test_fetch_url_cached
@@ -428,6 +430,8 @@ def main():
         ("octopus_intelligent_devices", test_octopus_intelligent_devices_wrapper, "Octopus intelligent devices tests (flexPlannedDispatches, energyAddedKwh)", False),
         ("octopus_sensor_due", test_octopus_sensor_due_wrapper, "Octopus intelligent sensor 2-minute update scheduling tests", False),
         ("octopus_day_night_rates", test_octopus_day_night_rates_wrapper, "Octopus day/night rate window selection tests (IOG TOU, GO, Economy 7)", False),
+        ("octopus_tou_windows", test_octopus_tou_windows_wrapper, "Octopus TOU window detection and UTC-anchored fallback window tests", False),
+        ("basic_rates_utc", test_basic_rates_utc, "basic_rates utc option tests", False),
         ("download_octopus_rates", test_octopus_download_rates_wrapper, "Test download octopus rates", False),
         ("fetch_octopus_rates", test_fetch_octopus_rates, "Fetch Octopus rates tests", False),
         ("fetch_tariffs", test_fetch_tariffs, "Fetch tariffs tests", False),

--- a/docs/energy-rates.md
+++ b/docs/energy-rates.md
@@ -454,7 +454,7 @@ If there are any gaps in the 24-hour period then a zero rate will be assumed.
 **utc** can be set to `true` on a rate band to say that its start and end times are given in UTC
 rather than local time. Predbat then shifts the band by the local offset, so it stays aligned with
 your meter through British Summer Time instead of running an hour early. Use this when your meter's
-schedule is fixed to UTC - Octopus fix the Economy 7 smart-meter off-peak period to 00:30-07:30 UTC,
+schedule is fixed to UTC - Octopus fixes the Economy 7 smart-meter off-peak period to 00:30-07:30 UTC,
 which falls at 01:30-08:30 local during BST.
 
 ```yaml

--- a/docs/energy-rates.md
+++ b/docs/energy-rates.md
@@ -451,7 +451,60 @@ start and end can be omitted and Predbat will assume that you are on a single fl
 
 If there are any gaps in the 24-hour period then a zero rate will be assumed.
 
+**utc** can be set to `true` on a rate band to say that its start and end times are given in UTC
+rather than local time. Predbat then shifts the band by the local offset, so it stays aligned with
+your meter through British Summer Time instead of running an hour early. Use this when your meter's
+schedule is fixed to UTC - Octopus fix the Economy 7 smart-meter off-peak period to 00:30-07:30 UTC,
+which falls at 01:30-08:30 local during BST.
+
+```yaml
+  rates_import:
+    - start: "00:30:00"
+      end: "07:30:00"
+      rate: 13.04
+      utc: true
+    - start: "07:30:00"
+      end: "00:30:00"
+      rate: 29.26
+      utc: true
+```
+
 The gas rates are only required if you have a gas boiler, or an iBoost, and are using Predbat to determine whether it's cheaper to heat your hot water with the iBoost or via gas.
+
+## Manually configuring Octopus off-peak times
+
+Predbat works out the off-peak period of a day/night (two-register) Octopus tariff from the meter's
+own time-of-use labels, and falls back to the standard window for the tariff type if those are not
+available. If neither matches the bands your meter actually switches on, set `octopus_night_times`
+in apps.yaml to state them by hand. The **times** come from this setting while the **rates**
+continue to come from the Octopus integration, so you do not have to maintain the prices yourself:
+
+```yaml
+  octopus_night_times:
+    - start: "01:00:00"
+      end: "05:00:00"
+    - start: "13:00:00"
+      end: "16:00:00"
+    - start: "20:00:00"
+      end: "22:00:00"
+```
+
+Entries use the same start/end format as the rate bands above, and any number of off-peak blocks a
+day can be given - useful for an Economy 10 style meter with several off-peak periods. Every period
+not covered by an entry is charged at the day rate.
+
+As with the rate bands, `utc: true` marks an entry as being given in UTC rather than local time:
+
+```yaml
+  octopus_night_times:
+    - start: "00:30:00"
+      end: "07:30:00"
+      utc: true
+```
+
+This setting takes precedence over both the meter's reported schedule and the built-in defaults, so
+only set it if you have confirmed the real switching times - your bills, rather than the cost
+estimates in the Octopus account area, are the thing to check against.
 
 ## Manually over-riding energy rates
 


### PR DESCRIPTION
## The bug

Octopus fix the Economy 7 smart-meter off-peak period to **00:30–07:30 UTC**, which falls at 01:30–08:30 local during BST ([their documentation](https://octopus.energy)). Predbat applied that window to `now_utc_exact`, which is local-timezone aware despite its name (`datetime.now(self.local_tz)`), so `.replace(hour=0, minute=30)` pinned 00:30 *local*:

```
BST (Aug)  Predbat: 00:30-07:30 local (= 23:30-06:30 UTC)
           Octopus: 01:30-08:30 local (= 00:30-07:30 UTC)
GMT (Jan)  both agree
```

Correct all winter, **one hour early all summer** — missing the last hour of cheap rate and paying day rate for the hour before the window.

## Evidence

Confirmed against a live account across both DST states. The measurements API labels every half-hour interval with the `TOU_BUCKET_COST` bucket it bills against:

| | Local window | UTC window | Tariff |
|---|---|---|---|
| August (+0100) | 01:30 → 08:30 | 00:30 → 07:30 | `E-2R-OE-FIX-12M-26-06-11-B` |
| January (+0000) | 00:30 → 07:30 | 00:30 → 07:30 | `E-2R-OE-LOYAL-FIX-16M-25-02-12-B` |

A fixed UTC window under two *different* tariffs — so the schedule belongs to the meter, not the tariff.

## Changes

- **Read the meter's real windows** from the `TOU_BUCKET_COST` labels (cached per day), falling back to the hard-wired windows whenever the lookup yields nothing — no MPAN, no labels, a single bucket, or an error.
- **Generalise the schedule builder to N off-peak blocks a day**, so an Economy 10 style meter with several bands works rather than assuming one.
- **Anchor each window to the clock it is actually fixed to.** Economy 7 and any TOU-derived schedule are UTC; GO and Intelligent GO are local wall-clock windows advertised year-round and must not move with the seasons. Local anchors are re-normalised per day so the wall-clock time holds across a DST change.
- **`utc: true` on `basic_rates` entries**, shifting a manually entered window by the local offset.
- **New `octopus_night_times` apps.yaml setting** for a meter whose real bands the API does not report. Times from the setting, rates still from the Octopus integration. Takes precedence over both the meter's labels and the built-in defaults.
- **`--night-window` diagnostic** in the `octopus.py` CLI harness, reporting a meter's real switching times from its TOU labels — for triaging similar reports.

Resulting behaviour:

| | BST | GMT |
|---|---|---|
| eco7 (UTC) | 01:30–08:30 local | 00:30–07:30 local |
| go (local) | 00:30–05:30 local | 00:30–05:30 local |
| iog (local) | 23:30–05:30 local | 23:30–05:30 local |

## Configuration

```yaml
  octopus_night_times:
    - start: "01:00:00"
      end: "05:00:00"
    - start: "13:00:00"
      end: "16:00:00"
```

```yaml
  rates_import:
    - start: "00:30:00"
      end: "07:30:00"
      rate: 13.04
      utc: true
```

## Testing

14 new tests across two files, all written before the implementation and watched fail for the right reason. Full suite **270 passed, 0 failed**; pre-commit clean.

Covered: UTC vs local anchoring in both DST states; a control asserting E7 and GO diverge at the *same* clock instant, so a future change re-unifying the anchoring cannot pass silently; TOU-label detection; multi-block schedules; every fallback path; manual configuration and its precedence.

## Reviewer notes

- **GO/IOG anchoring is a behaviour change** for anyone whose rates come through this path — those tariffs normally expose `standard-unit-rates` and never reach it, so real-world impact should be nil, but worth a look.
- **The DST re-normalisation of local anchors** is a fix beyond the reported bug: `+timedelta(days=n)` on a localised datetime carries the original offset, so local windows previously drifted an hour across a DST boundary within the 8-day schedule. No test spans a boundary crossing explicitly — the new tests pin wall-clock times either side, not the transition itself.
- **`basic_rates` is flake8 complexity 46** before this change; the `utc` handling adds roughly one branch to an already very large function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)