### PR TITLE
fix(ohme): migrate max-charge and target-rule calls to Ohme's v2 API

### DIFF
--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -706,7 +706,7 @@ class OhmeAPI(ComponentBase):
         if entity_id.endswith("_target_time"):
             if value in OPTIONS_TIME:
                 hour, minute = map(int, value.split(":"))
-                await self.client.async_apply_session_rule(target_time=(hour, minute))
+                await self.client.async_set_target(target_time=(hour, minute))
                 self.log(f"Info: Ohme API: Set target time to {hour:02d}:{minute:02d}")
             else:
                 self.log(f"Warn: Ohme API: Invalid target time value: {value}")
@@ -719,7 +719,7 @@ class OhmeAPI(ComponentBase):
         # which is also what ohme_automatic_octopus_intelligent binds octopus_charge_limit to
         if entity_id.endswith("_target_percent"):
             if (isinstance(value, float) or isinstance(value, int)) and 0 <= value <= 100:
-                await self.client.async_apply_session_rule(target_percent=int(value))
+                await self.client.async_set_target(target_percent=int(value))
             else:
                 self.log(f"Warn: Ohme API: Invalid target SoC value: {value}")
         elif entity_id.endswith("_preconditioning"):
@@ -730,10 +730,10 @@ class OhmeAPI(ComponentBase):
                 return
             if value == 0:
                 self.log(f"Info: Ohme API: Set preconditioning to off")
-                await self.client.async_apply_session_rule(pre_condition=True)
+                await self.client.async_set_target(pre_condition_length=0)
             else:
                 self.log(f"Info: Ohme API: Set preconditioning length to {int(value)} mins")
-                await self.client.async_apply_session_rule(pre_condition=True, pre_condition_length=int(value))
+                await self.client.async_set_target(pre_condition_length=int(value))
 
     async def switch_event_handler(self, entity_id, service):
         """
@@ -890,7 +890,7 @@ class OhmeApiClient:
                 async with self._session.request(
                     method=method,
                     url=f"https://api.ohme.io{url}",
-                    data=json.dumps(data) if data and method in {"PUT", "POST"} else data,
+                    data=json.dumps(data) if data and method in {"PUT", "POST", "PATCH"} else data,
                     headers={
                         "Authorization": f"Firebase {self._token}",
                         "Content-Type": "application/json",
@@ -1064,7 +1064,7 @@ class OhmeApiClient:
         """Enable max charge"""
         result = await self._make_request(
             "PUT",
-            f"/v1/chargeSessions/{self.serial}/rule?maxCharge=" + str(state).lower(),
+            f"/v2/charge-devices/{self.serial}/charge-sessions/active/{self.serial}/max-charge?enabled=" + str(state).lower(),
         )
         return bool(result)
 
@@ -1079,48 +1079,6 @@ class OhmeApiClient:
             await self.async_max_charge(False)
         elif mode is ChargerMode.PAUSED:
             await self.async_pause_charge()
-
-    async def async_apply_session_rule(
-        self,
-        max_price: Optional[float] = None,
-        target_time: Optional[tuple[int, int]] = None,
-        target_percent: Optional[int] = None,
-        pre_condition: Optional[bool] = None,
-        pre_condition_length: Optional[int] = None,
-    ) -> bool:
-        """Apply rule to ongoing charge/stop max charge."""
-        # Check every property. If we've provided it, use that. If not, use the existing.
-        if max_price is None:
-            if "settings" in self._last_rule and self._last_rule["settings"] is not None and len(self._last_rule["settings"]) > 1:
-                max_price = self._last_rule["settings"][0]["enabled"]
-            else:
-                max_price = False
-
-        if target_percent is None:
-            target_percent = self._last_rule["targetPercent"] if "targetPercent" in self._last_rule else 80
-
-        if pre_condition is None:
-            pre_condition = self._last_rule["preconditioningEnabled"] if "preconditioningEnabled" in self._last_rule else False
-
-        if not pre_condition_length:
-            pre_condition_length = self._last_rule["preconditionLengthMins"] if ("preconditionLengthMins" in self._last_rule and self._last_rule["preconditionLengthMins"] is not None) else 30
-
-        if target_time is None:
-            # Default to 9am
-            target_time_cache = self._last_rule["targetTime"] if "targetTime" in self._last_rule else 32400
-            target_time = (target_time_cache // 3600, (target_time_cache % 3600) // 60)
-
-        target_ts = int(time_next_occurs(target_time[0], target_time[1]).timestamp() * 1000)
-
-        # Convert these to string form
-        max_price_str = "true" if max_price else "false"
-        pre_condition_str = "true" if pre_condition else "false"
-
-        result = await self._make_request(
-            "PUT",
-            f"/v1/chargeSessions/{self.serial}/rule?enableMaxPrice={max_price_str}&targetTs={target_ts}&enablePreconditioning={pre_condition_str}&toPercent={target_percent}&preconditionLengthMins={pre_condition_length}",
-        )
-        return bool(result)
 
     async def async_change_price_cap(self, enabled: Optional[bool] = None, cap: Optional[float] = None) -> bool:
         """Change price cap settings."""
@@ -1169,25 +1127,39 @@ class OhmeApiClient:
         target_time: Optional[tuple[int, int]] = None,
         pre_condition_length: Optional[int] = None,
     ) -> bool:
-        """Set a target time/percentage."""
-        pre_condition: Optional[bool] = None
-        if pre_condition_length is not None:
-            pre_condition = bool(pre_condition_length)
+        """Set a target time/percentage/preconditioning on the applicable rule.
 
-        if self._charge_in_progress():
-            await self.async_apply_session_rule(
-                target_time=target_time,
-                target_percent=target_percent,
-                pre_condition=pre_condition,
-                pre_condition_length=pre_condition_length,
-            )
-        else:
-            await self.async_update_schedule(
-                target_time=target_time,
-                target_percent=target_percent,
-                pre_condition=pre_condition,
-                pre_condition_length=pre_condition_length,
-            )
+        Upstream moved this from a PUT against the now-dead /v1/chargeSessions/{id}/rule (which
+        served both an in-progress session and the next scheduled one, chosen by
+        _charge_in_progress()) to a single PATCH against /v2/users/me/charge-rules/{id} that works
+        for either case - the id itself already resolves to whichever rule is live (issue #4719).
+        async_update_schedule (PUT /v1/chargeRules/{id}) is untouched upstream and still used for
+        the next-session case elsewhere, so it is kept as-is alongside this.
+        """
+        data: dict = {}
+
+        if target_percent is not None:
+            data["targetPercent"] = target_percent
+
+        if target_time is not None:
+            data["targetTime"] = (target_time[0] * 3600) + (target_time[1] * 60)
+
+        if pre_condition_length is not None:
+            data["preconditioning"] = {
+                "enabled": pre_condition_length > 0,
+                "lengthMins": pre_condition_length or 15,
+                "temperature": None,
+            }
+
+        session_id = self._last_rule.get("id")
+        if session_id is None:
+            session_id = self._next_session.get("id")
+
+        await self._make_request(
+            "PATCH",
+            f"/v2/users/me/charge-rules/{session_id}?persist=true&recalculateSession=true",
+            data=data,
+        )
         return True
 
     async def async_set_configuration_value(self, values: Mapping[str, bool]) -> bool:

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -775,7 +775,7 @@ def _test_ohme_client_async_max_charge_enable(my_predbat=None):
     # Check request was logged
     last_request = client.request_log[-1]
     assert last_request["method"] == "PUT", f"Expected PUT, got {last_request['method']}"
-    assert "maxCharge=true" in last_request["url"], f"Expected maxCharge=true in URL, got {last_request['url']}"
+    assert "enabled=true" in last_request["url"], f"Expected enabled=true in URL, got {last_request['url']}"
 
     print("PASS: async_max_charge enables max charge")
     return 0
@@ -794,7 +794,7 @@ def _test_ohme_client_async_max_charge_disable(my_predbat=None):
 
     # Check request was logged
     last_request = client.request_log[-1]
-    assert "maxCharge=false" in last_request["url"], f"Expected maxCharge=false in URL, got {last_request['url']}"
+    assert "enabled=false" in last_request["url"], f"Expected enabled=false in URL, got {last_request['url']}"
 
     print("PASS: async_max_charge disables max charge")
     return 0
@@ -811,16 +811,20 @@ def _test_ohme_client_async_set_target(my_predbat=None):
         "power": {"watt": 7200},
         "appliedRule": {"targetPercent": 80}
     }
-    client._last_rule = {"targetPercent": 80, "targetTime": 25200, "preconditioningEnabled": False}
+    client._last_rule = {"id": "RULE-456", "targetPercent": 80, "targetTime": 25200, "preconditioningEnabled": False}
 
     result = run_async(client.async_set_target(target_percent=90, target_time=(8, 30)))
 
     assert result == True, f"Expected True, got {result}"
 
-    # Check request was logged
+    # Check request was logged - a PATCH against the rule id from _last_rule, with the changed
+    # fields in the JSON body rather than the URL (#4719: the old PUT-with-query-params rule
+    # endpoint was withdrawn upstream)
     last_request = client.request_log[-1]
-    assert last_request["method"] == "PUT", f"Expected PUT, got {last_request['method']}"
-    assert "toPercent=90" in last_request["url"], f"Expected toPercent=90 in URL, got {last_request['url']}"
+    assert last_request["method"] == "PATCH", f"Expected PATCH, got {last_request['method']}"
+    assert "/v2/users/me/charge-rules/RULE-456" in last_request["url"], f"Expected the rule id in the URL, got {last_request['url']}"
+    assert last_request["data"]["targetPercent"] == 90, f"Expected targetPercent=90 in the body, got {last_request['data']}"
+    assert last_request["data"]["targetTime"] == 30600, f"Expected targetTime=30600 in the body, got {last_request['data']}"
 
     print("PASS: async_set_target sets target for active session")
     return 0
@@ -1338,7 +1342,7 @@ def _test_ohme_client_async_set_mode_max_charge(my_predbat=None):
     # Check request was made to enable max charge
     last_request = client.request_log[-1]
     assert last_request["method"] == "PUT", f"Expected PUT, got {last_request['method']}"
-    assert "maxCharge=true" in last_request["url"], f"Expected maxCharge=true in URL, got {last_request['url']}"
+    assert "enabled=true" in last_request["url"], f"Expected enabled=true in URL, got {last_request['url']}"
 
     print("PASS: async_set_mode correctly enables MAX_CHARGE")
     return 0
@@ -1357,7 +1361,7 @@ def _test_ohme_client_async_set_mode_smart_charge(my_predbat=None):
     # Check request was made to disable max charge
     last_request = client.request_log[-1]
     assert last_request["method"] == "PUT", f"Expected PUT, got {last_request['method']}"
-    assert "maxCharge=false" in last_request["url"], f"Expected maxCharge=false in URL, got {last_request['url']}"
+    assert "enabled=false" in last_request["url"], f"Expected enabled=false in URL, got {last_request['url']}"
 
     print("PASS: async_set_mode correctly enables SMART_CHARGE")
     return 0
@@ -1395,7 +1399,7 @@ def _test_ohme_client_async_set_mode_string(my_predbat=None):
     # Check request was made to disable max charge
     last_request = client.request_log[-1]
     assert last_request["method"] == "PUT", f"Expected PUT, got {last_request['method']}"
-    assert "maxCharge=false" in last_request["url"], f"Expected maxCharge=false in URL, got {last_request['url']}"
+    assert "enabled=false" in last_request["url"], f"Expected enabled=false in URL, got {last_request['url']}"
 
     print("PASS: async_set_mode correctly handles string mode")
     return 0
@@ -1781,7 +1785,7 @@ def _test_ohme_control_edge_triggered(my_predbat=None):
     # Entering the window sets max charge once
     run_async(api.control_charge())
     assert len(api.client.request_log) == 1, f"Expected one command, got {api.client.request_log}"
-    assert "maxCharge=true" in api.client.request_log[0]["url"], f"Expected max charge, got {api.client.request_log[0]['url']}"
+    assert "enabled=true" in api.client.request_log[0]["url"], f"Expected max charge, got {api.client.request_log[0]['url']}"
 
     # Still inside it, and the charger already agrees - no repeat command
     api.client._charge_session = {"mode": "MAX_CHARGE"}
@@ -1821,7 +1825,7 @@ def _test_ohme_control_reapplies_on_drift(my_predbat=None):
     run_async(api.control_charge())
 
     assert len(api.client.request_log) == 2, f"Expected the change to be corrected, got {api.client.request_log}"
-    assert "maxCharge=true" in api.client.request_log[1]["url"], f"Expected max charge re-applied, got {api.client.request_log[1]['url']}"
+    assert "enabled=true" in api.client.request_log[1]["url"], f"Expected max charge re-applied, got {api.client.request_log[1]['url']}"
     assert any("changed away from what Predbat set" in msg for msg in api.log_messages), f"Expected a drift log, got {api.log_messages}"
 
     # An unplugged charger has nothing to correct
@@ -1848,7 +1852,7 @@ def _test_ohme_control_read_only_release(my_predbat=None):
     api.base.set_read_only = True
     run_async(api.control_charge())
     assert any("releasing the charger back to Ohme" in msg for msg in api.log_messages), f"Expected a release log, got {api.log_messages}"
-    assert "maxCharge=false" in api.client.request_log[-1]["url"], f"Expected max charge cleared, got {api.client.request_log[-1]['url']}"
+    assert "enabled=false" in api.client.request_log[-1]["url"], f"Expected max charge cleared, got {api.client.request_log[-1]['url']}"
     assert api.control_charging is None, "Expected tracked state cleared after releasing"
 
     # Staying in read only must not keep sending commands
@@ -1861,7 +1865,7 @@ def _test_ohme_control_read_only_release(my_predbat=None):
     api.base.set_read_only = False
     run_async(api.control_charge())
     assert len(api.client.request_log) == count + 1, f"Expected control to resume, got {api.client.request_log}"
-    assert "maxCharge=true" in api.client.request_log[-1]["url"], f"Expected max charge re-applied, got {api.client.request_log[-1]['url']}"
+    assert "enabled=true" in api.client.request_log[-1]["url"], f"Expected max charge re-applied, got {api.client.request_log[-1]['url']}"
     assert any("Read only mode cleared" in msg for msg in api.log_messages), f"Expected a resume log, got {api.log_messages}"
 
     print("PASS: read only released and resumed the charger")
@@ -1877,20 +1881,20 @@ def _test_ohme_control_restores_target(my_predbat=None):
     api = _ohme_control_api(windows=[window], now=tz.localize(datetime.datetime(2026, 8, 22, 23, 30)))
     # The user's own target, which max charge overrides while Predbat is in control
     api.client._charge_session = {"mode": "SMART_CHARGE", "power": {"watt": 0}, "appliedRule": {"targetPercent": 70, "targetTime": 25200}}
-    api.client._last_rule = {"targetPercent": 70}
+    api.client._last_rule = {"id": "RULE-70", "targetPercent": 70}
 
     run_async(api.control_charge())
     assert api.control_saved_target == 70, f"Expected the target to be snapshotted before max charge, got {api.control_saved_target}"
 
     # Snapshot must be taken before the max charge command, not after it
-    assert "maxCharge=true" in api.client.request_log[0]["url"], f"Expected max charge, got {api.client.request_log[0]['url']}"
+    assert "enabled=true" in api.client.request_log[0]["url"], f"Expected max charge, got {api.client.request_log[0]['url']}"
 
     # Releasing puts the user's target back so Ohme's own schedule is left correct
     api.base.set_read_only = True
     run_async(api.control_charge())
 
-    urls = [request["url"] for request in api.client.request_log]
-    assert any("toPercent=70" in url for url in urls), f"Expected the target to be restored, got {urls}"
+    restore_requests = [request for request in api.client.request_log if request["method"] == "PATCH"]
+    assert any(request["data"].get("targetPercent") == 70 for request in restore_requests), f"Expected the target to be restored, got {restore_requests}"
     assert api.control_saved_target is None, "Expected the saved target to be cleared after restoring"
     assert any("Restored the charger target to 70%" in msg for msg in api.log_messages), f"Expected a restore log, got {api.log_messages}"
 
@@ -2817,7 +2821,7 @@ def _test_ohme_select_event_handler_target_time(my_predbat=None):
 
     # Setup client with test data
     api.client._charge_session = {"mode": "SMART_CHARGE"}
-    api.client._last_rule = {"targetTime": 25200}  # 07:00
+    api.client._last_rule = {"id": "RULE-TIME", "targetTime": 25200}  # 07:00
 
     # Call select_event_handler with valid target time
     run_async(api.select_event_handler("select.predbat_ohme_target_time", "08:30"))
@@ -2825,9 +2829,9 @@ def _test_ohme_select_event_handler_target_time(my_predbat=None):
     # Verify request was made
     assert len(api.client.request_log) == 1, f"Expected 1 request, got {len(api.client.request_log)}"
     request = api.client.request_log[0]
-    assert request["method"] == "PUT", f"Expected PUT request, got {request['method']}"
-    assert "/v1/chargeSessions/" in request["url"], f"Expected chargeSessions URL, got {request['url']}"
-    assert "targetTs=" in request["url"], f"Expected targetTs in URL, got {request['url']}"
+    assert request["method"] == "PATCH", f"Expected PATCH request, got {request['method']}"
+    assert "/v2/users/me/charge-rules/RULE-TIME" in request["url"], f"Expected charge-rules URL, got {request['url']}"
+    assert request["data"]["targetTime"] == 30600, f"Expected targetTime=30600 (08:30) in the body, got {request['data']}"
 
     # Verify log message
     assert len(api.log_messages) == 1, f"Expected 1 log message, got {len(api.log_messages)}"
@@ -2871,7 +2875,7 @@ def _test_ohme_number_event_handler_target_soc(my_predbat=None):
 
     # Setup client with test data
     api.client._charge_session = {"mode": "SMART_CHARGE"}
-    api.client._last_rule = {"targetPercent": 80}
+    api.client._last_rule = {"id": "RULE-80", "targetPercent": 80}
 
     # Call number_event_handler with valid target SoC
     run_async(api.number_event_handler("number.predbat_ohme_target_percent", 90))
@@ -2879,8 +2883,8 @@ def _test_ohme_number_event_handler_target_soc(my_predbat=None):
     # Verify request was made
     assert len(api.client.request_log) == 1, f"Expected 1 request, got {len(api.client.request_log)}"
     request = api.client.request_log[0]
-    assert request["method"] == "PUT", f"Expected PUT request, got {request['method']}"
-    assert "toPercent=90" in request["url"], f"Expected toPercent=90 in URL, got {request['url']}"
+    assert request["method"] == "PATCH", f"Expected PATCH request, got {request['method']}"
+    assert request["data"]["targetPercent"] == 90, f"Expected targetPercent=90 in the body, got {request['data']}"
 
     print("PASS: number_event_handler correctly handles target_soc")
     return 0
@@ -2901,8 +2905,8 @@ def _test_ohme_number_event_handler_matches_published_entities(my_predbat=None):
         "batterySoc": {"wh": 15000, "percent": 75},
         "allSessionSlots": [],
     }
-    api.client._next_session = {"targetPercent": 80, "targetTime": 25200}
-    api.client._last_rule = {"targetPercent": 80, "preconditioningEnabled": True, "preconditionLengthMins": 30}
+    api.client._next_session = {"id": "NEXT-80", "targetPercent": 80, "targetTime": 25200}
+    api.client._last_rule = {"id": "RULE-80", "targetPercent": 80, "preconditioningEnabled": True, "preconditionLengthMins": 30}
     api.client._cars = [{"name": "Tesla Model 3"}]
     run_async(api.publish_data())
 
@@ -2919,7 +2923,7 @@ def _test_ohme_number_event_handler_matches_published_entities(my_predbat=None):
     # Specifically check the target percent value reaches the rule
     api.client.request_log = []
     run_async(api.number_event_handler("number.predbat_ohme_target_percent", 65))
-    assert "toPercent=65" in api.client.request_log[0]["url"], f"Expected toPercent=65, got {api.client.request_log[0]['url']}"
+    assert api.client.request_log[0]["data"]["targetPercent"] == 65, f"Expected targetPercent=65 in the body, got {api.client.request_log[0]}"
 
     print(f"PASS: all {len(published)} published number entities are handled")
     return 0
@@ -2959,7 +2963,7 @@ def _test_ohme_number_event_handler_preconditioning(my_predbat=None):
 
     # Setup client with test data
     api.client._charge_session = {"mode": "SMART_CHARGE"}
-    api.client._last_rule = {"preconditioningEnabled": False, "preconditionLengthMins": 30}
+    api.client._last_rule = {"id": "RULE-9", "preconditioningEnabled": False, "preconditionLengthMins": 30}
 
     # Call number_event_handler with preconditioning length
     run_async(api.number_event_handler("number.predbat_ohme_preconditioning", 45))
@@ -2967,9 +2971,9 @@ def _test_ohme_number_event_handler_preconditioning(my_predbat=None):
     # Verify request was made
     assert len(api.client.request_log) == 1, f"Expected 1 request, got {len(api.client.request_log)}"
     request = api.client.request_log[0]
-    assert request["method"] == "PUT", f"Expected PUT request, got {request['method']}"
-    assert "preconditionLengthMins=45" in request["url"], f"Expected preconditionLengthMins=45, got {request['url']}"
-    assert "enablePreconditioning=true" in request["url"], f"Expected enablePreconditioning=true, got {request['url']}"
+    assert request["method"] == "PATCH", f"Expected PATCH request, got {request['method']}"
+    assert request["data"]["preconditioning"]["lengthMins"] == 45, f"Expected preconditioning lengthMins=45, got {request['data']}"
+    assert request["data"]["preconditioning"]["enabled"] is True, f"Expected preconditioning enabled=True, got {request['data']}"
 
     # Verify log message
     assert len(api.log_messages) == 1, f"Expected 1 log message, got {len(api.log_messages)}"
@@ -3046,7 +3050,7 @@ def _test_ohme_switch_event_handler_max_charge_on(my_predbat=None):
     assert len(api.client.request_log) == 1, f"Expected 1 request, got {len(api.client.request_log)}"
     request = api.client.request_log[0]
     assert request["method"] == "PUT", f"Expected PUT request, got {request['method']}"
-    assert "maxCharge=true" in request["url"], f"Expected maxCharge=true, got {request['url']}"
+    assert "enabled=true" in request["url"], f"Expected enabled=true, got {request['url']}"
 
     print("PASS: switch_event_handler correctly handles max_charge turn_on")
     return 0
@@ -3069,7 +3073,7 @@ def _test_ohme_switch_event_handler_max_charge_off(my_predbat=None):
     assert len(api.client.request_log) == 1, f"Expected 1 request, got {len(api.client.request_log)}"
     request = api.client.request_log[0]
     assert request["method"] == "PUT", f"Expected PUT request, got {request['method']}"
-    assert "maxCharge=false" in request["url"], f"Expected maxCharge=false, got {request['url']}"
+    assert "enabled=false" in request["url"], f"Expected enabled=false, got {request['url']}"
 
     print("PASS: switch_event_handler correctly handles max_charge turn_off")
     return 0


### PR DESCRIPTION
## Summary

Fixes #4719. Predbat vendors a copy of `dan-r/ohmepy` pinned at 1.5.1. Upstream moved these two calls to v2 endpoints in 1.6.0 ("Move to v2 API for setting charge target") and withdrew the v1 routes server-side, so Predbat-led charge control has been returning HTTP 404 for every user with `ohme_control: true` since it shipped two days ago (v8.52.0).

- `async_max_charge`: `PUT /v1/chargeSessions/{id}/rule?maxCharge=` (dead) -> `PUT /v2/charge-devices/{id}/charge-sessions/active/{id}/max-charge?enabled=`
- `async_apply_session_rule` (dead endpoint, same `/rule` path) removed entirely. Its four callers (target time, target percent, preconditioning on/off) now go through `async_set_target`, rewritten to match upstream's replacement: a single `PATCH /v2/users/me/charge-rules/{id}` with a JSON body, rather than branching on whether a charge is in progress to pick between the old `PUT .../rule` and `PUT /v1/chargeRules/{id}` - the rule id upstream resolves to already accounts for that. `async_update_schedule` (`PUT /v1/chargeRules/{id}`) is untouched upstream and kept as-is.
- `_make_request` only JSON-encoded the request body for PUT/POST, not PATCH - would have sent a raw dict as the body for the new call and failed regardless of the URL fix. Added PATCH to the set, matching upstream's own `_make_request`.
- The old preconditioning-off path passed `pre_condition=True` (inverted) to `async_apply_session_rule` - moot now since the new signature has no such parameter, disabled state is derived from `pre_condition_length == 0` instead.

## Scope

Deliberately tight to what this issue needs. Predbat's vendored copy is four releases behind upstream (1.5.1 vs current 1.9.1), and those releases include unrelated changes (e.g. an `advancedSettings`/CT-clamp removal in 1.6.0) that are not touched here - this is not a full re-vendor, and `VERSION` is left at `1.5.1` rather than claimed otherwise.

## Verification

Implemented against upstream `ohmepy`'s current source (`dan-r/ohmepy` on GitHub), not a live Ohme account - there's no way to verify the exact v2 request/response shapes without one. Asked the reporter (@danmoo117) in #4719 to test against their Home Pro before this merges.

One related gap: the `_make_request` PATCH fix isn't exercised by the existing test suite, since `MockOhmeApiClient` overrides `_make_request` entirely rather than testing the real implementation's request-building logic. Low risk (single-line, matches upstream's own tested code exactly) but flagging it rather than claiming full coverage.

## Test plan

- [x] `./run_all --test ohme` passes
- [x] `./run_pre_commit` passes (ruff, black, cspell, markdownlint, full test suite)
- [ ] Reporter confirms against a live Home Pro (blocking merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)