### PR TITLE
fix(debug): let Companion-app users get a debug snapshot without a browser

### DIFF
--- a/apps/predbat/debug_history.py
+++ b/apps/predbat/debug_history.py
@@ -157,7 +157,7 @@ async def capture_snapshot(storage, yaml_text, now_utc, max_count, max_age=None)
     # what makes it reachable by a HA Companion-app user, whose embedded webview cannot save the
     # tgz/single-file download routes (it ignores Content-Disposition: attachment) but can still
     # browse to a real file there with File Editor/Samba.
-filename = snapshot_filename(snapshot_id)
+    filename = snapshot_filename(snapshot_id)
     if not await storage.save_debug_copy(filename, yaml_text):
         raise IOError("Failed to save debug snapshot {}".format(filename))
 

--- a/apps/predbat/debug_history.py
+++ b/apps/predbat/debug_history.py
@@ -157,7 +157,9 @@ async def capture_snapshot(storage, yaml_text, now_utc, max_count, max_age=None)
     # what makes it reachable by a HA Companion-app user, whose embedded webview cannot save the
     # tgz/single-file download routes (it ignores Content-Disposition: attachment) but can still
     # browse to a real file there with File Editor/Samba.
-    await storage.save_debug_copy(snapshot_filename(snapshot_id), yaml_text)
+filename = snapshot_filename(snapshot_id)
+    if not await storage.save_debug_copy(filename, yaml_text):
+        raise IOError("Failed to save debug snapshot {}".format(filename))
 
     index = await list_snapshots(storage)
     index = [existing for existing in index if existing.get("id") != snapshot_id]

--- a/apps/predbat/debug_history.py
+++ b/apps/predbat/debug_history.py
@@ -9,8 +9,14 @@
 Captures create_debug_yaml()'s output on a coarse interval and keeps the most recent
 ones, so there is always some recent history to replay a bug report against without
 switch.predbat_debug_enable having already been on before the problem happened.
-Everything goes through the Storage abstraction rather than the filesystem, because
-there may not be one.
+
+The ring's own index (which snapshot ids exist and when they were taken) goes through
+the generic Storage abstraction, since it is small and needs no particular backend. A
+snapshot's actual text is written just once, straight to config_root/debug/ via
+save_debug_copy()/load_debug_copy()/delete_debug_copy() (see #4720) - not duplicated
+into the generic cache store as well, since create_debug_yaml() already writes its own
+output to that same real directory unconditionally, so nothing here is any more
+filesystem-dependent than the feature it is capturing snapshots of.
 """
 
 import datetime
@@ -21,8 +27,12 @@ STORAGE_MODULE = "debug_history"
 INDEX_NAME = "snapshots_index"
 
 
-def _snapshot_key(snapshot_id):
-    """Return the storage filename holding one snapshot's debug-yaml text."""
+def _legacy_snapshot_key(snapshot_id):
+    """Return the pre-#4720 generic-cache-store key a snapshot's content used to be saved under.
+
+    Only ever read/expired now, never written to - see resolve_and_load_snapshot() and
+    _discard_snapshot() for why an entry might still exist there after an install upgrades.
+    """
     return "snapshot_{}".format(snapshot_id)
 
 
@@ -59,6 +69,12 @@ async def resolve_and_load_snapshot(storage, snapshot_id):
     could resolve to a different snapshot than the one whose bytes were actually loaded,
     serving one snapshot's data under another's filename.
 
+    Falls back to the pre-#4720 legacy cache/ key if nothing is in debug/ for this id -
+    a snapshot captured before an install upgraded to this version has its content there,
+    not in debug/, and it stays downloadable this way for the rest of its normal time in
+    the ring rather than silently going dark the moment the install updates. _discard_snapshot()
+    reaps that legacy entry once the snapshot is naturally evicted, same as any other.
+
     Returns (None, None) when nothing could be resolved or loaded.
     """
     if not storage:
@@ -68,7 +84,9 @@ async def resolve_and_load_snapshot(storage, snapshot_id):
         if not snapshots:
             return None, None
         snapshot_id = snapshots[0]["id"]
-    data = await storage.load(STORAGE_MODULE, _snapshot_key(snapshot_id))
+    data = await storage.load_debug_copy(snapshot_filename(snapshot_id))
+    if data is None:
+        data = await storage.load(STORAGE_MODULE, _legacy_snapshot_key(snapshot_id))
     return snapshot_id, data
 
 
@@ -89,27 +107,33 @@ async def load_snapshot(storage, snapshot_id):
 async def _discard_snapshot(storage, snapshot_id):
     """Remove an evicted snapshot's stored text so the ring does not leak it.
 
-    The real Storage component has no ``delete`` method, so the primary path is to
-    overwrite it with ``None`` and set an expiry in the past, which lets
-    ``storage.cleanup()`` reclaim it later. A ``delete`` method is still preferred
-    when a backend (or a test fake) provides one.
+    Also reaps the pre-#4720 legacy cache/ copy, if one is still there: before this,
+    a snapshot's content lived in the generic cache store under "snapshot_<id>" with no
+    expiry, so cleanup() (which only reaps entries that have one) would never have
+    touched it - an install upgrading straight from that version would otherwise leak
+    one orphaned pair of cache/ files per snapshot that existed at upgrade time, forever.
+    Every id in the index is eventually evicted here as the ring rotates regardless of
+    when it was captured, so this opportunistic check-then-expire, run on each eviction,
+    is enough to reap every legacy entry within one ring's worth of time - no separate
+    one-off migration sweep is needed. A snapshot captured under the current scheme never
+    has a legacy entry, so the extra load() below is the only cost in the common case.
     """
-    key = _snapshot_key(snapshot_id)
-    if hasattr(storage, "delete"):
-        await storage.delete(STORAGE_MODULE, key)
-        return
-    expired = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
-    await storage.save(STORAGE_MODULE, key, None, format="text", expiry=expired)
+    await storage.delete_debug_copy(snapshot_filename(snapshot_id))
+    legacy_key = _legacy_snapshot_key(snapshot_id)
+    if await storage.load(STORAGE_MODULE, legacy_key) is not None:
+        expired = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
+        await storage.save(STORAGE_MODULE, legacy_key, None, format="text", expiry=expired)
 
 
 async def capture_snapshot(storage, yaml_text, now_utc, max_count, max_age=None):
     """Save a new debug snapshot and prune the ring. Returns the snapshot id.
 
     ``yaml_text`` must be ``create_debug_yaml(write_file=False)``'s already-rendered
-    YAML string - saved with ``format="text"`` (raw passthrough), NOT ``format="yaml"``,
-    which would run ``yaml.safe_dump()`` on an already-serialised string a second time
-    and turn it into an unreadable quoted block scalar that ``unit_test.py --debug_file``
-    could not parse.
+    YAML string, written verbatim - save_debug_copy() writes exactly the text it is
+    given with no re-serialisation, so (unlike a generic ``storage.save(..., format="yaml")``
+    call, which would run ``yaml.safe_dump()`` on an already-serialised string a second
+    time) the result stays plain, readable YAML that ``unit_test.py --debug_file`` can
+    parse straight back.
 
     ``max_count`` is passed in per call (the live config value) rather than a fixed
     module constant, so a change to the retention count takes effect on the very next
@@ -129,7 +153,11 @@ async def capture_snapshot(storage, yaml_text, now_utc, max_count, max_age=None)
         return None
 
     snapshot_id = now_utc.strftime("%Y%m%d-%H%M%S")
-    await storage.save(STORAGE_MODULE, _snapshot_key(snapshot_id), yaml_text, format="text")
+    # Written straight to config_root/debug/ (#4720), not the generic cache store - this is also
+    # what makes it reachable by a HA Companion-app user, whose embedded webview cannot save the
+    # tgz/single-file download routes (it ignores Content-Disposition: attachment) but can still
+    # browse to a real file there with File Editor/Samba.
+    await storage.save_debug_copy(snapshot_filename(snapshot_id), yaml_text)
 
     index = await list_snapshots(storage)
     index = [existing for existing in index if existing.get("id") != snapshot_id]

--- a/apps/predbat/storage.py
+++ b/apps/predbat/storage.py
@@ -452,11 +452,11 @@ class StorageLocalFiles(StorageBase):
     async def save_debug_copy(self, filename, text):
         """Write a plain-text mirror of already-serialised text into config_root/debug/.
 
-        No metadata sidecar and no format envelope - this is a human-facing copy for
-        someone to find with File Editor/Samba and attach to a GitHub issue, not
-        something Predbat itself reads back, so it is written exactly as given under
-        its own real filename, sitting alongside the raw predbat_debug_*.yaml files
-        switch.predbat_debug_enable already writes to the same directory (see #4720).
+        No metadata sidecar and no format envelope - this is both a human-facing file for
+        someone to find with File Editor/Samba and the rolling history's primary stored
+        content, read back through load_debug_copy(). It is written exactly as given under
+        its real filename alongside the raw predbat_debug_*.yaml files that
+        switch.predbat_debug_enable already writes to this directory (see #4720).
 
         Args:
             filename: Name of the file to write, including its extension

--- a/apps/predbat/storage.py
+++ b/apps/predbat/storage.py
@@ -112,6 +112,41 @@ class StorageBase(ABC):
         """Delete all expired cached files."""
         pass
 
+    async def save_debug_copy(self, filename, text):
+        """Write a plain-text mirror of already-serialised text for a human to find on disk.
+
+        Default no-op: a backend with no real filesystem (there may not be one - see
+        debug_history.py) has nothing sensible to do here, and a caller must not have to
+        know or care which kind of backend it is talking to before calling this.
+
+        Args:
+            filename: Name of the file to write, including its extension
+            text: Already-serialised text to write verbatim
+
+        Returns:
+            True on success, False otherwise (including "not supported by this backend")
+        """
+        return False
+
+    async def delete_debug_copy(self, filename):
+        """Remove a file previously written by save_debug_copy(). Default no-op.
+
+        Args:
+            filename: Name of the file to remove
+        """
+        return None
+
+    async def load_debug_copy(self, filename):
+        """Load text previously written by save_debug_copy(). Default no-op.
+
+        Args:
+            filename: Name of the file to read
+
+        Returns:
+            The file's text, or None if missing or unsupported by this backend
+        """
+        return None
+
     async def _acquire_refresh_lock(self, module, filename):
         """Try to acquire a refresh lock for a key. Default: always succeeds (no coordination).
 
@@ -197,6 +232,7 @@ class StorageLocalFiles(StorageBase):
             log: Logging function
         """
         self.cache_path = os.path.join(config_root, "cache")
+        self.debug_path = os.path.join(config_root, "debug")
         self.log = log
         os.makedirs(self.cache_path, exist_ok=True)
 
@@ -413,6 +449,61 @@ class StorageLocalFiles(StorageBase):
 
             self.log("Storage: Cleaned up expired cache file {} (module={})".format(stem, module))
 
+    async def save_debug_copy(self, filename, text):
+        """Write a plain-text mirror of already-serialised text into config_root/debug/.
+
+        No metadata sidecar and no format envelope - this is a human-facing copy for
+        someone to find with File Editor/Samba and attach to a GitHub issue, not
+        something Predbat itself reads back, so it is written exactly as given under
+        its own real filename, sitting alongside the raw predbat_debug_*.yaml files
+        switch.predbat_debug_enable already writes to the same directory (see #4720).
+
+        Args:
+            filename: Name of the file to write, including its extension
+            text: Already-serialised text to write verbatim
+
+        Returns:
+            True on success, False on failure
+        """
+        data_path = os.path.join(self.debug_path, os.path.basename(filename))
+        try:
+            os.makedirs(self.debug_path, exist_ok=True)
+            async with aiofiles.open(data_path, "w") as f:
+                await f.write(text)
+        except IOError as e:
+            self.log("Storage: Warn: Failed to write debug copy {}: {}".format(data_path, e))
+            return False
+        return True
+
+    async def delete_debug_copy(self, filename):
+        """Remove a file previously written by save_debug_copy(). Best-effort - a missing file is not an error.
+
+        Args:
+            filename: Name of the file to remove
+        """
+        data_path = os.path.join(self.debug_path, os.path.basename(filename))
+        try:
+            if os.path.exists(data_path):
+                os.remove(data_path)
+        except OSError as e:
+            self.log("Storage: Warn: Failed to delete debug copy {}: {}".format(data_path, e))
+
+    async def load_debug_copy(self, filename):
+        """Load text previously written by save_debug_copy() from config_root/debug/.
+
+        Args:
+            filename: Name of the file to read
+
+        Returns:
+            The file's text, or None if it does not exist
+        """
+        data_path = os.path.join(self.debug_path, os.path.basename(filename))
+        try:
+            async with aiofiles.open(data_path, "r") as f:
+                return await f.read()
+        except IOError:
+            return None
+
 
 class StorageComponent(ComponentBase):
     """Storage component providing save/load access to a cache backend.
@@ -478,6 +569,37 @@ class StorageComponent(ComponentBase):
             Cached or freshly fetched data, or None if nothing could be obtained
         """
         return await self.backend.fetch_cached(module, filename, fetch_fn, fresh_minutes=fresh_minutes, stale_minutes=stale_minutes, format=format)
+
+    async def save_debug_copy(self, filename, text):
+        """Write a plain-text debug-directory mirror via the storage backend.
+
+        Args:
+            filename: Name of the file to write, including its extension
+            text: Already-serialised text to write verbatim
+
+        Returns:
+            True on success, False otherwise
+        """
+        return await self.backend.save_debug_copy(filename, text)
+
+    async def delete_debug_copy(self, filename):
+        """Remove a file previously written by save_debug_copy() via the storage backend.
+
+        Args:
+            filename: Name of the file to remove
+        """
+        return await self.backend.delete_debug_copy(filename)
+
+    async def load_debug_copy(self, filename):
+        """Load text previously written by save_debug_copy() via the storage backend.
+
+        Args:
+            filename: Name of the file to read
+
+        Returns:
+            The file's text, or None if missing
+        """
+        return await self.backend.load_debug_copy(filename)
 
     async def run(self, seconds, first):
         """Run the storage component, cleaning up expired files every hour.

--- a/apps/predbat/tests/test_debug_history.py
+++ b/apps/predbat/tests/test_debug_history.py
@@ -12,26 +12,31 @@
 import asyncio
 import datetime
 import io
+import os
 import tempfile
 import shutil
 import tarfile
 
-from debug_history import STORAGE_MODULE, _discard_snapshot, annotate_steps_back, build_archive, capture_snapshot, list_snapshots, load_all_snapshots, load_snapshot, snapshot_filename
+from debug_history import INDEX_NAME, STORAGE_MODULE, _discard_snapshot, _legacy_snapshot_key, annotate_steps_back, build_archive, capture_snapshot, list_snapshots, load_all_snapshots, load_snapshot, snapshot_filename
 from storage import StorageLocalFiles
 
 
 class FakeStorage:
-    """An in-memory stand-in for the Storage component that supports ``delete``.
+    """An in-memory stand-in for the Storage component.
 
-    Exercises the primary eviction path in ``debug_history``, where a genuine
-    ``delete`` method is available and preferred over the fallback.
+    ``store`` backs the generic save()/load() surface, used only for the ring's own
+    index. ``debug_copies`` backs save_debug_copy()/load_debug_copy()/delete_debug_copy(),
+    used for a snapshot's actual text (see #4720) - the two are deliberately separate
+    dicts, mirroring how the real backend keeps the index in config_root/cache/ and
+    snapshot content in config_root/debug/.
     """
 
     def __init__(self):
         """Start with nothing stored."""
         self.store = {}
-        self.deleted = []
         self.save_calls = []
+        self.debug_copies = {}
+        self.debug_copies_deleted = []
 
     async def save(self, module, filename, data, format="yaml", expiry=None):
         """Record a saved value, the format it was saved with, and that a save happened."""
@@ -43,33 +48,19 @@ class FakeStorage:
         entry = self.store.get((module, filename))
         return entry[0] if entry else None
 
-    async def delete(self, module, filename):
-        """Remove a stored value and record that it happened."""
-        self.deleted.append(filename)
-        self.store.pop((module, filename), None)
+    async def save_debug_copy(self, filename, text):
+        """Record a debug/ write, matching StorageLocalFiles.save_debug_copy()."""
+        self.debug_copies[filename] = text
+        return True
 
+    async def load_debug_copy(self, filename):
+        """Return previously written debug/ text, or None, matching StorageLocalFiles.load_debug_copy()."""
+        return self.debug_copies.get(filename)
 
-class FakeStorageNoDelete:
-    """An in-memory stand-in for the Storage component with no ``delete`` method.
-
-    Matches the real Storage component's actual surface, so it exercises the
-    fallback eviction path: overwriting the evicted snapshot with ``None`` and a
-    past expiry, via ``save``, rather than calling a method that does not exist.
-    """
-
-    def __init__(self):
-        """Start with nothing stored."""
-        self.store = {}
-        self.expiries = {}
-
-    async def save(self, module, filename, data, format="yaml", expiry=None):
-        """Record a saved value and the expiry it was saved with, if any."""
-        self.store[(module, filename)] = data
-        self.expiries[(module, filename)] = expiry
-
-    async def load(self, module, filename):
-        """Return a stored value, or None."""
-        return self.store.get((module, filename))
+    async def delete_debug_copy(self, filename):
+        """Record a debug/ deletion, matching StorageLocalFiles.delete_debug_copy()."""
+        self.debug_copies_deleted.append(filename)
+        self.debug_copies.pop(filename, None)
 
 
 def sample_yaml_text(marker):
@@ -96,10 +87,12 @@ def test_debug_history(my_predbat):
         print("  ERROR: loaded snapshot should match what was saved verbatim, got {!r}".format(loaded))
         failed = True
 
-    print("Test: snapshot text is saved with format='text', not 'yaml' (must not be re-serialised)")
-    saved_entry = storage.store.get((STORAGE_MODULE, "snapshot_{}".format(snapshot_id)))
-    if saved_entry is None or saved_entry[1] != "text":
-        print("  ERROR: snapshot should be saved with format='text', got {}".format(saved_entry))
+    print("Test: snapshot text is written via save_debug_copy(), verbatim, not through the generic cache store (#4720)")
+    if storage.debug_copies.get(snapshot_filename(snapshot_id)) != sample_yaml_text(1):
+        print("  ERROR: snapshot text should be in debug_copies verbatim, got {!r}".format(storage.debug_copies.get(snapshot_filename(snapshot_id))))
+        failed = True
+    if (STORAGE_MODULE, "snapshot_{}".format(snapshot_id)) in storage.store:
+        print("  ERROR: snapshot text should not also be duplicated into the generic cache store")
         failed = True
 
     print("Test: the index is newest-first")
@@ -125,8 +118,8 @@ def test_debug_history(my_predbat):
     if asyncio.run(load_snapshot(minute_storage, older_id)) is not None:
         print("  ERROR: the older same-minute capture should have been discarded from storage, not just the index")
         failed = True
-    if "snapshot_{}".format(older_id) not in minute_storage.deleted:
-        print("  ERROR: expected the older same-minute capture to go through the normal discard path, deletions were {}".format(minute_storage.deleted))
+    if snapshot_filename(older_id) not in minute_storage.debug_copies_deleted:
+        print("  ERROR: expected the older same-minute capture to go through the normal discard path, deletions were {}".format(minute_storage.debug_copies_deleted))
         failed = True
 
     print("Test: captures in different minutes are unaffected by the same-minute dedup")
@@ -165,7 +158,7 @@ def test_debug_history(my_predbat):
         print("  ERROR: with no max_age given, only max_count should apply - both should survive, got {}".format(asyncio.run(list_snapshots(no_age_storage))))
         failed = True
 
-    print("Test: pruning to a configured count (not a fixed constant) evicts the oldest and deletes it (delete-capable backend)")
+    print("Test: pruning to a configured count (not a fixed constant) evicts the oldest and deletes its debug/ file (#4720)")
     storage = FakeStorage()
     max_count = 5
     ids = []
@@ -179,35 +172,15 @@ def test_debug_history(my_predbat):
     if ids[0] in [entry["id"] for entry in index]:
         print("  ERROR: the oldest snapshot should have been evicted from the index")
         failed = True
-    if "snapshot_{}".format(ids[0]) not in storage.deleted:
-        print("  ERROR: the evicted snapshot should be deleted, deletions were {}".format(storage.deleted))
+    if snapshot_filename(ids[0]) not in storage.debug_copies_deleted:
+        print("  ERROR: the evicted snapshot's debug/ file should have been deleted too, deletions were {}".format(storage.debug_copies_deleted))
         failed = True
     if asyncio.run(load_snapshot(storage, ids[0])) is not None:
         print("  ERROR: an evicted snapshot should no longer load")
         failed = True
-
-    print("Test: pruning evicts via the fallback (expiry) path when delete is unavailable")
-    no_delete_storage = FakeStorageNoDelete()
-    ids = []
-    for offset in range(max_count + 2):
-        this_time = now + datetime.timedelta(hours=offset)
-        ids.append(asyncio.run(capture_snapshot(no_delete_storage, sample_yaml_text(offset), this_time, max_count=max_count)))
-    index = asyncio.run(list_snapshots(no_delete_storage))
-    if len(index) != max_count:
-        print("  ERROR: the ring should hold {} snapshots without delete, got {}".format(max_count, len(index)))
-        failed = True
-    if asyncio.run(load_snapshot(no_delete_storage, ids[0])) is not None:
-        print("  ERROR: an evicted snapshot should read back as None when the fallback blanking is used")
-        failed = True
-    evicted_expiry = no_delete_storage.expiries.get((STORAGE_MODULE, "snapshot_{}".format(ids[0])))
-    if evicted_expiry is None:
-        print("  ERROR: the fallback should set an expiry on the blanked snapshot so cleanup() can reclaim it")
-        failed = True
-    elif evicted_expiry.tzinfo is None:
-        print("  ERROR: the fallback expiry should be timezone-aware, got {!r}".format(evicted_expiry))
-        failed = True
-    elif evicted_expiry >= datetime.datetime.now(datetime.timezone.utc):
-        print("  ERROR: the fallback expiry should be in the past, got {!r}".format(evicted_expiry))
+    surviving_id = ids[-1]
+    if storage.debug_copies.get(snapshot_filename(surviving_id)) != sample_yaml_text(max_count + 1):
+        print("  ERROR: a surviving snapshot's debug/ file should hold its yaml text verbatim, got {!r}".format(storage.debug_copies.get(snapshot_filename(surviving_id))))
         failed = True
 
     print("Test: annotate_steps_back adds 0,1,2... in order without mutating its input")
@@ -268,7 +241,7 @@ def test_debug_history(my_predbat):
         print("  ERROR: capture_snapshot(None, ...) should give None rather than raising")
         failed = True
 
-    print("Test: format='text' round-trips genuine YAML-syntax content (colons, nesting, newlines) through the real Storage backend")
+    print("Test: snapshot text round-trips genuine YAML-syntax content (colons, nesting, newlines) through a real Storage backend, unaltered")
     tmpdir = tempfile.mkdtemp()
     try:
         log_messages = []
@@ -279,22 +252,82 @@ def test_debug_history(my_predbat):
         if real_loaded != yaml_like_text:
             print("  ERROR: real Storage round-trip should return the exact original text, got {!r} expected {!r}".format(real_loaded, yaml_like_text))
             failed = True
-        # This is exactly the trap being guarded against: if capture_snapshot ever saved with
-        # format="yaml" instead of "text", the colons/indentation in yaml_like_text would come
-        # back re-escaped as a quoted scalar rather than as the original text.
+        # save_debug_copy() has no format/serialisation step to trip over (unlike a generic
+        # storage.save(..., format="yaml") call, which would re-escape this as a quoted scalar) -
+        # confirm the colons/indentation genuinely survived the round trip through real disk I/O.
         if ":" not in real_loaded or "\n" not in real_loaded:
             print("  ERROR: round-tripped text lost its YAML structure (colons/newlines), got {!r}".format(real_loaded))
             failed = True
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
-    print("Test: _discard_snapshot uses delete when available, expiry fallback otherwise (direct, not just via pruning)")
+    print("Test: an install upgrading straight from before #4720 still loads its old snapshots, and eviction reaps the leftover legacy cache/ file from disk (real Storage backend)")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        real_storage = StorageLocalFiles(tmpdir, lambda msg: None)
+        pre_upgrade_text = sample_yaml_text("pre-upgrade-on-disk")
+        pre_upgrade_id = now.strftime("%Y%m%d-%H%M%S")
+        # Simulate exactly what the pre-#4720 code left behind: an index entry, and content
+        # saved to the generic cache store under the legacy key - no debug/ file at all.
+        asyncio.run(real_storage.save(STORAGE_MODULE, INDEX_NAME, [{"id": pre_upgrade_id, "timestamp": now.isoformat()}], format="json"))
+        asyncio.run(real_storage.save(STORAGE_MODULE, _legacy_snapshot_key(pre_upgrade_id), pre_upgrade_text, format="text"))
+        legacy_meta_path = os.path.join(tmpdir, "cache", "{}_{}.meta".format(STORAGE_MODULE, _legacy_snapshot_key(pre_upgrade_id)))
+        if not os.path.exists(legacy_meta_path):
+            print("  ERROR: test setup bug - the simulated legacy cache/ file should exist on disk before eviction")
+            failed = True
+
+        if asyncio.run(load_snapshot(real_storage, pre_upgrade_id)) != pre_upgrade_text:
+            print("  ERROR: a pre-upgrade snapshot should still load from the real backend via the legacy-key fallback")
+            failed = True
+
+        asyncio.run(_discard_snapshot(real_storage, pre_upgrade_id))
+        asyncio.run(real_storage.cleanup())
+        if os.path.exists(legacy_meta_path):
+            print("  ERROR: the legacy cache/ file should have been reaped from disk after eviction + cleanup()")
+            failed = True
+        if asyncio.run(load_snapshot(real_storage, pre_upgrade_id)) is not None:
+            print("  ERROR: the pre-upgrade snapshot should no longer load once its legacy entry has been reaped")
+            failed = True
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    print("Test: _discard_snapshot removes the snapshot's debug/ file directly (called outside of pruning too)")
     direct_storage = FakeStorage()
     asyncio.run(capture_snapshot(direct_storage, sample_yaml_text("to-discard"), now, max_count=15))
     ids_before = [entry["id"] for entry in asyncio.run(list_snapshots(direct_storage))]
     asyncio.run(_discard_snapshot(direct_storage, ids_before[0]))
-    if "snapshot_{}".format(ids_before[0]) not in direct_storage.deleted:
-        print("  ERROR: _discard_snapshot should call delete when the backend supports it")
+    if snapshot_filename(ids_before[0]) not in direct_storage.debug_copies_deleted:
+        print("  ERROR: _discard_snapshot should delete the snapshot's debug/ file")
+        failed = True
+
+    print("Test: a snapshot captured under the pre-#4720 scheme (content in the legacy cache/ key, nothing in debug/) still loads (#4720 upgrade path)")
+    legacy_storage = FakeStorage()
+    legacy_id = asyncio.run(capture_snapshot(legacy_storage, sample_yaml_text("pre-upgrade"), now, max_count=15))
+    legacy_storage.debug_copies.pop(snapshot_filename(legacy_id), None)  # simulate: never written under the old scheme
+    legacy_storage.store[(STORAGE_MODULE, _legacy_snapshot_key(legacy_id))] = (sample_yaml_text("pre-upgrade"), "text")  # simulate: still sitting there from before the upgrade
+    if asyncio.run(load_snapshot(legacy_storage, legacy_id)) != sample_yaml_text("pre-upgrade"):
+        print("  ERROR: a pre-upgrade snapshot with only a legacy cache/ entry should still load via the fallback")
+        failed = True
+
+    print("Test: evicting a pre-#4720 snapshot also expires its legacy cache/ entry, so an upgrade does not leak it forever (#4720)")
+    if asyncio.run(legacy_storage.load(STORAGE_MODULE, _legacy_snapshot_key(legacy_id))) is None:
+        print("  ERROR: test setup bug - the legacy entry should still be there before eviction")
+        failed = True
+    asyncio.run(_discard_snapshot(legacy_storage, legacy_id))
+    legacy_entry = legacy_storage.store.get((STORAGE_MODULE, _legacy_snapshot_key(legacy_id)))
+    if legacy_entry is None:
+        print("  ERROR: _discard_snapshot should overwrite the legacy entry (with an expiry), not remove it outright - it has no delete() to call")
+        failed = True
+    if asyncio.run(load_snapshot(legacy_storage, legacy_id)) is not None:
+        print("  ERROR: the legacy entry should no longer be readable as snapshot content once evicted")
+        failed = True
+    # A snapshot that never had a legacy entry (the common, post-upgrade case) must not gain one -
+    # _discard_snapshot should not write legacy junk for every future eviction, only reap real leftovers.
+    fresh_storage = FakeStorage()
+    fresh_id = asyncio.run(capture_snapshot(fresh_storage, sample_yaml_text("fresh"), now, max_count=15))
+    asyncio.run(_discard_snapshot(fresh_storage, fresh_id))
+    if (STORAGE_MODULE, _legacy_snapshot_key(fresh_id)) in fresh_storage.store:
+        print("  ERROR: a snapshot with no legacy entry should not have one created on eviction")
         failed = True
 
     print("Test: snapshot_filename is keyed on the timestamp id alone, not on ring position")
@@ -336,7 +369,7 @@ def test_debug_history(my_predbat):
     partial_storage = FakeStorage()
     asyncio.run(capture_snapshot(partial_storage, sample_yaml_text("keep"), now, max_count=15))
     missing_id = asyncio.run(capture_snapshot(partial_storage, sample_yaml_text("gone"), now + datetime.timedelta(hours=1), max_count=15))
-    partial_storage.store.pop((STORAGE_MODULE, "snapshot_{}".format(missing_id)), None)  # simulate a corrupt/evicted entry still left in the index
+    partial_storage.debug_copies.pop(snapshot_filename(missing_id), None)  # simulate a corrupt/evicted entry still left in the index
     named_partial = asyncio.run(load_all_snapshots(partial_storage))
     if len(named_partial) != 1 or named_partial[0][1] != sample_yaml_text("keep"):
         print("  ERROR: expected only the loadable snapshot to survive, got {}".format(named_partial))

--- a/apps/predbat/tests/test_debug_history_capture.py
+++ b/apps/predbat/tests/test_debug_history_capture.py
@@ -15,6 +15,7 @@ methods: a real StorageComponent/StorageLocalFiles backend wrapped in a minimal
 _MockComponents shim, rather than mocking the storage calls themselves.
 """
 
+import os
 import shutil
 import tempfile
 from datetime import timedelta
@@ -72,6 +73,11 @@ def test_debug_history_capture(my_predbat):
             failed += 1
         if my_predbat.debug_history_last_capture != my_predbat.now_utc:
             print("  FAILED: debug_history_last_capture should be updated to now_utc")
+            failed += 1
+        debug_dir = os.path.join(tmpdir, "debug")
+        mirrored = [f for f in os.listdir(debug_dir)] if os.path.isdir(debug_dir) else []
+        if len(mirrored) != 1:
+            print("  FAILED: expected _capture_debug_history() to also write one file into config_root/debug/ (#4720), got {}".format(mirrored))
             failed += 1
 
         print("Test 2: a second call well within the interval is skipped")

--- a/apps/predbat/tests/test_storage.py
+++ b/apps/predbat/tests/test_storage.py
@@ -162,6 +162,32 @@ def test_storage(my_predbat=None):
         out = run_async(storage.fetch_cached("fc6", "missing", _fetch_raise, fresh_minutes=30, stale_minutes=35, format="json"))
         assert out is None, "hard miss with raising fetch should return None: {}".format(out)
 
+        # save_debug_copy() writes a plain file straight into config_root/debug/, not cache/ (#4720)
+        assert run_async(storage.save_debug_copy("predbat_debug_20260101-000000.yaml", "raw: text\n")) is True
+        debug_dir = os.path.join(tmpdir, "debug")
+        debug_copy_path = os.path.join(debug_dir, "predbat_debug_20260101-000000.yaml")
+        assert os.path.exists(debug_copy_path), "save_debug_copy should create config_root/debug/<filename>"
+        with open(debug_copy_path, "r") as f:
+            assert f.read() == "raw: text\n", "debug copy should hold the text verbatim, with no format envelope"
+        assert not os.path.exists(os.path.join(debug_dir, "predbat_debug_20260101-000000.meta")), "debug copy should have no metadata sidecar"
+
+        # load_debug_copy() reads it straight back, verbatim
+        assert run_async(storage.load_debug_copy("predbat_debug_20260101-000000.yaml")) == "raw: text\n"
+
+        # load_debug_copy() on a file that was never written returns None rather than raising
+        assert run_async(storage.load_debug_copy("never_written.yaml")) is None
+
+        # delete_debug_copy() removes it; a second call on an already-missing file must not raise
+        run_async(storage.delete_debug_copy("predbat_debug_20260101-000000.yaml"))
+        assert not os.path.exists(debug_copy_path), "delete_debug_copy should remove the file"
+        run_async(storage.delete_debug_copy("predbat_debug_20260101-000000.yaml"))
+        assert run_async(storage.load_debug_copy("predbat_debug_20260101-000000.yaml")) is None, "a deleted debug copy should no longer load"
+
+        # a path-separator-bearing filename is confined to debug/, not written outside it
+        run_async(storage.save_debug_copy("../escape.yaml", "x"))
+        assert os.path.exists(os.path.join(debug_dir, "escape.yaml")), "save_debug_copy should strip any directory component from filename"
+        assert not os.path.exists(os.path.join(tmpdir, "escape.yaml")), "save_debug_copy must not write outside config_root/debug/"
+
         print("All storage tests passed!")
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -177,6 +177,18 @@ def run_web_functions_tests(my_predbat):
         failed += 1
 
     # -------------------------------------------------------------------------
+    # Companion app cannot save tgz/create-debug downloads (its webview ignores
+    # Content-Disposition: attachment) - the dash page must say so and point at the
+    # debug/ folder mirror instead of trying to detect/grey out the links (#4720)
+    print("Test: dashboard explains the Companion app download limitation and the debug/ folder workaround")
+    if "Companion app" not in status_html:
+        print(f"  ERROR: expected a Companion app caveat on the dash page, got: {status_html}")
+        failed += 1
+    if "{}/debug/".format(my_predbat.config_root_p) not in status_html:
+        print(f"  ERROR: expected the caveat to point at config_root_p/debug/, got: {status_html}")
+        failed += 1
+
+    # -------------------------------------------------------------------------
     # is_running() must handle both the legacy naive last_updated format (pre-existing
     # installs, before record_status() started writing a timezone-aware value) and the
     # current timezone-aware format, without raising on the naive/aware datetime subtraction

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -967,6 +967,15 @@ class WebInterface(ComponentBase):
         text += "<tr><td>Download</td><td><a href='./debug_plan'>predbat_plan.html</a></td></tr>\n"
         text += "<tr><td>History</td><td><a href='./debug_history_download_all'>Download all (.tgz)</a></td></tr>\n"
         text += "<tr><td>Restart</td><td><button onclick='restartPredbat()' style='background-color: #ff4444; color: white; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer; font-weight: bold;'>Restart Predbat</button></td></tr>\n"
+        # The HA Companion app's embedded webview does not act on Content-Disposition: attachment,
+        # so it renders these downloads inline instead of saving them - a client limitation with no
+        # server-side fix (see #4720). Rather than try to detect the app (its webview sends no
+        # reliable identifying User-Agent - see #4720 discussion) and grey the links out, which risks
+        # false-positives against a genuine desktop browser, just say so for everyone.
+        text += "<tr><td colspan='2' style='font-size:0.85em; color:var(--text-secondary,#888); padding-top:6px;'>"
+        text += "'Create' and 'Download' above need a web browser - the HA Companion app cannot save files from them. "
+        text += "Companion app users can instead browse to <code>{}/debug/</code>, which also holds the rolling snapshot history as plain, readable files.".format(self.base.config_root_p)
+        text += "</td></tr>\n"
         text += "</table>\n"
         text += "</div>\n"
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -819,6 +819,8 @@ This file contains a full export of your current Predbat config and is extremely
 
 Predbat automatically turns this switch back Off after 2 hours if it's still on, to bound the raw disk writes it triggers if left on by accident - if you need a longer debug session than that, you'll need to turn it back On again.
 
+**Note:** The **Create**/**Download** links on the web interface's **Debug** panel (including `predbat_debug.yaml`, `predbat.log`, and the debug history `.tgz`) only work from a web browser. The HA Companion app's built-in browser does not save files when you tap them - it just displays the raw content on screen instead. If you're on the Companion app, browse to the `debug/` folder under your Predbat config directory directly (e.g. with the File editor or Samba add-on) and pick the file up from there instead.
+
 The following automation might be useful to automatically turn off Predbat debug mode sooner than that, after turning it on to capture the debug logs:
 
 ```yaml
@@ -859,6 +861,8 @@ Turning on `switch.predbat_debug_enable` only captures debug information from th
 - **switch.predbat_debug_history_force_capture** - turn this on to trigger an immediate snapshot rather than waiting for the next scheduled one, useful from an automation that has just spotted something worth investigating. Predbat resets the switch back off itself once the snapshot has been taken, and still takes the snapshot even if `debug_history_enable` is off.
 
 Retained snapshots can all be downloaded together as a single `.tgz` archive from a link on the web interface's dashboard **Debug** panel, or individually from the **Debug** column shown on the plan's **History** view (next to any time slot a snapshot was captured for exactly). An automation can also fetch the most recent snapshot directly without needing to know its exact timestamp, by calling `GET <predbat-url>/debug_history_download?id=latest` after turning `switch.predbat_debug_history_force_capture` on.
+
+Each snapshot is written as a plain `predbat_debug_<timestamp>.yaml` file into the same `debug/` folder as the `switch.predbat_debug_enable` output described above - useful in its own right (a full rolling history sitting on disk, not just what the switch happened to catch), and it's the way to get a snapshot to attach to a GitHub issue from the HA Companion app, where the `.tgz`/single-file download links above don't work (see the note above). These files are pruned in step with the ring buffer itself, so there are never more of them on disk than `debug_history_count` snapshots.
 
 ## Updating Predbat
 


### PR DESCRIPTION
## Summary
- The HA Companion app's embedded webview ignores `Content-Disposition: attachment`, so the Debug panel's `.tgz`/single-file download links just render the content inline instead of saving it - a client-side limitation with no server fix, discussed in #4720.
- Every rolling debug-history snapshot (#4417) is now written straight to `config_root/debug/` - the same directory `switch.predbat_debug_enable` already uses - via new `save_debug_copy()`/`load_debug_copy()`/`delete_debug_copy()` methods on the Storage abstraction, so a Companion-app user can grab one with File Editor/Samba instead of the browser-only download routes.
- The dashboard's Debug panel and `docs/customisation.md` now say so.
- An install upgrading straight from before this change still has its existing snapshots readable (and eventually cleaned up) via a legacy-key fallback - see "Note on storage layout" below.

## Note on storage layout
`cache/` is generally the right place for cache-like, regenerable data, and this PR deliberately doesn't put snapshot content there - it goes straight to `debug/`, with only the small index staying in `cache/`. That's a pragmatic workaround for this specific problem (a real file on disk is what makes it reachable from the Companion app at all), not a new general pattern - it works here because `create_debug_yaml()` already writes unconditionally to that same real directory for `switch.predbat_debug_enable`, so nothing here is any more filesystem-dependent than the feature it's capturing snapshots of.

## Test plan
- [x] `./run_pre_commit` (ruff, black, cspell, markdownlint, interrogate 100% on touched files) - green
- [x] `./run_all --quick` - green, including new tests for: the debug/ write/read/delete path, the pre-#4720 legacy-key fallback (read) and reap (on eviction) on a real Storage backend, and the dashboard's Companion-app caveat text

Fixes #4720