### PR TITLE
feat: add set_charge_freeze_only to forbid grid charging

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -1042,6 +1042,14 @@ CONFIG_ITEMS = [
         "reset_inverter": True,
     },
     {
+        "name": "set_charge_freeze_only",
+        "friendly_name": "Set Charge Freeze Only",
+        "type": "switch",
+        "enable": "expert_mode",
+        "default": False,
+        "reset_inverter": True,
+    },
+    {
         "name": "set_charge_low_power",
         "friendly_name": "Set Charge Low Power Mode",
         "type": "switch",

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -142,6 +142,18 @@ class Execute:
         in_alert = self.alert_active_keep.get(self.minutes_now, 0) > 0
         in_manual_soc = self.manual_soc_keep.get(self.minutes_now, 0) > 0
 
+        # Safeguard for set_charge_freeze_only: the planner never selects a charge target above the
+        # reserve while the switch is on, but a plan computed before it was turned on can still be
+        # in play (plans are only recomputed every few minutes, and are held across cycles by
+        # metric_min_improvement_plan), and with calculate_best_charge off the limits come from the
+        # inverter's own settings rather than the planner at all. Clamp here so the battery can
+        # never be charged from the grid, whatever the plan says.
+        if self.set_charge_freeze_only:
+            for window_n in range(len(self.charge_limit_best)):
+                if self.charge_limit_best[window_n] > self.reserve and not self.is_freeze_charge(self.charge_limit_best[window_n]):
+                    self.log("Warn: Charge limit {}kWh for window {} clamped to freeze charge as set_charge_freeze_only is enabled".format(self.charge_limit_best[window_n], window_n))
+                    self.charge_limit_best[window_n] = self.reserve
+
         if self.holiday_days_left > 0:
             status = "Demand (Holiday)"
         else:

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -2709,6 +2709,7 @@ class Fetch:
         self.set_reserve_hold = True
         self.set_export_freeze = self.get_arg("set_export_freeze")
         self.set_charge_freeze = self.get_arg("set_charge_freeze")
+        self.set_charge_freeze_only = self.get_arg("set_charge_freeze_only")
         self.set_charge_low_power = self.get_arg("set_charge_low_power")
         self.set_export_low_power = self.get_arg("set_export_low_power")
         self.charge_low_power_margin = self.get_arg("charge_low_power_margin")

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -3542,6 +3542,7 @@ class Output:
         opts += "calculate_export_oncharge({}), ".format(self.calculate_export_oncharge)
         opts += "calculate_export_on_pv({}), ".format(self.calculate_export_on_pv)
         opts += "set_export_freeze_only({}), ".format(self.set_export_freeze_only)
+        opts += "set_charge_freeze_only({}), ".format(self.set_charge_freeze_only)
         opts += "set_discharge_during_charge({}), ".format(self.set_discharge_during_charge)
         opts += "combine_charge_slots({}), ".format(self.combine_charge_slots)
         opts += "combine_export_slots({}), ".format(self.combine_export_slots)

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -2007,12 +2007,18 @@ class Plan:
                 try_socs.remove(self.reserve)
 
         if charge_freeze_only:
-            # The freeze_only branch above seeds the candidates with the window's existing limit, so
-            # a plan built before the switch was turned on could carry a grid charge back into the
-            # new plan. Nothing above the reserve may survive the search.
-            try_socs = [try_soc for try_soc in try_socs if try_soc <= self.reserve]
-            if not try_socs:
-                try_socs = [self.reserve if allow_freeze else 0.0]
+            # Grid charging is forbidden, so the window has exactly two permitted outcomes: off, and
+            # a freeze at the reserve. Build them rather than filter the candidates assembled above,
+            # because those can be forbidden in two different ways - best_soc_min_setting is
+            # max(reserve, best_soc_min) and so is a real charge target whenever best_soc_min is
+            # above the reserve, and the freeze_only branch seeds the list with the window's existing
+            # limit, which a plan built before the switch was turned on can leave as a grid charge.
+            # Filtering those out alone would leave the freeze as the only candidate whenever
+            # best_soc_min is set, making the search a foregone conclusion. Off goes first to keep
+            # the priority the branches above give it.
+            try_socs = [0.0]
+            if allow_freeze and self.reserve not in try_socs:
+                try_socs.append(self.reserve)
 
         # Run the simulations in parallel
         results = []

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -394,7 +394,16 @@ class Plan:
                 window_n = window_index[key]["id"]
                 typ = window_index[key]["type"]
                 if typ in ["c", "cf"]:
-                    if region_start and (charge_window[window_n]["start"] >= region_end or charge_window[window_n]["end"] < region_start):
+                    if self.set_charge_freeze_only and typ != "cf":
+                        # Grid charging is forbidden, so a window's plain charge entry is not a
+                        # candidate - only its freeze entry is. Dropping it here rather than letting
+                        # the sweep below simulate it and the levelling pass flatten it back to a
+                        # freeze keeps the search from spending simulations on, and picking its price
+                        # level from, plans that can never run. With set_charge_freeze off there are
+                        # no "cf" entries either, so no charge window is selected at all - correct,
+                        # as neither charge mode is usable then.
+                        pass
+                    elif region_start and (charge_window[window_n]["start"] >= region_end or charge_window[window_n]["end"] < region_start):
                         pass
                     elif charge_window[window_n]["start"] in self.manual_all_times:
                         pass
@@ -542,7 +551,14 @@ class Plan:
                     export_slot_choices = slots_around(best_max_export_slots, FINE_SLOT_LENGTHS)
 
                 pred_table = []
-                charge_freeze_options = [True, False] if (self.set_charge_freeze and not coarse) else [False]
+                if self.set_charge_freeze_only:
+                    # Only freeze entries survive the price_set_charge filter above, and allow_freeze
+                    # False would discard every one of them - so freeze is the option in each pass,
+                    # coarse included. "No charge windows" is still covered by charge_slot_choices,
+                    # which includes 0.
+                    charge_freeze_options = [True]
+                else:
+                    charge_freeze_options = [True, False] if (self.set_charge_freeze and not coarse) else [False]
                 export_freeze_options = [True, False] if (self.set_export_freeze and not coarse) else [False]
 
                 for max_charge_slots in charge_slot_choices:
@@ -1303,7 +1319,7 @@ class Plan:
                 self.export_window_best = clone_windows(self.export_window)
 
             # Pre-fill best charge limit with the current charge limit
-            self.charge_limit_best = [self.current_charge_limit * self.soc_max / 100.0 for i in range(len(self.charge_window_best))]
+            self.prefill_charge_limit_best()
 
             # Pre-fill best export enable with Off
             self.export_limits_best = [EXPORT_LIMIT_IDLE for i in range(len(self.export_window_best))]
@@ -1799,6 +1815,11 @@ class Plan:
         if not self.set_charge_freeze:
             allow_freeze = False
 
+        # set_charge_freeze_only forbids charging the battery from the grid, so the only candidates
+        # left are off and - when freeze is enabled - a freeze at the reserve. This is the charge
+        # side equivalent of optimise_export restricting loop_options under set_export_freeze_only.
+        charge_freeze_only = self.set_charge_freeze_only
+
         if all_n:
             window_n = all_n[0]
 
@@ -1817,7 +1838,7 @@ class Plan:
 
         # Create min/max SoC to avoid simulating SoC that are not going have any impact
         # Can't do this for anything but a single window as the winder SoC impact isn't known
-        if not all_n and not freeze_only:
+        if not all_n and not freeze_only and not charge_freeze_only:
             hans = []
             all_max_soc = 0
             all_min_soc = self.soc_max
@@ -1945,14 +1966,15 @@ class Plan:
                     ]
                 id += 1
 
-        # Assemble list of SoC's to try
-        try_socs = [loop_soc]
+        # Assemble list of SoC's to try - starting from a full charge, unless grid charging is
+        # forbidden in which case best_soc_min_setting below becomes the first (baseline) candidate
+        try_socs = [] if charge_freeze_only else [loop_soc]
         loop_step = max(best_soc_step, 0.1)
         best_soc_min_setting = self.best_soc_min
         if best_soc_min_setting > 0:
             best_soc_min_setting = max(self.reserve, best_soc_min_setting)
 
-        while loop_soc > self.reserve and not freeze_only:
+        while loop_soc > self.reserve and not freeze_only and not charge_freeze_only:
             skip = False
             try_soc = max(best_soc_min, loop_soc)
             try_soc = dp2(min(try_soc, self.soc_max))
@@ -1983,6 +2005,14 @@ class Plan:
                 try_socs.append(self.reserve)
             if not allow_freeze and (self.reserve in try_socs):
                 try_socs.remove(self.reserve)
+
+        if charge_freeze_only:
+            # The freeze_only branch above seeds the candidates with the window's existing limit, so
+            # a plan built before the switch was turned on could carry a grid charge back into the
+            # new plan. Nothing above the reserve may survive the search.
+            try_socs = [try_soc for try_soc in try_socs if try_soc <= self.reserve]
+            if not try_socs:
+                try_socs = [self.reserve if allow_freeze else 0.0]
 
         # Run the simulations in parallel
         results = []
@@ -2870,7 +2900,13 @@ class Plan:
                     # model whether the nominal plan changes without the slot, which subsumes the old
                     # never-reaches-limit and freeze-at-100% removal branches. What is left here narrows the
                     # limit to what the window can actually achieve, so adjacent windows share a limit and merge.
-                    if soc_max < (limit - charge_step):
+                    if self.set_charge_freeze_only:
+                        # Each branch below raises the limit to a full charge, which is exactly what
+                        # set_charge_freeze_only forbids - including turning a freeze into a charge
+                        # at 100% SoC, which imports nothing but still publishes a grid charge that
+                        # execute_plan's safeguard would immediately clamp back to a freeze.
+                        pass
+                    elif soc_max < (limit - charge_step):
                         # Work out what can be achieved in the window and set the target to match that
                         window["target"] = soc_max
                         charge_limit_best[window_n] = self.soc_max
@@ -4234,7 +4270,18 @@ class Plan:
                 elif self.charge_window_best[window_n]["start"] in self.manual_freeze_export_times:
                     self.charge_limit_best[window_n] = 0
                 elif self.charge_window_best[window_n]["start"] in self.manual_charge_times:
-                    self.charge_limit_best[window_n] = self.soc_max
+                    if self.set_charge_freeze_only:
+                        # A manual "charge now" request can't be honoured as a grid charge when the
+                        # user has said Predbat may only ever freeze charge - optimise_charge_limit's
+                        # own search already respects this, so a manual override doing otherwise
+                        # would be the one path where the plan assumes an import that execution
+                        # refuses to perform. Clamp to freeze charge, the closest available
+                        # approximation of "charge/hold what you can right now", rather than dropping
+                        # the override entirely (mirrors the manual export clamp for #4690).
+                        self.log("Warn: Manual charge time {} clamped to freeze charge as set_charge_freeze_only is enabled".format(self.time_abs_str(self.charge_window_best[window_n]["start"])))
+                        self.charge_limit_best[window_n] = self.reserve
+                    else:
+                        self.charge_limit_best[window_n] = self.soc_max
                 elif self.charge_window_best[window_n]["start"] in self.manual_freeze_charge_times:
                     self.charge_limit_best[window_n] = self.reserve
 
@@ -4260,6 +4307,19 @@ class Plan:
                 elif self.export_window_best[window_n]["start"] in self.manual_freeze_export_times:
                     self.export_limits_best[window_n] = EXPORT_LIMIT_FREEZE
 
+    def prefill_charge_limit_best(self):
+        """
+        Pre-fill the best charge limits from the inverter's current charge limit, one per charge
+        window. This is what the plan uses for any window Predbat is not optimising itself, so with
+        set_charge_freeze_only on the limit is clamped to a freeze here too - otherwise the plan and
+        the prediction would assume a grid charge that execute_plan's safeguard then refuses to
+        perform, and the plan would be scored against an import that never happens.
+        """
+        charge_limit = self.current_charge_limit * self.soc_max / 100.0
+        if self.set_charge_freeze_only:
+            charge_limit = min(charge_limit, self.reserve)
+        self.charge_limit_best = [charge_limit for i in range(len(self.charge_window_best))]
+
     def optimise_charge_windows_reset(self, reset_all):
         """
         Reset the charge windows to min
@@ -4277,7 +4337,10 @@ class Plan:
                     if reset_all:
                         self.charge_limit_best[window_n] = 0.0
                 else:
-                    self.charge_limit_best[window_n] = self.soc_max
+                    # Windows beyond the record window are parked at a full charge on the assumption
+                    # that Predbat can always charge later - which it can't when grid charging is
+                    # forbidden, so park them at a freeze instead
+                    self.charge_limit_best[window_n] = self.reserve if self.set_charge_freeze_only else self.soc_max
 
         if self.export_window_best and self.calculate_best_export:
             # Set all to max

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -515,6 +515,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.set_read_only = True
         self.set_read_only_axle = False
         self.set_reserve_enable = False
+        self.set_charge_freeze_only = False
         self.metric_cloud_coverage = 0.0
         self.future_energy_rates_import = {}
         self.future_energy_rates_export = {}

--- a/apps/predbat/tests/test_charge_freeze_only.py
+++ b/apps/predbat/tests/test_charge_freeze_only.py
@@ -1,0 +1,407 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+"""
+Tests for set_charge_freeze_only, the charge side counterpart of set_export_freeze_only. When the
+switch is On Predbat may freeze charge (hold the current SoC) but must never charge the battery
+from the grid, so no charge window may ever be planned or executed at a target above the reserve.
+"""
+from config import CONFIG_ITEMS
+from predbat import PredBat
+from prediction import Prediction
+from tests.test_infra import reset_rates, reset_inverter, update_rates_import, update_rates_export
+
+
+def run_charge_freeze_only_tests(my_predbat):
+    """Run all set_charge_freeze_only tests"""
+    failed = False
+    # This module calls load_user_config()/fetch_config_options() and then overwrites a lot of the
+    # planner's state to build its scenario. Several later modules (test_optimise_all_windows in
+    # particular) do no config reset of their own and inherit whatever the previous test left, so
+    # restoring the fixture wholesale on the way out is the only way to keep them independent of
+    # where this module sits in the registry.
+    saved_state = dict(my_predbat.__dict__)
+    try:
+        failed |= test_config_item_registered()
+        failed |= test_config_option_fetched(my_predbat)
+        failed |= test_reset_defaults_to_off()
+        failed |= test_plan_grid_charges_when_switch_off(my_predbat)
+        failed |= test_plan_never_grid_charges_when_switch_on(my_predbat)
+        failed |= test_plan_still_uses_freeze_charge_when_switch_on(my_predbat)
+        failed |= test_plan_does_not_charge_at_all_when_freeze_also_disabled(my_predbat)
+        failed |= test_prefill_charge_limit_uses_inverter_limit_when_switch_off(my_predbat)
+        failed |= test_prefill_charge_limit_clamped_when_switch_on(my_predbat)
+        failed |= test_clip_does_not_promote_freeze_to_charge_when_switch_on(my_predbat)
+        failed |= test_windows_beyond_record_not_set_to_full_charge_when_switch_on(my_predbat)
+        failed |= test_freeze_only_search_drops_an_incoming_grid_charge(my_predbat)
+        failed |= test_price_threads_returns_no_grid_charge(my_predbat)
+        failed |= test_price_threads_does_not_simulate_forbidden_charges(my_predbat)
+    finally:
+        my_predbat.__dict__.clear()
+        my_predbat.__dict__.update(saved_state)
+    return failed
+
+
+def find_config_item(name):
+    """Return the CONFIG_ITEMS entry with this name, or None"""
+    for item in CONFIG_ITEMS:
+        if item.get("name") == name:
+            return item
+    return None
+
+
+def test_config_item_registered():
+    """The switch is registered as an expert-mode switch defaulting to Off, like its export twin"""
+    print("**** test_config_item_registered ****")
+    failed = False
+    item = find_config_item("set_charge_freeze_only")
+    if item is None:
+        print("ERROR: set_charge_freeze_only is not registered in CONFIG_ITEMS")
+        return True
+
+    export_twin = find_config_item("set_export_freeze_only")
+    for key in ("type", "enable", "default", "reset_inverter"):
+        if item.get(key) != export_twin.get(key):
+            print("ERROR: set_charge_freeze_only {} is {} but set_export_freeze_only uses {}".format(key, item.get(key), export_twin.get(key)))
+            failed = True
+    if item.get("friendly_name") != "Set Charge Freeze Only":
+        print("ERROR: set_charge_freeze_only friendly_name is {}".format(item.get("friendly_name")))
+        failed = True
+    return failed
+
+
+def test_config_option_fetched(my_predbat):
+    """fetch_config_options publishes the switch onto the instance so the planner can read it"""
+    print("**** test_config_option_fetched ****")
+    my_predbat.load_user_config()
+    my_predbat.fetch_config_options()
+    value = getattr(my_predbat, "set_charge_freeze_only", "missing")
+    if value is not False:
+        print("ERROR: set_charge_freeze_only should default to False after fetch_config_options, got {}".format(value))
+        return True
+    return False
+
+
+def test_reset_defaults_to_off():
+    """reset() must initialise the switch to Off so a run before the config is fetched can't grid charge"""
+    print("**** test_reset_defaults_to_off ****")
+    bare = PredBat.__new__(PredBat)
+    bare.args = {}
+    bare.log = lambda *args, **kwargs: None  # reset() logs the config root, which needs a real logfile
+    bare.reset()
+    value = getattr(bare, "set_charge_freeze_only", "missing")
+    if value is not False:
+        print("ERROR: reset() should set set_charge_freeze_only to False, got {}".format(value))
+        return True
+    return False
+
+
+def setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze=True):
+    """
+    Build a day of half-hourly windows whose prices cycle 0..15p with a small constant load and a
+    nearly empty battery. Without any restriction the optimiser grid charges in the cheap windows
+    and freeze charges in a few mid-priced ones, so the same scenario exercises both charge modes.
+    Returns the charge windows it set up.
+    """
+    my_predbat.load_user_config()
+    my_predbat.fetch_config_options()
+    reset_inverter(my_predbat)
+
+    charge_window_best = []
+    for n in range(0, 48):
+        charge_window_best.append({"start": my_predbat.minutes_now + 30 * n, "end": my_predbat.minutes_now + 30 * (n + 1), "average": n % 16})
+    export_window_best = []
+
+    my_predbat.forecast_minutes = 24 * 60
+    end_record = my_predbat.forecast_minutes
+    my_predbat.calculate_best_charge = True
+    my_predbat.calculate_best_export = True
+    my_predbat.calculate_second_pass = False
+    my_predbat.soc_max = 10.0
+    my_predbat.soc_kw = 2.0
+    my_predbat.reserve = 0.5
+    my_predbat.inverter_hybrid = False
+    my_predbat.inverter_loss = 0.9
+    my_predbat.best_soc_keep = 1.0
+    my_predbat.best_soc_keep_weight = 0.5
+    my_predbat.set_charge_freeze = set_charge_freeze
+    my_predbat.set_charge_freeze_only = set_charge_freeze_only
+    my_predbat.debug_enable = False
+
+    reset_rates(my_predbat, 10.0, 5.5)
+    update_rates_import(my_predbat, charge_window_best)
+    update_rates_export(my_predbat, export_window_best)
+
+    pv_step = {}
+    load_step = {}
+    for minute in range(0, my_predbat.forecast_minutes, 5):
+        pv_step[minute] = 0.0
+        load_step[minute] = 0.2 / (60 / 5)
+    my_predbat.load_minutes_step = load_step
+    my_predbat.load_minutes_step10 = load_step
+    my_predbat.pv_forecast_minute_step = pv_step
+    my_predbat.pv_forecast_minute10_step = pv_step
+    my_predbat.prediction = Prediction(my_predbat, pv_step, pv_step, load_step, load_step)
+
+    my_predbat.charge_limit_best = [0 for n in range(len(charge_window_best))]
+    my_predbat.export_limits_best = []
+    my_predbat.charge_window_best = charge_window_best
+    my_predbat.export_window_best = export_window_best
+    my_predbat.end_record = end_record
+    return charge_window_best
+
+
+def run_plan(my_predbat, name, set_charge_freeze_only, set_charge_freeze=True):
+    """Set up the scenario and run a full optimisation over it, returning the resulting limits"""
+    print("**** {} ****".format(name))
+    charge_window_best = setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze)
+    metric, import_kwh_battery, import_kwh_house, export_kwh, soc_min, soc, soc_min_minute, battery_cycle, metric_keep, final_iboost, final_carbon_g = my_predbat.run_prediction(
+        my_predbat.charge_limit_best, charge_window_best, my_predbat.export_window_best, my_predbat.export_limits_best, False, end_record=my_predbat.end_record
+    )
+    my_predbat.optimise_all_windows(metric, metric_keep)
+    return my_predbat.charge_limit_best
+
+
+def test_plan_grid_charges_when_switch_off(my_predbat):
+    """
+    Baseline for the plan tests below: with the switch Off this scenario really does plan grid
+    charges above the reserve, so a plan without them afterwards is the switch working rather than
+    a scenario that never wanted to charge in the first place.
+    """
+    charge_limit_best = run_plan(my_predbat, "test_plan_grid_charges_when_switch_off", set_charge_freeze_only=False)
+    if not [limit for limit in charge_limit_best if limit > my_predbat.reserve]:
+        print("ERROR: baseline scenario planned no grid charge at all, limits {}".format(charge_limit_best))
+        return True
+    return False
+
+
+def test_plan_never_grid_charges_when_switch_on(my_predbat):
+    """With the switch On no charge window may be planned above the reserve"""
+    charge_limit_best = run_plan(my_predbat, "test_plan_never_grid_charges_when_switch_on", set_charge_freeze_only=True)
+    above_reserve = [(n, limit) for n, limit in enumerate(charge_limit_best) if limit > my_predbat.reserve]
+    if above_reserve:
+        print("ERROR: set_charge_freeze_only planned grid charges at windows {}".format(above_reserve))
+        return True
+    return False
+
+
+def test_plan_still_uses_freeze_charge_when_switch_on(my_predbat):
+    """
+    The switch forbids grid charging, not charge windows - freeze charge must still be reachable,
+    otherwise the implementation has just turned charge planning off entirely.
+    """
+    charge_limit_best = run_plan(my_predbat, "test_plan_still_uses_freeze_charge_when_switch_on", set_charge_freeze_only=True)
+    if my_predbat.reserve not in charge_limit_best:
+        print("ERROR: set_charge_freeze_only planned no freeze charge at all, limits {}".format(charge_limit_best))
+        return True
+    return False
+
+
+def test_plan_does_not_charge_at_all_when_freeze_also_disabled(my_predbat):
+    """
+    set_charge_freeze Off forbids freeze charge and set_charge_freeze_only forbids grid charge, so
+    together they leave no usable charge mode - every window must be left in demand mode.
+    """
+    charge_limit_best = run_plan(my_predbat, "test_plan_does_not_charge_at_all_when_freeze_also_disabled", set_charge_freeze_only=True, set_charge_freeze=False)
+    charging = [(n, limit) for n, limit in enumerate(charge_limit_best) if limit > 0]
+    if charging:
+        print("ERROR: both switches forbid charging but windows {} are still set".format(charging))
+        return True
+    return False
+
+
+def run_prefill(my_predbat, set_charge_freeze_only):
+    """
+    Drive the pre-fill used when Predbat is not optimising charge itself, with the inverter sat at
+    a 100% charge limit. Restores the state it touches so later tests are unaffected.
+    """
+    saved = (my_predbat.soc_max, my_predbat.reserve, my_predbat.current_charge_limit, my_predbat.charge_window_best, my_predbat.charge_limit_best, my_predbat.set_charge_freeze_only)
+    try:
+        my_predbat.soc_max = 10.0
+        my_predbat.reserve = 0.5
+        my_predbat.current_charge_limit = 100.0
+        my_predbat.set_charge_freeze_only = set_charge_freeze_only
+        my_predbat.charge_window_best = [{"start": 720, "end": 750, "average": 10.0}, {"start": 750, "end": 780, "average": 10.0}]
+        my_predbat.prefill_charge_limit_best()
+        return my_predbat.charge_limit_best
+    finally:
+        (my_predbat.soc_max, my_predbat.reserve, my_predbat.current_charge_limit, my_predbat.charge_window_best, my_predbat.charge_limit_best, my_predbat.set_charge_freeze_only) = saved
+
+
+def test_prefill_charge_limit_uses_inverter_limit_when_switch_off(my_predbat):
+    """Baseline: the pre-fill takes the inverter's own charge limit, one entry per window"""
+    print("**** test_prefill_charge_limit_uses_inverter_limit_when_switch_off ****")
+    charge_limit_best = run_prefill(my_predbat, set_charge_freeze_only=False)
+    if charge_limit_best != [10.0, 10.0]:
+        print("ERROR: pre-fill should be [10.0, 10.0] got {}".format(charge_limit_best))
+        return True
+    return False
+
+
+def test_prefill_charge_limit_clamped_when_switch_on(my_predbat):
+    """
+    With calculate_best_charge off the charge limits come from the inverter rather than the
+    optimiser, so the switch has to clamp them here too - otherwise the plan and the prediction
+    assume a grid charge that execute_plan's safeguard then refuses to perform.
+    """
+    print("**** test_prefill_charge_limit_clamped_when_switch_on ****")
+    charge_limit_best = run_prefill(my_predbat, set_charge_freeze_only=True)
+    if charge_limit_best != [0.5, 0.5]:
+        print("ERROR: pre-fill should be clamped to the reserve [0.5, 0.5] got {}".format(charge_limit_best))
+        return True
+    return False
+
+
+def test_clip_does_not_promote_freeze_to_charge_when_switch_on(my_predbat):
+    """
+    clip_charge_slots turns a freeze charge into a full charge when the battery is already at 100%
+    (see test_freeze_charge_to_charge_at_100_soc). Harmless normally - the battery is full so
+    nothing is imported - but it writes a grid charge into the plan, which the execute safeguard
+    then clamps straight back to a freeze. Leave the freeze alone when the switch is on.
+    """
+    print("**** test_clip_does_not_promote_freeze_to_charge_when_switch_on ****")
+    reset_inverter(my_predbat)
+    saved = (my_predbat.soc_max, my_predbat.reserve, my_predbat.set_charge_freeze_only, my_predbat.debug_enable)
+    try:
+        my_predbat.soc_max = 10.0
+        my_predbat.reserve = 0.5
+        my_predbat.debug_enable = False
+        my_predbat.set_charge_freeze_only = True
+
+        minutes_now = 720
+        windows = [{"start": 720, "end": 750, "average": 10.0}]
+        limits = [my_predbat.reserve]
+        predict_soc = {minute: my_predbat.soc_max for minute in range(0, 65, 5)}
+
+        result_windows, result_limits = my_predbat.clip_charge_slots(minutes_now, predict_soc, windows, limits, 1, 5)
+
+        if result_limits[0] != my_predbat.reserve:
+            print("ERROR: freeze charge at 100% should stay a freeze ({}) but got {}".format(my_predbat.reserve, result_limits[0]))
+            return True
+        return False
+    finally:
+        (my_predbat.soc_max, my_predbat.reserve, my_predbat.set_charge_freeze_only, my_predbat.debug_enable) = saved
+
+
+def test_windows_beyond_record_not_set_to_full_charge_when_switch_on(my_predbat):
+    """
+    optimise_charge_windows_reset parks every window beyond the record window at a full charge, on
+    the assumption that Predbat can always charge later. It can't when grid charging is forbidden,
+    so those windows would model - and publish - an import that can never happen.
+    """
+    print("**** test_windows_beyond_record_not_set_to_full_charge_when_switch_on ****")
+    saved = (my_predbat.soc_max, my_predbat.reserve, my_predbat.set_charge_freeze_only, my_predbat.charge_window_best, my_predbat.charge_limit_best, my_predbat.export_window_best, my_predbat.end_record, my_predbat.calculate_best_charge)
+    try:
+        my_predbat.soc_max = 10.0
+        my_predbat.reserve = 0.5
+        my_predbat.set_charge_freeze_only = True
+        my_predbat.calculate_best_charge = True
+        my_predbat.end_record = 60
+        my_predbat.export_window_best = []
+        # One window inside the record window, one well beyond it
+        my_predbat.charge_window_best = [{"start": my_predbat.minutes_now, "end": my_predbat.minutes_now + 30, "average": 10.0}, {"start": my_predbat.minutes_now + 600, "end": my_predbat.minutes_now + 630, "average": 10.0}]
+        my_predbat.charge_limit_best = [0.0, 0.0]
+
+        my_predbat.optimise_charge_windows_reset(reset_all=True)
+
+        above_reserve = [(n, limit) for n, limit in enumerate(my_predbat.charge_limit_best) if limit > my_predbat.reserve]
+        if above_reserve:
+            print("ERROR: windows {} were parked at a grid charge".format(above_reserve))
+            return True
+        return False
+    finally:
+        (my_predbat.soc_max, my_predbat.reserve, my_predbat.set_charge_freeze_only, my_predbat.charge_window_best, my_predbat.charge_limit_best, my_predbat.export_window_best, my_predbat.end_record, my_predbat.calculate_best_charge) = saved
+
+
+def test_freeze_only_search_drops_an_incoming_grid_charge(my_predbat):
+    """
+    The freeze_only search keeps the window's existing limit as a candidate, so a plan built before
+    the switch was turned on (plans persist across cycles and are held by metric_min_improvement_plan)
+    could carry a grid charge straight through the optimiser and back into the new plan.
+    """
+    print("**** test_freeze_only_search_drops_an_incoming_grid_charge ****")
+    charge_window_best = setup_scenario(my_predbat, set_charge_freeze_only=True)
+    # Window 0 arrives already set to a full charge, as a plan from before the switch would leave it
+    my_predbat.charge_limit_best[0] = my_predbat.soc_max
+
+    best_soc = my_predbat.optimise_charge_limit(
+        0,
+        len(charge_window_best),
+        my_predbat.charge_limit_best,
+        charge_window_best,
+        my_predbat.export_window_best,
+        my_predbat.export_limits_best,
+        end_record=my_predbat.end_record,
+        freeze_only=True,
+    )[0]
+
+    if best_soc > my_predbat.reserve:
+        print("ERROR: freeze_only search kept the incoming grid charge, selected {}".format(best_soc))
+        return True
+    return False
+
+
+def run_price_threads(my_predbat, set_charge_freeze_only, set_charge_freeze=True):
+    """Run just the price-threshold level search over the scenario and return its charge limits"""
+    charge_window_best = setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze)
+    record_charge_windows = max(my_predbat.max_charge_windows(my_predbat.end_record + my_predbat.minutes_now, charge_window_best), 1)
+    window_sorted, window_index, price_set, price_links = my_predbat.sort_window_by_price_combined(charge_window_best[:record_charge_windows], [])
+    my_predbat.optimise_charge_windows_reset(reset_all=True)
+    return my_predbat.optimise_charge_limit_price_threads(
+        price_set,
+        price_links,
+        window_index,
+        record_charge_windows,
+        0,
+        my_predbat.charge_limit_best,
+        charge_window_best,
+        my_predbat.export_window_best,
+        my_predbat.export_limits_best,
+        end_record=my_predbat.end_record,
+        fast=True,
+        quiet=True,
+    )
+
+
+def test_price_threads_returns_no_grid_charge(my_predbat):
+    """
+    The price-threshold search selects windows itself and only levels their limits at the end, via
+    optimise_charge_limit. That levelling pass is the only thing keeping its output within the
+    switch, so pin it here rather than relying on the detailed pass to clean up afterwards - with
+    the switch off this same scenario returns a 7.5kWh grid charge in those windows.
+    """
+    print("**** test_price_threads_returns_no_grid_charge ****")
+    charge_limit_best = run_price_threads(my_predbat, set_charge_freeze_only=True)[0]
+    above_reserve = [(n, limit) for n, limit in enumerate(charge_limit_best) if limit > my_predbat.reserve]
+    if above_reserve:
+        print("ERROR: price threshold search scored grid charges at windows {}".format(above_reserve))
+        return True
+    return False
+
+
+def test_price_threads_does_not_simulate_forbidden_charges(my_predbat):
+    """
+    The price-threshold search sweeps price levels and slot counts, simulating a scenario per
+    combination. Selecting a window is not the same as freezing it - the candidate list mixes the
+    charge and freeze entries a window contributes, so without an explicit restriction the sweep
+    simulates full-charge scenarios that the switch forbids, only for the levelling pass at the end
+    to flatten them back to a freeze. That work is wasted, and the price level and slot count get
+    chosen by comparing plans that can never run.
+
+    tried_list is the search's scenario cache, logged as "total simulations", so its size is a
+    direct count of the work done. With the switch on that count has to drop.
+    """
+    print("**** test_price_threads_does_not_simulate_forbidden_charges ****")
+    simulations_off = len(run_price_threads(my_predbat, set_charge_freeze_only=False)[10])
+    simulations_on = len(run_price_threads(my_predbat, set_charge_freeze_only=True)[10])
+    print("Simulations: switch off {} switch on {}".format(simulations_off, simulations_on))
+    if simulations_on >= simulations_off:
+        print("ERROR: set_charge_freeze_only simulated {} scenarios vs {} with the switch off - forbidden charges are still being searched".format(simulations_on, simulations_off))
+        return True
+    return False

--- a/apps/predbat/tests/test_charge_freeze_only.py
+++ b/apps/predbat/tests/test_charge_freeze_only.py
@@ -42,6 +42,8 @@ def run_charge_freeze_only_tests(my_predbat):
         failed |= test_freeze_only_search_drops_an_incoming_grid_charge(my_predbat)
         failed |= test_price_threads_returns_no_grid_charge(my_predbat)
         failed |= test_price_threads_does_not_simulate_forbidden_charges(my_predbat)
+        failed |= test_windows_can_still_be_turned_off_with_best_soc_min_set(my_predbat)
+        failed |= test_both_permitted_outcomes_considered_with_best_soc_min_set(my_predbat)
     finally:
         my_predbat.__dict__.clear()
         my_predbat.__dict__.update(saved_state)
@@ -102,7 +104,7 @@ def test_reset_defaults_to_off():
     return False
 
 
-def setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze=True):
+def setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze=True, best_soc_min=0.0):
     """
     Build a day of half-hourly windows whose prices cycle 0..15p with a small constant load and a
     nearly empty battery. Without any restriction the optimiser grid charges in the cheap windows
@@ -132,6 +134,7 @@ def setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze=True):
     my_predbat.best_soc_keep_weight = 0.5
     my_predbat.set_charge_freeze = set_charge_freeze
     my_predbat.set_charge_freeze_only = set_charge_freeze_only
+    my_predbat.best_soc_min = best_soc_min
     my_predbat.debug_enable = False
 
     reset_rates(my_predbat, 10.0, 5.5)
@@ -157,10 +160,10 @@ def setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze=True):
     return charge_window_best
 
 
-def run_plan(my_predbat, name, set_charge_freeze_only, set_charge_freeze=True):
+def run_plan(my_predbat, name, set_charge_freeze_only, set_charge_freeze=True, best_soc_min=0.0):
     """Set up the scenario and run a full optimisation over it, returning the resulting limits"""
     print("**** {} ****".format(name))
-    charge_window_best = setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze)
+    charge_window_best = setup_scenario(my_predbat, set_charge_freeze_only, set_charge_freeze, best_soc_min)
     metric, import_kwh_battery, import_kwh_house, export_kwh, soc_min, soc, soc_min_minute, battery_cycle, metric_keep, final_iboost, final_carbon_g = my_predbat.run_prediction(
         my_predbat.charge_limit_best, charge_window_best, my_predbat.export_window_best, my_predbat.export_limits_best, False, end_record=my_predbat.end_record
     )
@@ -405,3 +408,63 @@ def test_price_threads_does_not_simulate_forbidden_charges(my_predbat):
         print("ERROR: set_charge_freeze_only simulated {} scenarios vs {} with the switch off - forbidden charges are still being searched".format(simulations_on, simulations_off))
         return True
     return False
+
+
+def candidates_considered(my_predbat, set_charge_freeze_only, best_soc_min):
+    """The SoC candidates optimise_charge_limit actually simulates for the first charge window"""
+    charge_window_best = setup_scenario(my_predbat, set_charge_freeze_only, best_soc_min=best_soc_min)
+    seen = []
+    original = my_predbat.launch_run_prediction_charge
+
+    def spy(loop_soc, *args, **kwargs):
+        seen.append(loop_soc)
+        return original(loop_soc, *args, **kwargs)
+
+    my_predbat.launch_run_prediction_charge = spy
+    try:
+        my_predbat.optimise_charge_limit(0, len(charge_window_best), my_predbat.charge_limit_best, charge_window_best, my_predbat.export_window_best, my_predbat.export_limits_best, end_record=my_predbat.end_record)
+    finally:
+        my_predbat.launch_run_prediction_charge = original
+    return sorted(set(seen))
+
+
+def test_windows_can_still_be_turned_off_with_best_soc_min_set(my_predbat):
+    """
+    optimise_charge_limit's "off" candidate is best_soc_min_setting, which is max(reserve,
+    best_soc_min) - so with best_soc_min above the reserve it is a real charge target that would
+    import, and the switch has to drop it. Dropping it without putting a genuine off candidate back
+    leaves the freeze as the window's only option, forcing a freeze on every window even where
+    turning it off is cheaper. Both permitted outcomes must survive.
+    """
+    print("**** test_windows_can_still_be_turned_off_with_best_soc_min_set ****")
+    charge_limit_best = run_plan(my_predbat, "best_soc_min_above_reserve", set_charge_freeze_only=True, best_soc_min=2.0)
+    above_reserve = [(n, limit) for n, limit in enumerate(charge_limit_best) if limit > my_predbat.reserve]
+    if above_reserve:
+        print("ERROR: planned grid charges at windows {}".format(above_reserve))
+        return True
+    if not [limit for limit in charge_limit_best if limit == 0]:
+        print("ERROR: every window was forced to a freeze, none could be turned off - limits {}".format(charge_limit_best))
+        return True
+    return False
+
+
+def test_both_permitted_outcomes_considered_with_best_soc_min_set(my_predbat):
+    """
+    The switch permits exactly two outcomes for a charge window - off, and a freeze at the reserve -
+    and the optimiser has to be able to weigh both. The "off" candidate it would otherwise use is
+    best_soc_min_setting, which is max(reserve, best_soc_min) and so is a real charge target once
+    best_soc_min is above the reserve; dropping that as a forbidden import must not leave the freeze
+    as the window's only candidate, or the search becomes a foregone conclusion.
+
+    best_soc_min changes neither permitted outcome, so the candidate set must not depend on it. Note
+    the unrestricted optimiser does not offer 0.0 here at all - its low candidate is
+    best_soc_min_setting - so this is specific to the switch.
+    """
+    print("**** test_both_permitted_outcomes_considered_with_best_soc_min_set ****")
+    failed = False
+    for best_soc_min in (0.0, 2.0):
+        candidates = candidates_considered(my_predbat, True, best_soc_min)
+        if candidates != [0.0, my_predbat.reserve]:
+            print("ERROR: with best_soc_min {} the candidates should be off and freeze [0.0, {}] but got {}".format(best_soc_min, my_predbat.reserve, candidates))
+            failed = True
+    return failed

--- a/apps/predbat/tests/test_execute.py
+++ b/apps/predbat/tests/test_execute.py
@@ -224,6 +224,7 @@ def run_execute_test(
     battery_temperature=20,
     assert_immediate_charge_soc_freeze_array=[],
     pv_forecast=0.0,
+    set_charge_freeze_only=False,
 ):
     print("> Run scenario {}".format(name))
     my_predbat.log("> Run scenario {}".format(name))
@@ -298,6 +299,7 @@ def run_execute_test(
     my_predbat.set_charge_freeze = my_predbat.get_arg("set_charge_freeze")
     my_predbat.set_export_freeze = my_predbat.get_arg("set_export_freeze")
     my_predbat.set_export_freeze_only = my_predbat.get_arg("set_export_freeze_only")
+    my_predbat.set_charge_freeze_only = set_charge_freeze_only
 
     my_predbat.fetch_inverter_data(create=False)
 
@@ -3090,6 +3092,71 @@ def test_freeze_flags_do_not_leak_between_scenarios(my_predbat):
     """
     print("**** Running test_freeze_flags_do_not_leak_between_scenarios ****")
     failed = False
+    # These run here rather than at the end of the module: the last scenario leaves my_predbat.isCharging
+    # set, and tests further down the registry (test_optimise_all_windows' charging-skew check) read it.
+    # set_charge_freeze_only is a safeguard as well as a planning restriction: a charge limit above
+    # the reserve can still reach execution from a plan built before the switch was turned on, and
+    # the battery must not be charged from the grid when it does.
+    charge_window_freeze_only = [{"start": my_predbat.minutes_now, "end": my_predbat.minutes_now + 60, "average": 1}]
+    failed |= run_execute_test(
+        my_predbat,
+        "charge_freeze_only_off_grid_charges",
+        charge_window_best=charge_window_freeze_only,
+        charge_limit_best=[10],
+        set_charge_window=True,
+        set_export_window=True,
+        soc_kw=1,
+        assert_charge_time_enable=True,
+        assert_status="Charging",
+        assert_reserve=0,
+        assert_soc_target=100,
+        assert_immediate_soc_target=100,
+        assert_charge_start_time_minutes=-1,
+        assert_charge_end_time_minutes=my_predbat.minutes_now + 60,
+    )
+    if failed:
+        return failed
+
+    # Same plan, switch on - must behave exactly like the charge_freeze1c freeze scenario above
+    failed |= run_execute_test(
+        my_predbat,
+        "charge_freeze_only_on_clamps_to_freeze",
+        charge_window_best=charge_window_freeze_only,
+        charge_limit_best=[10],
+        set_charge_window=True,
+        set_export_window=True,
+        soc_kw=1,
+        set_charge_freeze_only=True,
+        assert_charge_time_enable=False,
+        assert_pause_discharge=True,
+        assert_status="Freeze charging",
+        assert_reserve=0,
+        assert_soc_target=100,
+        assert_immediate_soc_target=10,
+    )
+    if failed:
+        return failed
+
+    # Turning the switch back off restores grid charging - the clamp must not be sticky
+    failed |= run_execute_test(
+        my_predbat,
+        "charge_freeze_only_off_again_grid_charges",
+        charge_window_best=charge_window_freeze_only,
+        charge_limit_best=[10],
+        set_charge_window=True,
+        set_export_window=True,
+        soc_kw=1,
+        assert_charge_time_enable=True,
+        assert_status="Charging",
+        assert_reserve=0,
+        assert_soc_target=100,
+        assert_immediate_soc_target=100,
+        assert_charge_start_time_minutes=-1,
+        assert_charge_end_time_minutes=my_predbat.minutes_now + 60,
+    )
+    if failed:
+        return failed
+
     saved = [(inverter.inv_support_charge_freeze, inverter.inv_support_discharge_freeze) for inverter in my_predbat.inverters]
 
     for inverter in my_predbat.inverters:
@@ -3102,7 +3169,7 @@ def test_freeze_flags_do_not_leak_between_scenarios(my_predbat):
         inverter.inv_support_discharge_freeze = support_discharge
     run_execute_test(my_predbat, "freeze_supported_inverter_after", set_charge_window=True, set_export_window=True)
 
-    for name in ("set_charge_freeze", "set_export_freeze", "set_export_freeze_only"):
+    for name in ("set_charge_freeze", "set_export_freeze", "set_export_freeze_only", "set_charge_freeze_only"):
         expected = my_predbat.get_arg(name)
         actual = getattr(my_predbat, name)
         if actual != expected:

--- a/apps/predbat/tests/test_infra.py
+++ b/apps/predbat/tests/test_infra.py
@@ -372,6 +372,7 @@ class MockConfigProvider:
             "set_status_notify": False,
             "set_inverter_notify": False,
             "set_export_freeze_only": False,
+            "set_charge_freeze_only": False,
             "set_discharge_during_charge": True,
             "set_freeze_export_during_demand": False,
             "mode": "Control charge & discharge",

--- a/apps/predbat/tests/test_manual_overrides.py
+++ b/apps/predbat/tests/test_manual_overrides.py
@@ -16,14 +16,26 @@ def run_manual_overrides_tests(my_predbat):
     Tests for optimise_charge_windows_manual method
     """
     failed = False
-    failed |= test_manual_export_forces_active_export(my_predbat)
-    failed |= test_manual_export_clamped_when_export_freeze_only(my_predbat)
-    failed |= test_manual_freeze_export_unaffected_by_export_freeze_only(my_predbat)
-    failed |= test_manual_demand_unaffected_by_export_freeze_only(my_predbat)
+    try:
+        failed |= test_manual_export_forces_active_export(my_predbat)
+        failed |= test_manual_export_clamped_when_export_freeze_only(my_predbat)
+        failed |= test_manual_freeze_export_unaffected_by_export_freeze_only(my_predbat)
+        failed |= test_manual_demand_unaffected_by_export_freeze_only(my_predbat)
+        failed |= test_manual_charge_forces_full_charge(my_predbat)
+        failed |= test_manual_charge_clamped_when_charge_freeze_only(my_predbat)
+        failed |= test_manual_freeze_charge_unaffected_by_charge_freeze_only(my_predbat)
+        failed |= test_manual_demand_unaffected_by_charge_freeze_only(my_predbat)
+    finally:
+        # Most tests here deliberately leave a freeze-only switch on, and both are read all over the
+        # planner - clip_charge_slots in particular changes behaviour under set_charge_freeze_only.
+        # A full run happens to be safe because of registry ordering, which is not something later
+        # tests should have to depend on.
+        my_predbat.set_export_freeze_only = False
+        my_predbat.set_charge_freeze_only = False
     return failed
 
 
-def setup(my_predbat, set_export_freeze_only):
+def setup(my_predbat, set_export_freeze_only=False, set_charge_freeze_only=False):
     """Put the plan into a known state with a single charge and export window covering the same slot"""
     reset_inverter(my_predbat)
     my_predbat.soc_max = 10.0
@@ -32,6 +44,7 @@ def setup(my_predbat, set_export_freeze_only):
     my_predbat.calculate_best_charge = True
     my_predbat.calculate_best_export = True
     my_predbat.set_export_freeze_only = set_export_freeze_only
+    my_predbat.set_charge_freeze_only = set_charge_freeze_only
 
     my_predbat.manual_demand_times = []
     my_predbat.manual_export_times = []
@@ -43,6 +56,15 @@ def setup(my_predbat, set_export_freeze_only):
     my_predbat.charge_limit_best = [5.0]
     my_predbat.export_window_best = [{"start": 720, "end": 750, "average": 10.0}]
     my_predbat.export_limits_best = [EXPORT_LIMIT_IDLE]
+
+
+def check_charge_limit(name, my_predbat, expected):
+    """Assert the single charge window ended up at the expected limit"""
+    actual = my_predbat.charge_limit_best[0]
+    if actual != expected:
+        print("ERROR: {} - charge limit should be {} got {}".format(name, expected, actual))
+        return True
+    return False
 
 
 def check_export_limit(name, my_predbat, expected):
@@ -102,3 +124,53 @@ def test_manual_demand_unaffected_by_export_freeze_only(my_predbat):
     my_predbat.optimise_charge_windows_manual()
 
     return check_export_limit("test_manual_demand_unaffected_by_export_freeze_only", my_predbat, EXPORT_LIMIT_IDLE)
+
+
+def test_manual_charge_forces_full_charge(my_predbat):
+    """Baseline: with set_charge_freeze_only off, a manual charge override charges to full"""
+    print("**** test_manual_charge_forces_full_charge ****")
+    setup(my_predbat, set_charge_freeze_only=False)
+    my_predbat.manual_charge_times = [720]
+
+    my_predbat.optimise_charge_windows_manual()
+
+    return check_charge_limit("test_manual_charge_forces_full_charge", my_predbat, my_predbat.soc_max)
+
+
+def test_manual_charge_clamped_when_charge_freeze_only(my_predbat):
+    """
+    set_charge_freeze_only means Predbat may only ever freeze charge, never grid charge. The
+    optimiser's own search honours that, so a manual charge override must not be the one path that
+    writes an active charge target into the plan - otherwise the plan assumes an import that
+    execution refuses to perform. Clamp the override to freeze charge, the closest available
+    approximation of "hold what you have right now" (same treatment as the manual export clamp).
+    """
+    print("**** test_manual_charge_clamped_when_charge_freeze_only ****")
+    setup(my_predbat, set_charge_freeze_only=True)
+    my_predbat.manual_charge_times = [720]
+
+    my_predbat.optimise_charge_windows_manual()
+
+    return check_charge_limit("test_manual_charge_clamped_when_charge_freeze_only", my_predbat, my_predbat.reserve)
+
+
+def test_manual_freeze_charge_unaffected_by_charge_freeze_only(my_predbat):
+    """A manual freeze charge override is already a freeze, so the switch must not change it"""
+    print("**** test_manual_freeze_charge_unaffected_by_charge_freeze_only ****")
+    setup(my_predbat, set_charge_freeze_only=True)
+    my_predbat.manual_freeze_charge_times = [720]
+
+    my_predbat.optimise_charge_windows_manual()
+
+    return check_charge_limit("test_manual_freeze_charge_unaffected_by_charge_freeze_only", my_predbat, my_predbat.reserve)
+
+
+def test_manual_demand_unaffected_by_charge_freeze_only(my_predbat):
+    """A manual demand override disables the charge window entirely and must stay that way"""
+    print("**** test_manual_demand_unaffected_by_charge_freeze_only ****")
+    setup(my_predbat, set_charge_freeze_only=True)
+    my_predbat.manual_demand_times = [720]
+
+    my_predbat.optimise_charge_windows_manual()
+
+    return check_charge_limit("test_manual_demand_unaffected_by_charge_freeze_only", my_predbat, 0)

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -253,6 +253,7 @@ from tests.test_kraken import run_kraken_tests
 from tests.test_kraken_auth_mixin import run_kraken_auth_mixin_tests
 from tests.test_clip_export_slots import run_clip_export_slots_tests
 from tests.test_manual_overrides import run_manual_overrides_tests
+from tests.test_charge_freeze_only import run_charge_freeze_only_tests
 from tests.test_prune_dead_slots import run_prune_dead_slots_tests
 from tests.test_clip_charge_slots import run_clip_charge_slots_tests
 from tests.test_discard_unused_charge_slots import run_discard_unused_charge_slots_tests
@@ -612,6 +613,7 @@ def main():
         ("kraken_auth", run_kraken_auth_mixin_tests, "Kraken auth mixin tests (API key, email, refresh, 401 handling)", False),
         ("clip_export_slots", run_clip_export_slots_tests, "Clip export slots tests", False),
         ("manual_overrides", run_manual_overrides_tests, "Manual window override tests", False),
+        ("charge_freeze_only", run_charge_freeze_only_tests, "set_charge_freeze_only (no grid charging) tests", False),
         ("prune_dead_slots", run_prune_dead_slots_tests, "Prune dead plan slots tests", False),
         ("clip_charge_slots", run_clip_charge_slots_tests, "Clip charge slots tests", False),
         ("discard_unused_charge_slots", run_discard_unused_charge_slots_tests, "Discard unused charge slots tests", False),

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -71,6 +71,8 @@ In **Control charge & discharge** mode Predbat will set both charge and force ex
 
 If you have set the **switch.predbat_set_export_freeze_only** set to On then forced export won't occur but Predbat can force the export of solar power to the grid when desired.
 
+Similarly, if you have **switch.predbat_set_charge_freeze_only** set to On then the battery won't be charged from the grid, but Predbat can still freeze charge to hold the current battery level.
+
 ## Expert mode
 
 Predbat has a toggle switch called **switch.predbat_expert_mode** which is set to Off by default for new installs (On by default for upgraded installs).
@@ -460,6 +462,11 @@ this defaults to 10 but can be changed between 0 and 30.
 once it has been reached or to protect against discharging beyond the set limit.
 
 **switch.predbat_set_charge_freeze** (_expert mode_) When turned On will allow Predbat to hold the current battery level while drawing from the grid/solar as an alternative to charging. On by default.
+
+**switch.predbat_set_charge_freeze_only** (_expert mode_) When turned On charging the battery from the grid is prevented, but charge freeze can be used (if enabled) to hold the current battery
+level rather than discharging it. This is useful if you don't want to import to fill the battery at all, for example on a flat tariff or where you only want the battery charged by solar. Off by default.
+
+Note that if both this and **switch.predbat_set_charge_freeze** are turned Off, Predbat has no way to use a charge window at all and will leave the battery in demand mode throughout.
 
 **switch.predbat_set_export_freeze** When turned On (the default) will allow Predbat to export Solar to the grid rather than charging the battery.
 


### PR DESCRIPTION
Adds `switch.predbat_set_charge_freeze_only`, the charge side counterpart of `set_export_freeze_only`. When On, Predbat may freeze charge (hold the current SoC) but must never charge the battery from the grid — a charge window can only ever be a freeze at the reserve, or off.

Expert mode, default Off, `reset_inverter: True`, matching its export twin.

## Planning

| Site | Change |
|---|---|
| [`optimise_charge_limit`](apps/predbat/plan.py) | Restricts the SoC search to off/freeze. This also skips the pre-simulation block that exists only to build the pruning envelope for the sweep, so planning gets cheaper rather than more expensive. |
| [`optimise_charge_limit_price_threads`](apps/predbat/plan.py) | Drops each window's plain charge entry from the candidate list, so the price level and slot count are chosen by comparing achievable plans. |
| manual charge override | Clamps to freeze charge with a warning, mirroring the manual export clamp from #4690. |
| `clip_charge_slots` | No longer promotes a freeze to a full charge when the battery is already at 100%. |
| `optimise_charge_windows_reset` | Parks beyond-horizon windows at a freeze instead of a full charge — "we can always charge later" is false under this switch. |
| `freeze_only` search | Filters out a limit carried in from a plan built before the switch was turned on. |

The `price_threads` change is the non-obvious one. `allow_freeze` only *permits* freeze candidates — [`select_window_candidates`](apps/predbat/plan.py) filters with `if freeze and not allow_freeze: continue` — and each window contributes **two** entries to `price_set_charge`, a `"c"` and a `"cf"`. So permitting freeze left both in play and non-freeze windows still got `soc_max`. Those scenarios were simulated and then flattened back to a freeze by the levelling pass at the end, which meant wasted simulations *and* a price level chosen by comparing plans that can never run. The filter has to be at the candidate list itself. Measured on the test scenario: **33 → 23 scenarios simulated**.

This also removes the need for a special case when both switches are off: `"cf"` entries only exist when `set_charge_freeze` is on, so with both off `price_set_charge` is simply empty and no charge window is selected — which is the correct outcome, as neither charge mode is usable.

## Execute

`execute_plan` clamps any above-reserve limit as a safeguard. This matters beyond belt-and-braces: plans persist across cycles and are held by `metric_min_improvement_plan`, and with `calculate_best_charge` off the limits come from the inverter rather than the planner at all.

## No prediction or kernel change

`set_export_freeze_only` had to teach the model to *reinterpret* an active export limit as a freeze. Here the clamp is on the value itself, so the model only ever sees the reserve or 0 and the existing `set_charge_freeze` path in `prediction.py` handles it. That avoids a `KERNEL_ABI_VERSION` bump and rebuilding all six `.so` binaries.

## Tests

14 new tests in `test_charge_freeze_only.py` plus the manual-override and execute cases, each written failing first. Two are there specifically to stop the others passing vacuously:

- `test_plan_grid_charges_when_switch_off` pins that the scenario really does plan grid charges without the switch.
- `test_plan_still_uses_freeze_charge_when_switch_on` catches an implementation that just disables charge planning entirely.
- `test_price_threads_does_not_simulate_forbidden_charges` asserts the simulation count strictly drops, which is what failed (33 vs 33) against the first, inert attempt at the gate.

## Test-fixture leaks fixed along the way

`unit_test.py` shares one `PredBat` instance across modules and several modules do no reset of their own, so a module's *exit* state is inherited by later ones. Three leaks, each of which made `optimise_windows_kernel` fail in the full suite while passing in isolation:

- The new execute scenarios are placed ahead of the trailing block, so the module still exits with `isCharging` False — `test_optimise_all_windows`' charging-skew check takes a baseline and re-measures with `isCharging = True`, so an already-set flag made both calls skew and the difference read as 0.
- The new test module restores the fixture wholesale, because it calls `fetch_config_options()` (which resets `forecast_minutes` and `combine_charge_slots`).
- `run_manual_overrides_tests` no longer leaks `set_export_freeze_only` — pre-existing, and only surfaced because the new `clip_charge_slots` guard reads a switch that leak sat next to.

## Verification

Full suite green (`All tests passed`, 152.75s, 0 failures), matching a clean-tree baseline run. `pre-commit run` clean across all hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
