### PR TITLE
fix(components): log when a component is skipped for missing config

### DIFF
--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -667,6 +667,8 @@ class Components:
                 continue
 
             have_all_args = True
+            missing_config = []
+            required_or_config = []
             self.components[component_name] = None
             self.component_tasks[component_name] = None
 
@@ -684,8 +686,10 @@ class Components:
                     continue
                 elif required_true and not self.base.get_arg(arg_info["config"], False, indirect=False):
                     have_all_args = False
+                    missing_config.append(arg_info["config"])
                 elif required and self.base.get_arg(arg_info["config"], None, indirect=False) is None:
                     have_all_args = False
+                    missing_config.append(arg_info["config"])
                 else:
                     arg_dict[arg] = self.base.get_arg(arg_info["config"], default, indirect=indirect)
             required_or = component_info.get("required_or", [])
@@ -693,9 +697,22 @@ class Components:
             if required_or:
                 if not any(arg_dict.get(arg, None) for arg in required_or):
                     have_all_args = False
+                    required_or_config = [component_info["args"][arg]["config"] for arg in required_or]
             if have_all_args:
                 self.log(f"Initialising {component_info['name']} interface")
                 self.components[component_name] = component_info["class"](self.base, **arg_dict)
+            else:
+                configured_args = getattr(self.base, "args_from_apps_yaml", None)
+                if configured_args is None:
+                    configured_args = self.base.args
+                component_configured = any(configured_args.get(arg_info["config"]) for arg_info in component_info["args"].values())
+                if component_configured:
+                    reasons = []
+                    if missing_config:
+                        reasons.append(f"missing required configuration: {', '.join(missing_config)}")
+                    if required_or_config:
+                        reasons.append(f"needs at least one of: {', '.join(required_or_config)}")
+                    self.log(f"Warn: Skipping {component_info['name']} interface, {'; '.join(reasons)}")
 
     def start(self, only=None, phase=0):
         """Start all initialised components"""

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -686,7 +686,7 @@ class Components:
                     continue
                 elif required_true and not self.base.get_arg(arg_info["config"], False, indirect=False):
                     have_all_args = False
-                    missing_config.append(arg_info["config"])
+                    missing_config.append(f"{arg_info['config']} (must be true)")
                 elif required and self.base.get_arg(arg_info["config"], None, indirect=False) is None:
                     have_all_args = False
                     missing_config.append(arg_info["config"])

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -798,7 +798,7 @@ class _GatingBase:
     def __init__(self, config):
         self._config = config
         self.prefix = "predbat"
-        self.args = {}
+        self.args = config.copy()
         self.local_tz = datetime.now().astimezone().tzinfo
         self.log_messages = []
 
@@ -842,6 +842,27 @@ def test_solis_not_activated_without_credentials():
     if not failed:
         print("PASSED: Solis not activated without credentials")
     return failed
+
+
+def test_solis_skipped_component_logging():
+    """Solis logs missing credential alternatives only when partly configured."""
+    import components as components_module
+
+    unconfigured_base = _GatingBase({})
+    components_module.Components(unconfigured_base).initialize(only="solis", phase=1)
+    if any("Skipping Solis Cloud API interface" in message for message in unconfigured_base.log_messages):
+        print("ERROR: Unconfigured Solis component should be skipped without a warning")
+        return True
+
+    configured_base = _GatingBase({"solis_auth_method": "oauth"})
+    components_module.Components(configured_base).initialize(only="solis", phase=1)
+    expected = "Warn: Skipping Solis Cloud API interface, needs at least one of: solis_api_key, solis_access_token"
+    if expected not in configured_base.log_messages:
+        print("ERROR: Partly configured Solis component should log missing credential alternatives")
+        return True
+
+    print("PASSED: Solis skipped component logging")
+    return False
 
 
 def test_solis_activated_with_api_key():
@@ -1305,6 +1326,7 @@ def run_solis_tests(my_predbat):
         # Run tests
         failed |= test_oauth_bearer_headers()
         failed |= test_solis_not_activated_without_credentials()
+        failed |= test_solis_skipped_component_logging()
         failed |= test_solis_activated_with_api_key()
         failed |= test_solis_activated_with_oauth_token()
         failed |= test_initialize_attribute_parity_with_mock()


### PR DESCRIPTION
## Problem

The component loader logs `Initialising <name> interface` when a component starts, but there is no `else` branch. A component skipped because a required arg is missing from configuration produces **no output whatsoever** — no warning, no error, no trace that it was ever considered.

The user only ever sees a distant downstream symptom. A missing energy-provider account identifier, for instance, surfaces as:

```
Warning: No import rate data provided
Error: Import rates are all zero, not able to compute a plan
```

with nothing anywhere connecting that to the component that never started, or naming the setting responsible.

Diagnosing it currently means grepping the whole log for `Initialising` lines and noticing which expected component is **absent**. Proving a negative is a poor diagnostic tool — it only works if you already know what should have been there. This cost me a long detour on a real fault before the missing key turned up.

## Change

Collect the config keys that caused the skip and log them. All three failure branches are covered — `required_true`, `required`, and `required_or`:

```
Warn: Skipping Solis Cloud API interface, needs at least one of: solis_api_key, solis_access_token
Warn: Skipping <name> interface, missing required configuration: <keys>
```

Both reasons join with `; ` when a component trips more than one.

The keys reported are the **config** names (`arg_info["config"]`), i.e. what the user would recognise from their own `apps.yaml`, not the internal arg names.

`required_or` deliberately reads "needs at least one of" rather than "missing", since any one of them satisfies it.

## Avoiding noise

The warning only fires when at least one of the component's own settings was actually supplied. A component the user has not configured at all stays silent, so this adds nothing for unused integrations — only for the case that is genuinely worth reporting, where the configuration is partly there but incomplete.

The "is it configured at all" check reads raw args (via the existing `args_from_apps_yaml` convention already used in `component_base.py`) rather than `get_arg`, because `get_arg` applies defaults — a defaulted arg would otherwise make every component look configured.

## Behaviour

Unchanged. Which components start is identical; this is diagnostics only.

## Tests

Adds `test_solis_skipped_component_logging` covering both sides: an unconfigured component stays silent, a partly configured one logs the missing alternatives.

This required one change to the shared `_GatingBase` fixture — `self.args` now mirrors the supplied config instead of being empty, so the new code path has realistic args to read. The existing tests in that file are unaffected: `_GatingBase.get_arg` reads `self._config`, not `self.args`, so component activation behaviour in those tests is untouched.
