### PR TITLE
Allow adding and deleting apps.yaml list entries and settings from the apps editor

### DIFF
--- a/apps/predbat/tests/test_web_apps_edit.py
+++ b/apps/predbat/tests/test_web_apps_edit.py
@@ -35,6 +35,11 @@ APPS_YAML_FIXTURE = """pred_bat:
       id: three
   battery_charge_low:
     normal: 10
+  nested_matrix:
+    - - 1
+      - 2
+    - - 3
+      - 4
 """
 
 
@@ -141,6 +146,39 @@ def run_web_apps_edit_tests(my_predbat):
         ordered = sorted(["compare_list[2]", "compare_list[10]", "compare_list[2].name"], key=web_interface._yaml_path_sort_key, reverse=True)
         if ordered != ["compare_list[10]", "compare_list[2].name", "compare_list[2]"]:
             print("  ERROR: unexpected delete ordering: {}".format(ordered))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: a directly nested list tokenizes every bracket pair in a path component")
+        if web_interface._split_yaml_path("foo[0][1]") != ["foo", "[0]", "[1]"]:
+            print("  ERROR: expected foo[0][1] to split into foo, [0], [1], got: {}".format(web_interface._split_yaml_path("foo[0][1]")))
+            failed += 1
+        if web_interface._split_yaml_path("foo[0][]") != ["foo", "[0]", "[]"]:
+            print("  ERROR: expected foo[0][] to split into foo, [0], [], got: {}".format(web_interface._split_yaml_path("foo[0][]")))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: a directly nested list item can be deleted")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"nested_matrix[0][1]": _delete("nested_matrix[0][1]")})
+        if not result.get("success"):
+            print("  ERROR: expected the nested-list delete to succeed, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if list(saved["pred_bat"]["nested_matrix"][0]) != [1]:
+            print("  ERROR: expected nested_matrix[0] to be [1], got: {}".format(list(saved["pred_bat"]["nested_matrix"][0])))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: a directly nested list can have an item appended")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"nested_matrix[1][]#1": _add("nested_matrix[1][]", "5")})
+        if not result.get("success"):
+            print("  ERROR: expected the nested-list add to succeed, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if list(saved["pred_bat"]["nested_matrix"][1]) != [3, 4, 5]:
+            print("  ERROR: expected nested_matrix[1] to be [3, 4, 5], got: {}".format(list(saved["pred_bat"]["nested_matrix"][1])))
             failed += 1
 
         # ---------------------------------------------------------------------
@@ -259,11 +297,78 @@ def run_web_apps_edit_tests(my_predbat):
             failed += 1
 
         # ---------------------------------------------------------------------
+        print("Test: isNested cannot be spoofed true to delete a top-level argument")
+        web_interface = _reset_fixture(my_predbat)
+        spoofed_delete = {"rowId": 1, "originalValue": "", "newValue": "", "type": "delete", "isNested": True, "path": "compare_list"}
+        result = _post_changes(web_interface, {"compare_list": spoofed_delete})
+        if result.get("success"):
+            print("  ERROR: expected the spoofed top-level delete to be refused, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if "compare_list" not in saved["pred_bat"]:
+            print("  ERROR: the top-level compare_list was removed from apps.yaml by a spoofed isNested flag")
+            failed += 1
+
+        # ---------------------------------------------------------------------
         print("Test: an empty value is refused rather than written as null")
         web_interface = _reset_fixture(my_predbat)
         result = _post_changes(web_interface, {"compare_list[]#1": _add("compare_list[]", "   ")})
         if result.get("success"):
             print("  ERROR: expected an empty added value to be refused, got: {}".format(result))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: adding a compare profile without an id is refused")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"compare_list[]#1": _add("compare_list[]", "name: No Id\n")})
+        if result.get("success"):
+            print("  ERROR: expected the id-less profile to be refused, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if _names(saved["pred_bat"]["compare_list"]) != ["Tariff One", "Tariff Two", "Tariff Three"]:
+            print("  ERROR: expected apps.yaml to be unchanged, got: {}".format(_names(saved["pred_bat"]["compare_list"])))
+            failed += 1
+        if _names(web_interface.args["compare_list"]) != ["Tariff One", "Tariff Two", "Tariff Three"]:
+            print("  ERROR: expected the live args to be unchanged too, got: {}".format(_names(web_interface.args["compare_list"])))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: adding a compare profile with a duplicate id is refused")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"compare_list[]#1": _add("compare_list[]", "name: Clash\nid: one\n")})
+        if result.get("success"):
+            print("  ERROR: expected the duplicate id to be refused, got: {}".format(result))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: deleting a compare profile's id is refused, since results are indexed by it")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"compare_list[0].id": _delete("compare_list[0].id")})
+        if result.get("success"):
+            print("  ERROR: expected removing a profile's id to be refused, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if "id" not in saved["pred_bat"]["compare_list"][0]:
+            print("  ERROR: apps.yaml was written with an id-less compare profile")
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: a batch that fails partway leaves apps.yaml and the live args untouched")
+        web_interface = _reset_fixture(my_predbat)
+        changes = {
+            "compare_list[]#1": _add("compare_list[]", "name: Should Not Land\nid: unsaved\n"),
+            "compare_list[9]": _delete("compare_list[9]"),
+        }
+        result = _post_changes(web_interface, changes)
+        if result.get("success"):
+            print("  ERROR: expected the batch to fail because of the out-of-range delete, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if _names(saved["pred_bat"]["compare_list"]) != ["Tariff One", "Tariff Two", "Tariff Three"]:
+            print("  ERROR: expected apps.yaml to be unaffected by the failed batch, got: {}".format(_names(saved["pred_bat"]["compare_list"])))
+            failed += 1
+        if _names(web_interface.args["compare_list"]) != ["Tariff One", "Tariff Two", "Tariff Three"]:
+            print("  ERROR: expected the live args to be unaffected by the failed batch too, got: {}".format(_names(web_interface.args["compare_list"])))
             failed += 1
 
         # ---------------------------------------------------------------------

--- a/apps/predbat/tests/test_web_apps_edit.py
+++ b/apps/predbat/tests/test_web_apps_edit.py
@@ -1,0 +1,327 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""Tests for adding and deleting apps.yaml list items and settings from the structured /apps
+editor (issue #4714 - compare profiles could only be edited, never added or removed).
+Follows the FakeRequest pattern of test_web_debug_history_routes.py.
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+
+from ruamel.yaml import YAML
+
+from web import WebInterface
+from web_helper import get_apps_js
+
+APPS_YAML_FIXTURE = """pred_bat:
+  # Tariffs to compare against the current one
+  compare_list:
+    - name: Tariff One
+      id: one
+    - name: Tariff Two
+      id: two
+    - name: Tariff Three
+      id: three
+  battery_charge_low:
+    normal: 10
+"""
+
+
+class FakeRequest:
+    """A minimal aiohttp-request stand-in exposing only the POST data the handler reads."""
+
+    def __init__(self, postdata):
+        """Store the POST data this request will hand back."""
+        self.postdata = postdata
+
+    async def post(self):
+        """Return the stored POST data, as aiohttp does."""
+        return self.postdata
+
+
+def _load_yaml(path="apps.yaml"):
+    """Load a YAML file from the temporary working directory."""
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with open(path, "r") as handle:
+        return yaml.load(handle)
+
+
+def _reset_fixture(my_predbat):
+    """Write a fresh apps.yaml fixture and return a WebInterface bound to a matching args copy."""
+    with open("apps.yaml", "w") as handle:
+        handle.write(APPS_YAML_FIXTURE)
+
+    web_interface = WebInterface.__new__(WebInterface)
+    web_interface.base = my_predbat
+    web_interface.log = my_predbat.log
+    web_interface.prefix = my_predbat.prefix
+    # The live args are a separate copy of the same structure, as they are in Predbat itself
+    web_interface.args = _load_yaml()["pred_bat"]
+    return web_interface
+
+
+def _post_changes(web_interface, changes):
+    """Post a set of changes to html_apps_post and return the decoded JSON response."""
+    request = FakeRequest({"changes": json.dumps(changes)})
+    response = asyncio.run(web_interface.html_apps_post(request))
+    return json.loads(response.text)
+
+
+def _delete(path):
+    """Build the change entry the browser sends when a row is marked for deletion."""
+    return {"rowId": 1001, "originalValue": "", "newValue": "", "type": "delete", "isNested": True, "path": path}
+
+
+def _add(path, value):
+    """Build the change entry the browser sends when a new entry or setting is added."""
+    return {"rowId": None, "originalValue": "", "newValue": value, "type": "add", "isNested": True, "path": path}
+
+
+def _names(compare_list):
+    """Return the name of every entry in a compare_list."""
+    return [entry.get("name", "") for entry in compare_list]
+
+
+def run_web_apps_edit_tests(my_predbat):
+    """Unit tests for the delete and add change types of the structured apps.yaml editor."""
+    failed = 0
+    print("**** Running apps.yaml editor add/delete tests ****")
+
+    original_dir = os.getcwd()
+    temp_dir = tempfile.mkdtemp(prefix="predbat_test_apps_edit_")
+    try:
+        os.chdir(temp_dir)
+
+        # ---------------------------------------------------------------------
+        print("Test: deleting one compare profile removes just that profile")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"compare_list[1]": _delete("compare_list[1]")})
+        if not result.get("success"):
+            print("  ERROR: expected the delete to succeed, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if _names(saved["pred_bat"]["compare_list"]) != ["Tariff One", "Tariff Three"]:
+            print("  ERROR: expected One and Three left in apps.yaml, got: {}".format(_names(saved["pred_bat"]["compare_list"])))
+            failed += 1
+        if _names(web_interface.args["compare_list"]) != ["Tariff One", "Tariff Three"]:
+            print("  ERROR: expected the live args to match the file, got: {}".format(_names(web_interface.args["compare_list"])))
+            failed += 1
+        with open("apps.yaml", "r") as handle:
+            raw = handle.read()
+        if "# Tariffs to compare against the current one" not in raw:
+            print("  ERROR: expected the apps.yaml comment to survive the round trip, got:\n{}".format(raw))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: deleting two profiles at once is not confused by the shifting indices")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"compare_list[0]": _delete("compare_list[0]"), "compare_list[2]": _delete("compare_list[2]")})
+        if not result.get("success"):
+            print("  ERROR: expected the two deletes to succeed, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if _names(saved["pred_bat"]["compare_list"]) != ["Tariff Two"]:
+            print("  ERROR: expected only Tariff Two left, got: {}".format(_names(saved["pred_bat"]["compare_list"])))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: delete paths sort deepest and highest index first")
+        ordered = sorted(["compare_list[2]", "compare_list[10]", "compare_list[2].name"], key=web_interface._yaml_path_sort_key, reverse=True)
+        if ordered != ["compare_list[10]", "compare_list[2].name", "compare_list[2]"]:
+            print("  ERROR: unexpected delete ordering: {}".format(ordered))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: two new compare profiles can be added in one save")
+        web_interface = _reset_fixture(my_predbat)
+        changes = {
+            "compare_list[]#1": _add("compare_list[]", "name: Tariff Four\nid: four\nrates_import_octopus_url: https://example.com/four\n"),
+            "compare_list[]#2": _add("compare_list[]", "name: Tariff Five\nid: five\n"),
+        }
+        result = _post_changes(web_interface, changes)
+        if not result.get("success"):
+            print("  ERROR: expected the adds to succeed, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if _names(saved["pred_bat"]["compare_list"]) != ["Tariff One", "Tariff Two", "Tariff Three", "Tariff Four", "Tariff Five"]:
+            print("  ERROR: unexpected profiles after adding, got: {}".format(_names(saved["pred_bat"]["compare_list"])))
+            failed += 1
+        added = saved["pred_bat"]["compare_list"][3]
+        if added.get("id") != "four" or added.get("rates_import_octopus_url") != "https://example.com/four":
+            print("  ERROR: the added profile did not keep its settings, got: {}".format(dict(added)))
+            failed += 1
+        if _names(web_interface.args["compare_list"]) != ["Tariff One", "Tariff Two", "Tariff Three", "Tariff Four", "Tariff Five"]:
+            print("  ERROR: expected the live args to match the file, got: {}".format(_names(web_interface.args["compare_list"])))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: a new setting can be added to an existing profile, keeping its type")
+        web_interface = _reset_fixture(my_predbat)
+        changes = {
+            "compare_list[0].rates_import_octopus_url#1": _add("compare_list[0].rates_import_octopus_url", "https://example.com/one"),
+            "battery_charge_low.low#2": _add("battery_charge_low.low", "5"),
+        }
+        result = _post_changes(web_interface, changes)
+        if not result.get("success"):
+            print("  ERROR: expected the new settings to be added, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if saved["pred_bat"]["compare_list"][0].get("rates_import_octopus_url") != "https://example.com/one":
+            print("  ERROR: the new profile setting was not saved, got: {}".format(dict(saved["pred_bat"]["compare_list"][0])))
+            failed += 1
+        if saved["pred_bat"]["battery_charge_low"].get("low") != 5:
+            print("  ERROR: expected a numeric 5, got: {!r}".format(saved["pred_bat"]["battery_charge_low"].get("low")))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: an edit and a delete in the same save both land on the right entries")
+        web_interface = _reset_fixture(my_predbat)
+        changes = {
+            "compare_list[2].name": {"rowId": 1002, "originalValue": "Tariff Three", "newValue": "Renamed", "type": "string", "isNested": True, "path": "compare_list[2].name"},
+            "compare_list[0]": _delete("compare_list[0]"),
+        }
+        result = _post_changes(web_interface, changes)
+        if not result.get("success"):
+            print("  ERROR: expected the edit and delete to succeed, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if _names(saved["pred_bat"]["compare_list"]) != ["Tariff Two", "Renamed"]:
+            print("  ERROR: expected Tariff Two and Renamed, got: {}".format(_names(saved["pred_bat"]["compare_list"])))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: editing a profile and deleting it in the same save is not an error")
+        web_interface = _reset_fixture(my_predbat)
+        changes = {
+            "compare_list[0].name": {"rowId": 1002, "originalValue": "Tariff One", "newValue": "Renamed", "type": "string", "isNested": True, "path": "compare_list[0].name"},
+            "compare_list[0]#delete": _delete("compare_list[0]"),
+        }
+        result = _post_changes(web_interface, changes)
+        if not result.get("success"):
+            print("  ERROR: expected an edit of a deleted profile to be harmless, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if _names(saved["pred_bat"]["compare_list"]) != ["Tariff Two", "Tariff Three"]:
+            print("  ERROR: expected Tariff One to be gone, got: {}".format(_names(saved["pred_bat"]["compare_list"])))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: adding a setting that already exists is refused and apps.yaml is left alone")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"compare_list[0].name#1": _add("compare_list[0].name", "Clash")})
+        if result.get("success"):
+            print("  ERROR: expected the duplicate setting to be refused, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if _names(saved["pred_bat"]["compare_list"]) != ["Tariff One", "Tariff Two", "Tariff Three"]:
+            print("  ERROR: expected apps.yaml to be unchanged, got: {}".format(_names(saved["pred_bat"]["compare_list"])))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: deleting an entry that is not there is refused")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"compare_list[9]": _delete("compare_list[9]")})
+        if result.get("success"):
+            print("  ERROR: expected the out of range delete to be refused, got: {}".format(result))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: appending to something that is not a list is refused")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"battery_charge_low[]#1": _add("battery_charge_low[]", "10")})
+        if result.get("success"):
+            print("  ERROR: expected appending to a dictionary to be refused, got: {}".format(result))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: a top-level argument cannot be added or deleted")
+        web_interface = _reset_fixture(my_predbat)
+        top_level_delete = {"rowId": 1, "originalValue": "", "newValue": "", "type": "delete", "isNested": False}
+        result = _post_changes(web_interface, {"compare_list": top_level_delete})
+        if result.get("success"):
+            print("  ERROR: expected a top-level delete to be refused, got: {}".format(result))
+            failed += 1
+        saved = _load_yaml()
+        if "compare_list" not in saved["pred_bat"]:
+            print("  ERROR: the top-level compare_list was removed from apps.yaml")
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: an empty value is refused rather than written as null")
+        web_interface = _reset_fixture(my_predbat)
+        result = _post_changes(web_interface, {"compare_list[]#1": _add("compare_list[]", "   ")})
+        if result.get("success"):
+            print("  ERROR: expected an empty added value to be refused, got: {}".format(result))
+            failed += 1
+
+        # ---------------------------------------------------------------------
+        print("Test: the rendered compare_list offers delete and add buttons")
+        web_interface = _reset_fixture(my_predbat)
+        html = web_interface.render_type("compare_list", web_interface.args["compare_list"], "", [1000])
+        for expected in ["data-nested-path='compare_list[0]'", "deleteNestedValue(1001)", "addListItem('compare_list', 'compare_list'", "addDictKey('compare_list[0]'"]:
+            if expected not in html:
+                print("  ERROR: expected {!r} in the rendered compare_list, got:\n{}".format(expected, html))
+                failed += 1
+
+        # ---------------------------------------------------------------------
+        # There is no JS engine in this test suite, so the client half is checked structurally,
+        # as test_debug_history_client_js.py does
+        print("Test: the page JS defines the delete and add handlers the buttons call")
+        apps_js = get_apps_js("{}")
+        for expected in ["function deleteNestedValue(", "function undoDeleteNestedValue(", "function addListItem(", "function addDictKey(", "function registerPendingAdd(", "function cancelPendingAdd("]:
+            if expected not in apps_js:
+                print("  ERROR: expected {!r} in the apps page JS".format(expected))
+                failed += 1
+
+        print("Test: a delete is queued rather than applied, and the button is found by id not by class")
+        delete_src = apps_js[apps_js.index("function deleteNestedValue(") : apps_js.index("function undoDeleteNestedValue(")]
+        if "type: 'delete'" not in delete_src or "path: nestedPath" not in delete_src:
+            print("  ERROR: expected deleteNestedValue to queue a nested delete change, got:\n{}".format(delete_src))
+            failed += 1
+        # Keyed apart from an edit of the same value, so undoing the delete keeps the edit
+        if "pendingChanges[nestedPath + '#delete']" not in delete_src:
+            print("  ERROR: expected the deletion to be keyed separately from an edit of the same value, got:\n{}".format(delete_src))
+            failed += 1
+        # A row containing a nested table also contains its children's delete buttons, so a
+        # querySelector('.delete-button') would relabel the wrong one
+        if "querySelector('.delete-button')" in apps_js:
+            print("  ERROR: the delete button must be looked up by id, as a row can contain its children's buttons")
+            failed += 1
+        if "getElementById('delete_button_' + rowId)" not in apps_js:
+            print("  ERROR: expected the delete button to be looked up by its own id")
+            failed += 1
+
+        print("Test: each addition gets a unique change key so several can target one list")
+        add_src = apps_js[apps_js.index("function registerPendingAdd(") : apps_js.index("function cancelPendingAdd(")]
+        if "addCounter += 1" not in add_src or "path + '#' + addCounter" not in add_src:
+            print("  ERROR: expected registerPendingAdd to key each addition uniquely, got:\n{}".format(add_src))
+            failed += 1
+        if "type: 'add'" not in add_src:
+            print("  ERROR: expected registerPendingAdd to queue an add change, got:\n{}".format(add_src))
+            failed += 1
+
+        print("Test: discarding changes undoes queued deletions and additions too")
+        discard_src = apps_js[apps_js.index("function discardAllChanges(") :]
+        if "change.type === 'delete'" not in discard_src or "change.type === 'add'" not in discard_src:
+            print("  ERROR: expected discardAllChanges to restore deleted rows and drop added ones, got:\n{}".format(discard_src))
+            failed += 1
+
+    finally:
+        os.chdir(original_dir)
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    if failed:
+        print("**** ERROR: {} apps.yaml editor add/delete test(s) failed ****".format(failed))
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -105,6 +105,7 @@ from tests.test_hainterface_lifecycle import run_hainterface_lifecycle_tests
 from tests.test_hainterface_websocket import run_hainterface_websocket_tests
 from tests.test_history_chunking import run_history_chunking_tests
 from tests.test_web_if import run_test_web_if
+from tests.test_web_apps_edit import run_web_apps_edit_tests
 from tests.test_web_chart_currency import test_rates_chart_series_names_use_currency_symbol
 from tests.test_web_debug_history_routes import test_web_debug_history_routes
 from tests.test_debug_history_client_js import test_debug_history_client_js
@@ -457,6 +458,7 @@ def main():
         ("manual_times", run_test_manual_times, "Manual times tests", False),
         ("manual_select", run_test_manual_select, "Manual select tests", False),
         ("web_if", run_test_web_if, "Web interface tests", False),
+        ("web_apps_edit", run_web_apps_edit_tests, "Apps.yaml editor add/delete tests (issue #4714)", False),
         ("web_chart_currency", test_rates_chart_series_names_use_currency_symbol, "Rates chart series names follow currency_symbols tests", False),
         ("web_debug_history_routes", test_web_debug_history_routes, "Debug-history web routes tests (#4438 review items 4, 6, 21)", False),
         ("debug_history_client_js", test_debug_history_client_js, "Debug-history client-side JS structure tests (#4438 review item 22)", False),

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -3695,18 +3695,14 @@ chart.render();
         """
         Split a dot-notation path into keys, with each list index as its own '[n]' key
         """
-        pre_keys = path.split(".")
         keys = []
-        # Split out set of square brackets into a different key
-        for key in pre_keys:
-            if "[" in key and "]" in key:
-                # Handle keys with square brackets, e.g., "battery_charge_low[0]"
-                base_key, index = key.split("[")
-                index = index.rstrip("]")
-                keys.append(base_key)
-                keys.append(f"[{index}]")
-            else:
-                keys.append(key)
+        # Split out every set of square brackets into its own key, e.g. "battery_charge_low[0]"
+        # into "battery_charge_low", "[0]", and a directly nested list's "foo[0][1]" into
+        # "foo", "[0]", "[1]"
+        for component in path.split("."):
+            for token in re.split(r"(\[[^\[\]]*\])", component):
+                if token:
+                    keys.append(token)
         return keys
 
     def _yaml_path_index(self, key, path):
@@ -3827,6 +3823,27 @@ chart.render();
             else:
                 raise KeyError(f"Final key '{key}' not found in path '{path}'")
 
+    def _validate_compare_list(self, compare_list):
+        """
+        Check every compare_list profile still has the unique id and non-empty name that
+        compare.py indexes results by, raising ValueError if a batch has left one without
+        """
+        if not compare_list:
+            return
+
+        seen_ids = set()
+        for entry in compare_list:
+            if not isinstance(entry, dict):
+                raise ValueError("Each compare_list entry must be a dictionary with an id and a name")
+            entry_id = entry.get("id")
+            if not entry_id:
+                raise ValueError("Each compare_list entry requires a non-empty 'id'")
+            if entry_id in seen_ids:
+                raise ValueError(f"Duplicate compare_list id '{entry_id}'")
+            seen_ids.add(entry_id)
+            if not entry.get("name"):
+                raise ValueError(f"compare_list entry '{entry_id}' requires a non-empty 'name'")
+
     async def html_apps_post(self, request):
         """
         Handle POST request for apps page - batch edit values
@@ -3863,9 +3880,13 @@ chart.render();
                 return web.json_response({"success": False, "message": "pred_bat section not found in apps.yaml"})
 
             # Process each change - additions and updates are applied first, then deletions, as
-            # deleting a list item shifts the indices every other path was rendered against
+            # deleting a list item shifts the indices every other path was rendered against.
+            # Every mutation lands on live_args, a copy of self.args, rather than self.args
+            # itself - a batch that fails partway, or whose file write fails, must never leave
+            # self.args (which is the same object as self.base.args) reflecting only some of it
             updated_args = []
             deleted_paths = []
+            live_args = copy.deepcopy(self.args)
             for path_or_arg, change_info in changes.items():
                 change_type = change_info.get("type", "numerical")
                 is_nested = change_info.get("isNested", False)
@@ -3873,8 +3894,12 @@ chart.render();
                 # path is taken from the change itself rather than from the key
                 path_or_arg = change_info.get("path", path_or_arg) if is_nested else path_or_arg
 
-                if change_type in ("add", "delete") and not is_nested:
-                    return web.json_response({"success": False, "message": f"Only nested values can be added or deleted, not {path_or_arg}"})
+                if change_type in ("add", "delete"):
+                    # Determine nesting from the parsed path itself, not the client-supplied
+                    # isNested flag, so a delete posted with isNested spoofed true still cannot
+                    # reach a bare top-level key
+                    if len(self._split_yaml_path(path_or_arg)) < 2:
+                        return web.json_response({"success": False, "message": f"Only nested values can be added or deleted, not {path_or_arg}"})
 
                 if change_type == "delete":
                     deleted_paths.append(path_or_arg)
@@ -3890,7 +3915,7 @@ chart.render();
                         return web.json_response({"success": False, "message": f"Invalid value format for {path_or_arg}: {str(e)}"})
                     try:
                         self._add_nested_yaml_value(data[ROOT_YAML_KEY], path_or_arg, added_value)
-                        self._add_nested_yaml_value(self.args, path_or_arg, copy.deepcopy(added_value))
+                        self._add_nested_yaml_value(live_args, path_or_arg, copy.deepcopy(added_value))
                     except (KeyError, TypeError) as e:
                         return web.json_response({"success": False, "message": f"Could not add {path_or_arg}: {str(e)}"})
                     updated_args.append(f"added {path_or_arg}")
@@ -3917,7 +3942,7 @@ chart.render();
                     # Handle nested paths like "battery_charge_low.normal"
                     try:
                         self._update_nested_yaml_value(data[ROOT_YAML_KEY], path_or_arg, converted_value)
-                        self._update_nested_yaml_value(self.args, path_or_arg, converted_value)
+                        self._update_nested_yaml_value(live_args, path_or_arg, converted_value)
                         updated_args.append(f"{path_or_arg}={converted_value}")
                     except (KeyError, TypeError) as e:
                         return web.json_response({"success": False, "message": f"Path {path_or_arg} not found or invalid: {str(e)}"})
@@ -3925,7 +3950,7 @@ chart.render();
                     # Handle top-level arguments
                     if path_or_arg in data[ROOT_YAML_KEY]:
                         data[ROOT_YAML_KEY][path_or_arg] = converted_value
-                        self.args[path_or_arg] = converted_value  # Update the base args as well
+                        live_args[path_or_arg] = converted_value
                         updated_args.append(f"{path_or_arg}={converted_value}")
                     else:
                         return web.json_response({"success": False, "message": f"Argument {path_or_arg} not found in apps.yaml"})
@@ -3935,15 +3960,28 @@ chart.render();
             for path in sorted(deleted_paths, key=self._yaml_path_sort_key, reverse=True):
                 try:
                     self._delete_nested_yaml_value(data[ROOT_YAML_KEY], path)
-                    self._delete_nested_yaml_value(self.args, path)
+                    self._delete_nested_yaml_value(live_args, path)
                 except (KeyError, TypeError) as e:
                     return web.json_response({"success": False, "message": f"Could not delete {path}: {str(e)}"})
                 updated_args.append(f"deleted {path}")
+
+            # Compare profiles are indexed by id elsewhere (e.g. compare.py), so a batch that
+            # leaves one without an id or name, or with a duplicate id, must be refused
+            try:
+                self._validate_compare_list(data[ROOT_YAML_KEY].get("compare_list"))
+            except ValueError as e:
+                return web.json_response({"success": False, "message": str(e)})
 
             # Write back to the file, preserving comments and formatting
             try:
                 with open(apps_yaml_path, "w") as f:
                     yaml.dump(data, f)
+
+                # Only now that the whole batch has validated and the file write has succeeded is
+                # the live config published - in place, so self.args (the same object as
+                # self.base.args) never reflects a partially applied batch
+                self.args.clear()
+                self.args.update(live_args)
 
                 change_count = len(updated_args)
                 self.log(f"Batch updated {change_count} arguments in apps.yaml: {', '.join(updated_args)}")

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -2745,6 +2745,23 @@ chart.render();
 
         raise web.HTTPFound("./config")
 
+    def render_delete_button(self, nested_row_id):
+        """
+        Render the delete button shown against a nested list item or dictionary key
+        """
+        return f'<button class="delete-button" id="delete_button_{nested_row_id}" onclick="deleteNestedValue({nested_row_id})">Delete</button>'
+
+    def render_add_row(self, function, js_args, label, row_counter):
+        """
+        Render the trailing table row holding an add button, which doubles as the anchor new rows are inserted before
+        """
+        if row_counter is None:
+            return ""
+        row_counter[0] += 1
+        anchor_id = row_counter[0]
+        args = ", ".join(["'{}'".format(html_module.escape(str(item), quote=True)) for item in js_args] + [str(anchor_id)])
+        return f"<tr id='add_anchor_{anchor_id}'><td colspan='2'></td><td><button class=\"add-button\" onclick=\"{function}({args})\">{label}</button></td></tr>\n"
+
     def render_type(self, arg, value, parent_path="", row_counter=None):
         """
         Render a value based on its type with support for nested editing.
@@ -2762,67 +2779,81 @@ chart.render();
         """
         text = ""
         if isinstance(value, list):
+            list_path = parent_path if parent_path else arg
             text += "<table>"
             for idx, item in enumerate(value):
-                nested_path = f"{parent_path}[{idx}]" if parent_path else f"{arg}[{idx}]"
+                nested_path = f"{list_path}[{idx}]"
 
                 # Check if this list item is editable
                 can_edit = self.is_editable_value(item)
                 actions_cell = ""
+                nested_row_id = None
 
-                if can_edit and row_counter is not None:
+                if row_counter is not None:
                     row_counter[0] += 1
                     nested_row_id = row_counter[0]
 
-                    if isinstance(item, bool):
-                        toggle_class = "toggle-button active" if item else "toggle-button"
-                        actions_cell = f'<button class="{toggle_class}" onclick="toggleNestedValue({nested_row_id})" data-value="{str(item).lower()}" data-path="{nested_path}"></button>'
-                    else:
-                        actions_cell = f'<button class="edit-button" onclick="editNestedValue({nested_row_id})" data-path="{nested_path}">Edit</button>'
+                    if can_edit:
+                        if isinstance(item, bool):
+                            toggle_class = "toggle-button active" if item else "toggle-button"
+                            actions_cell = f'<button class="{toggle_class}" onclick="toggleNestedValue({nested_row_id})" data-value="{str(item).lower()}" data-path="{nested_path}"></button>'
+                        else:
+                            actions_cell = f'<button class="edit-button" onclick="editNestedValue({nested_row_id})" data-path="{nested_path}">Edit</button>'
 
-                    # Store the nested value info for later processing
-                    if not hasattr(self, "_nested_values"):
-                        self._nested_values = {}
-                    self._nested_values[nested_row_id] = {"path": nested_path, "value": item}
+                        # Store the nested value info for later processing
+                        if not hasattr(self, "_nested_values"):
+                            self._nested_values = {}
+                        self._nested_values[nested_row_id] = {"path": nested_path, "value": item}
+
+                    # Every list item can be removed, whether or not its value itself is editable
+                    actions_cell += self.render_delete_button(nested_row_id)
 
                 raw_value = self.resolve_value_raw(arg, item)
 
-                if actions_cell:
-                    text += f"<tr id='nested_row_{row_counter[0] if can_edit else 'static'}' data-nested-path='{nested_path}' data-nested-original='{html_module.escape(str(raw_value))}'><td>- </td><td id='nested_value_{row_counter[0] if can_edit else 'static'}'>{self.render_type(arg, item, nested_path, row_counter)}</td><td>{actions_cell}</td></tr>\n"
+                if nested_row_id is not None:
+                    text += f"<tr id='nested_row_{nested_row_id}' data-nested-path='{nested_path}' data-nested-original='{html_module.escape(str(raw_value))}'><td>- </td><td id='nested_value_{nested_row_id}'>{self.render_type(arg, item, nested_path, row_counter)}</td><td>{actions_cell}</td></tr>\n"
                 else:
                     text += "<tr><td>- {}</td></tr>\n".format(self.render_type(arg, item, nested_path, row_counter))
+            text += self.render_add_row("addListItem", [list_path, arg], "Add item", row_counter)
             text += "</table>"
         elif isinstance(value, dict):
+            dict_path = parent_path if parent_path else arg
             text += "<table>"
             for key in value:
-                nested_path = f"{parent_path}.{key}" if parent_path else f"{arg}.{key}"
+                nested_path = f"{dict_path}.{key}"
                 nested_value = value[key]
 
                 # Check if this nested value is editable
                 can_edit = self.is_editable_value(nested_value)
                 actions_cell = ""
+                nested_row_id = None
 
-                if can_edit and row_counter is not None:
+                if row_counter is not None:
                     row_counter[0] += 1
                     nested_row_id = row_counter[0]
 
-                    if isinstance(nested_value, bool):
-                        toggle_class = "toggle-button active" if nested_value else "toggle-button"
-                        actions_cell = f'<button class="{toggle_class}" onclick="toggleNestedValue({nested_row_id})" data-value="{str(nested_value).lower()}" data-path="{nested_path}"></button>'
-                    else:
-                        actions_cell = f'<button class="edit-button" onclick="editNestedValue({nested_row_id})" data-path="{nested_path}">Edit</button>'
+                    if can_edit:
+                        if isinstance(nested_value, bool):
+                            toggle_class = "toggle-button active" if nested_value else "toggle-button"
+                            actions_cell = f'<button class="{toggle_class}" onclick="toggleNestedValue({nested_row_id})" data-value="{str(nested_value).lower()}" data-path="{nested_path}"></button>'
+                        else:
+                            actions_cell = f'<button class="edit-button" onclick="editNestedValue({nested_row_id})" data-path="{nested_path}">Edit</button>'
 
-                    # Store the nested value info for later processing
-                    if not hasattr(self, "_nested_values"):
-                        self._nested_values = {}
-                    self._nested_values[nested_row_id] = {"path": nested_path, "value": nested_value}
+                        # Store the nested value info for later processing
+                        if not hasattr(self, "_nested_values"):
+                            self._nested_values = {}
+                        self._nested_values[nested_row_id] = {"path": nested_path, "value": nested_value}
+
+                    # Every setting can be removed, whether or not its value itself is editable
+                    actions_cell += self.render_delete_button(nested_row_id)
 
                 raw_value = self.resolve_value_raw(key, nested_value)
 
-                if actions_cell:
-                    text += f"<tr id='nested_row_{row_counter[0] if can_edit else 'static'}' data-nested-path='{nested_path}' data-nested-original='{html_module.escape(str(raw_value))}'><td><b>{key}: </b></td><td id='nested_value_{row_counter[0] if can_edit else 'static'}'>{self.render_type(key, nested_value, nested_path, row_counter)}</td><td>{actions_cell}</td></tr>\n"
+                if nested_row_id is not None:
+                    text += f"<tr id='nested_row_{nested_row_id}' data-nested-path='{nested_path}' data-nested-original='{html_module.escape(str(raw_value))}'><td><b>{key}: </b></td><td id='nested_value_{nested_row_id}'>{self.render_type(key, nested_value, nested_path, row_counter)}</td><td>{actions_cell}</td></tr>\n"
                 else:
                     text += "<tr><td><b>{}: </b></td><td colspan='2'>{}</td></tr>\n".format(key, self.render_type(key, nested_value, nested_path, row_counter))
+            text += self.render_add_row("addDictKey", [dict_path], "Add setting", row_counter)
             text += "</table>"
         elif isinstance(value, str):
             pat = re.match(r"^[a-zA-Z_]+\.\S+", value)
@@ -3660,9 +3691,9 @@ chart.render();
         text += "</body></html>\n"
         return web.Response(content_type="text/html", text=text)
 
-    def _update_nested_yaml_value(self, data, path, value):
+    def _split_yaml_path(self, path):
         """
-        Update a nested value in YAML data using a dot-notation path
+        Split a dot-notation path into keys, with each list index as its own '[n]' key
         """
         pre_keys = path.split(".")
         keys = []
@@ -3676,14 +3707,26 @@ chart.render();
                 keys.append(f"[{index}]")
             else:
                 keys.append(key)
+        return keys
 
+    def _yaml_path_index(self, key, path):
+        """
+        Return the integer index held by a '[n]' path key, raising KeyError if it is not one
+        """
+        index = key[1:-1]
+        if not index.isdigit():
+            raise KeyError(f"Invalid list index '{key}' in path '{path}'")
+        return int(index)
+
+    def _navigate_yaml_path(self, data, keys, path):
+        """
+        Walk YAML data along all but the last key and return the container holding the final key
+        """
         current = data
-
-        # Navigate to the parent of the target value
         for key in keys[:-1]:
             if key.startswith("[") and key.endswith("]"):
                 # Handle numerical index in square brackets
-                index = int(key[1:-1])
+                index = self._yaml_path_index(key, path)
                 if not isinstance(current, list) or index >= len(current):
                     raise KeyError(f"Index '{index}' out of range in path '{path}'")
                 current = current[index]
@@ -3691,12 +3734,83 @@ chart.render();
                 current = current[key]
             else:
                 raise KeyError(f"Key '{key}' not found in path '{path}'")
+        return current
+
+    def _yaml_path_sort_key(self, path):
+        """
+        Return a sort key for a path so that deeper paths and higher list indices sort last
+        """
+        sort_key = []
+        for key in self._split_yaml_path(path):
+            if key.startswith("[") and key.endswith("]") and key[1:-1].isdigit():
+                sort_key.append((0, int(key[1:-1]), ""))
+            else:
+                sort_key.append((1, 0, str(key)))
+        return sort_key
+
+    def _parse_yaml_fragment(self, text):
+        """
+        Parse a user supplied YAML fragment (a scalar, or a block of key: value lines) into a value
+        """
+        yaml = YAML()
+        yaml.preserve_quotes = True
+        value = yaml.load(text)
+        if value is None:
+            raise ValueError("value is empty")
+        return value
+
+    def _delete_nested_yaml_value(self, data, path):
+        """
+        Delete a nested list item or dictionary key from YAML data using a dot-notation path
+        """
+        keys = self._split_yaml_path(path)
+        current = self._navigate_yaml_path(data, keys, path)
+
+        key = keys[-1]
+        if key.startswith("[") and key.endswith("]"):
+            # Handle numerical index in square brackets
+            index = self._yaml_path_index(key, path)
+            if not isinstance(current, list) or index >= len(current):
+                raise KeyError(f"Index '{index}' out of range in path '{path}'")
+            del current[index]
+        elif isinstance(current, dict) and key in current:
+            del current[key]
+        else:
+            raise KeyError(f"Final key '{key}' not found in path '{path}'")
+
+    def _add_nested_yaml_value(self, data, path, value):
+        """
+        Add a new list item (path ending in '[]') or dictionary key to YAML data using a dot-notation path
+        """
+        keys = self._split_yaml_path(path)
+        current = self._navigate_yaml_path(data, keys, path)
+
+        key = keys[-1]
+        if key == "[]":
+            if not isinstance(current, list):
+                raise KeyError(f"Path '{path}' does not refer to a list")
+            current.append(value)
+        elif key.startswith("[") and key.endswith("]"):
+            raise KeyError(f"Cannot add at an existing list index, use [] to append in path '{path}'")
+        elif not isinstance(current, dict):
+            raise KeyError(f"Path '{path}' does not refer to a dictionary")
+        elif key in current:
+            raise KeyError(f"Key '{key}' already exists in path '{path}'")
+        else:
+            current[key] = value
+
+    def _update_nested_yaml_value(self, data, path, value):
+        """
+        Update a nested value in YAML data using a dot-notation path
+        """
+        keys = self._split_yaml_path(path)
+        current = self._navigate_yaml_path(data, keys, path)
 
         # Set the final value
         key = keys[-1]
         if key.startswith("[") and key.endswith("]"):
             # Handle numerical index in square brackets
-            index = int(key[1:-1])
+            index = self._yaml_path_index(key, path)
             if not isinstance(current, list) or index >= len(current):
                 raise KeyError(f"Index '{index}' out of range in path '{path}'")
             current[index] = value
@@ -3748,12 +3862,39 @@ chart.render();
             if ROOT_YAML_KEY not in data:
                 return web.json_response({"success": False, "message": "pred_bat section not found in apps.yaml"})
 
-            # Process each change
+            # Process each change - additions and updates are applied first, then deletions, as
+            # deleting a list item shifts the indices every other path was rendered against
             updated_args = []
+            deleted_paths = []
             for path_or_arg, change_info in changes.items():
-                new_value = change_info["newValue"]
                 change_type = change_info.get("type", "numerical")
                 is_nested = change_info.get("isNested", False)
+                # Adds are keyed uniquely by the browser so several can target one list, so the
+                # path is taken from the change itself rather than from the key
+                path_or_arg = change_info.get("path", path_or_arg) if is_nested else path_or_arg
+
+                if change_type in ("add", "delete") and not is_nested:
+                    return web.json_response({"success": False, "message": f"Only nested values can be added or deleted, not {path_or_arg}"})
+
+                if change_type == "delete":
+                    deleted_paths.append(path_or_arg)
+                    continue
+
+                new_value = change_info["newValue"]
+
+                if change_type == "add":
+                    # Added values are entered as YAML so a whole new list entry can be created at once
+                    try:
+                        added_value = self._parse_yaml_fragment(new_value)
+                    except Exception as e:
+                        return web.json_response({"success": False, "message": f"Invalid value format for {path_or_arg}: {str(e)}"})
+                    try:
+                        self._add_nested_yaml_value(data[ROOT_YAML_KEY], path_or_arg, added_value)
+                        self._add_nested_yaml_value(self.args, path_or_arg, copy.deepcopy(added_value))
+                    except (KeyError, TypeError) as e:
+                        return web.json_response({"success": False, "message": f"Could not add {path_or_arg}: {str(e)}"})
+                    updated_args.append(f"added {path_or_arg}")
+                    continue
 
                 # Convert the new value to appropriate type
                 try:
@@ -3788,6 +3929,16 @@ chart.render();
                         updated_args.append(f"{path_or_arg}={converted_value}")
                     else:
                         return web.json_response({"success": False, "message": f"Argument {path_or_arg} not found in apps.yaml"})
+
+            # Deletions run last, deepest path and highest list index first, so that one deletion
+            # never shifts the index another one still refers to
+            for path in sorted(deleted_paths, key=self._yaml_path_sort_key, reverse=True):
+                try:
+                    self._delete_nested_yaml_value(data[ROOT_YAML_KEY], path)
+                    self._delete_nested_yaml_value(self.args, path)
+                except (KeyError, TypeError) as e:
+                    return web.json_response({"success": False, "message": f"Could not delete {path}: {str(e)}"})
+                updated_args.append(f"deleted {path}")
 
             # Write back to the file, preserving comments and formatting
             try:

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -1726,6 +1726,186 @@ function saveNestedValue(rowId) {
     updateChangeCounter();
 }
 
+// Counter used to give each pending addition a unique key, as several can target the same list
+let addCounter = 0;
+
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function deleteNestedValue(rowId) {
+    const row = document.getElementById('nested_row_' + rowId);
+    const nestedPath = row.dataset.nestedPath;
+
+    // Keyed separately from an edit of the same value, so that undoing the deletion does not
+    // also silently undo a pending edit - the server applies edits before any deletion
+    pendingChanges[nestedPath + '#delete'] = {
+        rowId: rowId,
+        originalValue: row.dataset.nestedOriginal,
+        newValue: '',
+        type: 'delete',
+        isNested: true,
+        path: nestedPath
+    };
+
+    row.classList.add('row-deleted');
+    setDeleteButtonState(rowId, true);
+    updateChangeCounter();
+}
+
+function undoDeleteNestedValue(rowId) {
+    const row = document.getElementById('nested_row_' + rowId);
+    const nestedPath = row.dataset.nestedPath;
+
+    delete pendingChanges[nestedPath + '#delete'];
+    row.classList.remove('row-deleted');
+    setDeleteButtonState(rowId, false);
+    updateChangeCounter();
+}
+
+function setDeleteButtonState(rowId, deleted) {
+    // The button is looked up by id rather than by class, as a row holding a nested table
+    // also contains the delete buttons of all of its children
+    const button = document.getElementById('delete_button_' + rowId);
+    if (!button) return;
+    if (deleted) {
+        button.textContent = 'Undo';
+        button.setAttribute('onclick', 'undoDeleteNestedValue(' + rowId + ')');
+    } else {
+        button.textContent = 'Delete';
+        button.setAttribute('onclick', 'deleteNestedValue(' + rowId + ')');
+    }
+}
+
+function hideAddDialog() {
+    const overlay = document.querySelector('.add-overlay');
+    if (overlay) {
+        overlay.remove();
+    }
+}
+
+// Show a dialog collecting one or more fields, calling onConfirm with an id -> value object
+function showAddDialog(title, help, fields, onConfirm) {
+    const overlay = document.createElement('div');
+    overlay.className = 'confirmation-overlay add-overlay';
+
+    let fieldsHtml = '';
+    fields.forEach(field => {
+        if (field.type === 'textarea') {
+            fieldsHtml += `<label class="add-dialog-label" for="add_field_${field.id}">${field.label}</label>
+                           <textarea class="add-dialog-input" id="add_field_${field.id}" rows="5"></textarea>`;
+        } else {
+            fieldsHtml += `<label class="add-dialog-label" for="add_field_${field.id}">${field.label}</label>
+                           <input type="text" class="add-dialog-input" id="add_field_${field.id}">`;
+        }
+    });
+
+    overlay.innerHTML = `
+        <div class="confirmation-dialog">
+            <h3>${title}</h3>
+            <p>${help}</p>
+            ${fieldsHtml}
+            <div class="confirmation-buttons">
+                <button class="cancel-button-dialog" onclick="hideAddDialog()">Cancel</button>
+                <button class="confirm-button" id="addDialogConfirm">Add</button>
+            </div>
+        </div>
+    `;
+
+    document.body.appendChild(overlay);
+
+    // Pre-fill any defaults, which cannot go in the markup above as they may contain newlines
+    fields.forEach(field => {
+        document.getElementById('add_field_' + field.id).value = field.value || '';
+    });
+
+    document.getElementById('addDialogConfirm').onclick = () => {
+        const values = {};
+        for (const field of fields) {
+            values[field.id] = document.getElementById('add_field_' + field.id).value;
+        }
+        if (onConfirm(values)) {
+            hideAddDialog();
+        }
+    };
+
+    document.getElementById('add_field_' + fields[0].id).focus();
+}
+
+// Insert a pending row above the add button and register the change, returning the change key
+function registerPendingAdd(anchorId, path, valueText, nameHtml, valueHtml) {
+    addCounter += 1;
+    const changeKey = path + '#' + addCounter;
+
+    pendingChanges[changeKey] = {
+        rowId: null,
+        originalValue: '',
+        newValue: valueText,
+        type: 'add',
+        isNested: true,
+        path: path,
+        pendingRowId: addCounter
+    };
+
+    const anchor = document.getElementById('add_anchor_' + anchorId);
+    const row = document.createElement('tr');
+    row.id = 'pending_row_' + addCounter;
+    row.className = 'row-added';
+    row.dataset.changeKey = changeKey;
+    row.innerHTML = `<td>${nameHtml}</td><td>${valueHtml}</td>` +
+                    `<td><button class="cancel-button" onclick="cancelPendingAdd(${addCounter})">Remove</button></td>`;
+    anchor.parentNode.insertBefore(row, anchor);
+
+    updateChangeCounter();
+    return changeKey;
+}
+
+function cancelPendingAdd(pendingRowId) {
+    const row = document.getElementById('pending_row_' + pendingRowId);
+    if (!row) return;
+    delete pendingChanges[row.dataset.changeKey];
+    row.remove();
+    updateChangeCounter();
+}
+
+function addListItem(listPath, argName, anchorId) {
+    // compare_list entries need at least a name and an id, so offer them as a starting point
+    const template = (argName === 'compare_list') ? 'name: My Tariff\\nid: my_tariff' : '';
+    const help = (argName === 'compare_list')
+        ? 'Enter the new tariff to compare, one <b>setting: value</b> per line. A <b>name</b> and a unique <b>id</b> are required.'
+        : 'Enter the new entry in YAML format - a single value, or one <b>setting: value</b> per line.';
+
+    showAddDialog('Add entry to ' + listPath, help, [{id: 'value', label: 'New entry', type: 'textarea', value: template}], (values) => {
+        const valueText = values.value;
+        if (!valueText.trim()) {
+            showMessage('Value cannot be empty', 'error');
+            return false;
+        }
+        registerPendingAdd(anchorId, listPath + '[]', valueText, '+ ', '<pre>' + escapeHtml(valueText) + '</pre>');
+        return true;
+    });
+}
+
+function addDictKey(dictPath, anchorId) {
+    showAddDialog('Add setting to ' + dictPath, 'Enter the name of the new setting and its value.',
+                  [{id: 'key', label: 'Setting name', type: 'text'}, {id: 'value', label: 'Value', type: 'text'}], (values) => {
+        const key = values.key.trim();
+        const valueText = values.value;
+        if (!key.match(/^[A-Za-z0-9_-]+$/)) {
+            showMessage('Setting name must contain only letters, numbers, dashes or underscores', 'error');
+            return false;
+        }
+        if (!valueText.trim()) {
+            showMessage('Value cannot be empty', 'error');
+            return false;
+        }
+        registerPendingAdd(anchorId, dictPath + '.' + key, valueText, '<b>' + escapeHtml(key) + ': </b>', escapeHtml(valueText));
+        return true;
+    });
+}
+
 function markNestedRowAsChanged(rowId) {
     const row = document.getElementById('nested_row_' + rowId);
     row.classList.add('row-changed');
@@ -1742,7 +1922,20 @@ function discardAllChanges() {
     for (const pathOrArgName in pendingChanges) {
         const change = pendingChanges[pathOrArgName];
 
-        if (change.isNested) {
+        if (change.type === 'delete') {
+            // Restore a row marked for deletion
+            const row = document.getElementById('nested_row_' + change.rowId);
+            if (row) {
+                row.classList.remove('row-deleted');
+            }
+            setDeleteButtonState(change.rowId, false);
+        } else if (change.type === 'add') {
+            // Drop the preview row of a pending addition
+            const row = document.getElementById('pending_row_' + change.pendingRowId);
+            if (row) {
+                row.remove();
+            }
+        } else if (change.isNested) {
             // Handle nested values
             const row = document.getElementById('nested_row_' + change.rowId);
             const valueCell = document.getElementById('nested_value_' + change.rowId);
@@ -1888,6 +2081,57 @@ def get_apps_css():
 
 .edit-button:hover {
     background-color: #45a049;
+}
+
+.delete-button, .add-button {
+    color: white;
+    border: none;
+    padding: 4px 8px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 12px;
+    margin: 2px 2px;
+    cursor: pointer;
+    border-radius: 3px;
+}
+
+.delete-button {
+    background-color: #dc3545;
+}
+
+.delete-button:hover {
+    background-color: #c82333;
+}
+
+.add-button {
+    background-color: #17a2b8;
+}
+
+.add-button:hover {
+    background-color: #138496;
+}
+
+.add-dialog-label {
+    display: block;
+    font-weight: bold;
+    margin-top: 10px;
+}
+
+.add-dialog-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 13px;
+}
+
+body.dark-mode .add-dialog-input {
+    background-color: #2d2d2d;
+    color: #e0e0e0;
+    border: 1px solid #555;
 }
 
 .edit-input {
@@ -2100,6 +2344,29 @@ body.dark-mode .toggle-button::before {
 .row-changed {
     background-color: #fff3cd !important;
     border-left: 4px solid #ffc107 !important;
+}
+
+/* Rows pending deletion or addition */
+.row-deleted {
+    background-color: #f8d7da !important;
+    border-left: 4px solid #dc3545 !important;
+    text-decoration: line-through;
+    opacity: 0.7;
+}
+
+.row-added {
+    background-color: #d4edda !important;
+    border-left: 4px solid #28a745 !important;
+}
+
+body.dark-mode .row-deleted {
+    background-color: #3f1e1e !important;
+    border-left: 4px solid #dc3545 !important;
+}
+
+body.dark-mode .row-added {
+    background-color: #1e3f20 !important;
+    border-left: 4px solid #28a745 !important;
 }
 
 /* Dark mode save controls styles */

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -163,6 +163,11 @@ Click the edit button to change a value, when all the edits are complete hit sav
 
 <img alt="image of Predbat apps view" src="https://github.com/user-attachments/assets/f9aacd17-f25b-45d6-95fe-229431a1f4d6" />
 
+Alongside the edit button, each entry of a list and each setting within it can be removed with the **Delete** button, and new ones created with the
+**Add item** and **Add setting** buttons at the end of each group. This is how you add, change or remove a [tariff to compare](compare.md) without hand-editing
+the YAML - **Add item** against `compare_list` asks for the new tariff as one `setting: value` per line, starting from a template of the required `name` and `id`.
+Deletions and additions are only pending until you hit save, so they can be undone first with the **Undo**, **Remove** and **Discard Changes** buttons.
+
 Predbat validates your `apps.yaml` every time it runs and if there are any configuration issues it displays a count of those errors and highlights the items in error in red:
 
 ![image](images/web-interface-apps-yaml-validation-error.png)


### PR DESCRIPTION
This is an automated draft PR generated from issue #4714 — a maintainer should review it before merging.

Fixes #4714

## Summary

The structured `/apps` editor could only change the value of settings that already existed, so a compare profile could be edited but never removed, added, or given a new setting — `_update_nested_yaml_value` raised `KeyError` for an unknown final key and `html_apps_post` had no wire representation for a delete or a create.

This adds both halves:

- **Rendering** (`render_type`): every nested list entry and every setting now gets a **Delete** button, and each list/dictionary gets an **Add item** / **Add setting** row at the end. List entries that are themselves dictionaries (a compare profile) previously rendered with no row id and no actions at all, so they now get both.
- **Client** (`get_apps_js`): deletions and additions are queued like any other edit and only applied on save, so they can be undone (**Undo** / **Remove**) or dropped with **Discard Changes**. **Add item** against `compare_list` opens with a `name:`/`id:` template, so adding a tariff to compare no longer means hand-editing YAML.
- **Server** (`html_apps_post`): new `add` and `delete` change types, with `_add_nested_yaml_value` / `_delete_nested_yaml_value` alongside the existing update helper (whose path parsing and navigation are now shared). Added values are parsed as a YAML fragment, so a whole new list entry with its own settings can be created in one go and keeps its types.

Two ordering details worth reviewing:

- Deletions are applied **after** all edits and additions, sorted deepest path and highest list index first, because paths were rendered against the pre-delete indices — deleting `compare_list[0]` and `compare_list[2]` in one save otherwise removes the wrong second entry.
- Adds are keyed uniquely by the browser (`path#n`) so several can target the same list, and a deletion is keyed `path#delete` so undoing it does not silently discard a pending edit of the same row. The server therefore takes the path from the change itself rather than from the key.

Both `add` and `delete` are refused for top-level arguments, so this cannot restructure `apps.yaml` above the list/dictionary level. The raw `/apps_editor` remains the way to do that.

## Testing

- New `apps/predbat/tests/test_web_apps_edit.py` (registered as `web_apps_edit` in `TEST_REGISTRY`) — 16 checks covering single and multiple deletions, the index-shift regression, adding two profiles at once, adding a typed setting, an edit plus a delete in one save, the refusal cases (duplicate key, out-of-range index, appending to a dictionary, top-level add/delete, empty value), comment preservation through the ruamel round trip, and the rendered buttons. The client half is asserted structurally, as `test_debug_history_client_js.py` does, since there is no JS engine in the suite. `tools/triage_test.sh web_apps_edit` passes.
- `coverage/run_pre_commit` passes: all 12 hooks Passed, and `run_all --quick` reports all tests passed (4 slow tests skipped). That includes `web_if`, which exercises `GET`/`POST /apps` end to end.

## Notes

Documentation for the new buttons added to the Apps View section of `docs/web-interface.md`.