### PR TITLE
BOT_REVIEW triggers a follow-up review on already-triaged issues

### DIFF
--- a/.claude/skills/issue-triage-followup/SKILL.md
+++ b/.claude/skills/issue-triage-followup/SKILL.md
@@ -25,7 +25,7 @@ Same as `/issue-triage` step 2: if the new information links a log file, a `pred
 - Sync the clone first, so you are reading the code you think you are:
 
   ```bash
-  git fetch origin main && git reset --hard origin/main && git clean -fd
+  git fetch origin main && git checkout main && git reset --hard origin/main && git clean -fd
   git describe --tags
   ```
 

--- a/.claude/skills/issue-triage-followup/SKILL.md
+++ b/.claude/skills/issue-triage-followup/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: issue-triage-followup
+description: Re-review an already-triaged batpred GitHub issue in light of information added since the original triage, and post a follow-up comment updating the assessment if warranted.
+allowed-tools: You can view and edit files in this repo, run local tests, download and grep issue attachments, access the issue in github with 'gh' and use git commands to check history and re-sync the clone. Do not go outside this sandbox or push any changes back to git.
+---
+
+# Issue Triage Follow-up
+
+You are re-reviewing one already-triaged GitHub issue on `springfall2008/batpred`, incorporating anything added since the bot's previous triage comment. The working directory is a dedicated local clone of the repo — investigate using it directly.
+
+Arguments: `<issue-number> [scratch=<dir>]`, same convention as `/issue-triage`. If no `scratch=` is given (an interactive invocation), use `/tmp/predbat-triage/<issue-number>` and `mkdir -p` it yourself.
+
+## 1. Read the issue and find what's new
+
+Fetch it with `gh issue view <number> --json title,body,labels,comments`. Find the bot's most recent prior comment (opens with "automated first-pass triage" or "automated follow-up triage review"). Everything posted **after** that comment — reporter replies, new logs, a maintainer's note — is the new information this review exists to act on.
+
+If there's nothing posted since the last bot comment, say so plainly in your follow-up comment rather than inventing a reason to change anything.
+
+## 2. Fetch any new attachments
+
+Same as `/issue-triage` step 2: if the new information links a log file, a `predbat_debug.yaml`, or a zip of either, download it into the scratch directory and size/grep it rather than reading it whole.
+
+## 3. Re-investigate against current main
+
+- Sync the clone first, so you are reading the code you think you are:
+
+  ```bash
+  git fetch origin main && git reset --hard origin/main && git clean -fd
+  git describe --tags
+  ```
+
+- Read [../issue-triage/references/debug-journal.md](../issue-triage/references/debug-journal.md) before revising your assessment.
+- Re-check `git log`/`git blame` on the relevant area — the fix may have landed on `main` since the original triage.
+- If the new information points at a test module, run it via `tools/triage_test.sh <name> <scratch>/test.log` (never the full suite).
+
+## 4. Decide whether the assessment changes
+
+Compare your updated understanding against the original triage comment's classification, priority, and root-cause pointer:
+
+- If nothing material changed, say so — confirming the original assessment still holds is a legitimate outcome, not a reason to avoid posting.
+- If the classification, priority, or root-cause should change given the new information, update it. You may change or remove a label **you previously applied as the bot** (classification, priority, `waiting_for_user`) — never remove a label a human added.
+- Apply the same duplicate check as `/issue-triage` step 4 if the new information suggests one.
+
+## 5. Post one follow-up comment
+
+Check the comment history first: if the most recent comment is already a bot comment with nothing from a human posted after it, stop — this review already happened and nothing new has arrived since.
+
+Post exactly one comment via `gh issue comment <number> --body "..."`, opening with a line disclosing this is an automated follow-up triage review (a maintainer will review before any action is taken), followed by: what was new since the last review, whether the classification/priority/root-cause changed and why (or confirmation nothing changed), and any further information request.
+
+Do **not** touch the `BOT_TRIAGED` or `BOT_REVIEW` labels — the daemon manages both.
+
+## Guardrails
+
+- Analysis only: no commits, no pushes, no PRs, no code changes that leave this clone.
+- Never remove a label a human applied; you may only revise labels the bot itself applied.
+- Never close an issue except a confident duplicate.
+- If a command you needed was blocked by permissions, say plainly in the comment what you could not do — never word it so a step you skipped reads as one you completed.

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -571,38 +571,111 @@ class MarkReviewFailedTests(unittest.TestCase):
         )
 
 
+class TriageFollowupTests(DaemonPathsTestCase):
+    """Tests for triage_followup(), new - the BOT_REVIEW follow-up flow for issues
+    that already carry BOT_TRIAGED."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_invokes_claude_with_the_read_only_triage_permission_set(self, mock_run):
+        """Runs /issue-triage-followup with the same read-only allow/deny lists as
+        first-pass triage - a follow-up never writes code or opens a PR."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage_followup(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/issue-triage-followup 4720", cmd[2])
+        self.assertIn(triage_daemon.ALLOWED_TOOLS, cmd)
+        self.assertIn(triage_daemon.DISALLOWED_TOOLS, cmd)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_raises_on_a_non_zero_exit(self, mock_run):
+        """Unlike create_pr(), a follow-up failure raises - process_bot_review_issue()
+        treats this the same way as a first-pass triage failure."""
+        mock_run.return_value = MagicMock(returncode=1)
+        with self.assertRaises(subprocess.CalledProcessError):
+            triage_daemon.triage_followup(4720)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_writes_a_log_file(self, mock_run):
+        """A per-issue follow-up log file is created under LOG_DIR."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage_followup(4720)
+        self.assertTrue((self.log_dir / "issue-4720-followup.log").exists())
+
+
 class ProcessBotReviewIssueTests(unittest.TestCase):
-    """Tests for process_bot_review_issue(), new in the BOT_REVIEW flow."""
+    """Tests for process_bot_review_issue(), covering all three BOT_REVIEW paths:
+    first-pass triage, follow-up review, and old pre-label-ticket backfill."""
 
     def setUp(self):
         """Patch every collaborator process_bot_review_issue() calls."""
         self.patches = {}
-        for name in ["ensure_triaged", "sync_repo", "reset_scratch", "triage", "remove_review_label", "mark_review_failed"]:
+        for name in [
+            "is_already_triaged",
+            "find_triage_comment",
+            "backfill_triaged_label",
+            "sync_repo",
+            "reset_scratch",
+            "triage",
+            "triage_followup",
+            "remove_review_label",
+            "mark_review_failed",
+        ]:
             patcher = patch.object(triage_daemon, name)
             self.patches[name] = patcher.start()
             self.addCleanup(patcher.stop)
 
-    def test_already_triaged_just_removes_the_label(self):
-        """An already-triaged issue skips triage() entirely."""
-        self.patches["ensure_triaged"].return_value = True
+    def test_already_triaged_runs_a_follow_up_review(self):
+        """An issue already carrying BOT_TRIAGED gets a follow-up review, not a fresh
+        first-pass triage, and not the old-ticket backfill path."""
+        self.patches["is_already_triaged"].return_value = True
         triage_daemon.process_bot_review_issue({"number": 3100, "labels": [{"name": "BOT_TRIAGED"}], "title": "Old ticket needing review"})
+        self.patches["find_triage_comment"].assert_not_called()
         self.patches["triage"].assert_not_called()
+        self.patches["sync_repo"].assert_called_once()
+        self.patches["reset_scratch"].assert_called_once()
+        self.patches["triage_followup"].assert_called_once_with(3100)
         self.patches["remove_review_label"].assert_called_once_with(3100)
         self.patches["mark_review_failed"].assert_not_called()
 
-    def test_not_triaged_runs_triage_then_removes_the_label(self):
-        """An untriaged issue is synced, triaged, then the trigger label is removed."""
-        self.patches["ensure_triaged"].return_value = False
+    def test_old_pre_label_ticket_backfills_without_a_follow_up(self):
+        """A pre-BOT_TRIAGED-label ticket with an existing comment is backfilled and
+        left alone - catching up on backlog is not the same as new information having
+        arrived, so no follow-up runs."""
+        self.patches["is_already_triaged"].return_value = False
+        self.patches["find_triage_comment"].return_value = True
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": [], "title": "Old ticket needing review"})
+        self.patches["backfill_triaged_label"].assert_called_once_with(3100)
+        self.patches["triage"].assert_not_called()
+        self.patches["triage_followup"].assert_not_called()
+        self.patches["sync_repo"].assert_not_called()
+        self.patches["reset_scratch"].assert_not_called()
+        self.patches["remove_review_label"].assert_called_once_with(3100)
+        self.patches["mark_review_failed"].assert_not_called()
+
+    def test_never_triaged_runs_first_pass_triage(self):
+        """An issue with neither the label nor an existing comment gets a first-pass triage."""
+        self.patches["is_already_triaged"].return_value = False
+        self.patches["find_triage_comment"].return_value = False
         triage_daemon.process_bot_review_issue({"number": 3100, "labels": [], "title": "Old ticket needing review"})
         self.patches["sync_repo"].assert_called_once()
         self.patches["reset_scratch"].assert_called_once()
         self.patches["triage"].assert_called_once_with(3100)
+        self.patches["triage_followup"].assert_not_called()
         self.patches["remove_review_label"].assert_called_once_with(3100)
         self.patches["mark_review_failed"].assert_not_called()
 
-    def test_failed_triage_marks_failed_instead_of_removing_the_label(self):
-        """A triage() failure swaps to BOT_FAILED rather than retrying next poll."""
-        self.patches["ensure_triaged"].return_value = False
+    def test_failed_follow_up_marks_failed_instead_of_removing_the_label(self):
+        """A triage_followup() failure swaps to BOT_FAILED rather than retrying next poll."""
+        self.patches["is_already_triaged"].return_value = True
+        self.patches["triage_followup"].side_effect = subprocess.CalledProcessError(1, ["claude"])
+        triage_daemon.process_bot_review_issue({"number": 3100, "labels": [{"name": "BOT_TRIAGED"}], "title": "Old ticket needing review"})
+        self.patches["mark_review_failed"].assert_called_once_with(3100)
+        self.patches["remove_review_label"].assert_not_called()
+
+    def test_failed_first_pass_triage_marks_failed_instead_of_removing_the_label(self):
+        """A triage() failure (first-pass path) also swaps to BOT_FAILED."""
+        self.patches["is_already_triaged"].return_value = False
+        self.patches["find_triage_comment"].return_value = False
         self.patches["triage"].side_effect = subprocess.CalledProcessError(1, ["claude"])
         triage_daemon.process_bot_review_issue({"number": 3100, "labels": [], "title": "Old ticket needing review"})
         self.patches["mark_review_failed"].assert_called_once_with(3100)
@@ -611,7 +684,7 @@ class ProcessBotReviewIssueTests(unittest.TestCase):
     @patch("builtins.print")
     def test_prints_the_title_and_link_before_doing_anything(self, mock_print):
         """Prints the issue's title and an openable GitHub link as soon as work starts."""
-        self.patches["ensure_triaged"].return_value = True
+        self.patches["is_already_triaged"].return_value = True
         triage_daemon.process_bot_review_issue({"number": 3100, "labels": [], "title": "Old ticket needing review"})
         printed = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
         self.assertIn("Old ticket needing review", printed)

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -577,9 +577,8 @@ class TriageFollowupTests(DaemonPathsTestCase):
 
     @patch("triage_daemon.subprocess.run")
     def test_invokes_claude_with_the_read_only_triage_permission_set(self, mock_run):
-        """Runs /issue-triage-followup with the same read-only allow/deny lists as
-        first-pass triage - a follow-up never writes code or opens a PR."""
-        mock_run.return_value = MagicMock(returncode=0)
+        """Runs /issue-triage-followup with the same triage allow/deny lists as
+        first-pass triage (no commits, pushes, or PR creation)."""
         triage_daemon.triage_followup(4720)
         cmd = mock_run.call_args[0][0]
         self.assertIn("/issue-triage-followup 4720", cmd[2])

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -579,6 +579,7 @@ class TriageFollowupTests(DaemonPathsTestCase):
     def test_invokes_claude_with_the_read_only_triage_permission_set(self, mock_run):
         """Runs /issue-triage-followup with the same triage allow/deny lists as
         first-pass triage (no commits, pushes, or PR creation)."""
+        mock_run.return_value = MagicMock(returncode=0)
         triage_daemon.triage_followup(4720)
         cmd = mock_run.call_args[0][0]
         self.assertIn("/issue-triage-followup 4720", cmd[2])

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -413,6 +413,42 @@ def triage(issue_number):
     print(f"[triage] issue #{issue_number}: exited {result.returncode}", flush=True)
 
 
+def triage_followup(issue_number):
+    """Run the /issue-triage-followup skill for one issue - a re-review incorporating
+    information added since the original triage, under the same read-only permission
+    set as first-pass /issue-triage (never writes code or opens a PR).
+    """
+    cmd = [
+        "claude",
+        "-p",
+        f"/issue-triage-followup {issue_number} scratch={SCRATCH_DIR}",
+        "--permission-mode",
+        "dontAsk",
+        "--allowedTools",
+        ALLOWED_TOOLS,
+        "--disallowedTools",
+        DISALLOWED_TOOLS,
+        "--verbose",
+        "--add-dir",
+        str(SCRATCH_DIR),
+        "--max-turns",
+        "60",
+        "--max-budget-usd",
+        "10.00",
+    ]
+    log_path = LOG_DIR / f"issue-{issue_number}-followup.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"[review] issue #{issue_number}: starting follow-up, logging to {log_path}", flush=True)
+    with log_path.open("a") as log_handle:
+        log_handle.write(f"\n==== issue #{issue_number} follow-up started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
+        log_handle.flush()
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        log_handle.write(f"==== issue #{issue_number} follow-up exited {result.returncode} ====\n")
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, cmd)
+    print(f"[review] issue #{issue_number}: follow-up exited {result.returncode}", flush=True)
+
+
 def create_pr(issue_number):
     """Run the /issue-pr skill for one issue under the push/PR-create-capable permission set.
 
@@ -518,25 +554,38 @@ def mark_review_failed(issue_number):
 
 
 def process_bot_review_issue(issue):
-    """Run /issue-triage on an issue tagged BOT_REVIEW if it isn't already triaged,
-    then remove the trigger label. Exists for issues older than the daemon's
-    last_processed pointer, which the new-issue poll never sees.
+    """Run the right BOT_REVIEW action for one issue, then remove the trigger label.
 
-    A failed triage swaps BOT_REVIEW for BOT_FAILED instead of leaving BOT_REVIEW in
-    place, so a persistently failing issue isn't retried every poll cycle.
+    Three cases: an issue already carrying BOT_TRIAGED gets a follow-up review via
+    /issue-triage-followup, incorporating anything new since the original triage. An
+    old, pre-BOT_TRIAGED-label issue that already has a bot triage comment is just
+    backfilled with the label - catching up on backlog isn't the same as new
+    information having arrived, so no follow-up runs for it. Anything else gets a
+    first-pass /issue-triage, for issues older than the daemon's last_processed
+    pointer, which the new-issue poll never sees.
+
+    A failed triage or follow-up swaps BOT_REVIEW for BOT_FAILED instead of leaving
+    BOT_REVIEW in place, so a persistently failing issue isn't retried every poll cycle.
     """
     issue_number = issue["number"]
     labels = issue.get("labels", [])
     print(f'[review] issue #{issue_number}: "{issue["title"]}" - {issue_url(issue_number)}', flush=True)
-    if ensure_triaged(issue_number, labels):
+
+    if is_already_triaged(labels):
+        action_name, action = "follow-up", triage_followup
+    elif find_triage_comment(issue_number):
+        backfill_triaged_label(issue_number)
         remove_review_label(issue_number)
         return
+    else:
+        action_name, action = "first-pass triage", triage
+
     sync_repo()
     reset_scratch()
     try:
-        triage(issue_number)
+        action(issue_number)
     except subprocess.CalledProcessError as exc:
-        print(f"[review] issue #{issue_number}: triage failed: {exc}", flush=True)
+        print(f"[review] issue #{issue_number}: {action_name} failed: {exc}", flush=True)
         mark_review_failed(issue_number)
         return
     remove_review_label(issue_number)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -415,8 +415,8 @@ def triage(issue_number):
 
 def triage_followup(issue_number):
     """Run the /issue-triage-followup skill for one issue - a re-review incorporating
-    information added since the original triage, under the same read-only permission
-    set as first-pass /issue-triage (never writes code or opens a PR).
+    information added since the original triage, under the same triage permission
+    set as first-pass /issue-triage (no commits, pushes, or PR creation).
     """
     cmd = [
         "claude",


### PR DESCRIPTION
## Summary

Previously, adding `BOT_REVIEW` to an issue that already carried `BOT_TRIAGED` was a no-op (existing-ticket backfill logic treated "already triaged" as "nothing to do"). This adds a genuine follow-up path.

`process_bot_review_issue()` is now a three-way branch:

- **`BOT_TRIAGED` present** → runs the new `/issue-triage-followup` skill, which reads everything posted on the issue since the bot's last comment and re-assesses in light of it. Confirming nothing changed is a valid, expected outcome, not something to avoid reporting.
- **No label but an existing bot triage comment found** (the original old-ticket backfill case) → just backfills `BOT_TRIAGED`, no follow-up runs. Catching up on pre-daemon backlog isn't the same as new information having arrived.
- **Neither** → first-pass `/issue-triage`, unchanged.

All three converge on removing `BOT_REVIEW` on success, or swapping to `BOT_FAILED` on failure — same pattern as before.

`/issue-triage-followup` reuses the existing read-only `ALLOWED_TOOLS`/`DISALLOWED_TOOLS` (no new permission grants) — it never writes code, commits, or opens a PR, same as first-pass `/issue-triage`.

## Notes

- While implementing, `process_bot_review_issue()`'s failure-logging line used `action.__name__` to name which step failed — this crashes when the collaborator is mocked in tests (`MagicMock` doesn't support dunder attribute access), which is exactly how the test suite caught it before it shipped. Replaced with a plain string tracked alongside the callable.
- Design doc: none written — this is a small, bounded extension of the existing `BOT_PR`/`BOT_REVIEW` machinery from #4733, reusing all existing labels and permission sets.

## Test plan

- [x] `python3 tools/test_triage_daemon.py -v` — 59/59 passing
- [x] `./run_pre_commit` (full suite) — clean
- [x] `coverage/venv` quick suite (`unit_test.py --quick`) — clean, 0 failures
- [ ] End-to-end: watched the live daemon process real `BOT_REVIEW` issues while writing this (see the daemon's own logs) — the follow-up path itself hasn't been exercised against a live already-triaged issue yet