### PR TITLE
Add bot PR flow: BOT_PR label triggers implementation + draft PR

### DIFF
--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -37,14 +37,16 @@ Fetch it with `gh issue view <number> --json title,body,labels,comments`. The bo
 
 ## 4. Quality gate
 
-Both of these must pass before you continue to step 5:
+Both of these must pass before you continue to step 5. `run_pre_commit` must run with `coverage/` as the working directory (it sources `coverage/setup.csh` internally); `tools/triage_test.sh` must run from the repo root. Change directory explicitly for each rather than assuming where you're left afterwards:
 
 ```bash
-cd coverage && ./run_pre_commit
+cd coverage
+./run_pre_commit
+cd ..
 tools/triage_test.sh <name> <scratch>/test.log
 ```
 
-Use the test module named in the triage comment, or the one `TEST_REGISTRY` maps to the area you changed. If there's no clean single-module mapping, run `./run_all --quick` instead (from `coverage/`) rather than guessing at a module name.
+Use the test module named in the triage comment, or the one `TEST_REGISTRY` maps to the area you changed. If there's no clean single-module mapping, run `./run_all --quick` instead (from `coverage/`, same as above) rather than guessing at a module name.
 
 If either fails, stop here — do not commit, push, or open a PR. Go to step 7 and report what failed.
 
@@ -53,11 +55,13 @@ If either fails, stop here — do not commit, push, or open a PR. Go to step 7 a
 Branch name: `fix/<slug>-<issue-number>` for a `bug` classification, `feat/<slug>-<issue-number>` for `enhancement` — matching this repo's existing convention (e.g. `fix/solis-tou-bit-refused-4707`). `<slug>` is a short kebab-case description of the change.
 
 ```bash
-git checkout -b fix/<slug>-<issue-number>
+git checkout -B fix/<slug>-<issue-number>
 git add <changed files>
 git commit -m "<one-line summary of the fix>"
 git push -u origin fix/<slug>-<issue-number>
 ```
+
+`-B` rather than `-b`: if a previous attempt reached branch creation and then failed on push or PR creation, the local branch is left behind, and a retry's plain `-b` would fail with "branch already exists." `-B` resets it to the current `HEAD` instead, so a retry always starts clean.
 
 Never push to `main`, and never force-push.
 

--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -64,7 +64,7 @@ Never push to `main`, and never force-push.
 ## 6. Open the draft PR
 
 ```bash
-gh pr create --draft --reviewer springfall2008 \
+gh pr create --draft --assignee springfall2008 \
   --title "<one-line summary>" \
   --body "$(cat <<'EOF'
 This is an automated draft PR generated from issue #<issue-number> — a maintainer should review it before merging.

--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -40,7 +40,7 @@ Fetch it with `gh issue view <number> --json title,body,labels,comments`. The bo
 Both of these must pass before you continue to step 5:
 
 ```bash
-./run_pre_commit
+cd coverage && ./run_pre_commit
 tools/triage_test.sh <name> <scratch>/test.log
 ```
 

--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: issue-pr
+description: Implement the fix or feature described in an already-triaged batpred GitHub issue and open a draft pull request referencing it, for maintainer review.
+allowed-tools: You can view and edit files in this repo, write code and tests, run local tests and pre-commit, commit and push a new branch, and open a draft pull request with 'gh'. Do not merge, close, or push directly to main.
+---
+
+# Issue PR
+
+You are implementing the fix or feature described in one already-triaged GitHub issue on `springfall2008/batpred`, and opening a draft pull request for maintainer review. The working directory is the same dedicated local clone the triage skill uses — investigate and work using it directly.
+
+Arguments: `<issue-number> [scratch=<dir>]`, same convention as `/issue-triage`. If no `scratch=` is given (an interactive invocation), use `/tmp/predbat-triage/<issue-number>` and `mkdir -p` it yourself.
+
+This skill assumes the issue has already been triaged — the daemon only invokes it once that's confirmed. Read the existing triage comment before doing anything else.
+
+## 1. Read the ticket
+
+Fetch it with `gh issue view <number> --json title,body,labels,comments`. The bot's own triage comment (opens with "automated first-pass triage") already has the classification, priority, and any root-cause pointer — start from there rather than re-investigating from scratch.
+
+## 2. Investigate
+
+- Sync the clone first, so you are reading the code you think you are:
+
+  ```bash
+  git fetch origin main && git reset --hard origin/main && git clean -fd
+  git describe --tags
+  ```
+
+- Read [../issue-triage/references/debug-journal.md](../issue-triage/references/debug-journal.md) before forming an implementation approach — it maps common symptoms to modules and records known per-integration behaviour from past investigations. Its entries are dated observations, not current truth — confirm anything you rely on against the working tree.
+- Read the relevant source area named in the triage comment's root-cause pointer, or that the issue's classification points to.
+- Check `git log`/`git blame` on that area — the triage comment may already cover this, but confirm nothing has changed on `main` since triage ran.
+
+## 3. Implement
+
+- Write the fix or feature following this repo's conventions (`CLAUDE.md`, already loaded automatically for this session): `lower_case_with_underscores` naming, 256-character line length, a one-line docstring on every new function or class.
+- Add or update a unit test for the change, in the matching `apps/predbat/tests/test_<feature>.py` module (registered in `TEST_REGISTRY` in `apps/predbat/unit_test.py` if it's a new module) — `CLAUDE.md` requires unit tests for all new code, no exceptions for bot-authored ones.
+- Keep the change scoped to what the issue describes. Don't refactor unrelated code, even if you notice something else worth fixing.
+
+## 4. Quality gate
+
+Both of these must pass before you continue to step 5:
+
+```bash
+./run_pre_commit
+tools/triage_test.sh <name> <scratch>/test.log
+```
+
+Use the test module named in the triage comment, or the one `TEST_REGISTRY` maps to the area you changed. If there's no clean single-module mapping, run `./run_all --quick` instead (from `coverage/`) rather than guessing at a module name.
+
+If either fails, stop here — do not commit, push, or open a PR. Go to step 7 and report what failed.
+
+## 5. Branch, commit, push
+
+Branch name: `fix/<slug>-<issue-number>` for a `bug` classification, `feat/<slug>-<issue-number>` for `enhancement` — matching this repo's existing convention (e.g. `fix/solis-tou-bit-refused-4707`). `<slug>` is a short kebab-case description of the change.
+
+```bash
+git checkout -b fix/<slug>-<issue-number>
+git add <changed files>
+git commit -m "<one-line summary of the fix>"
+git push -u origin fix/<slug>-<issue-number>
+```
+
+Never push to `main`, and never force-push.
+
+## 6. Open the draft PR
+
+```bash
+gh pr create --draft --reviewer springfall2008 \
+  --title "<one-line summary>" \
+  --body "$(cat <<'EOF'
+This is an automated draft PR generated from issue #<issue-number> — a maintainer should review it before merging.
+
+Fixes #<issue-number>
+
+## Summary
+
+<what changed and why, in a sentence or two>
+
+## Testing
+
+<what you ran in step 4 and its result>
+
+## Notes
+
+<a debug-journal.md reference if one informed the approach, otherwise omit this section>
+EOF
+)"
+```
+
+This is the last step on success — there is nothing further to report; the daemon detects the new PR itself.
+
+## 7. On failure
+
+If step 4's quality gate failed, or an earlier step couldn't proceed (e.g. the fix genuinely needs information only a maintainer has), post exactly one comment on the issue via `gh issue comment <number> --body "..."` explaining plainly what you attempted and what failed — never word it so a skipped step reads as one you completed (same guardrail as the triage skill). Then stop. Do not commit, push, or open a PR — the daemon detects this outcome itself by finding no PR referencing the issue afterwards.
+
+## Guardrails
+
+- Never push to `main` or force-push.
+- Never merge, close, or edit an existing PR.
+- Never remove a label a human applied.
+- The PR is always a draft — never open it as ready-for-review.
+- If a command you needed was blocked by permissions, say plainly in the failure comment what you could not do.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -94,6 +94,8 @@ Check existing comments first — if one from you is already there, stop; don't 
 
 Post exactly one comment via `gh issue comment <number> --body "..."`, opening with a line disclosing this is an automated first-pass triage (a maintainer will review before any action is taken), followed by: classification, priority (if set), what you investigated and found (including test result if you ran one), a root-cause pointer if you have one, and any information request.
 
+After posting, apply the `BOT_TRIAGED` label via `gh issue edit <number> --add-label BOT_TRIAGED` — every triage run gets this label, including a duplicate-close, regardless of classification. It marks the issue as triaged for the separate PR-creation flow (see `.claude/skills/issue-pr/SKILL.md`).
+
 ## Guardrails
 
 - Analysis only: no commits, no pushes, no PRs, no code changes that leave this clone.

--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -615,6 +615,7 @@ unpickles
 unpushed
 unsmoothed
 unstaged
+untriaged
 urandom
 urlsafe
 uscapacity

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,12 @@ repos:
     language: python
     entry: python .cspell/sort_dictionary.py
     files: ^\.cspell\/custom-dictionary-workspace\.txt$
+  - id: triage-daemon-tests
+    name: triage daemon unit tests
+    language: python
+    entry: python tools/test_triage_daemon.py
+    files: ^tools/(triage_daemon\.py|test_triage_daemon\.py)$
+    pass_filenames: false
 - repo: https://gitlab.com/bmares/check-json5
   rev: v1.0.0
   hooks:

--- a/docs/superpowers/plans/2026-08-25-bot-pr-flow.md
+++ b/docs/superpowers/plans/2026-08-25-bot-pr-flow.md
@@ -1,0 +1,1253 @@
+# Bot PR Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Tasks 12 and 13 are explicitly **not** for automated execution — see their headers.
+
+**Goal:** Extend the issue-triage bot so that adding the `BOT_PR` label to an already-triaged GitHub issue makes it implement the fix/feature and open a draft PR for maintainer review.
+
+**Architecture:** `tools/triage_daemon.py` gains a second poll (issues labelled `BOT_PR`) alongside its existing new-issue poll, orchestrating a precondition check, a duplicate-work guard, and a new `/issue-pr` skill invocation under a separate, more permissive tool allowlist. State lives entirely in GitHub labels (`BOT_TRIAGED`, `BOT_PR_OPENED`, `BOT_PR_FAILED`) — no new fields in `state.json`. Success/failure is judged by re-checking for the PR afterwards, not by the invocation's exit code.
+
+**Tech Stack:** Python 3 stdlib (`subprocess`, `json`, `pathlib`, `unittest`, `unittest.mock`), `gh` CLI, Claude Code CLI (`claude -p`), pre-commit.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md`
+
+## Global Constraints
+
+- Line length: 256 chars (Black), 250 chars (Flake8).
+- Docstrings: one-line docstring on every new function (100% coverage required per CLAUDE.md's `interrogate` policy).
+- British English spelling in all prose/comments/docstrings (e.g. "labelled" not "labeled", "behaviour" not "behavior") — this repo enforces `en-gb` via CSpell.
+- Variable naming: `lower_case_with_underscores`.
+- Unit tests required for all new code (CLAUDE.md).
+- `tools/triage_daemon.py` and its test file have no dependency on `apps/predbat` — do not import from it, and do not register the new tests in `TEST_REGISTRY`/`run_all`.
+- Every `subprocess.run` call in `tools/triage_daemon.py` uses `check=True` unless the call's own failure is meaningful to the caller (matches the existing pattern in the file).
+
+---
+
+## Task 1: Apply `BOT_TRIAGED` label from the existing triage skill
+
+**Files:**
+- Modify: `.claude/skills/issue-triage/SKILL.md:91-95` (step 9)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: every future triage run applies the `BOT_TRIAGED` label — later tasks' `is_already_triaged()` (Task 4) depends on this label existing on newly-triaged issues.
+
+- [ ] **Step 1: Edit step 9 of the skill**
+
+Find this text in `.claude/skills/issue-triage/SKILL.md`:
+
+```markdown
+## 9. Post one comment
+
+Check existing comments first — if one from you is already there, stop; don't post again.
+
+Post exactly one comment via `gh issue comment <number> --body "..."`, opening with a line disclosing this is an automated first-pass triage (a maintainer will review before any action is taken), followed by: classification, priority (if set), what you investigated and found (including test result if you ran one), a root-cause pointer if you have one, and any information request.
+```
+
+Replace it with:
+
+```markdown
+## 9. Post one comment
+
+Check existing comments first — if one from you is already there, stop; don't post again.
+
+Post exactly one comment via `gh issue comment <number> --body "..."`, opening with a line disclosing this is an automated first-pass triage (a maintainer will review before any action is taken), followed by: classification, priority (if set), what you investigated and found (including test result if you ran one), a root-cause pointer if you have one, and any information request.
+
+After posting, apply the `BOT_TRIAGED` label via `gh issue edit <number> --add-label BOT_TRIAGED` — every triage run gets this label, including a duplicate-close, regardless of classification. It marks the issue as triaged for the separate PR-creation flow (see `.claude/skills/issue-pr/SKILL.md`).
+```
+
+- [ ] **Step 2: Verify**
+
+Read the file back and confirm the new paragraph reads correctly after step 9's existing content, before the `## Guardrails` section.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/issue-triage/SKILL.md
+git commit -m "feat(issue-triage): apply BOT_TRIAGED label after posting the triage comment"
+```
+
+---
+
+## Task 2: Test file skeleton and characterisation tests for existing functions
+
+**Files:**
+- Create: `tools/test_triage_daemon.py`
+
+**Interfaces:**
+- Consumes: `triage_daemon.load_state`, `triage_daemon.save_state`, `triage_daemon.fetch_new_issues` (all pre-existing, unchanged signatures).
+- Produces: `DaemonPathsTestCase` — a base `unittest.TestCase` that patches `triage_daemon.BASE_DIR`, `STATE_FILE`, `LOG_DIR`, `CLONE_DIR`, `SCRATCH_DIR` onto a temp directory for the duration of a test, exposing `self.state_file` and `self.log_dir`. Every later task's tests that touch daemon paths or `subprocess.run` inherit from this class.
+
+These are **characterisation tests** for code that already exists and already works — there is no red phase for this task. Write each test, run it, and confirm it passes immediately.
+
+- [ ] **Step 1: Write the test file**
+
+```python
+#!/usr/bin/env python3
+"""Unit tests for tools/triage_daemon.py.
+
+Runs standalone, not through coverage/run_all: the daemon has no dependency on
+apps/predbat, so folding these into TEST_REGISTRY would be a layering violation.
+Run directly with `python3 tools/test_triage_daemon.py`. Every gh/git/claude call is
+mocked - nothing here touches a real repo, GitHub, or Claude Code session.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import triage_daemon
+
+
+class DaemonPathsTestCase(unittest.TestCase):
+    """Base class that points the daemon's module-level paths at a scratch temp dir."""
+
+    def setUp(self):
+        """Create a scratch directory and patch the daemon's path constants onto it."""
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        base = Path(self.tmp_dir.name)
+        self.state_file = base / "state.json"
+        self.log_dir = base / "logs"
+        self._patch("BASE_DIR", base)
+        self._patch("STATE_FILE", self.state_file)
+        self._patch("LOG_DIR", self.log_dir)
+        self._patch("CLONE_DIR", base / "batpred")
+        self._patch("SCRATCH_DIR", base / "scratch")
+
+    def _patch(self, name, value):
+        """Patch a module-level constant on triage_daemon for the duration of the test."""
+        patcher = patch.object(triage_daemon, name, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class LoadSaveStateTests(DaemonPathsTestCase):
+    """Characterisation tests for load_state()/save_state() - pre-existing, unchanged."""
+
+    def test_save_then_load_round_trips(self):
+        """A saved state dict is returned unchanged by a subsequent load."""
+        triage_daemon.save_state({"last_processed": 42})
+        self.assertEqual(triage_daemon.load_state(), {"last_processed": 42})
+
+    def test_load_missing_file_returns_default(self):
+        """With no state file yet, load_state() returns the zeroed default."""
+        self.assertEqual(triage_daemon.load_state(), {"last_processed": 0})
+
+    def test_load_corrupt_file_returns_default(self):
+        """A truncated/corrupt state file is treated the same as a missing one."""
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        self.state_file.write_text("{not valid json")
+        self.assertEqual(triage_daemon.load_state(), {"last_processed": 0})
+
+
+class FetchNewIssuesTests(unittest.TestCase):
+    """Characterisation tests for fetch_new_issues() - pre-existing, unchanged."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_filters_and_sorts_by_issue_number(self, mock_run):
+        """Only issues newer than since_number are returned, sorted ascending."""
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps(
+                [
+                    {"number": 10, "createdAt": "2026-01-01T00:00:00Z"},
+                    {"number": 8, "createdAt": "2025-12-01T00:00:00Z"},
+                    {"number": 12, "createdAt": "2026-02-01T00:00:00Z"},
+                ]
+            )
+        )
+        result = triage_daemon.fetch_new_issues(9)
+        self.assertEqual([issue["number"] for issue in result], [10, 12])
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the tests and confirm they pass**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: all 4 tests PASS (no red phase — these characterise existing, already-correct behaviour).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/test_triage_daemon.py
+git commit -m "test(triage_daemon): add test file with characterisation tests for existing functions"
+```
+
+---
+
+## Task 3: `fetch_bot_pr_issues()`
+
+**Files:**
+- Modify: `tools/triage_daemon.py` (add function near `fetch_new_issues`)
+- Modify: `tools/test_triage_daemon.py`
+
+**Interfaces:**
+- Consumes: `REPO` (module constant, pre-existing).
+- Produces: `fetch_bot_pr_issues() -> list[dict]`, each dict shaped `{"number": int, "labels": [{"name": str, ...}, ...]}` — Task 9's `process_bot_pr_issue()` iterates this list directly.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tools/test_triage_daemon.py`, after `FetchNewIssuesTests`:
+
+```python
+class FetchBotPrIssuesTests(unittest.TestCase):
+    """Tests for fetch_bot_pr_issues(), new in the bot PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_queries_open_issues_labelled_bot_pr(self, mock_run):
+        """Calls gh issue list scoped to the BOT_PR label and returns the parsed issues."""
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps([{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}])
+        )
+        result = triage_daemon.fetch_bot_pr_issues()
+        self.assertEqual(result, [{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}])
+        args = mock_run.call_args[0][0]
+        self.assertIn("--label", args)
+        self.assertEqual(args[args.index("--label") + 1], "BOT_PR")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: FAIL with `AttributeError: module 'triage_daemon' has no attribute 'fetch_bot_pr_issues'`
+
+- [ ] **Step 3: Implement**
+
+In `tools/triage_daemon.py`, add directly after `fetch_new_issues()`:
+
+```python
+def fetch_bot_pr_issues():
+    """Return open issues currently labelled BOT_PR, each with its full label list."""
+    result = subprocess.run(
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_PR", "--json", "number,labels"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/triage_daemon.py tools/test_triage_daemon.py
+git commit -m "feat(triage_daemon): add fetch_bot_pr_issues()"
+```
+
+---
+
+## Task 4: BOT_PR precondition check (`ensure_triaged` and helpers)
+
+**Files:**
+- Modify: `tools/triage_daemon.py`
+- Modify: `tools/test_triage_daemon.py`
+
+**Interfaces:**
+- Consumes: nothing new (uses stdlib `subprocess`/`json` already imported).
+- Produces:
+  - `TRIAGE_DISCLOSURE_MARKER` (module constant, str) — the substring identifying a bot triage comment.
+  - `is_already_triaged(labels: list[dict]) -> bool`
+  - `find_triage_comment(issue_number: int) -> bool`
+  - `backfill_triaged_label(issue_number: int) -> None`
+  - `ensure_triaged(issue_number: int, labels: list[dict]) -> bool` — Task 9's `process_bot_pr_issue()` calls this directly.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tools/test_triage_daemon.py`, after `FetchBotPrIssuesTests`:
+
+```python
+class EnsureTriagedTests(unittest.TestCase):
+    """Tests for the BOT_PR precondition check, new in the bot PR flow."""
+
+    def test_is_already_triaged_true_when_label_present(self):
+        """BOT_TRIAGED anywhere in the label list is detected."""
+        self.assertTrue(triage_daemon.is_already_triaged([{"name": "bug"}, {"name": "BOT_TRIAGED"}]))
+
+    def test_is_already_triaged_false_when_label_absent(self):
+        """A label list without BOT_TRIAGED is not mistaken for one."""
+        self.assertFalse(triage_daemon.is_already_triaged([{"name": "bug"}]))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_find_triage_comment_true_when_disclosure_present(self, mock_run):
+        """A comment containing the triage disclosure line counts as already triaged."""
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps({"comments": [{"body": "This is an automated first-pass triage of..."}]})
+        )
+        self.assertTrue(triage_daemon.find_triage_comment(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_find_triage_comment_false_when_no_match(self, mock_run):
+        """Unrelated comments don't count as a triage comment."""
+        mock_run.return_value = MagicMock(stdout=json.dumps({"comments": [{"body": "thanks for the report"}]}))
+        self.assertFalse(triage_daemon.find_triage_comment(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_ensure_triaged_skips_lookup_when_label_present(self, mock_run):
+        """With BOT_TRIAGED already on the issue, no gh calls are made at all."""
+        result = triage_daemon.ensure_triaged(4720, [{"name": "BOT_TRIAGED"}])
+        self.assertTrue(result)
+        mock_run.assert_not_called()
+
+    @patch("triage_daemon.backfill_triaged_label")
+    @patch("triage_daemon.find_triage_comment", return_value=True)
+    def test_ensure_triaged_backfills_when_comment_found(self, mock_find, mock_backfill):
+        """An old issue with a triage comment but no label gets the label backfilled."""
+        result = triage_daemon.ensure_triaged(4720, [{"name": "bug"}])
+        self.assertTrue(result)
+        mock_backfill.assert_called_once_with(4720)
+
+    @patch("triage_daemon.backfill_triaged_label")
+    @patch("triage_daemon.find_triage_comment", return_value=False)
+    def test_ensure_triaged_false_when_neither_found(self, mock_find, mock_backfill):
+        """No label and no comment means /issue-triage still needs to run."""
+        result = triage_daemon.ensure_triaged(4720, [{"name": "bug"}])
+        self.assertFalse(result)
+        mock_backfill.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: FAIL with `AttributeError: module 'triage_daemon' has no attribute 'is_already_triaged'`
+
+- [ ] **Step 3: Implement**
+
+In `tools/triage_daemon.py`, add after `fetch_bot_pr_issues()`:
+
+```python
+TRIAGE_DISCLOSURE_MARKER = "automated first-pass triage"
+
+
+def is_already_triaged(labels):
+    """Return True if BOT_TRIAGED is present in a gh --json labels list."""
+    return any(label["name"] == "BOT_TRIAGED" for label in labels)
+
+
+def find_triage_comment(issue_number):
+    """Return True if the issue already carries a bot triage comment (pre-BOT_TRIAGED-label issues)."""
+    result = subprocess.run(
+        ["gh", "issue", "view", str(issue_number), "--json", "comments"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    comments = json.loads(result.stdout).get("comments", [])
+    return any(TRIAGE_DISCLOSURE_MARKER in comment.get("body", "") for comment in comments)
+
+
+def backfill_triaged_label(issue_number):
+    """Apply BOT_TRIAGED to an issue found to already have a bot triage comment."""
+    subprocess.run(["gh", "issue", "edit", str(issue_number), "--add-label", "BOT_TRIAGED"], check=True)
+
+
+def ensure_triaged(issue_number, labels):
+    """Return True if the issue is (now) marked BOT_TRIAGED; False if /issue-triage still needs to run.
+
+    Checks the label first, then falls back to scanning comments for issues triaged
+    before BOT_TRIAGED existed, backfilling the label onto them when found.
+    """
+    if is_already_triaged(labels):
+        return True
+    if find_triage_comment(issue_number):
+        backfill_triaged_label(issue_number)
+        return True
+    return False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: PASS (11 tests total so far)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/triage_daemon.py tools/test_triage_daemon.py
+git commit -m "feat(triage_daemon): add BOT_PR precondition check (ensure_triaged)"
+```
+
+---
+
+## Task 5: Duplicate-work guard
+
+**Files:**
+- Modify: `tools/triage_daemon.py`
+- Modify: `tools/test_triage_daemon.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `build_duplicate_search_query(issue_number: int) -> str`, `has_existing_pr(issue_number: int) -> bool` — Task 9's `process_bot_pr_issue()` calls `has_existing_pr()` both as the entry guard and as the post-hoc success check.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tools/test_triage_daemon.py`, after `EnsureTriagedTests`:
+
+```python
+class DuplicateGuardTests(unittest.TestCase):
+    """Tests for the duplicate-work guard, new in the bot PR flow."""
+
+    def test_search_query_uses_quoted_fixes_phrase(self):
+        """The query searches the exact quoted phrase, not a bare issue number."""
+        self.assertEqual(triage_daemon.build_duplicate_search_query(4720), '"Fixes #4720" in:body')
+
+    @patch("triage_daemon.subprocess.run")
+    def test_has_existing_pr_true_when_match_found(self, mock_run):
+        """A non-empty search result means a PR already exists for this issue."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 99}]))
+        self.assertTrue(triage_daemon.has_existing_pr(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_has_existing_pr_false_when_no_match(self, mock_run):
+        """An empty search result means no PR exists yet for this issue."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([]))
+        self.assertFalse(triage_daemon.has_existing_pr(4720))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: FAIL with `AttributeError: module 'triage_daemon' has no attribute 'build_duplicate_search_query'`
+
+- [ ] **Step 3: Implement**
+
+In `tools/triage_daemon.py`, add after `ensure_triaged()`:
+
+```python
+def build_duplicate_search_query(issue_number):
+    """Build the gh pr list --search query used to detect an existing PR for an issue.
+
+    Matches the exact "Fixes #N" phrase the issue-pr skill always includes in its PR
+    body, rather than a bare issue number, which could match an unrelated PR.
+    """
+    return f'"Fixes #{issue_number}" in:body'
+
+
+def has_existing_pr(issue_number):
+    """Return True if a PR already references this issue, in any state."""
+    query = build_duplicate_search_query(issue_number)
+    result = subprocess.run(
+        ["gh", "pr", "list", "--search", query, "--state", "all", "--json", "number"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return len(json.loads(result.stdout)) > 0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: PASS (14 tests total so far)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/triage_daemon.py tools/test_triage_daemon.py
+git commit -m "feat(triage_daemon): add duplicate-work guard (has_existing_pr)"
+```
+
+---
+
+## Task 6: Label-swap helpers
+
+**Files:**
+- Modify: `tools/triage_daemon.py`
+- Modify: `tools/test_triage_daemon.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `mark_pr_opened(issue_number: int) -> None`, `mark_pr_failed(issue_number: int) -> None` — Task 9's `process_bot_pr_issue()` calls exactly one of these per run.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tools/test_triage_daemon.py`, after `DuplicateGuardTests`:
+
+```python
+class LabelSwapTests(unittest.TestCase):
+    """Tests for mark_pr_opened/mark_pr_failed, new in the bot PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_opened_swaps_labels(self, mock_run):
+        """Removes BOT_PR and adds BOT_PR_OPENED."""
+        triage_daemon.mark_pr_opened(4720)
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "issue", "edit", "4720", "--remove-label", "BOT_PR", "--add-label", "BOT_PR_OPENED"])
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_failed_swaps_labels(self, mock_run):
+        """Removes BOT_PR and adds BOT_PR_FAILED."""
+        triage_daemon.mark_pr_failed(4720)
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "issue", "edit", "4720", "--remove-label", "BOT_PR", "--add-label", "BOT_PR_FAILED"])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: FAIL with `AttributeError: module 'triage_daemon' has no attribute 'mark_pr_opened'`
+
+- [ ] **Step 3: Implement**
+
+In `tools/triage_daemon.py`, add after `has_existing_pr()`:
+
+```python
+def mark_pr_opened(issue_number):
+    """Swap BOT_PR for BOT_PR_OPENED once the draft PR has been confirmed open."""
+    subprocess.run(
+        ["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_PR", "--add-label", "BOT_PR_OPENED"],
+        check=True,
+    )
+
+
+def mark_pr_failed(issue_number):
+    """Swap BOT_PR for BOT_PR_FAILED so a failed run isn't retried every poll cycle."""
+    subprocess.run(
+        ["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_PR", "--add-label", "BOT_PR_FAILED"],
+        check=True,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: PASS (16 tests total so far)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/triage_daemon.py tools/test_triage_daemon.py
+git commit -m "feat(triage_daemon): add mark_pr_opened/mark_pr_failed label-swap helpers"
+```
+
+---
+
+## Task 7: Permission model — `ALLOWED_TOOLS_PR` / `DISALLOWED_TOOLS_PR`
+
+**Files:**
+- Modify: `tools/triage_daemon.py:83-174` (the existing `ALLOWED_TOOLS`/`DISALLOWED_TOOLS` block)
+- Modify: `tools/test_triage_daemon.py`
+
+**Interfaces:**
+- Consumes: `EDIT_SCOPE`, `SCRATCH_SCOPE` (pre-existing module constants, unchanged).
+- Produces: `ALLOWED_TOOLS` and `DISALLOWED_TOOLS` (pre-existing names, values byte-identical to before this task), plus new `ALLOWED_TOOLS_PR` and `DISALLOWED_TOOLS_PR` (both comma-joined strings, same format `triage()`/Task 8's `create_pr()` already expect from `ALLOWED_TOOLS`/`DISALLOWED_TOOLS`).
+
+This task is a **refactor with no behaviour change** to `ALLOWED_TOOLS`/`DISALLOWED_TOOLS` — it extracts their list literals into named base lists so the PR variants can be derived without duplicating ~50 lines of text. The tests exist specifically to pin that relationship down, since this is the security boundary between "opens a draft PR" and "can merge/close/administer the repo."
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tools/test_triage_daemon.py`, after `LabelSwapTests`:
+
+```python
+class PermissionModelTests(unittest.TestCase):
+    """Regression tests for the ALLOWED_TOOLS/DISALLOWED_TOOLS delta between the
+    read-only triage invocation and the push/PR-create-capable /issue-pr invocation.
+    This boundary should never drift silently."""
+
+    def test_triage_allowed_tools_still_contains_the_broad_gh_grant(self):
+        """Sanity check that the refactor didn't drop the base allowlist's core entry."""
+        self.assertIn("Bash(gh *)", triage_daemon.ALLOWED_TOOLS.split(","))
+
+    def test_pr_disallowed_tools_still_blocks_dangerous_gh_subcommands(self):
+        """Everything dangerous stays denied for the PR flow too."""
+        still_denied = [
+            "Bash(gh pr merge*)",
+            "Bash(gh pr close*)",
+            "Bash(gh repo*)",
+            "Bash(gh release*)",
+            "Bash(gh workflow*)",
+            "Bash(gh auth*)",
+            "Bash(gh secret*)",
+            "Bash(gh api*)",
+            "mcp__*",
+        ]
+        pr_denied = triage_daemon.DISALLOWED_TOOLS_PR.split(",")
+        for entry in still_denied:
+            self.assertIn(entry, pr_denied)
+
+    def test_pr_disallowed_tools_carves_out_exactly_three_entries(self):
+        """Only git push, git commit and gh pr create are removed from the denial list."""
+        base = set(triage_daemon.DISALLOWED_TOOLS.split(","))
+        pr = set(triage_daemon.DISALLOWED_TOOLS_PR.split(","))
+        self.assertEqual(base - pr, {"Bash(git push*)", "Bash(git commit*)", "Bash(gh pr create*)"})
+
+    def test_pr_allowed_tools_is_a_superset_of_the_triage_allowlist(self):
+        """The PR flow's allowlist only ever adds to the read-only allowlist, never removes."""
+        base = set(triage_daemon.ALLOWED_TOOLS.split(","))
+        pr = set(triage_daemon.ALLOWED_TOOLS_PR.split(","))
+        self.assertTrue(base.issubset(pr))
+
+    def test_pr_allowed_tools_adds_exactly_the_expected_entries(self):
+        """The only additions are add/commit/push/pr-create/pre-commit."""
+        base = set(triage_daemon.ALLOWED_TOOLS.split(","))
+        pr = set(triage_daemon.ALLOWED_TOOLS_PR.split(","))
+        self.assertEqual(
+            pr - base,
+            {
+                "Bash(git add*)",
+                "Bash(git commit*)",
+                "Bash(git push*)",
+                "Bash(gh pr create*)",
+                "Bash(./run_pre_commit*)",
+                "Bash(./run_pre_commit)",
+            },
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: FAIL with `AttributeError: module 'triage_daemon' has no attribute 'ALLOWED_TOOLS_PR'` (the first test passes; the rest fail on the missing attribute).
+
+- [ ] **Step 3: Implement**
+
+In `tools/triage_daemon.py`, replace the entire existing block from `EDIT_SCOPE = ...` through the end of the `DISALLOWED_TOOLS = ",".join(...)` call (currently lines 83-174) with:
+
+```python
+EDIT_SCOPE = f"//{CLONE_DIR.relative_to('/')}/**"
+SCRATCH_SCOPE = f"//{SCRATCH_DIR.relative_to('/')}/**"
+_ALLOWED_TOOLS_BASE = [
+    # Read the issue, search for duplicates, post the triage comment
+    "Bash(gh *)",
+    # Git history, and the re-sync/discard the skill does before investigating
+    "Bash(git log*)",
+    "Bash(git diff*)",
+    "Bash(git show*)",
+    "Bash(git blame*)",
+    "Bash(git grep*)",
+    "Bash(git status*)",
+    "Bash(git branch*)",
+    "Bash(git tag*)",
+    "Bash(git describe*)",
+    "Bash(git rev-parse*)",
+    "Bash(git remote -v*)",
+    "Bash(git remote show*)",
+    "Bash(git fetch*)",
+    "Bash(git reset*)",
+    "Bash(git checkout*)",
+    "Bash(git restore*)",
+    "Bash(git clean*)",
+    "Bash(git stash*)",
+    # Running one targeted test. tools/triage_test.sh keeps the cd into
+    # coverage/ and the output redirect inside the script, because Claude Code
+    # prompts on a cd combined with an output redirect - which is what the
+    # obvious "cd coverage && ./run_all --test X > log 2>&1" form is, so it is
+    # denied outright under dontAsk no matter what rules are listed here.
+    "Bash(tools/triage_test.sh *)",
+    "Bash(./tools/triage_test.sh *)",
+    "Bash(cd *)",
+    "Bash(./run_all *)",
+    "Bash(./run_all)",
+    "Bash(python3 *)",
+    # Pulling issue attachments down and picking them apart. A predbat.log
+    # is often tens of MB - too big for WebFetch and too big to read into
+    # context, so it gets downloaded and grepped instead.
+    "Bash(curl *)",
+    "Bash(mkdir *)",
+    "Bash(unzip *)",
+    "Bash(gunzip *)",
+    "Bash(zcat *)",
+    "Bash(tar *)",
+    "Bash(file *)",
+    "Bash(ls *)",
+    "Bash(find *)",
+    "Bash(wc *)",
+    "Bash(head *)",
+    "Bash(tail *)",
+    "Bash(cat *)",
+    "Bash(grep *)",
+    "Bash(rg *)",
+    "Bash(sed *)",
+    "Bash(awk *)",
+    "Bash(sort *)",
+    "Bash(uniq *)",
+    "Bash(cut *)",
+    "Bash(tr *)",
+    "Bash(tee *)",
+    "Bash(echo *)",
+    # Edit rules cover every file-editing tool (Write included) - a Write(path)
+    # rule is not matched by the file permission check, so don't add one.
+    f"Edit({EDIT_SCOPE})",
+    f"Edit({SCRATCH_SCOPE})",
+    "WebFetch",
+    "Read",
+    "Grep",
+    "Glob",
+]
+ALLOWED_TOOLS = ",".join(_ALLOWED_TOOLS_BASE)
+# The /issue-pr invocation needs everything the read-only triage flow has, plus
+# committing/pushing its branch, opening the PR, and running pre-commit as a quality gate.
+_ALLOWED_TOOLS_PR_EXTRA = [
+    "Bash(git add*)",
+    "Bash(git commit*)",
+    "Bash(git push*)",
+    "Bash(gh pr create*)",
+    "Bash(./run_pre_commit*)",
+    "Bash(./run_pre_commit)",
+]
+ALLOWED_TOOLS_PR = ",".join(_ALLOWED_TOOLS_BASE + _ALLOWED_TOOLS_PR_EXTRA)
+# Deny wins over allow, so these carve the publishing commands back out of
+# the broad "Bash(gh *)" / "Bash(git ...)" entries above.
+_DISALLOWED_TOOLS_BASE = [
+    "mcp__*",
+    "Bash(git push*)",
+    "Bash(git commit*)",
+    "Bash(git remote add*)",
+    "Bash(git remote set-url*)",
+    "Bash(gh pr create*)",
+    "Bash(gh pr merge*)",
+    "Bash(gh pr close*)",
+    "Bash(gh repo*)",
+    "Bash(gh release*)",
+    "Bash(gh workflow*)",
+    "Bash(gh auth*)",
+    "Bash(gh secret*)",
+    "Bash(gh api*)",
+]
+DISALLOWED_TOOLS = ",".join(_DISALLOWED_TOOLS_BASE)
+# The PR flow needs to push its branch and open the PR - carve those three back out of
+# the base denial list. Everything else (merge, close, repo/release/workflow/auth/secret/
+# api admin, all mcp__*) stays denied.
+_PR_REMOVED_DENIALS = {"Bash(git push*)", "Bash(git commit*)", "Bash(gh pr create*)"}
+DISALLOWED_TOOLS_PR = ",".join(item for item in _DISALLOWED_TOOLS_BASE if item not in _PR_REMOVED_DENIALS)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: PASS (21 tests total so far)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/triage_daemon.py tools/test_triage_daemon.py
+git commit -m "refactor(triage_daemon): derive ALLOWED_TOOLS_PR/DISALLOWED_TOOLS_PR from the triage allowlist"
+```
+
+---
+
+## Task 8: `create_pr()`
+
+**Files:**
+- Modify: `tools/triage_daemon.py`
+- Modify: `tools/test_triage_daemon.py`
+
+**Interfaces:**
+- Consumes: `ALLOWED_TOOLS_PR`, `DISALLOWED_TOOLS_PR` (Task 7), `CLONE_DIR`, `SCRATCH_DIR`, `LOG_DIR` (pre-existing module constants).
+- Produces: `create_pr(issue_number: int) -> None` — Task 9's `process_bot_pr_issue()` calls this and then checks `has_existing_pr()` afterwards; `create_pr()`'s own return value carries no success/failure meaning (see docstring — a `claude -p` session exits 0 whether it opened a PR or posted a failure comment instead, so the exit code can't be used to decide the outcome).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tools/test_triage_daemon.py`, after `PermissionModelTests`:
+
+```python
+class CreatePrTests(DaemonPathsTestCase):
+    """Tests for create_pr(), new in the bot PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_invokes_claude_with_the_pr_permission_set(self, mock_run):
+        """Runs the /issue-pr skill with the PR-flow allow/deny lists and budget caps."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.create_pr(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/issue-pr 4720", cmd[2])
+        self.assertIn(triage_daemon.ALLOWED_TOOLS_PR, cmd)
+        self.assertIn(triage_daemon.DISALLOWED_TOOLS_PR, cmd)
+        self.assertIn("150", cmd)
+        self.assertIn("25.00", cmd)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_does_not_raise_on_a_non_zero_exit(self, mock_run):
+        """Unlike triage(), a non-zero exit is logged, not raised - the caller decides
+        success by checking for the PR afterwards, not from this function's return."""
+        mock_run.return_value = MagicMock(returncode=1)
+        triage_daemon.create_pr(4720)  # must not raise
+
+    @patch("triage_daemon.subprocess.run")
+    def test_writes_a_log_file(self, mock_run):
+        """A per-issue PR-flow log file is created under LOG_DIR."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.create_pr(4720)
+        self.assertTrue((self.log_dir / "issue-4720-pr.log").exists())
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: FAIL with `AttributeError: module 'triage_daemon' has no attribute 'create_pr'`
+
+- [ ] **Step 3: Implement**
+
+In `tools/triage_daemon.py`, add directly after `triage()`:
+
+```python
+def create_pr(issue_number):
+    """Run the /issue-pr skill for one issue under the push/PR-create-capable permission set.
+
+    Whether it succeeded is judged by the caller re-checking has_existing_pr()
+    afterwards, not by this function's return value or the invocation's exit code -
+    a claude -p session that completes normally exits 0 whether it opened a PR or
+    decided the quality gate failed and posted a comment instead.
+    """
+    cmd = [
+        "claude",
+        "-p",
+        f"/issue-pr {issue_number} scratch={SCRATCH_DIR}",
+        "--permission-mode",
+        "dontAsk",
+        "--allowedTools",
+        ALLOWED_TOOLS_PR,
+        "--disallowedTools",
+        DISALLOWED_TOOLS_PR,
+        "--verbose",
+        "--add-dir",
+        str(SCRATCH_DIR),
+        "--max-turns",
+        "150",
+        "--max-budget-usd",
+        "25.00",
+    ]
+    log_path = LOG_DIR / f"issue-{issue_number}-pr.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"[pr] issue #{issue_number}: starting, logging to {log_path}", flush=True)
+    with log_path.open("a") as log_handle:
+        log_handle.write(f"\n==== issue #{issue_number} PR flow started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
+        log_handle.flush()
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        log_handle.write(f"==== issue #{issue_number} PR flow exited {result.returncode} ====\n")
+    print(f"[pr] issue #{issue_number}: exited {result.returncode}", flush=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: PASS (24 tests total so far)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/triage_daemon.py tools/test_triage_daemon.py
+git commit -m "feat(triage_daemon): add create_pr() to invoke the /issue-pr skill"
+```
+
+---
+
+## Task 9: `process_bot_pr_issue()` and daemon loop wiring
+
+**Files:**
+- Modify: `tools/triage_daemon.py` (`main()`)
+- Modify: `tools/test_triage_daemon.py`
+
+**Interfaces:**
+- Consumes: `has_existing_pr` (Task 5), `sync_repo`, `reset_scratch`, `triage` (all pre-existing), `ensure_triaged` (Task 4), `create_pr` (Task 8), `mark_pr_opened`, `mark_pr_failed` (Task 6).
+- Produces: `process_bot_pr_issue(issue: dict) -> None`, called from `main()` for every result of `fetch_bot_pr_issues()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tools/test_triage_daemon.py`, after `CreatePrTests`:
+
+```python
+class ProcessBotPrIssueTests(unittest.TestCase):
+    """Tests for process_bot_pr_issue(), the orchestrator wiring the whole BOT_PR flow
+    together - new in the bot PR flow."""
+
+    def setUp(self):
+        """Patch every collaborator process_bot_pr_issue() calls."""
+        self.patches = {}
+        for name in [
+            "has_existing_pr",
+            "sync_repo",
+            "reset_scratch",
+            "ensure_triaged",
+            "triage",
+            "create_pr",
+            "mark_pr_opened",
+            "mark_pr_failed",
+        ]:
+            patcher = patch.object(triage_daemon, name)
+            self.patches[name] = patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_skips_entirely_when_pr_already_exists(self):
+        """An issue that already has a referencing PR is left alone."""
+        self.patches["has_existing_pr"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        self.patches["sync_repo"].assert_not_called()
+        self.patches["create_pr"].assert_not_called()
+
+    def test_runs_triage_first_when_not_yet_triaged(self):
+        """An untriaged issue is triaged before the PR flow runs."""
+        self.patches["has_existing_pr"].side_effect = [False, True]  # entry guard, then post-hoc check
+        self.patches["ensure_triaged"].return_value = False
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        self.patches["triage"].assert_called_once_with(4720)
+        self.patches["create_pr"].assert_called_once_with(4720)
+
+    def test_skips_triage_when_already_triaged(self):
+        """An already-triaged issue goes straight to the PR flow."""
+        self.patches["has_existing_pr"].side_effect = [False, True]
+        self.patches["ensure_triaged"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [{"name": "BOT_TRIAGED"}]})
+        self.patches["triage"].assert_not_called()
+        self.patches["create_pr"].assert_called_once_with(4720)
+
+    def test_marks_opened_when_a_pr_exists_afterwards(self):
+        """If a PR references the issue after create_pr() runs, swap to BOT_PR_OPENED."""
+        self.patches["has_existing_pr"].side_effect = [False, True]
+        self.patches["ensure_triaged"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        self.patches["mark_pr_opened"].assert_called_once_with(4720)
+        self.patches["mark_pr_failed"].assert_not_called()
+
+    def test_marks_failed_when_no_pr_exists_afterwards(self):
+        """If no PR exists after create_pr() runs (quality gate failed), swap to BOT_PR_FAILED."""
+        self.patches["has_existing_pr"].side_effect = [False, False]
+        self.patches["ensure_triaged"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        self.patches["mark_pr_failed"].assert_called_once_with(4720)
+        self.patches["mark_pr_opened"].assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: FAIL with `AttributeError: module 'triage_daemon' has no attribute 'process_bot_pr_issue'`
+
+- [ ] **Step 3: Implement**
+
+In `tools/triage_daemon.py`, add directly after `create_pr()`:
+
+```python
+def process_bot_pr_issue(issue):
+    """Run the full BOT_PR flow for one issue: guard against duplicate work, ensure it's
+    triaged, run the PR flow, then swap the label based on whether a PR now exists.
+    """
+    issue_number = issue["number"]
+    labels = issue.get("labels", [])
+    if has_existing_pr(issue_number):
+        print(f"[pr] issue #{issue_number}: a PR already references this issue, skipping", flush=True)
+        return
+    sync_repo()
+    reset_scratch()
+    if not ensure_triaged(issue_number, labels):
+        triage(issue_number)
+    create_pr(issue_number)
+    if has_existing_pr(issue_number):
+        mark_pr_opened(issue_number)
+    else:
+        mark_pr_failed(issue_number)
+```
+
+Then modify `main()` to also process `BOT_PR` issues each poll cycle. Find:
+
+```python
+    state = load_state()
+    while True:
+        try:
+            for issue in fetch_new_issues(state["last_processed"]):
+                sync_repo()
+                reset_scratch()
+                triage(issue["number"])
+                state["last_processed"] = issue["number"]
+                save_state(state)
+        except subprocess.CalledProcessError as exc:
+            print(f"[triage] error: {exc}", flush=True)
+        time.sleep(POLL_SECONDS)
+```
+
+Replace it with:
+
+```python
+    state = load_state()
+    while True:
+        try:
+            for issue in fetch_new_issues(state["last_processed"]):
+                sync_repo()
+                reset_scratch()
+                triage(issue["number"])
+                state["last_processed"] = issue["number"]
+                save_state(state)
+            for issue in fetch_bot_pr_issues():
+                process_bot_pr_issue(issue)
+        except subprocess.CalledProcessError as exc:
+            print(f"[triage] error: {exc}", flush=True)
+        time.sleep(POLL_SECONDS)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 tools/test_triage_daemon.py -v`
+Expected: PASS (29 tests total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/triage_daemon.py tools/test_triage_daemon.py
+git commit -m "feat(triage_daemon): add process_bot_pr_issue() and wire it into the poll loop"
+```
+
+---
+
+## Task 10: New skill — `.claude/skills/issue-pr/SKILL.md`
+
+**Files:**
+- Create: `.claude/skills/issue-pr/SKILL.md`
+
+**Interfaces:**
+- Consumes: `.claude/skills/issue-triage/references/debug-journal.md` (existing, referenced not duplicated), `CLAUDE.md` (repo root, read automatically by Claude Code from the working directory).
+- Produces: the `/issue-pr <issue-number> [scratch=<dir>]` slash command Task 8's `create_pr()` invokes.
+
+- [ ] **Step 1: Write the skill file**
+
+```markdown
+---
+name: issue-pr
+description: Implement the fix or feature described in an already-triaged batpred GitHub issue and open a draft pull request referencing it, for maintainer review.
+allowed-tools: You can view and edit files in this repo, write code and tests, run local tests and pre-commit, commit and push a new branch, and open a draft pull request with 'gh'. Do not merge, close, or push directly to main.
+---
+
+# Issue PR
+
+You are implementing the fix or feature described in one already-triaged GitHub issue on `springfall2008/batpred`, and opening a draft pull request for maintainer review. The working directory is the same dedicated local clone the triage skill uses — investigate and work using it directly.
+
+Arguments: `<issue-number> [scratch=<dir>]`, same convention as `/issue-triage`. If no `scratch=` is given (an interactive invocation), use `/tmp/predbat-triage/<issue-number>` and `mkdir -p` it yourself.
+
+This skill assumes the issue has already been triaged — the daemon only invokes it once that's confirmed. Read the existing triage comment before doing anything else.
+
+## 1. Read the ticket
+
+Fetch it with `gh issue view <number> --json title,body,labels,comments`. The bot's own triage comment (opens with "automated first-pass triage") already has the classification, priority, and any root-cause pointer — start from there rather than re-investigating from scratch.
+
+## 2. Investigate
+
+- Sync the clone first, so you are reading the code you think you are:
+
+  ```bash
+  git fetch origin main && git reset --hard origin/main && git clean -fd
+  git describe --tags
+  ```
+
+- Read [../issue-triage/references/debug-journal.md](../issue-triage/references/debug-journal.md) before forming an implementation approach — it maps common symptoms to modules and records known per-integration behaviour from past investigations. Its entries are dated observations, not current truth — confirm anything you rely on against the working tree.
+- Read the relevant source area named in the triage comment's root-cause pointer, or that the issue's classification points to.
+- Check `git log`/`git blame` on that area — the triage comment may already cover this, but confirm nothing has changed on `main` since triage ran.
+
+## 3. Implement
+
+- Write the fix or feature following this repo's conventions (`CLAUDE.md`, already loaded automatically for this session): `lower_case_with_underscores` naming, 256-character line length, a one-line docstring on every new function or class.
+- Add or update a unit test for the change, in the matching `apps/predbat/tests/test_<feature>.py` module (registered in `TEST_REGISTRY` in `apps/predbat/unit_test.py` if it's a new module) — `CLAUDE.md` requires unit tests for all new code, no exceptions for bot-authored ones.
+- Keep the change scoped to what the issue describes. Don't refactor unrelated code, even if you notice something else worth fixing.
+
+## 4. Quality gate
+
+Both of these must pass before you continue to step 5:
+
+```bash
+./run_pre_commit
+tools/triage_test.sh <name> <scratch>/test.log
+```
+
+Use the test module named in the triage comment, or the one `TEST_REGISTRY` maps to the area you changed. If there's no clean single-module mapping, run `./run_all --quick` instead (from `coverage/`) rather than guessing at a module name.
+
+If either fails, stop here — do not commit, push, or open a PR. Go to step 7 and report what failed.
+
+## 5. Branch, commit, push
+
+Branch name: `fix/<slug>-<issue-number>` for a `bug` classification, `feat/<slug>-<issue-number>` for `enhancement` — matching this repo's existing convention (e.g. `fix/solis-tou-bit-refused-4707`). `<slug>` is a short kebab-case description of the change.
+
+```bash
+git checkout -b fix/<slug>-<issue-number>
+git add <changed files>
+git commit -m "<one-line summary of the fix>"
+git push -u origin fix/<slug>-<issue-number>
+```
+
+Never push to `main`, and never force-push.
+
+## 6. Open the draft PR
+
+```bash
+gh pr create --draft --reviewer springfall2008 \
+  --title "<one-line summary>" \
+  --body "$(cat <<'EOF'
+This is an automated draft PR generated from issue #<issue-number> — a maintainer should review it before merging.
+
+Fixes #<issue-number>
+
+## Summary
+
+<what changed and why, in a sentence or two>
+
+## Testing
+
+<what you ran in step 4 and its result>
+
+## Notes
+
+<a debug-journal.md reference if one informed the approach, otherwise omit this section>
+EOF
+)"
+```
+
+This is the last step on success — there is nothing further to report; the daemon detects the new PR itself.
+
+## 7. On failure
+
+If step 4's quality gate failed, or an earlier step couldn't proceed (e.g. the fix genuinely needs information only a maintainer has), post exactly one comment on the issue via `gh issue comment <number> --body "..."` explaining plainly what you attempted and what failed — never word it so a skipped step reads as one you completed (same guardrail as the triage skill). Then stop. Do not commit, push, or open a PR — the daemon detects this outcome itself by finding no PR referencing the issue afterwards.
+
+## Guardrails
+
+- Never push to `main` or force-push.
+- Never merge, close, or edit an existing PR.
+- Never remove a label a human applied.
+- The PR is always a draft — never open it as ready-for-review.
+- If a command you needed was blocked by permissions, say plainly in the failure comment what you could not do.
+```
+
+- [ ] **Step 2: Verify**
+
+Read the file back and confirm the frontmatter parses (matches the shape of `.claude/skills/issue-triage/SKILL.md`'s frontmatter) and the relative link to `debug-journal.md` resolves: `ls .claude/skills/issue-triage/references/debug-journal.md` from repo root.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/issue-pr/SKILL.md
+git commit -m "feat(issue-pr): add the issue-pr skill"
+```
+
+---
+
+## Task 11: Wire the new tests into pre-commit
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+**Interfaces:**
+- Consumes: `tools/test_triage_daemon.py` (Tasks 2–9).
+- Produces: nothing consumed by later tasks — this is the last automated task.
+
+- [ ] **Step 1: Add the local hook**
+
+In `.pre-commit-config.yaml`, add a new hook to the existing `repo: local` block (the one that already contains `cspell-dictionary-sorter`):
+
+Find:
+
+```yaml
+- repo: local
+  hooks:
+  - id: cspell-dictionary-sorter
+    name: cspell dictionary sorter
+    language: python
+    entry: python .cspell/sort_dictionary.py
+    files: ^\.cspell\/custom-dictionary-workspace\.txt$
+```
+
+Replace with:
+
+```yaml
+- repo: local
+  hooks:
+  - id: cspell-dictionary-sorter
+    name: cspell dictionary sorter
+    language: python
+    entry: python .cspell/sort_dictionary.py
+    files: ^\.cspell\/custom-dictionary-workspace\.txt$
+  - id: triage-daemon-tests
+    name: triage daemon unit tests
+    language: python
+    entry: python tools/test_triage_daemon.py
+    files: ^tools/(triage_daemon\.py|test_triage_daemon\.py)$
+    pass_filenames: false
+```
+
+- [ ] **Step 2: Verify the hook runs and passes**
+
+Run: `cd coverage && source setup.csh && python3 -m pre_commit run triage-daemon-tests --files ../tools/triage_daemon.py`
+Expected: the hook fires and reports success (29 tests passing).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "chore: run triage_daemon.py unit tests via pre-commit"
+```
+
+---
+
+## Task 12: Create the GitHub labels — **manual, run by the user, not automated**
+
+This task modifies live state on `springfall2008/batpred` (visible labels on a public repo). Do not run these commands as part of automated task execution — present them to the user and let them run it, or get explicit confirmation before running.
+
+- [ ] **Step 1: Create the four labels**
+
+```bash
+gh label create BOT_TRIAGED --repo springfall2008/batpred --color 0e8a16 --description "Has been through the triage bot"
+gh label create BOT_PR --repo springfall2008/batpred --color 5319e7 --description "Trigger: bot should implement this ticket and open a draft PR"
+gh label create BOT_PR_OPENED --repo springfall2008/batpred --color 0e8a16 --description "Bot PR flow opened a draft PR for this ticket"
+gh label create BOT_PR_FAILED --repo springfall2008/batpred --color d93f0b --description "Bot PR flow's quality gate failed; see the comment for details"
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+gh label list --repo springfall2008/batpred | grep -E "^BOT_"
+```
+
+Expected: all four labels listed.
+
+- [ ] **Step 3: Confirm the daemon's `gh auth` identity has push access**
+
+Per the spec (Section 6.1): whatever GitHub identity `tools/triage_daemon.py` runs as needs push access to `springfall2008/batpred`, and must not be `springfall2008` itself (it sets you as reviewer, and GitHub disallows self-review). Confirm this on whichever machine runs the daemon before enabling `BOT_PR` for real use:
+
+```bash
+gh auth status
+```
+
+---
+
+## Task 13: End-to-end verification — **manual, human-supervised, not automated**
+
+This exercises the live daemon against the real repo with push/PR-create permissions — do not run unsupervised. Requires Task 12 complete.
+
+- [ ] **Step 1: Dry run against a real triaged issue**
+
+Pick an issue already carrying a bot triage comment (or let the daemon triage a fresh one first). Add the `BOT_PR` label:
+
+```bash
+gh issue edit <number> --repo springfall2008/batpred --add-label BOT_PR
+```
+
+- [ ] **Step 2: Watch the daemon log**
+
+```bash
+tail -f ~/predbat-triage-bot/logs/issue-<number>-pr.log
+```
+
+Confirm: the branch is created, the commit looks right, `./run_pre_commit` and the targeted test both pass in the log, the branch is pushed, and a draft PR appears on GitHub with `springfall2008` as reviewer, `Fixes #<number>` in the body, and the disclosure line.
+
+- [ ] **Step 3: Confirm the label swap**
+
+```bash
+gh issue view <number> --repo springfall2008/batpred --json labels
+```
+
+Expected: `BOT_PR` is gone, `BOT_PR_OPENED` is present.
+
+- [ ] **Step 4: Confirm the failure path separately**
+
+Add `BOT_PR` to a ticket engineered to fail the quality gate (e.g. one whose obvious fix would break an existing test). Confirm: no branch is pushed, no PR opens, one comment is posted explaining the failure, and the issue ends up with `BOT_PR_FAILED` instead of `BOT_PR`.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Section 2 (labels) → Tasks 1, 12. Section 2.1 (backfill) → Task 4. Section 3 (issue-triage modification) → Task 1. Section 4 (daemon changes, including the corrected success-detection mechanism) → Tasks 3, 5, 6, 9. Section 5 (issue-pr skill) → Task 10. Section 6 (permission model) → Tasks 7, 8; Section 6.1 (infra prerequisite) → Task 12 Step 3. Section 7.1 (unit tests) → Tasks 2–9. Section 7.2 (pre-commit wiring) → Task 11. Section 7.3 (E2E verification) → Task 13. Section 8 (error handling table) → covered across Tasks 4, 5, 9.
+- **Placeholder scan:** no TBD/TODO; every code block is complete, runnable code, not a description of code.
+- **Type consistency:** `has_existing_pr(issue_number)`, `ensure_triaged(issue_number, labels)`, `create_pr(issue_number)`, `mark_pr_opened(issue_number)`/`mark_pr_failed(issue_number)` use the same parameter names and call signatures everywhere they appear across Tasks 4–9. `process_bot_pr_issue(issue)` consistently takes the raw dict shape `fetch_bot_pr_issues()` (Task 3) produces.

--- a/docs/superpowers/plans/2026-08-25-bot-pr-flow.md
+++ b/docs/superpowers/plans/2026-08-25-bot-pr-flow.md
@@ -1074,7 +1074,7 @@ Never push to `main`, and never force-push.
 ## 6. Open the draft PR
 
 ```bash
-gh pr create --draft --reviewer springfall2008 \
+gh pr create --draft --assignee springfall2008 \
   --title "<one-line summary>" \
   --body "$(cat <<'EOF'
 This is an automated draft PR generated from issue #<issue-number> — a maintainer should review it before merging.
@@ -1204,7 +1204,7 @@ Expected: all four labels listed.
 
 - [ ] **Step 3: Confirm the daemon's `gh auth` identity has push access**
 
-Per the spec (Section 6.1): whatever GitHub identity `tools/triage_daemon.py` runs as needs push access to `springfall2008/batpred`, and must not be `springfall2008` itself (it sets you as reviewer, and GitHub disallows self-review). Confirm this on whichever machine runs the daemon before enabling `BOT_PR` for real use:
+Per the spec (Section 6.1): whatever GitHub identity `tools/triage_daemon.py` runs as needs push access to `springfall2008/batpred`. No separate bot account is required — the PR uses `--assignee springfall2008` rather than `--reviewer`, and self-assignment is allowed, so the daemon can run as `springfall2008` itself. Confirm push access on whichever machine runs the daemon before enabling `BOT_PR` for real use:
 
 ```bash
 gh auth status
@@ -1230,7 +1230,7 @@ gh issue edit <number> --repo springfall2008/batpred --add-label BOT_PR
 tail -f ~/predbat-triage-bot/logs/issue-<number>-pr.log
 ```
 
-Confirm: the branch is created, the commit looks right, `./run_pre_commit` and the targeted test both pass in the log, the branch is pushed, and a draft PR appears on GitHub with `springfall2008` as reviewer, `Fixes #<number>` in the body, and the disclosure line.
+Confirm: the branch is created, the commit looks right, `./run_pre_commit` and the targeted test both pass in the log, the branch is pushed, and a draft PR appears on GitHub with `springfall2008` as assignee, `Fixes #<number>` in the body, and the disclosure line.
 
 - [ ] **Step 3: Confirm the label swap**
 

--- a/docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md
+++ b/docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md
@@ -171,12 +171,56 @@ as reviewer and GitHub does not allow self-review.
 
 ## 7. Testing
 
-No unit-test coverage is added for `triage_daemon.py` or the new skill — consistent with
-today, where `triage_daemon.py` and `issue-triage` have none either (they're operational
-tooling, not `apps/predbat` app code covered by `TEST_REGISTRY`). Verification is a
-manual dry run against a real triaged issue: add `BOT_PR`, watch the daemon log, confirm
-the branch/commit/PR look right end-to-end, then confirm the `BOT_PR_FAILED` path separately
-by pointing it at a ticket engineered to fail the quality gate.
+### 7.1 `triage_daemon.py` unit tests
+
+New file `tools/test_triage_daemon.py`, stdlib `unittest` + `unittest.mock` (no new
+dependency — `triage_daemon.py` itself only imports stdlib). It does **not** go through
+`coverage/run_all`/`TEST_REGISTRY`: every existing entry there imports `PredBat`/
+`TestHAInterface` from `apps/predbat`, and `triage_daemon.py` has no dependency on that
+app — folding it in would be a layering violation. Run directly with
+`python3 tools/test_triage_daemon.py`.
+
+Covers, with `subprocess.run` mocked (no real `gh`/`git`/`claude` calls):
+
+- `load_state()`/`save_state()` round-trip, including the corrupt-JSON fallback.
+- `fetch_new_issues()` and `fetch_bot_pr_issues()` parsing of `gh` JSON output.
+- The `BOT_PR` precondition check (Section 4 step 3): label present → proceeds directly;
+  label absent + comment found → backfills `BOT_TRIAGED` and proceeds; neither → triggers
+  `/issue-triage` first.
+- The duplicate-work guard's search query construction (Section 4 step 2) — asserts it
+  searches the quoted `"Fixes #<N>"` phrase, not a bare number.
+- The success/failure label-swap calls (`BOT_PR` → `BOT_PR_OPENED` / `BOT_PR_FAILED`).
+- A regression test asserting the exact `ALLOWED_TOOLS`/`DISALLOWED_TOOLS` delta between
+  the triage invocation and the new `/issue-pr` invocation (Section 6) — specifically that
+  `gh pr merge`, `gh pr close`, `gh repo*`, `gh release*`, `gh workflow*`, `gh auth*`,
+  `gh secret*`, `gh api*`, and all `mcp__*` stay denied for the PR flow too. This is the
+  one test worth never letting rot silently, since it's the thing standing between "opens
+  a draft PR" and "can merge/close/administer the repo."
+
+### 7.2 Wiring into pre-commit
+
+A new local hook in `.pre-commit-config.yaml`, following the existing `cspell-dictionary-sorter`
+pattern, scoped to only run when the daemon or its tests change:
+
+```yaml
+- id: triage-daemon-tests
+  name: triage daemon unit tests
+  language: python
+  entry: python tools/test_triage_daemon.py
+  files: ^tools/(triage_daemon\.py|test_triage_daemon\.py)$
+  pass_filenames: false
+```
+
+This makes it run both via local `./run_pre_commit` and the existing `pre-commit/action`
+step in `code-quality.yml` — no new CI job needed.
+
+### 7.3 End-to-end verification
+
+Beyond the unit tests, a manual dry run against a real triaged issue: add `BOT_PR`, watch
+the daemon log, confirm the branch/commit/PR look right end-to-end, then confirm the
+`BOT_PR_FAILED` path separately by pointing it at a ticket engineered to fail the quality
+gate. Unit tests cover the daemon's decision logic; they can't substitute for seeing a
+real `gh pr create --draft` succeed.
 
 ## 8. Error handling summary
 

--- a/docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md
+++ b/docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md
@@ -8,7 +8,7 @@ Status: Approved for implementation planning
 Extend the existing issue-triage bot (`tools/triage_daemon.py` + `.claude/skills/issue-triage/`)
 with a second, opt-in flow: when a maintainer adds the `BOT_PR` label to an already-triaged
 issue, the bot implements the fix/feature described in the ticket and opens a **draft** PR
-referencing it, with `springfall2008` set as reviewer.
+referencing it, with `springfall2008` set as assignee.
 
 Today the bot is strictly read/comment-only — `DISALLOWED_TOOLS` explicitly blocks
 `git push`, `git commit`, and `gh pr create`. This adds a genuinely new capability
@@ -121,7 +121,7 @@ same convention as the triage skill.
    (prefix from the triage classification), matching existing repo convention (e.g.
    `fix/solis-tou-bit-refused-4707`).
 6. **Open the draft PR** —
-   `gh pr create --draft --reviewer springfall2008 --title "..." --body "..."`. Body
+   `gh pr create --draft --assignee springfall2008 --title "..." --body "..."`. Body
    includes: a disclosure line ("automated draft PR generated from issue #N — needs
    maintainer review before merging"), `Fixes #N`, a summary, what was run in step 4 and
    its result, and a debug-journal reference if one was used. Report success back to the
@@ -171,8 +171,12 @@ investigation. Starting values; tune after the first few real runs.
 Whatever GitHub identity the daemon's `gh auth` already uses needs **push access** to
 `springfall2008/batpred`. Today that identity only ever reads and comments, so this has
 never been exercised — confirm (or grant) push/write access before enabling the `BOT_PR`
-label in the repo. This identity must not be `springfall2008` itself, since it sets you
-as reviewer and GitHub does not allow self-review.
+label in the repo.
+
+No separate bot account is required: the PR uses `--assignee springfall2008` rather than
+`--reviewer springfall2008`. GitHub blocks requesting a review from a PR's own author
+(so `--reviewer` would need a distinct identity from whichever account authors the PR),
+but self-assignment is allowed, so the daemon can run as `springfall2008` itself.
 
 ## 7. Testing
 

--- a/docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md
+++ b/docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md
@@ -1,0 +1,189 @@
+# Bot PR Flow — Design
+
+Date: 2026-08-25
+Status: Approved for implementation planning
+
+## 1. Purpose
+
+Extend the existing issue-triage bot (`tools/triage_daemon.py` + `.claude/skills/issue-triage/`)
+with a second, opt-in flow: when a maintainer adds the `BOT_PR` label to an already-triaged
+issue, the bot implements the fix/feature described in the ticket and opens a **draft** PR
+referencing it, with `springfall2008` set as reviewer.
+
+Today the bot is strictly read/comment-only — `DISALLOWED_TOOLS` explicitly blocks
+`git push`, `git commit`, and `gh pr create`. This adds a genuinely new capability
+(autonomous code changes + PR creation), gated behind a label a human deliberately adds,
+so it stays a single, opt-in trigger per issue rather than an always-on behaviour.
+
+Out of scope: auto-merging, closing issues, editing PRs after creation, and running on
+anything other than `springfall2008/batpred` issues.
+
+## 2. Labels
+
+Four labels, none of which exist in the repo today:
+
+| Label | Applied by | Meaning |
+|---|---|---|
+| `BOT_TRIAGED` | `issue-triage` skill, step 9 (new) | This issue has been through the triage bot — applied every time triage completes, including duplicate-closes. `BOT_` prefix to match `BOT_PR` and avoid colliding with an unrelated "triaged" label someone else might already use. |
+| `BOT_PR` | Maintainer (manual) | Trigger: implement this ticket and open a draft PR. |
+| `BOT_PR_OPENED` | `issue-pr` skill (new), on success | The PR flow completed; swapped in for `BOT_PR` so the daemon doesn't reprocess it. |
+| `BOT_PR_FAILED` | `issue-pr` skill (new), on failure | The PR flow's quality gate didn't pass; swapped in for `BOT_PR` so the daemon doesn't retry every poll. Re-add `BOT_PR` once the blocker is addressed. |
+
+Create with:
+
+```bash
+gh label create BOT_TRIAGED --repo springfall2008/batpred --color 0e8a16 --description "Has been through the triage bot"
+gh label create BOT_PR --repo springfall2008/batpred --color 5319e7 --description "Trigger: bot should implement this ticket and open a draft PR"
+gh label create BOT_PR_OPENED --repo springfall2008/batpred --color 0e8a16 --description "Bot PR flow opened a draft PR for this ticket"
+gh label create BOT_PR_FAILED --repo springfall2008/batpred --color d93f0b --description "Bot PR flow's quality gate failed; see the comment for details"
+```
+
+### 2.1 Backfill for pre-existing triaged issues
+
+`BOT_TRIAGED` only starts getting applied going forward, so an issue triaged before this
+change has a bot triage comment but no label. The precondition check (below) therefore
+checks the label first and falls back to scanning comments for the triage disclosure
+line if the label is absent. When the fallback finds a comment, it backfills the
+`BOT_TRIAGED` label onto the issue at that point — no separate migration script; the label
+set converges to consistent state the first time each old issue is touched.
+
+## 3. Modification to the existing `issue-triage` skill
+
+One addition to `.claude/skills/issue-triage/SKILL.md` step 9 (posting the comment):
+after posting, apply the `BOT_TRIAGED` label. This runs on the existing, already-live
+triage path for every new issue, not just ones later tagged `BOT_PR` — it is the
+mechanism that keeps the label current going forward. No other change to that skill;
+its permission set and read-only guarantee are unchanged, and no permission-set edit
+is needed for this addition either — the existing `Bash(gh *)` allow entry already
+covers `gh issue edit --add-label`, and only specific subcommands (`gh pr create`,
+`gh pr merge`, etc.) are carved back out via `DISALLOWED_TOOLS`.
+
+## 4. Daemon changes (`tools/triage_daemon.py`)
+
+Each poll cycle, alongside the existing `fetch_new_issues()` call:
+
+```python
+def fetch_bot_pr_issues():
+    result = subprocess.run(
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open",
+         "--label", "BOT_PR", "--json", "number,labels"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+```
+
+For each issue returned:
+
+1. `sync_repo()` / `reset_scratch()` (unchanged, same as today).
+2. Duplicate-work guard: `gh pr list --search "\"Fixes #<issue-number>\" in:body" --state all` —
+   searches for the exact phrase the skill always includes in its PR body (Section 5, step 6)
+   rather than a bare number, which could false-positive on an unrelated PR that happens to
+   mention the issue number. If a match exists, skip. Protects against reprocessing if the
+   daemon crashed between push and label-swap on a previous attempt.
+3. Precondition check — `BOT_TRIAGED` in the label list already returned by
+   `fetch_bot_pr_issues()` (no extra API call). If absent, fall back to
+   `gh issue view <number> --json comments` and scan for the triage disclosure line;
+   if found, backfill `BOT_TRIAGED` via `gh issue edit <number> --add-label BOT_TRIAGED`.
+   If neither, run `/issue-triage <number>` first (existing skill, existing permissions,
+   unchanged).
+4. Run `/issue-pr <number>` under the new permission set (Section 6).
+5. On success: `gh issue edit <number> --remove-label BOT_PR --add-label BOT_PR_OPENED`.
+6. On failure: `gh issue edit <number> --remove-label BOT_PR --add-label BOT_PR_FAILED`.
+   The `issue-pr` skill itself posts the explanatory comment before returning failure
+   (Section 5, step 7) — the daemon only swaps the label.
+
+State tracking is entirely label-based; no new fields in `state.json`.
+
+## 5. New skill: `.claude/skills/issue-pr/SKILL.md`
+
+Structured like `issue-triage/SKILL.md`. Arguments: `<issue-number> [scratch=<dir>]`,
+same convention as the triage skill.
+
+1. **Read the ticket** — issue body plus the existing bot triage comment (classification,
+   priority, root-cause pointer).
+2. **Investigate** — sync check (`git fetch origin main && git reset --hard origin/main
+   && git clean -fd`), read `.claude/skills/issue-triage/references/debug-journal.md`
+   (shared, not duplicated) and the relevant source area, `git log`/`git blame` for
+   recent related changes the reporter's version might not have.
+3. **Implement** — write the fix/feature per `CLAUDE.md` (docstrings, `lower_case_with_underscores`
+   naming, 256-char line length), and add/update a unit test — `CLAUDE.md` requires unit
+   tests for all new code, and `CLAUDE.md` is picked up automatically since Claude Code
+   reads it from the working directory with no extra wiring.
+4. **Quality gate** — run `./run_pre_commit` and the relevant test module via
+   `tools/triage_test.sh <name>` (or `./run_all --quick` if there's no clean single-module
+   mapping). Both must pass before continuing to step 5. If either fails, stop, do not
+   push or open a PR, and go to step 7.
+5. **Branch, commit, push** — branch named `fix/<slug>-<issue#>` or `feat/<slug>-<issue#>`
+   (prefix from the triage classification), matching existing repo convention (e.g.
+   `fix/solis-tou-bit-refused-4707`).
+6. **Open the draft PR** —
+   `gh pr create --draft --reviewer springfall2008 --title "..." --body "..."`. Body
+   includes: a disclosure line ("automated draft PR generated from issue #N — needs
+   maintainer review before merging"), `Fixes #N`, a summary, what was run in step 4 and
+   its result, and a debug-journal reference if one was used. Report success back to the
+   daemon.
+7. **On failure (from step 4, or any earlier step that can't proceed)** — post one comment
+   on the issue via `gh issue comment` explaining what was attempted and what failed
+   (same "say plainly what you could not do" guardrail as the triage skill). Report
+   failure back to the daemon; no branch is pushed, no PR is opened.
+
+## 6. Permission model
+
+A new `ALLOWED_TOOLS`/`DISALLOWED_TOOLS` pair, used **only** for the `/issue-pr`
+invocation. The existing `/issue-triage` invocation and its permissions are unchanged.
+
+Adds to the existing read-only allowlist (`git checkout*` is already allowed today and
+covers `git checkout -b`, so no new entry is needed for branch creation):
+
+```
+Bash(git add*)
+Bash(git commit*)
+Bash(git push*)
+Bash(gh pr create*)
+Bash(./run_pre_commit*)
+Bash(./run_pre_commit)
+```
+
+`gh issue edit` is deliberately *not* added here — the label swaps in Section 4 steps
+5–6 are done by the daemon's own Python code via `subprocess`, the same trust boundary
+as `sync_repo()`/`save_state()` today, not by the model inside the Claude Code session.
+Keeping that bookkeeping deterministic and outside the sandboxed session means a label
+swap can't be skipped by a model that forgets a step.
+
+Keeps blocking (same rationale as today — deny wins over the broad `Bash(gh *)` /
+`Bash(git ...)` allows): `gh pr merge`, `gh pr close`, `gh repo*`, `gh release*`,
+`gh workflow*`, `gh auth*`, `gh secret*`, `gh api*`, all `mcp__*`. `git push` is only
+ever invoked by the skill against a new `fix/`/`feat/` branch, never `main`, but nothing
+in the tool-permission layer enforces that — it relies on the skill instructions and
+draft-PR review before merge, same trust model as everything else in this daemon.
+
+`--max-turns 150` and `--max-budget-usd 25.00` (up from the triage flow's 60 / $10) —
+writing code, running pre-commit, and running tests is heavier than read-only
+investigation. Starting values; tune after the first few real runs.
+
+### 6.1 Infra prerequisite
+
+Whatever GitHub identity the daemon's `gh auth` already uses needs **push access** to
+`springfall2008/batpred`. Today that identity only ever reads and comments, so this has
+never been exercised — confirm (or grant) push/write access before enabling the `BOT_PR`
+label in the repo. This identity must not be `springfall2008` itself, since it sets you
+as reviewer and GitHub does not allow self-review.
+
+## 7. Testing
+
+No unit-test coverage is added for `triage_daemon.py` or the new skill — consistent with
+today, where `triage_daemon.py` and `issue-triage` have none either (they're operational
+tooling, not `apps/predbat` app code covered by `TEST_REGISTRY`). Verification is a
+manual dry run against a real triaged issue: add `BOT_PR`, watch the daemon log, confirm
+the branch/commit/PR look right end-to-end, then confirm the `BOT_PR_FAILED` path separately
+by pointing it at a ticket engineered to fail the quality gate.
+
+## 8. Error handling summary
+
+| Situation | Behaviour |
+|---|---|
+| `BOT_PR` added, issue not yet triaged (no label, no comment) | Daemon runs `/issue-triage` first, then proceeds. |
+| `BOT_PR` added, old issue triaged before labels existed | Fallback comment-scan finds it, backfills `BOT_TRIAGED`, proceeds. |
+| Daemon crashes between push and label-swap | Next poll's `gh pr list` guard finds the existing PR and skips reprocessing. |
+| Implementation fails to pass pre-commit/tests | No push, no PR; one comment posted; label swapped to `BOT_PR_FAILED`. |
+| `issue-pr` invocation errors outright (crash, budget/turn cap) | Same as above — daemon treats non-zero exit as failure and swaps to `BOT_PR_FAILED`. |

--- a/docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md
+++ b/docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md
@@ -87,10 +87,14 @@ For each issue returned:
    If neither, run `/issue-triage <number>` first (existing skill, existing permissions,
    unchanged).
 4. Run `/issue-pr <number>` under the new permission set (Section 6).
-5. On success: `gh issue edit <number> --remove-label BOT_PR --add-label BOT_PR_OPENED`.
-6. On failure: `gh issue edit <number> --remove-label BOT_PR --add-label BOT_PR_FAILED`.
-   The `issue-pr` skill itself posts the explanatory comment before returning failure
-   (Section 5, step 7) — the daemon only swaps the label.
+5. Check `has_existing_pr(<number>)` again afterwards — this is how success is judged,
+   *not* the invocation's exit code: a Claude Code session that completes normally still
+   exits 0 whether it opened a PR or decided the quality gate failed and posted a comment
+   instead, so the exit code alone can't distinguish the two outcomes.
+6. If a PR now exists: `gh issue edit <number> --remove-label BOT_PR --add-label BOT_PR_OPENED`.
+   If not: `gh issue edit <number> --remove-label BOT_PR --add-label BOT_PR_FAILED` — the
+   `issue-pr` skill itself posts the explanatory comment before stopping (Section 5, step 7);
+   the daemon only swaps the label.
 
 State tracking is entirely label-based; no new fields in `state.json`.
 
@@ -124,8 +128,9 @@ same convention as the triage skill.
    daemon.
 7. **On failure (from step 4, or any earlier step that can't proceed)** — post one comment
    on the issue via `gh issue comment` explaining what was attempted and what failed
-   (same "say plainly what you could not do" guardrail as the triage skill). Report
-   failure back to the daemon; no branch is pushed, no PR is opened.
+   (same "say plainly what you could not do" guardrail as the triage skill), then stop.
+   No branch is pushed, no PR is opened — the daemon detects this outcome itself by
+   checking for a PR afterwards, so there's nothing else this step needs to signal.
 
 ## 6. Permission model
 
@@ -189,7 +194,9 @@ Covers, with `subprocess.run` mocked (no real `gh`/`git`/`claude` calls):
   `/issue-triage` first.
 - The duplicate-work guard's search query construction (Section 4 step 2) — asserts it
   searches the quoted `"Fixes #<N>"` phrase, not a bare number.
-- The success/failure label-swap calls (`BOT_PR` → `BOT_PR_OPENED` / `BOT_PR_FAILED`).
+- The success/failure label-swap calls (`BOT_PR` → `BOT_PR_OPENED` / `BOT_PR_FAILED`),
+  driven by the post-hoc `has_existing_pr()` check described in Section 4 step 5, not by
+  the `/issue-pr` invocation's exit code.
 - A regression test asserting the exact `ALLOWED_TOOLS`/`DISALLOWED_TOOLS` delta between
   the triage invocation and the new `/issue-pr` invocation (Section 6) — specifically that
   `gh pr merge`, `gh pr close`, `gh repo*`, `gh release*`, `gh workflow*`, `gh auth*`,
@@ -230,4 +237,4 @@ real `gh pr create --draft` succeed.
 | `BOT_PR` added, old issue triaged before labels existed | Fallback comment-scan finds it, backfills `BOT_TRIAGED`, proceeds. |
 | Daemon crashes between push and label-swap | Next poll's `gh pr list` guard finds the existing PR and skips reprocessing. |
 | Implementation fails to pass pre-commit/tests | No push, no PR; one comment posted; label swapped to `BOT_PR_FAILED`. |
-| `issue-pr` invocation errors outright (crash, budget/turn cap) | Same as above — daemon treats non-zero exit as failure and swaps to `BOT_PR_FAILED`. |
+| `issue-pr` invocation errors outright (crash, budget/turn cap) | Same as above — no PR exists afterwards either way, so the daemon's post-hoc `has_existing_pr()` check swaps to `BOT_PR_FAILED` regardless of the invocation's exit code. |

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -265,5 +265,66 @@ class CreatePrTests(DaemonPathsTestCase):
         self.assertTrue((self.log_dir / "issue-4720-pr.log").exists())
 
 
+class ProcessBotPrIssueTests(unittest.TestCase):
+    """Tests for process_bot_pr_issue(), the orchestrator wiring the whole BOT_PR flow
+    together - new in the bot PR flow."""
+
+    def setUp(self):
+        """Patch every collaborator process_bot_pr_issue() calls."""
+        self.patches = {}
+        for name in [
+            "has_existing_pr",
+            "sync_repo",
+            "reset_scratch",
+            "ensure_triaged",
+            "triage",
+            "create_pr",
+            "mark_pr_opened",
+            "mark_pr_failed",
+        ]:
+            patcher = patch.object(triage_daemon, name)
+            self.patches[name] = patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_skips_entirely_when_pr_already_exists(self):
+        """An issue that already has a referencing PR is left alone."""
+        self.patches["has_existing_pr"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        self.patches["sync_repo"].assert_not_called()
+        self.patches["create_pr"].assert_not_called()
+
+    def test_runs_triage_first_when_not_yet_triaged(self):
+        """An untriaged issue is triaged before the PR flow runs."""
+        self.patches["has_existing_pr"].side_effect = [False, True]  # entry guard, then post-hoc check
+        self.patches["ensure_triaged"].return_value = False
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        self.patches["triage"].assert_called_once_with(4720)
+        self.patches["create_pr"].assert_called_once_with(4720)
+
+    def test_skips_triage_when_already_triaged(self):
+        """An already-triaged issue goes straight to the PR flow."""
+        self.patches["has_existing_pr"].side_effect = [False, True]
+        self.patches["ensure_triaged"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [{"name": "BOT_TRIAGED"}]})
+        self.patches["triage"].assert_not_called()
+        self.patches["create_pr"].assert_called_once_with(4720)
+
+    def test_marks_opened_when_a_pr_exists_afterwards(self):
+        """If a PR references the issue after create_pr() runs, swap to BOT_PR_OPENED."""
+        self.patches["has_existing_pr"].side_effect = [False, True]
+        self.patches["ensure_triaged"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        self.patches["mark_pr_opened"].assert_called_once_with(4720)
+        self.patches["mark_pr_failed"].assert_not_called()
+
+    def test_marks_failed_when_no_pr_exists_afterwards(self):
+        """If no PR exists after create_pr() runs (quality gate failed), swap to BOT_PR_FAILED."""
+        self.patches["has_existing_pr"].side_effect = [False, False]
+        self.patches["ensure_triaged"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        self.patches["mark_pr_failed"].assert_called_once_with(4720)
+        self.patches["mark_pr_opened"].assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -83,9 +83,7 @@ class FetchBotPrIssuesTests(unittest.TestCase):
     @patch("triage_daemon.subprocess.run")
     def test_queries_open_issues_labelled_bot_pr(self, mock_run):
         """Calls gh issue list scoped to the BOT_PR label and returns the parsed issues."""
-        mock_run.return_value = MagicMock(
-            stdout=json.dumps([{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}])
-        )
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}]))
         result = triage_daemon.fetch_bot_pr_issues()
         self.assertEqual(result, [{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}])
         args = mock_run.call_args[0][0]
@@ -107,9 +105,7 @@ class EnsureTriagedTests(unittest.TestCase):
     @patch("triage_daemon.subprocess.run")
     def test_find_triage_comment_true_when_disclosure_present(self, mock_run):
         """A comment containing the triage disclosure line counts as already triaged."""
-        mock_run.return_value = MagicMock(
-            stdout=json.dumps({"comments": [{"body": "This is an automated first-pass triage of..."}]})
-        )
+        mock_run.return_value = MagicMock(stdout=json.dumps({"comments": [{"body": "This is an automated first-pass triage of..."}]}))
         self.assertTrue(triage_daemon.find_triage_comment(4720))
 
     @patch("triage_daemon.subprocess.run")

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -114,6 +114,14 @@ class FetchBotPrIssuesTests(unittest.TestCase):
         json_fields = args[args.index("--json") + 1]
         self.assertIn("title", json_fields.split(","))
 
+    @patch("triage_daemon.subprocess.run")
+    def test_requests_a_generous_limit(self, mock_run):
+        """gh issue list defaults to 30 results; request enough that BOT_PR issues aren't silently dropped."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([]))
+        triage_daemon.fetch_bot_pr_issues()
+        args = mock_run.call_args[0][0]
+        self.assertIn("--limit", args)
+
 
 class EnsureTriagedTests(unittest.TestCase):
     """Tests for the BOT_PR precondition check, new in the bot PR flow."""
@@ -137,6 +145,23 @@ class EnsureTriagedTests(unittest.TestCase):
         """Unrelated comments don't count as a triage comment."""
         mock_run.return_value = MagicMock(stdout=json.dumps({"comments": [{"body": "thanks for the report"}]}))
         self.assertFalse(triage_daemon.find_triage_comment(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_find_triage_comment_scopes_to_repo(self, mock_run):
+        """Always passes --repo explicitly - the daemon's cwd isn't guaranteed to be the clone."""
+        mock_run.return_value = MagicMock(stdout=json.dumps({"comments": []}))
+        triage_daemon.find_triage_comment(4720)
+        args = mock_run.call_args[0][0]
+        self.assertIn("--repo", args)
+        self.assertEqual(args[args.index("--repo") + 1], "springfall2008/batpred")
+
+    @patch("triage_daemon.subprocess.run")
+    def test_backfill_triaged_label_scopes_to_repo(self, mock_run):
+        """Always passes --repo explicitly - the daemon's cwd isn't guaranteed to be the clone."""
+        triage_daemon.backfill_triaged_label(4720)
+        args = mock_run.call_args[0][0]
+        self.assertIn("--repo", args)
+        self.assertEqual(args[args.index("--repo") + 1], "springfall2008/batpred")
 
     @patch("triage_daemon.subprocess.run")
     def test_ensure_triaged_skips_lookup_when_label_present(self, mock_run):
@@ -181,23 +206,111 @@ class DuplicateGuardTests(unittest.TestCase):
         mock_run.return_value = MagicMock(stdout=json.dumps([]))
         self.assertFalse(triage_daemon.has_existing_pr(4720))
 
+    @patch("triage_daemon.subprocess.run")
+    def test_has_existing_pr_scopes_to_repo(self, mock_run):
+        """Always passes --repo explicitly - the daemon's cwd isn't guaranteed to be the clone."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([]))
+        triage_daemon.has_existing_pr(4720)
+        args = mock_run.call_args[0][0]
+        self.assertIn("--repo", args)
+        self.assertEqual(args[args.index("--repo") + 1], "springfall2008/batpred")
+
+
+class IsActionableTests(unittest.TestCase):
+    """Tests for is_actionable(), new - guards against implementing a closed,
+    duplicate, question, or configuration issue after an inline /issue-triage call."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_true_when_open_and_classified_bug(self, mock_run):
+        """An open issue classified bug is actionable."""
+        mock_run.return_value = MagicMock(stdout=json.dumps({"state": "OPEN", "labels": [{"name": "bug"}]}))
+        self.assertTrue(triage_daemon.is_actionable(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_true_when_open_and_classified_enhancement(self, mock_run):
+        """An open issue classified enhancement is actionable."""
+        mock_run.return_value = MagicMock(stdout=json.dumps({"state": "OPEN", "labels": [{"name": "enhancement"}]}))
+        self.assertTrue(triage_daemon.is_actionable(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_false_when_closed(self, mock_run):
+        """A closed issue (e.g. triaged as a duplicate and closed) is not actionable."""
+        mock_run.return_value = MagicMock(stdout=json.dumps({"state": "CLOSED", "labels": [{"name": "bug"}]}))
+        self.assertFalse(triage_daemon.is_actionable(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_false_when_classified_question(self, mock_run):
+        """A question isn't something to implement a PR for."""
+        mock_run.return_value = MagicMock(stdout=json.dumps({"state": "OPEN", "labels": [{"name": "question"}]}))
+        self.assertFalse(triage_daemon.is_actionable(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_scopes_to_repo(self, mock_run):
+        """Always passes --repo explicitly - the daemon's cwd isn't guaranteed to be the clone."""
+        mock_run.return_value = MagicMock(stdout=json.dumps({"state": "OPEN", "labels": []}))
+        triage_daemon.is_actionable(4720)
+        args = mock_run.call_args[0][0]
+        self.assertIn("--repo", args)
+        self.assertEqual(args[args.index("--repo") + 1], "springfall2008/batpred")
+
+
+class MarkPrNotActionableTests(unittest.TestCase):
+    """Tests for mark_pr_not_actionable(), new - explains why no PR was attempted."""
+
+    @patch("triage_daemon.mark_pr_failed")
+    @patch("triage_daemon.subprocess.run")
+    def test_comments_then_delegates_to_mark_pr_failed(self, mock_run, mock_mark_failed):
+        """Posts an explanatory comment, then reuses mark_pr_failed for the label swap."""
+        triage_daemon.mark_pr_not_actionable(4720)
+        comment_args = mock_run.call_args[0][0]
+        self.assertEqual(comment_args[:3], ["gh", "issue", "comment"])
+        mock_mark_failed.assert_called_once_with(4720)
+
 
 class LabelSwapTests(unittest.TestCase):
     """Tests for mark_pr_opened/mark_pr_failed, new in the bot PR flow."""
 
     @patch("triage_daemon.subprocess.run")
     def test_mark_pr_opened_swaps_labels(self, mock_run):
-        """Removes BOT_PR and adds BOT_PR_OPENED."""
+        """Removes BOT_PR and adds BOT_PR_OPENED, scoped to the configured repo."""
         triage_daemon.mark_pr_opened(4720)
         args = mock_run.call_args[0][0]
-        self.assertEqual(args, ["gh", "issue", "edit", "4720", "--remove-label", "BOT_PR", "--add-label", "BOT_PR_OPENED"])
+        self.assertEqual(
+            args,
+            [
+                "gh",
+                "issue",
+                "edit",
+                "4720",
+                "--repo",
+                "springfall2008/batpred",
+                "--remove-label",
+                "BOT_PR",
+                "--add-label",
+                "BOT_PR_OPENED",
+            ],
+        )
 
     @patch("triage_daemon.subprocess.run")
     def test_mark_pr_failed_swaps_labels(self, mock_run):
-        """Removes BOT_PR and adds BOT_PR_FAILED."""
+        """Removes BOT_PR and adds BOT_PR_FAILED, scoped to the configured repo."""
         triage_daemon.mark_pr_failed(4720)
         args = mock_run.call_args[0][0]
-        self.assertEqual(args, ["gh", "issue", "edit", "4720", "--remove-label", "BOT_PR", "--add-label", "BOT_PR_FAILED"])
+        self.assertEqual(
+            args,
+            [
+                "gh",
+                "issue",
+                "edit",
+                "4720",
+                "--repo",
+                "springfall2008/batpred",
+                "--remove-label",
+                "BOT_PR",
+                "--add-label",
+                "BOT_PR_FAILED",
+            ],
+        )
 
 
 class PermissionModelTests(unittest.TestCase):
@@ -254,6 +367,29 @@ class PermissionModelTests(unittest.TestCase):
             },
         )
 
+    def test_pr_disallowed_tools_still_blocks_force_push_variants(self):
+        """Even though the PR flow can push, force-push stays denied - defense in depth
+        against a prompt-injected instruction attempting to rewrite history."""
+        pr_denied = triage_daemon.DISALLOWED_TOOLS_PR.split(",")
+        self.assertTrue(any("force" in entry for entry in pr_denied), pr_denied)
+        self.assertTrue(any("-f" in entry for entry in pr_denied), pr_denied)
+
+
+class SyncRepoTests(unittest.TestCase):
+    """Tests for sync_repo(), modified to always return to main first."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_checks_out_main_before_resetting(self, mock_run):
+        """A previous crashed BOT_PR run can leave the clone on a fix/*|feat/* branch;
+        sync_repo must switch back to main before reset --hard, or it resets the wrong
+        branch and leaves the clone stuck off main."""
+        triage_daemon.sync_repo()
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        checkout_call = ["git", "-C", str(triage_daemon.CLONE_DIR), "checkout", "main"]
+        reset_call = ["git", "-C", str(triage_daemon.CLONE_DIR), "reset", "--hard", "origin/main"]
+        self.assertIn(checkout_call, calls)
+        self.assertLess(calls.index(checkout_call), calls.index(reset_call))
+
 
 class CreatePrTests(DaemonPathsTestCase):
     """Tests for create_pr(), new in the bot PR flow."""
@@ -298,20 +434,26 @@ class ProcessBotPrIssueTests(unittest.TestCase):
             "reset_scratch",
             "ensure_triaged",
             "triage",
+            "is_actionable",
             "create_pr",
             "mark_pr_opened",
             "mark_pr_failed",
+            "mark_pr_not_actionable",
         ]:
             patcher = patch.object(triage_daemon, name)
             self.patches[name] = patcher.start()
             self.addCleanup(patcher.stop)
+        # Most tests don't exercise the actionable check; default it out of the way.
+        self.patches["is_actionable"].return_value = True
 
-    def test_skips_entirely_when_pr_already_exists(self):
-        """An issue that already has a referencing PR is left alone."""
+    def test_marks_opened_when_pr_already_exists_on_entry(self):
+        """A pre-existing PR (e.g. from a crashed prior run that never reached the
+        label swap) converges the label to BOT_PR_OPENED instead of skipping forever."""
         self.patches["has_existing_pr"].return_value = True
         triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [], "title": "Solis TOU bit refused"})
         self.patches["sync_repo"].assert_not_called()
         self.patches["create_pr"].assert_not_called()
+        self.patches["mark_pr_opened"].assert_called_once_with(4720)
 
     def test_runs_triage_first_when_not_yet_triaged(self):
         """An untriaged issue is triaged before the PR flow runs."""
@@ -345,6 +487,18 @@ class ProcessBotPrIssueTests(unittest.TestCase):
         self.patches["mark_pr_failed"].assert_called_once_with(4720)
         self.patches["mark_pr_opened"].assert_not_called()
 
+    def test_not_actionable_after_triage_skips_create_pr(self):
+        """If an inline /issue-triage classifies the ticket as a duplicate (and closes
+        it), a question, or a configuration issue, the daemon must not implement it."""
+        self.patches["has_existing_pr"].return_value = False
+        self.patches["ensure_triaged"].return_value = False
+        self.patches["is_actionable"].return_value = False
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [], "title": "Solis TOU bit refused"})
+        self.patches["triage"].assert_called_once_with(4720)
+        self.patches["create_pr"].assert_not_called()
+        self.patches["mark_pr_not_actionable"].assert_called_once_with(4720)
+        self.patches["mark_pr_failed"].assert_not_called()
+
     @patch("builtins.print")
     def test_prints_the_title_and_link_before_doing_anything(self, mock_print):
         """Prints the issue's title and an openable GitHub link as soon as work starts."""
@@ -370,16 +524,24 @@ class FetchBotReviewIssuesTests(unittest.TestCase):
         json_fields = args[args.index("--json") + 1]
         self.assertIn("title", json_fields.split(","))
 
+    @patch("triage_daemon.subprocess.run")
+    def test_requests_a_generous_limit(self, mock_run):
+        """gh issue list defaults to 30 results; request enough that BOT_REVIEW issues aren't silently dropped."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([]))
+        triage_daemon.fetch_bot_review_issues()
+        args = mock_run.call_args[0][0]
+        self.assertIn("--limit", args)
+
 
 class RemoveReviewLabelTests(unittest.TestCase):
     """Tests for remove_review_label(), new in the BOT_REVIEW flow."""
 
     @patch("triage_daemon.subprocess.run")
     def test_removes_bot_review_label(self, mock_run):
-        """Removes BOT_REVIEW, adds nothing."""
+        """Removes BOT_REVIEW, scoped to the configured repo."""
         triage_daemon.remove_review_label(3100)
         args = mock_run.call_args[0][0]
-        self.assertEqual(args, ["gh", "issue", "edit", "3100", "--remove-label", "BOT_REVIEW"])
+        self.assertEqual(args, ["gh", "issue", "edit", "3100", "--repo", "springfall2008/batpred", "--remove-label", "BOT_REVIEW"])
 
 
 class MarkReviewFailedTests(unittest.TestCase):
@@ -387,11 +549,26 @@ class MarkReviewFailedTests(unittest.TestCase):
 
     @patch("triage_daemon.subprocess.run")
     def test_comments_then_swaps_labels(self, mock_run):
-        """Posts an explanatory comment, then swaps BOT_REVIEW for BOT_FAILED."""
+        """Posts an explanatory comment, then swaps BOT_REVIEW for BOT_FAILED, both scoped to the configured repo."""
         triage_daemon.mark_review_failed(3100)
         calls = [call.args[0] for call in mock_run.call_args_list]
         self.assertEqual(calls[0][:3], ["gh", "issue", "comment"])
-        self.assertEqual(calls[1], ["gh", "issue", "edit", "3100", "--remove-label", "BOT_REVIEW", "--add-label", "BOT_FAILED"])
+        self.assertIn("--repo", calls[0])
+        self.assertEqual(
+            calls[1],
+            [
+                "gh",
+                "issue",
+                "edit",
+                "3100",
+                "--repo",
+                "springfall2008/batpred",
+                "--remove-label",
+                "BOT_REVIEW",
+                "--add-label",
+                "BOT_FAILED",
+            ],
+        )
 
 
 class ProcessBotReviewIssueTests(unittest.TestCase):

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/triage_daemon.py.
+
+Runs standalone, not through coverage/run_all: the daemon has no dependency on
+apps/predbat, so folding these into TEST_REGISTRY would be a layering violation.
+Run directly with `python3 tools/test_triage_daemon.py`. Every gh/git/claude call is
+mocked - nothing here touches a real repo, GitHub, or Claude Code session.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import triage_daemon
+
+
+class DaemonPathsTestCase(unittest.TestCase):
+    """Base class that points the daemon's module-level paths at a scratch temp dir."""
+
+    def setUp(self):
+        """Create a scratch directory and patch the daemon's path constants onto it."""
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        base = Path(self.tmp_dir.name)
+        self.state_file = base / "state.json"
+        self.log_dir = base / "logs"
+        self._patch("BASE_DIR", base)
+        self._patch("STATE_FILE", self.state_file)
+        self._patch("LOG_DIR", self.log_dir)
+        self._patch("CLONE_DIR", base / "batpred")
+        self._patch("SCRATCH_DIR", base / "scratch")
+
+    def _patch(self, name, value):
+        """Patch a module-level constant on triage_daemon for the duration of the test."""
+        patcher = patch.object(triage_daemon, name, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class LoadSaveStateTests(DaemonPathsTestCase):
+    """Characterisation tests for load_state()/save_state() - pre-existing, unchanged."""
+
+    def test_save_then_load_round_trips(self):
+        """A saved state dict is returned unchanged by a subsequent load."""
+        triage_daemon.save_state({"last_processed": 42})
+        self.assertEqual(triage_daemon.load_state(), {"last_processed": 42})
+
+    def test_load_missing_file_returns_default(self):
+        """With no state file yet, load_state() returns the zeroed default."""
+        self.assertEqual(triage_daemon.load_state(), {"last_processed": 0})
+
+    def test_load_corrupt_file_returns_default(self):
+        """A truncated/corrupt state file is treated the same as a missing one."""
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        self.state_file.write_text("{not valid json")
+        self.assertEqual(triage_daemon.load_state(), {"last_processed": 0})
+
+
+class FetchNewIssuesTests(unittest.TestCase):
+    """Characterisation tests for fetch_new_issues() - pre-existing, unchanged."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_filters_and_sorts_by_issue_number(self, mock_run):
+        """Only issues newer than since_number are returned, sorted ascending."""
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps(
+                [
+                    {"number": 10, "createdAt": "2026-01-01T00:00:00Z"},
+                    {"number": 8, "createdAt": "2025-12-01T00:00:00Z"},
+                    {"number": 12, "createdAt": "2026-02-01T00:00:00Z"},
+                ]
+            )
+        )
+        result = triage_daemon.fetch_new_issues(9)
+        self.assertEqual([issue["number"] for issue in result], [10, 12])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -162,5 +162,23 @@ class DuplicateGuardTests(unittest.TestCase):
         self.assertFalse(triage_daemon.has_existing_pr(4720))
 
 
+class LabelSwapTests(unittest.TestCase):
+    """Tests for mark_pr_opened/mark_pr_failed, new in the bot PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_opened_swaps_labels(self, mock_run):
+        """Removes BOT_PR and adds BOT_PR_OPENED."""
+        triage_daemon.mark_pr_opened(4720)
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "issue", "edit", "4720", "--remove-label", "BOT_PR", "--add-label", "BOT_PR_OPENED"])
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_failed_swaps_labels(self, mock_run):
+        """Removes BOT_PR and adds BOT_PR_FAILED."""
+        triage_daemon.mark_pr_failed(4720)
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "issue", "edit", "4720", "--remove-label", "BOT_PR", "--add-label", "BOT_PR_FAILED"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -142,5 +142,25 @@ class EnsureTriagedTests(unittest.TestCase):
         mock_backfill.assert_not_called()
 
 
+class DuplicateGuardTests(unittest.TestCase):
+    """Tests for the duplicate-work guard, new in the bot PR flow."""
+
+    def test_search_query_uses_quoted_fixes_phrase(self):
+        """The query searches the exact quoted phrase, not a bare issue number."""
+        self.assertEqual(triage_daemon.build_duplicate_search_query(4720), '"Fixes #4720" in:body')
+
+    @patch("triage_daemon.subprocess.run")
+    def test_has_existing_pr_true_when_match_found(self, mock_run):
+        """A non-empty search result means a PR already exists for this issue."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 99}]))
+        self.assertTrue(triage_daemon.has_existing_pr(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_has_existing_pr_false_when_no_match(self, mock_run):
+        """An empty search result means no PR exists yet for this issue."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([]))
+        self.assertFalse(triage_daemon.has_existing_pr(4720))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -235,5 +235,35 @@ class PermissionModelTests(unittest.TestCase):
         )
 
 
+class CreatePrTests(DaemonPathsTestCase):
+    """Tests for create_pr(), new in the bot PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_invokes_claude_with_the_pr_permission_set(self, mock_run):
+        """Runs the /issue-pr skill with the PR-flow allow/deny lists and budget caps."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.create_pr(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/issue-pr 4720", cmd[2])
+        self.assertIn(triage_daemon.ALLOWED_TOOLS_PR, cmd)
+        self.assertIn(triage_daemon.DISALLOWED_TOOLS_PR, cmd)
+        self.assertIn("150", cmd)
+        self.assertIn("25.00", cmd)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_does_not_raise_on_a_non_zero_exit(self, mock_run):
+        """Unlike triage(), a non-zero exit is logged, not raised - the caller decides
+        success by checking for the PR afterwards, not from this function's return."""
+        mock_run.return_value = MagicMock(returncode=1)
+        triage_daemon.create_pr(4720)  # must not raise
+
+    @patch("triage_daemon.subprocess.run")
+    def test_writes_a_log_file(self, mock_run):
+        """A per-issue PR-flow log file is created under LOG_DIR."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.create_pr(4720)
+        self.assertTrue((self.log_dir / "issue-4720-pr.log").exists())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -8,6 +8,7 @@ mocked - nothing here touches a real repo, GitHub, or Claude Code session.
 """
 
 import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -320,6 +321,81 @@ class ProcessBotPrIssueTests(unittest.TestCase):
         triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
         self.patches["mark_pr_failed"].assert_called_once_with(4720)
         self.patches["mark_pr_opened"].assert_not_called()
+
+
+class FetchBotReviewIssuesTests(unittest.TestCase):
+    """Tests for fetch_bot_review_issues(), new in the BOT_REVIEW flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_queries_open_issues_labelled_bot_review(self, mock_run):
+        """Calls gh issue list scoped to the BOT_REVIEW label and returns the parsed issues."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 3100, "labels": [{"name": "BOT_REVIEW"}]}]))
+        result = triage_daemon.fetch_bot_review_issues()
+        self.assertEqual(result, [{"number": 3100, "labels": [{"name": "BOT_REVIEW"}]}])
+        args = mock_run.call_args[0][0]
+        self.assertIn("--label", args)
+        self.assertEqual(args[args.index("--label") + 1], "BOT_REVIEW")
+
+
+class RemoveReviewLabelTests(unittest.TestCase):
+    """Tests for remove_review_label(), new in the BOT_REVIEW flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_removes_bot_review_label(self, mock_run):
+        """Removes BOT_REVIEW, adds nothing."""
+        triage_daemon.remove_review_label(3100)
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "issue", "edit", "3100", "--remove-label", "BOT_REVIEW"])
+
+
+class MarkReviewFailedTests(unittest.TestCase):
+    """Tests for mark_review_failed(), new in the BOT_REVIEW flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_comments_then_swaps_labels(self, mock_run):
+        """Posts an explanatory comment, then swaps BOT_REVIEW for BOT_FAILED."""
+        triage_daemon.mark_review_failed(3100)
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        self.assertEqual(calls[0][:3], ["gh", "issue", "comment"])
+        self.assertEqual(calls[1], ["gh", "issue", "edit", "3100", "--remove-label", "BOT_REVIEW", "--add-label", "BOT_FAILED"])
+
+
+class ProcessBotReviewIssueTests(unittest.TestCase):
+    """Tests for process_bot_review_issue(), new in the BOT_REVIEW flow."""
+
+    def setUp(self):
+        """Patch every collaborator process_bot_review_issue() calls."""
+        self.patches = {}
+        for name in ["ensure_triaged", "sync_repo", "reset_scratch", "triage", "remove_review_label", "mark_review_failed"]:
+            patcher = patch.object(triage_daemon, name)
+            self.patches[name] = patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_already_triaged_just_removes_the_label(self):
+        """An already-triaged issue skips triage() entirely."""
+        self.patches["ensure_triaged"].return_value = True
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": [{"name": "BOT_TRIAGED"}]})
+        self.patches["triage"].assert_not_called()
+        self.patches["remove_review_label"].assert_called_once_with(3100)
+        self.patches["mark_review_failed"].assert_not_called()
+
+    def test_not_triaged_runs_triage_then_removes_the_label(self):
+        """An untriaged issue is synced, triaged, then the trigger label is removed."""
+        self.patches["ensure_triaged"].return_value = False
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": []})
+        self.patches["sync_repo"].assert_called_once()
+        self.patches["reset_scratch"].assert_called_once()
+        self.patches["triage"].assert_called_once_with(3100)
+        self.patches["remove_review_label"].assert_called_once_with(3100)
+        self.patches["mark_review_failed"].assert_not_called()
+
+    def test_failed_triage_marks_failed_instead_of_removing_the_label(self):
+        """A triage() failure swaps to BOT_FAILED rather than retrying next poll."""
+        self.patches["ensure_triaged"].return_value = False
+        self.patches["triage"].side_effect = subprocess.CalledProcessError(1, ["claude"])
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": []})
+        self.patches["mark_review_failed"].assert_called_once_with(3100)
+        self.patches["remove_review_label"].assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -77,5 +77,21 @@ class FetchNewIssuesTests(unittest.TestCase):
         self.assertEqual([issue["number"] for issue in result], [10, 12])
 
 
+class FetchBotPrIssuesTests(unittest.TestCase):
+    """Tests for fetch_bot_pr_issues(), new in the bot PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_queries_open_issues_labelled_bot_pr(self, mock_run):
+        """Calls gh issue list scoped to the BOT_PR label and returns the parsed issues."""
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps([{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}])
+        )
+        result = triage_daemon.fetch_bot_pr_issues()
+        self.assertEqual(result, [{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}])
+        args = mock_run.call_args[0][0]
+        self.assertIn("--label", args)
+        self.assertEqual(args[args.index("--label") + 1], "BOT_PR")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -59,8 +59,17 @@ class LoadSaveStateTests(DaemonPathsTestCase):
         self.assertEqual(triage_daemon.load_state(), {"last_processed": 0})
 
 
+class IssueUrlTests(unittest.TestCase):
+    """Tests for issue_url(), new - used to print an openable link when work starts."""
+
+    def test_builds_the_github_issue_url(self):
+        """Returns the standard GitHub issue URL for the configured repo."""
+        self.assertEqual(triage_daemon.issue_url(4720), "https://github.com/springfall2008/batpred/issues/4720")
+
+
 class FetchNewIssuesTests(unittest.TestCase):
-    """Characterisation tests for fetch_new_issues() - pre-existing, unchanged."""
+    """Characterisation tests for fetch_new_issues() - pre-existing, except for also
+    requesting the title field (used to print an openable link when work starts)."""
 
     @patch("triage_daemon.subprocess.run")
     def test_filters_and_sorts_by_issue_number(self, mock_run):
@@ -68,14 +77,23 @@ class FetchNewIssuesTests(unittest.TestCase):
         mock_run.return_value = MagicMock(
             stdout=json.dumps(
                 [
-                    {"number": 10, "createdAt": "2026-01-01T00:00:00Z"},
-                    {"number": 8, "createdAt": "2025-12-01T00:00:00Z"},
-                    {"number": 12, "createdAt": "2026-02-01T00:00:00Z"},
+                    {"number": 10, "createdAt": "2026-01-01T00:00:00Z", "title": "Ten"},
+                    {"number": 8, "createdAt": "2025-12-01T00:00:00Z", "title": "Eight"},
+                    {"number": 12, "createdAt": "2026-02-01T00:00:00Z", "title": "Twelve"},
                 ]
             )
         )
         result = triage_daemon.fetch_new_issues(9)
         self.assertEqual([issue["number"] for issue in result], [10, 12])
+
+    @patch("triage_daemon.subprocess.run")
+    def test_requests_the_title_field(self, mock_run):
+        """Requests title alongside number/createdAt, so it's available to print without a second call."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([]))
+        triage_daemon.fetch_new_issues(0)
+        args = mock_run.call_args[0][0]
+        json_fields = args[args.index("--json") + 1]
+        self.assertIn("title", json_fields.split(","))
 
 
 class FetchBotPrIssuesTests(unittest.TestCase):
@@ -84,12 +102,17 @@ class FetchBotPrIssuesTests(unittest.TestCase):
     @patch("triage_daemon.subprocess.run")
     def test_queries_open_issues_labelled_bot_pr(self, mock_run):
         """Calls gh issue list scoped to the BOT_PR label and returns the parsed issues."""
-        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}]))
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}], "title": "Solis TOU bit refused"}]))
         result = triage_daemon.fetch_bot_pr_issues()
-        self.assertEqual(result, [{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}]}])
+        self.assertEqual(
+            result,
+            [{"number": 4720, "labels": [{"name": "BOT_PR"}, {"name": "BOT_TRIAGED"}], "title": "Solis TOU bit refused"}],
+        )
         args = mock_run.call_args[0][0]
         self.assertIn("--label", args)
         self.assertEqual(args[args.index("--label") + 1], "BOT_PR")
+        json_fields = args[args.index("--json") + 1]
+        self.assertIn("title", json_fields.split(","))
 
 
 class EnsureTriagedTests(unittest.TestCase):
@@ -286,7 +309,7 @@ class ProcessBotPrIssueTests(unittest.TestCase):
     def test_skips_entirely_when_pr_already_exists(self):
         """An issue that already has a referencing PR is left alone."""
         self.patches["has_existing_pr"].return_value = True
-        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [], "title": "Solis TOU bit refused"})
         self.patches["sync_repo"].assert_not_called()
         self.patches["create_pr"].assert_not_called()
 
@@ -294,7 +317,7 @@ class ProcessBotPrIssueTests(unittest.TestCase):
         """An untriaged issue is triaged before the PR flow runs."""
         self.patches["has_existing_pr"].side_effect = [False, True]  # entry guard, then post-hoc check
         self.patches["ensure_triaged"].return_value = False
-        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [], "title": "Solis TOU bit refused"})
         self.patches["triage"].assert_called_once_with(4720)
         self.patches["create_pr"].assert_called_once_with(4720)
 
@@ -302,7 +325,7 @@ class ProcessBotPrIssueTests(unittest.TestCase):
         """An already-triaged issue goes straight to the PR flow."""
         self.patches["has_existing_pr"].side_effect = [False, True]
         self.patches["ensure_triaged"].return_value = True
-        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [{"name": "BOT_TRIAGED"}]})
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [{"name": "BOT_TRIAGED"}], "title": "Solis TOU bit refused"})
         self.patches["triage"].assert_not_called()
         self.patches["create_pr"].assert_called_once_with(4720)
 
@@ -310,7 +333,7 @@ class ProcessBotPrIssueTests(unittest.TestCase):
         """If a PR references the issue after create_pr() runs, swap to BOT_PR_OPENED."""
         self.patches["has_existing_pr"].side_effect = [False, True]
         self.patches["ensure_triaged"].return_value = True
-        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [], "title": "Solis TOU bit refused"})
         self.patches["mark_pr_opened"].assert_called_once_with(4720)
         self.patches["mark_pr_failed"].assert_not_called()
 
@@ -318,9 +341,18 @@ class ProcessBotPrIssueTests(unittest.TestCase):
         """If no PR exists after create_pr() runs (quality gate failed), swap to BOT_PR_FAILED."""
         self.patches["has_existing_pr"].side_effect = [False, False]
         self.patches["ensure_triaged"].return_value = True
-        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": []})
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [], "title": "Solis TOU bit refused"})
         self.patches["mark_pr_failed"].assert_called_once_with(4720)
         self.patches["mark_pr_opened"].assert_not_called()
+
+    @patch("builtins.print")
+    def test_prints_the_title_and_link_before_doing_anything(self, mock_print):
+        """Prints the issue's title and an openable GitHub link as soon as work starts."""
+        self.patches["has_existing_pr"].return_value = True
+        triage_daemon.process_bot_pr_issue({"number": 4720, "labels": [], "title": "Solis TOU bit refused"})
+        printed = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
+        self.assertIn("Solis TOU bit refused", printed)
+        self.assertIn("https://github.com/springfall2008/batpred/issues/4720", printed)
 
 
 class FetchBotReviewIssuesTests(unittest.TestCase):
@@ -329,12 +361,14 @@ class FetchBotReviewIssuesTests(unittest.TestCase):
     @patch("triage_daemon.subprocess.run")
     def test_queries_open_issues_labelled_bot_review(self, mock_run):
         """Calls gh issue list scoped to the BOT_REVIEW label and returns the parsed issues."""
-        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 3100, "labels": [{"name": "BOT_REVIEW"}]}]))
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 3100, "labels": [{"name": "BOT_REVIEW"}], "title": "Old ticket needing review"}]))
         result = triage_daemon.fetch_bot_review_issues()
-        self.assertEqual(result, [{"number": 3100, "labels": [{"name": "BOT_REVIEW"}]}])
+        self.assertEqual(result, [{"number": 3100, "labels": [{"name": "BOT_REVIEW"}], "title": "Old ticket needing review"}])
         args = mock_run.call_args[0][0]
         self.assertIn("--label", args)
         self.assertEqual(args[args.index("--label") + 1], "BOT_REVIEW")
+        json_fields = args[args.index("--json") + 1]
+        self.assertIn("title", json_fields.split(","))
 
 
 class RemoveReviewLabelTests(unittest.TestCase):
@@ -374,7 +408,7 @@ class ProcessBotReviewIssueTests(unittest.TestCase):
     def test_already_triaged_just_removes_the_label(self):
         """An already-triaged issue skips triage() entirely."""
         self.patches["ensure_triaged"].return_value = True
-        triage_daemon.process_bot_review_issue({"number": 3100, "labels": [{"name": "BOT_TRIAGED"}]})
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": [{"name": "BOT_TRIAGED"}], "title": "Old ticket needing review"})
         self.patches["triage"].assert_not_called()
         self.patches["remove_review_label"].assert_called_once_with(3100)
         self.patches["mark_review_failed"].assert_not_called()
@@ -382,7 +416,7 @@ class ProcessBotReviewIssueTests(unittest.TestCase):
     def test_not_triaged_runs_triage_then_removes_the_label(self):
         """An untriaged issue is synced, triaged, then the trigger label is removed."""
         self.patches["ensure_triaged"].return_value = False
-        triage_daemon.process_bot_review_issue({"number": 3100, "labels": []})
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": [], "title": "Old ticket needing review"})
         self.patches["sync_repo"].assert_called_once()
         self.patches["reset_scratch"].assert_called_once()
         self.patches["triage"].assert_called_once_with(3100)
@@ -393,9 +427,18 @@ class ProcessBotReviewIssueTests(unittest.TestCase):
         """A triage() failure swaps to BOT_FAILED rather than retrying next poll."""
         self.patches["ensure_triaged"].return_value = False
         self.patches["triage"].side_effect = subprocess.CalledProcessError(1, ["claude"])
-        triage_daemon.process_bot_review_issue({"number": 3100, "labels": []})
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": [], "title": "Old ticket needing review"})
         self.patches["mark_review_failed"].assert_called_once_with(3100)
         self.patches["remove_review_label"].assert_not_called()
+
+    @patch("builtins.print")
+    def test_prints_the_title_and_link_before_doing_anything(self, mock_print):
+        """Prints the issue's title and an openable GitHub link as soon as work starts."""
+        self.patches["ensure_triaged"].return_value = True
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": [], "title": "Old ticket needing review"})
+        printed = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
+        self.assertIn("Old ticket needing review", printed)
+        self.assertIn("https://github.com/springfall2008/batpred/issues/3100", printed)
 
 
 if __name__ == "__main__":

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -180,5 +180,60 @@ class LabelSwapTests(unittest.TestCase):
         self.assertEqual(args, ["gh", "issue", "edit", "4720", "--remove-label", "BOT_PR", "--add-label", "BOT_PR_FAILED"])
 
 
+class PermissionModelTests(unittest.TestCase):
+    """Regression tests for the ALLOWED_TOOLS/DISALLOWED_TOOLS delta between the
+    read-only triage invocation and the push/PR-create-capable /issue-pr invocation.
+    This boundary should never drift silently."""
+
+    def test_triage_allowed_tools_still_contains_the_broad_gh_grant(self):
+        """Sanity check that the refactor didn't drop the base allowlist's core entry."""
+        self.assertIn("Bash(gh *)", triage_daemon.ALLOWED_TOOLS.split(","))
+
+    def test_pr_disallowed_tools_still_blocks_dangerous_gh_subcommands(self):
+        """Everything dangerous stays denied for the PR flow too."""
+        still_denied = [
+            "Bash(gh pr merge*)",
+            "Bash(gh pr close*)",
+            "Bash(gh repo*)",
+            "Bash(gh release*)",
+            "Bash(gh workflow*)",
+            "Bash(gh auth*)",
+            "Bash(gh secret*)",
+            "Bash(gh api*)",
+            "mcp__*",
+        ]
+        pr_denied = triage_daemon.DISALLOWED_TOOLS_PR.split(",")
+        for entry in still_denied:
+            self.assertIn(entry, pr_denied)
+
+    def test_pr_disallowed_tools_carves_out_exactly_three_entries(self):
+        """Only git push, git commit and gh pr create are removed from the denial list."""
+        base = set(triage_daemon.DISALLOWED_TOOLS.split(","))
+        pr = set(triage_daemon.DISALLOWED_TOOLS_PR.split(","))
+        self.assertEqual(base - pr, {"Bash(git push*)", "Bash(git commit*)", "Bash(gh pr create*)"})
+
+    def test_pr_allowed_tools_is_a_superset_of_the_triage_allowlist(self):
+        """The PR flow's allowlist only ever adds to the read-only allowlist, never removes."""
+        base = set(triage_daemon.ALLOWED_TOOLS.split(","))
+        pr = set(triage_daemon.ALLOWED_TOOLS_PR.split(","))
+        self.assertTrue(base.issubset(pr))
+
+    def test_pr_allowed_tools_adds_exactly_the_expected_entries(self):
+        """The only additions are add/commit/push/pr-create/pre-commit."""
+        base = set(triage_daemon.ALLOWED_TOOLS.split(","))
+        pr = set(triage_daemon.ALLOWED_TOOLS_PR.split(","))
+        self.assertEqual(
+            pr - base,
+            {
+                "Bash(git add*)",
+                "Bash(git commit*)",
+                "Bash(git push*)",
+                "Bash(gh pr create*)",
+                "Bash(./run_pre_commit*)",
+                "Bash(./run_pre_commit)",
+            },
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -93,5 +93,54 @@ class FetchBotPrIssuesTests(unittest.TestCase):
         self.assertEqual(args[args.index("--label") + 1], "BOT_PR")
 
 
+class EnsureTriagedTests(unittest.TestCase):
+    """Tests for the BOT_PR precondition check, new in the bot PR flow."""
+
+    def test_is_already_triaged_true_when_label_present(self):
+        """BOT_TRIAGED anywhere in the label list is detected."""
+        self.assertTrue(triage_daemon.is_already_triaged([{"name": "bug"}, {"name": "BOT_TRIAGED"}]))
+
+    def test_is_already_triaged_false_when_label_absent(self):
+        """A label list without BOT_TRIAGED is not mistaken for one."""
+        self.assertFalse(triage_daemon.is_already_triaged([{"name": "bug"}]))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_find_triage_comment_true_when_disclosure_present(self, mock_run):
+        """A comment containing the triage disclosure line counts as already triaged."""
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps({"comments": [{"body": "This is an automated first-pass triage of..."}]})
+        )
+        self.assertTrue(triage_daemon.find_triage_comment(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_find_triage_comment_false_when_no_match(self, mock_run):
+        """Unrelated comments don't count as a triage comment."""
+        mock_run.return_value = MagicMock(stdout=json.dumps({"comments": [{"body": "thanks for the report"}]}))
+        self.assertFalse(triage_daemon.find_triage_comment(4720))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_ensure_triaged_skips_lookup_when_label_present(self, mock_run):
+        """With BOT_TRIAGED already on the issue, no gh calls are made at all."""
+        result = triage_daemon.ensure_triaged(4720, [{"name": "BOT_TRIAGED"}])
+        self.assertTrue(result)
+        mock_run.assert_not_called()
+
+    @patch("triage_daemon.backfill_triaged_label")
+    @patch("triage_daemon.find_triage_comment", return_value=True)
+    def test_ensure_triaged_backfills_when_comment_found(self, mock_find, mock_backfill):
+        """An old issue with a triage comment but no label gets the label backfilled."""
+        result = triage_daemon.ensure_triaged(4720, [{"name": "bug"}])
+        self.assertTrue(result)
+        mock_backfill.assert_called_once_with(4720)
+
+    @patch("triage_daemon.backfill_triaged_label")
+    @patch("triage_daemon.find_triage_comment", return_value=False)
+    def test_ensure_triaged_false_when_neither_found(self, mock_find, mock_backfill):
+        """No label and no comment means /issue-triage still needs to run."""
+        result = triage_daemon.ensure_triaged(4720, [{"name": "bug"}])
+        self.assertFalse(result)
+        mock_backfill.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -82,96 +82,110 @@ POLL_SECONDS = 300
 
 EDIT_SCOPE = f"//{CLONE_DIR.relative_to('/')}/**"
 SCRATCH_SCOPE = f"//{SCRATCH_DIR.relative_to('/')}/**"
-ALLOWED_TOOLS = ",".join(
-    [
-        # Read the issue, search for duplicates, post the triage comment
-        "Bash(gh *)",
-        # Git history, and the re-sync/discard the skill does before investigating
-        "Bash(git log*)",
-        "Bash(git diff*)",
-        "Bash(git show*)",
-        "Bash(git blame*)",
-        "Bash(git grep*)",
-        "Bash(git status*)",
-        "Bash(git branch*)",
-        "Bash(git tag*)",
-        "Bash(git describe*)",
-        "Bash(git rev-parse*)",
-        "Bash(git remote -v*)",
-        "Bash(git remote show*)",
-        "Bash(git fetch*)",
-        "Bash(git reset*)",
-        "Bash(git checkout*)",
-        "Bash(git restore*)",
-        "Bash(git clean*)",
-        "Bash(git stash*)",
-        # Running one targeted test. tools/triage_test.sh keeps the cd into
-        # coverage/ and the output redirect inside the script, because Claude Code
-        # prompts on a cd combined with an output redirect - which is what the
-        # obvious "cd coverage && ./run_all --test X > log 2>&1" form is, so it is
-        # denied outright under dontAsk no matter what rules are listed here.
-        "Bash(tools/triage_test.sh *)",
-        "Bash(./tools/triage_test.sh *)",
-        "Bash(cd *)",
-        "Bash(./run_all *)",
-        "Bash(./run_all)",
-        "Bash(python3 *)",
-        # Pulling issue attachments down and picking them apart. A predbat.log
-        # is often tens of MB - too big for WebFetch and too big to read into
-        # context, so it gets downloaded and grepped instead.
-        "Bash(curl *)",
-        "Bash(mkdir *)",
-        "Bash(unzip *)",
-        "Bash(gunzip *)",
-        "Bash(zcat *)",
-        "Bash(tar *)",
-        "Bash(file *)",
-        "Bash(ls *)",
-        "Bash(find *)",
-        "Bash(wc *)",
-        "Bash(head *)",
-        "Bash(tail *)",
-        "Bash(cat *)",
-        "Bash(grep *)",
-        "Bash(rg *)",
-        "Bash(sed *)",
-        "Bash(awk *)",
-        "Bash(sort *)",
-        "Bash(uniq *)",
-        "Bash(cut *)",
-        "Bash(tr *)",
-        "Bash(tee *)",
-        "Bash(echo *)",
-        # Edit rules cover every file-editing tool (Write included) - a Write(path)
-        # rule is not matched by the file permission check, so don't add one.
-        f"Edit({EDIT_SCOPE})",
-        f"Edit({SCRATCH_SCOPE})",
-        "WebFetch",
-        "Read",
-        "Grep",
-        "Glob",
-    ]
-)
+_ALLOWED_TOOLS_BASE = [
+    # Read the issue, search for duplicates, post the triage comment
+    "Bash(gh *)",
+    # Git history, and the re-sync/discard the skill does before investigating
+    "Bash(git log*)",
+    "Bash(git diff*)",
+    "Bash(git show*)",
+    "Bash(git blame*)",
+    "Bash(git grep*)",
+    "Bash(git status*)",
+    "Bash(git branch*)",
+    "Bash(git tag*)",
+    "Bash(git describe*)",
+    "Bash(git rev-parse*)",
+    "Bash(git remote -v*)",
+    "Bash(git remote show*)",
+    "Bash(git fetch*)",
+    "Bash(git reset*)",
+    "Bash(git checkout*)",
+    "Bash(git restore*)",
+    "Bash(git clean*)",
+    "Bash(git stash*)",
+    # Running one targeted test. tools/triage_test.sh keeps the cd into
+    # coverage/ and the output redirect inside the script, because Claude Code
+    # prompts on a cd combined with an output redirect - which is what the
+    # obvious "cd coverage && ./run_all --test X > log 2>&1" form is, so it is
+    # denied outright under dontAsk no matter what rules are listed here.
+    "Bash(tools/triage_test.sh *)",
+    "Bash(./tools/triage_test.sh *)",
+    "Bash(cd *)",
+    "Bash(./run_all *)",
+    "Bash(./run_all)",
+    "Bash(python3 *)",
+    # Pulling issue attachments down and picking them apart. A predbat.log
+    # is often tens of MB - too big for WebFetch and too big to read into
+    # context, so it gets downloaded and grepped instead.
+    "Bash(curl *)",
+    "Bash(mkdir *)",
+    "Bash(unzip *)",
+    "Bash(gunzip *)",
+    "Bash(zcat *)",
+    "Bash(tar *)",
+    "Bash(file *)",
+    "Bash(ls *)",
+    "Bash(find *)",
+    "Bash(wc *)",
+    "Bash(head *)",
+    "Bash(tail *)",
+    "Bash(cat *)",
+    "Bash(grep *)",
+    "Bash(rg *)",
+    "Bash(sed *)",
+    "Bash(awk *)",
+    "Bash(sort *)",
+    "Bash(uniq *)",
+    "Bash(cut *)",
+    "Bash(tr *)",
+    "Bash(tee *)",
+    "Bash(echo *)",
+    # Edit rules cover every file-editing tool (Write included) - a Write(path)
+    # rule is not matched by the file permission check, so don't add one.
+    f"Edit({EDIT_SCOPE})",
+    f"Edit({SCRATCH_SCOPE})",
+    "WebFetch",
+    "Read",
+    "Grep",
+    "Glob",
+]
+ALLOWED_TOOLS = ",".join(_ALLOWED_TOOLS_BASE)
+# The /issue-pr invocation needs everything the read-only triage flow has, plus
+# committing/pushing its branch, opening the PR, and running pre-commit as a quality gate.
+_ALLOWED_TOOLS_PR_EXTRA = [
+    "Bash(git add*)",
+    "Bash(git commit*)",
+    "Bash(git push*)",
+    "Bash(gh pr create*)",
+    "Bash(./run_pre_commit*)",
+    "Bash(./run_pre_commit)",
+]
+ALLOWED_TOOLS_PR = ",".join(_ALLOWED_TOOLS_BASE + _ALLOWED_TOOLS_PR_EXTRA)
 # Deny wins over allow, so these carve the publishing commands back out of
 # the broad "Bash(gh *)" / "Bash(git ...)" entries above.
-DISALLOWED_TOOLS = ",".join(
-    [
-        "mcp__*",
-        "Bash(git push*)",
-        "Bash(git commit*)",
-        "Bash(git remote add*)",
-        "Bash(git remote set-url*)",
-        "Bash(gh pr create*)",
-        "Bash(gh pr merge*)",
-        "Bash(gh pr close*)",
-        "Bash(gh repo*)",
-        "Bash(gh release*)",
-        "Bash(gh workflow*)",
-        "Bash(gh auth*)",
-        "Bash(gh secret*)",
-        "Bash(gh api*)",
-    ]
-)
+_DISALLOWED_TOOLS_BASE = [
+    "mcp__*",
+    "Bash(git push*)",
+    "Bash(git commit*)",
+    "Bash(git remote add*)",
+    "Bash(git remote set-url*)",
+    "Bash(gh pr create*)",
+    "Bash(gh pr merge*)",
+    "Bash(gh pr close*)",
+    "Bash(gh repo*)",
+    "Bash(gh release*)",
+    "Bash(gh workflow*)",
+    "Bash(gh auth*)",
+    "Bash(gh secret*)",
+    "Bash(gh api*)",
+]
+DISALLOWED_TOOLS = ",".join(_DISALLOWED_TOOLS_BASE)
+# The PR flow needs to push its branch and open the PR - carve those three back out of
+# the base denial list. Everything else (merge, close, repo/release/workflow/auth/secret/
+# api admin, all mcp__*) stays denied.
+_PR_REMOVED_DENIALS = {"Bash(git push*)", "Bash(git commit*)", "Bash(gh pr create*)"}
+DISALLOWED_TOOLS_PR = ",".join(item for item in _DISALLOWED_TOOLS_BASE if item not in _PR_REMOVED_DENIALS)
 
 
 def load_state():

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -204,9 +204,14 @@ def save_state(state):
     tmp_path.replace(STATE_FILE)
 
 
+def issue_url(issue_number):
+    """Return the GitHub URL for an issue, for easy opening from the daemon's log."""
+    return f"https://github.com/{REPO}/issues/{issue_number}"
+
+
 def fetch_new_issues(since_number):
     result = subprocess.run(
-        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--json", "number,createdAt", "--limit", "100"],
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--json", "number,createdAt,title", "--limit", "100"],
         capture_output=True,
         text=True,
         check=True,
@@ -219,7 +224,7 @@ def fetch_new_issues(since_number):
 def fetch_bot_pr_issues():
     """Return open issues currently labelled BOT_PR, each with its full label list."""
     result = subprocess.run(
-        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_PR", "--json", "number,labels"],
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_PR", "--json", "number,labels,title"],
         capture_output=True,
         text=True,
         check=True,
@@ -401,6 +406,7 @@ def process_bot_pr_issue(issue):
     """
     issue_number = issue["number"]
     labels = issue.get("labels", [])
+    print(f'[pr] issue #{issue_number}: "{issue["title"]}" - {issue_url(issue_number)}', flush=True)
     if has_existing_pr(issue_number):
         print(f"[pr] issue #{issue_number}: a PR already references this issue, skipping", flush=True)
         return
@@ -418,7 +424,7 @@ def process_bot_pr_issue(issue):
 def fetch_bot_review_issues():
     """Return open issues currently labelled BOT_REVIEW, each with its full label list."""
     result = subprocess.run(
-        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_REVIEW", "--json", "number,labels"],
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_REVIEW", "--json", "number,labels,title"],
         capture_output=True,
         text=True,
         check=True,
@@ -463,6 +469,7 @@ def process_bot_review_issue(issue):
     """
     issue_number = issue["number"]
     labels = issue.get("labels", [])
+    print(f'[review] issue #{issue_number}: "{issue["title"]}" - {issue_url(issue_number)}', flush=True)
     if ensure_triaged(issue_number, labels):
         remove_review_label(issue_number)
         return
@@ -485,6 +492,7 @@ def main():
     while True:
         try:
             for issue in fetch_new_issues(state["last_processed"]):
+                print(f'[triage] issue #{issue["number"]}: "{issue["title"]}" - {issue_url(issue["number"])}', flush=True)
                 sync_repo()
                 reset_scratch()
                 triage(issue["number"])

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -273,6 +273,22 @@ def has_existing_pr(issue_number):
     return len(json.loads(result.stdout)) > 0
 
 
+def mark_pr_opened(issue_number):
+    """Swap BOT_PR for BOT_PR_OPENED once the draft PR has been confirmed open."""
+    subprocess.run(
+        ["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_PR", "--add-label", "BOT_PR_OPENED"],
+        check=True,
+    )
+
+
+def mark_pr_failed(issue_number):
+    """Swap BOT_PR for BOT_PR_FAILED so a failed run isn't retried every poll cycle."""
+    subprocess.run(
+        ["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_PR", "--add-label", "BOT_PR_FAILED"],
+        check=True,
+    )
+
+
 def sync_repo():
     subprocess.run(["git", "-C", str(CLONE_DIR), "fetch", "origin", "main"], check=True)
     subprocess.run(["git", "-C", str(CLONE_DIR), "reset", "--hard", "origin/main"], check=True)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -415,6 +415,68 @@ def process_bot_pr_issue(issue):
         mark_pr_failed(issue_number)
 
 
+def fetch_bot_review_issues():
+    """Return open issues currently labelled BOT_REVIEW, each with its full label list."""
+    result = subprocess.run(
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_REVIEW", "--json", "number,labels"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def remove_review_label(issue_number):
+    """Remove BOT_REVIEW once the issue is confirmed triaged, so it isn't reprocessed."""
+    subprocess.run(["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_REVIEW"], check=True)
+
+
+def mark_review_failed(issue_number):
+    """Post a note and swap BOT_REVIEW for BOT_FAILED, so a failing triage isn't
+    retried (and re-billed) every poll cycle. Remove BOT_FAILED and re-add BOT_REVIEW
+    to retry once the underlying issue is fixed.
+    """
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--body",
+            "Automated triage failed to complete for this issue - see the triage bot's logs for details. " "Not retrying automatically; remove `BOT_FAILED` and re-add `BOT_REVIEW` to try again.",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_REVIEW", "--add-label", "BOT_FAILED"],
+        check=True,
+    )
+
+
+def process_bot_review_issue(issue):
+    """Run /issue-triage on an issue tagged BOT_REVIEW if it isn't already triaged,
+    then remove the trigger label. Exists for issues older than the daemon's
+    last_processed pointer, which the new-issue poll never sees.
+
+    A failed triage swaps BOT_REVIEW for BOT_FAILED instead of leaving BOT_REVIEW in
+    place, so a persistently failing issue isn't retried every poll cycle.
+    """
+    issue_number = issue["number"]
+    labels = issue.get("labels", [])
+    if ensure_triaged(issue_number, labels):
+        remove_review_label(issue_number)
+        return
+    sync_repo()
+    reset_scratch()
+    try:
+        triage(issue_number)
+    except subprocess.CalledProcessError as exc:
+        print(f"[review] issue #{issue_number}: triage failed: {exc}", flush=True)
+        mark_review_failed(issue_number)
+        return
+    remove_review_label(issue_number)
+
+
 def main():
     if not CLONE_DIR.exists():
         raise SystemExit(f"Expected a git clone at {CLONE_DIR} - see setup steps before running this daemon.")
@@ -430,6 +492,8 @@ def main():
                 save_state(state)
             for issue in fetch_bot_pr_issues():
                 process_bot_pr_issue(issue)
+            for issue in fetch_bot_review_issues():
+                process_bot_review_issue(issue)
         except subprocess.CalledProcessError as exc:
             print(f"[triage] error: {exc}", flush=True)
         time.sleep(POLL_SECONDS)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -395,6 +395,26 @@ def create_pr(issue_number):
     print(f"[pr] issue #{issue_number}: exited {result.returncode}", flush=True)
 
 
+def process_bot_pr_issue(issue):
+    """Run the full BOT_PR flow for one issue: guard against duplicate work, ensure it's
+    triaged, run the PR flow, then swap the label based on whether a PR now exists.
+    """
+    issue_number = issue["number"]
+    labels = issue.get("labels", [])
+    if has_existing_pr(issue_number):
+        print(f"[pr] issue #{issue_number}: a PR already references this issue, skipping", flush=True)
+        return
+    sync_repo()
+    reset_scratch()
+    if not ensure_triaged(issue_number, labels):
+        triage(issue_number)
+    create_pr(issue_number)
+    if has_existing_pr(issue_number):
+        mark_pr_opened(issue_number)
+    else:
+        mark_pr_failed(issue_number)
+
+
 def main():
     if not CLONE_DIR.exists():
         raise SystemExit(f"Expected a git clone at {CLONE_DIR} - see setup steps before running this daemon.")
@@ -408,6 +428,8 @@ def main():
                 triage(issue["number"])
                 state["last_processed"] = issue["number"]
                 save_state(state)
+            for issue in fetch_bot_pr_issues():
+                process_bot_pr_issue(issue)
         except subprocess.CalledProcessError as exc:
             print(f"[triage] error: {exc}", flush=True)
         time.sleep(POLL_SECONDS)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -202,6 +202,17 @@ def fetch_new_issues(since_number):
     return sorted(new, key=lambda i: i["number"])
 
 
+def fetch_bot_pr_issues():
+    """Return open issues currently labelled BOT_PR, each with its full label list."""
+    result = subprocess.run(
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_PR", "--json", "number,labels"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
 def sync_repo():
     subprocess.run(["git", "-C", str(CLONE_DIR), "fetch", "origin", "main"], check=True)
     subprocess.run(["git", "-C", str(CLONE_DIR), "reset", "--hard", "origin/main"], check=True)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -213,6 +213,45 @@ def fetch_bot_pr_issues():
     return json.loads(result.stdout)
 
 
+TRIAGE_DISCLOSURE_MARKER = "automated first-pass triage"
+
+
+def is_already_triaged(labels):
+    """Return True if BOT_TRIAGED is present in a gh --json labels list."""
+    return any(label["name"] == "BOT_TRIAGED" for label in labels)
+
+
+def find_triage_comment(issue_number):
+    """Return True if the issue already carries a bot triage comment (pre-BOT_TRIAGED-label issues)."""
+    result = subprocess.run(
+        ["gh", "issue", "view", str(issue_number), "--json", "comments"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    comments = json.loads(result.stdout).get("comments", [])
+    return any(TRIAGE_DISCLOSURE_MARKER in comment.get("body", "") for comment in comments)
+
+
+def backfill_triaged_label(issue_number):
+    """Apply BOT_TRIAGED to an issue found to already have a bot triage comment."""
+    subprocess.run(["gh", "issue", "edit", str(issue_number), "--add-label", "BOT_TRIAGED"], check=True)
+
+
+def ensure_triaged(issue_number, labels):
+    """Return True if the issue is (now) marked BOT_TRIAGED; False if /issue-triage still needs to run.
+
+    Checks the label first, then falls back to scanning comments for issues triaged
+    before BOT_TRIAGED existed, backfilling the label onto them when found.
+    """
+    if is_already_triaged(labels):
+        return True
+    if find_triage_comment(issue_number):
+        backfill_triaged_label(issue_number)
+        return True
+    return False
+
+
 def sync_repo():
     subprocess.run(["git", "-C", str(CLONE_DIR), "fetch", "origin", "main"], check=True)
     subprocess.run(["git", "-C", str(CLONE_DIR), "reset", "--hard", "origin/main"], check=True)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -408,7 +408,8 @@ def process_bot_pr_issue(issue):
     labels = issue.get("labels", [])
     print(f'[pr] issue #{issue_number}: "{issue["title"]}" - {issue_url(issue_number)}', flush=True)
     if has_existing_pr(issue_number):
-        print(f"[pr] issue #{issue_number}: a PR already references this issue, skipping", flush=True)
+        print(f"[pr] issue #{issue_number}: a PR already references this issue, marking opened", flush=True)
+        mark_pr_opened(issue_number)
         return
     sync_repo()
     reset_scratch()

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -185,7 +185,11 @@ DISALLOWED_TOOLS = ",".join(_DISALLOWED_TOOLS_BASE)
 # the base denial list. Everything else (merge, close, repo/release/workflow/auth/secret/
 # api admin, all mcp__*) stays denied.
 _PR_REMOVED_DENIALS = {"Bash(git push*)", "Bash(git commit*)", "Bash(gh pr create*)"}
-DISALLOWED_TOOLS_PR = ",".join(item for item in _DISALLOWED_TOOLS_BASE if item not in _PR_REMOVED_DENIALS)
+# Even though the PR flow can push, force-push variants stay denied - defense in depth
+# against a prompt-injected instruction attempting to rewrite history. Prefix-glob
+# matching can't parse flags, so this is a heuristic, not a guarantee.
+_PR_FORCE_PUSH_DENIALS = ["Bash(git push*--force*)", "Bash(git push*-f*)"]
+DISALLOWED_TOOLS_PR = ",".join([item for item in _DISALLOWED_TOOLS_BASE if item not in _PR_REMOVED_DENIALS] + _PR_FORCE_PUSH_DENIALS)
 
 
 def load_state():
@@ -224,7 +228,7 @@ def fetch_new_issues(since_number):
 def fetch_bot_pr_issues():
     """Return open issues currently labelled BOT_PR, each with its full label list."""
     result = subprocess.run(
-        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_PR", "--json", "number,labels,title"],
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_PR", "--json", "number,labels,title", "--limit", "100"],
         capture_output=True,
         text=True,
         check=True,
@@ -243,7 +247,7 @@ def is_already_triaged(labels):
 def find_triage_comment(issue_number):
     """Return True if the issue already carries a bot triage comment (pre-BOT_TRIAGED-label issues)."""
     result = subprocess.run(
-        ["gh", "issue", "view", str(issue_number), "--json", "comments"],
+        ["gh", "issue", "view", str(issue_number), "--repo", REPO, "--json", "comments"],
         capture_output=True,
         text=True,
         check=True,
@@ -254,7 +258,7 @@ def find_triage_comment(issue_number):
 
 def backfill_triaged_label(issue_number):
     """Apply BOT_TRIAGED to an issue found to already have a bot triage comment."""
-    subprocess.run(["gh", "issue", "edit", str(issue_number), "--add-label", "BOT_TRIAGED"], check=True)
+    subprocess.run(["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--add-label", "BOT_TRIAGED"], check=True)
 
 
 def ensure_triaged(issue_number, labels):
@@ -284,7 +288,7 @@ def has_existing_pr(issue_number):
     """Return True if a PR already references this issue, in any state."""
     query = build_duplicate_search_query(issue_number)
     result = subprocess.run(
-        ["gh", "pr", "list", "--search", query, "--state", "all", "--json", "number"],
+        ["gh", "pr", "list", "--repo", REPO, "--search", query, "--state", "all", "--json", "number"],
         capture_output=True,
         text=True,
         check=True,
@@ -292,10 +296,29 @@ def has_existing_pr(issue_number):
     return len(json.loads(result.stdout)) > 0
 
 
+def is_actionable(issue_number):
+    """Return True if the issue is open and classified bug or enhancement - the only
+    classifications /issue-pr should attempt to implement. Guards against an inline
+    /issue-triage call classifying the ticket as a duplicate (and closing it), a
+    question, or a configuration issue, which create_pr() must never run against.
+    """
+    result = subprocess.run(
+        ["gh", "issue", "view", str(issue_number), "--repo", REPO, "--json", "state,labels"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    if data["state"] != "OPEN":
+        return False
+    label_names = {label["name"] for label in data["labels"]}
+    return bool(label_names & {"bug", "enhancement"})
+
+
 def mark_pr_opened(issue_number):
     """Swap BOT_PR for BOT_PR_OPENED once the draft PR has been confirmed open."""
     subprocess.run(
-        ["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_PR", "--add-label", "BOT_PR_OPENED"],
+        ["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--remove-label", "BOT_PR", "--add-label", "BOT_PR_OPENED"],
         check=True,
     )
 
@@ -303,13 +326,40 @@ def mark_pr_opened(issue_number):
 def mark_pr_failed(issue_number):
     """Swap BOT_PR for BOT_PR_FAILED so a failed run isn't retried every poll cycle."""
     subprocess.run(
-        ["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_PR", "--add-label", "BOT_PR_FAILED"],
+        ["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--remove-label", "BOT_PR", "--add-label", "BOT_PR_FAILED"],
         check=True,
     )
 
 
+def mark_pr_not_actionable(issue_number):
+    """Post a note explaining why no PR was attempted, then reuse mark_pr_failed for
+    the label swap - the issue turned out closed, or not classified bug/enhancement.
+    """
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            REPO,
+            "--body",
+            "`BOT_PR` was added but this issue isn't actionable for an automated implementation " "(closed, or not classified `bug`/`enhancement`) - not attempting a PR. Remove `BOT_PR_FAILED` " "and re-add `BOT_PR` once the classification changes.",
+        ],
+        check=True,
+    )
+    mark_pr_failed(issue_number)
+
+
 def sync_repo():
+    """Sync the clone to origin/main, always returning to main first.
+
+    A crashed BOT_PR run can leave the clone checked out on a fix/*|feat/* branch;
+    without an explicit checkout, reset --hard would reset that branch instead of
+    main, leaving the clone stuck off main for every subsequent operation.
+    """
     subprocess.run(["git", "-C", str(CLONE_DIR), "fetch", "origin", "main"], check=True)
+    subprocess.run(["git", "-C", str(CLONE_DIR), "checkout", "main"], check=True)
     subprocess.run(["git", "-C", str(CLONE_DIR), "reset", "--hard", "origin/main"], check=True)
     # Drop untracked leftovers from the previous run's investigation. Not -x:
     # coverage/venv/ is gitignored and expensive to rebuild every issue.
@@ -402,7 +452,8 @@ def create_pr(issue_number):
 
 def process_bot_pr_issue(issue):
     """Run the full BOT_PR flow for one issue: guard against duplicate work, ensure it's
-    triaged, run the PR flow, then swap the label based on whether a PR now exists.
+    triaged and actionable, run the PR flow, then swap the label based on whether a PR
+    now exists.
     """
     issue_number = issue["number"]
     labels = issue.get("labels", [])
@@ -415,6 +466,10 @@ def process_bot_pr_issue(issue):
     reset_scratch()
     if not ensure_triaged(issue_number, labels):
         triage(issue_number)
+    if not is_actionable(issue_number):
+        print(f"[pr] issue #{issue_number}: not actionable (closed, or not classified bug/enhancement), skipping", flush=True)
+        mark_pr_not_actionable(issue_number)
+        return
     create_pr(issue_number)
     if has_existing_pr(issue_number):
         mark_pr_opened(issue_number)
@@ -425,7 +480,7 @@ def process_bot_pr_issue(issue):
 def fetch_bot_review_issues():
     """Return open issues currently labelled BOT_REVIEW, each with its full label list."""
     result = subprocess.run(
-        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_REVIEW", "--json", "number,labels,title"],
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--label", "BOT_REVIEW", "--json", "number,labels,title", "--limit", "100"],
         capture_output=True,
         text=True,
         check=True,
@@ -435,7 +490,7 @@ def fetch_bot_review_issues():
 
 def remove_review_label(issue_number):
     """Remove BOT_REVIEW once the issue is confirmed triaged, so it isn't reprocessed."""
-    subprocess.run(["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_REVIEW"], check=True)
+    subprocess.run(["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--remove-label", "BOT_REVIEW"], check=True)
 
 
 def mark_review_failed(issue_number):
@@ -449,13 +504,15 @@ def mark_review_failed(issue_number):
             "issue",
             "comment",
             str(issue_number),
+            "--repo",
+            REPO,
             "--body",
             "Automated triage failed to complete for this issue - see the triage bot's logs for details. " "Not retrying automatically; remove `BOT_FAILED` and re-add `BOT_REVIEW` to try again.",
         ],
         check=True,
     )
     subprocess.run(
-        ["gh", "issue", "edit", str(issue_number), "--remove-label", "BOT_REVIEW", "--add-label", "BOT_FAILED"],
+        ["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--remove-label", "BOT_REVIEW", "--add-label", "BOT_FAILED"],
         check=True,
     )
 

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -358,6 +358,43 @@ def triage(issue_number):
     print(f"[triage] issue #{issue_number}: exited {result.returncode}", flush=True)
 
 
+def create_pr(issue_number):
+    """Run the /issue-pr skill for one issue under the push/PR-create-capable permission set.
+
+    Whether it succeeded is judged by the caller re-checking has_existing_pr()
+    afterwards, not by this function's return value or the invocation's exit code -
+    a claude -p session that completes normally exits 0 whether it opened a PR or
+    decided the quality gate failed and posted a comment instead.
+    """
+    cmd = [
+        "claude",
+        "-p",
+        f"/issue-pr {issue_number} scratch={SCRATCH_DIR}",
+        "--permission-mode",
+        "dontAsk",
+        "--allowedTools",
+        ALLOWED_TOOLS_PR,
+        "--disallowedTools",
+        DISALLOWED_TOOLS_PR,
+        "--verbose",
+        "--add-dir",
+        str(SCRATCH_DIR),
+        "--max-turns",
+        "150",
+        "--max-budget-usd",
+        "25.00",
+    ]
+    log_path = LOG_DIR / f"issue-{issue_number}-pr.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"[pr] issue #{issue_number}: starting, logging to {log_path}", flush=True)
+    with log_path.open("a") as log_handle:
+        log_handle.write(f"\n==== issue #{issue_number} PR flow started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
+        log_handle.flush()
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        log_handle.write(f"==== issue #{issue_number} PR flow exited {result.returncode} ====\n")
+    print(f"[pr] issue #{issue_number}: exited {result.returncode}", flush=True)
+
+
 def main():
     if not CLONE_DIR.exists():
         raise SystemExit(f"Expected a git clone at {CLONE_DIR} - see setup steps before running this daemon.")

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -252,6 +252,27 @@ def ensure_triaged(issue_number, labels):
     return False
 
 
+def build_duplicate_search_query(issue_number):
+    """Build the gh pr list --search query used to detect an existing PR for an issue.
+
+    Matches the exact "Fixes #N" phrase the issue-pr skill always includes in its PR
+    body, rather than a bare issue number, which could match an unrelated PR.
+    """
+    return f'"Fixes #{issue_number}" in:body'
+
+
+def has_existing_pr(issue_number):
+    """Return True if a PR already references this issue, in any state."""
+    query = build_duplicate_search_query(issue_number)
+    result = subprocess.run(
+        ["gh", "pr", "list", "--search", query, "--state", "all", "--json", "number"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return len(json.loads(result.stdout)) > 0
+
+
 def sync_repo():
     subprocess.run(["git", "-C", str(CLONE_DIR), "fetch", "origin", "main"], check=True)
     subprocess.run(["git", "-C", str(CLONE_DIR), "reset", "--hard", "origin/main"], check=True)


### PR DESCRIPTION
## Summary

Extends the issue-triage bot (`tools/triage_daemon.py` + `.claude/skills/issue-triage/`) with two opt-in, label-triggered flows:

- **`BOT_PR`** on an already-triaged issue: implements the fix/feature described in the ticket and opens a **draft** PR referencing it, with `springfall2008` set as assignee.
- **`BOT_REVIEW`** on any issue: triages it even if it predates the daemon's `last_processed` pointer (the normal new-issue poll never sees older tickets). A no-op if already triaged.

Details:

- `.claude/skills/issue-triage/SKILL.md`: after posting the triage comment, apply a new `BOT_TRIAGED` label (marks an issue as triaged, with a fallback comment-scan + backfill for issues triaged before this label existed — this is also what makes `BOT_REVIEW` a safe no-op on already-triaged old tickets).
- `.claude/skills/issue-pr/SKILL.md` (new): implements the ticket, runs `./run_pre_commit` + the relevant test as a quality gate, and opens a draft PR — only on success.
- `tools/triage_daemon.py`: polls for `BOT_PR`/`BOT_REVIEW`-labelled issues each cycle.
  - `BOT_PR`: guards against duplicate work, runs `/issue-triage` first if needed, then `/issue-pr` under a separate, more permissive tool allowlist (`ALLOWED_TOOLS_PR`/`DISALLOWED_TOOLS_PR`, derived from the existing read-only allowlist — still blocks `gh pr merge/close`, `gh repo/release/workflow/auth/secret/api`, and all `mcp__*`). Success/failure is judged by re-checking for the PR afterwards, not the invocation's exit code (a `claude -p` session exits 0 either way).
  - `BOT_REVIEW`: runs `/issue-triage` (existing, unchanged permissions) if not already triaged, then removes the label. A failed triage swaps `BOT_REVIEW` for `BOT_FAILED` and posts an explanatory comment, rather than retrying (and re-billing) every 5-minute poll cycle — re-add `BOT_REVIEW` by hand to retry.
- `tools/test_triage_daemon.py` (new): 36 unit tests, stdlib-only, wired into `.pre-commit-config.yaml` as a local hook.

Design doc: `docs/superpowers/specs/2026-08-25-bot-pr-flow-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-25-bot-pr-flow.md`

## Before this is usable

`BOT_TRIAGED`/`BOT_PR`/`BOT_PR_OPENED`/`BOT_PR_FAILED` have been created on the repo. Still needed:
- Create `BOT_REVIEW` and `BOT_FAILED` labels.
- An end-to-end dry run against a real triaged issue (manual, per the plan's Task 13).

No separate bot account is required — the daemon can run as `springfall2008`, since `--assignee` (unlike `--reviewer`) allows self-assignment.

## Test plan

- [x] `python3 tools/test_triage_daemon.py -v` — 36/36 passing
- [x] `./run_pre_commit` (full suite) — clean
- [x] `coverage/venv` quick suite (`unit_test.py --quick`) — 268 test groups passing, 0 failures
- [ ] End-to-end dry run against a real triaged issue (manual, per plan Task 13)