### PR TITLE
fix(components): only treat gating args as evidence of configuration

### DIFF
--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -705,7 +705,19 @@ class Components:
                 configured_args = getattr(self.base, "args_from_apps_yaml", None)
                 if configured_args is None:
                     configured_args = self.base.args
-                component_configured = any(configured_args.get(arg_info["config"]) for arg_info in component_info["args"].values())
+                # Only args that gate activation identify a component the user is actually
+                # setting up. Incidental shared settings must not count - gecloud_data
+                # declares the general-purpose days_previous, which the shipped apps.yaml
+                # sets for everyone, so counting all args warns every non-GivEnergy user
+                # about an integration they never configured.
+                gating_args = set(required_or)
+                for arg, arg_info in component_info["args"].items():
+                    if arg_info.get("required", False) or arg_info.get("required_true", False):
+                        gating_args.add(arg)
+                # Presence, not truthiness: a setting supplied as empty or false is still an
+                # attempt to configure the component, and is exactly when the warning helps -
+                # e.g. a secret that unexpectedly resolved to an empty string.
+                component_configured = any(component_info["args"][arg]["config"] in configured_args for arg in gating_args)
                 if component_configured:
                     reasons = []
                     if missing_config:

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -848,13 +848,17 @@ def test_solis_skipped_component_logging():
     """Solis logs missing credential alternatives only when partly configured."""
     import components as components_module
 
-    unconfigured_base = _GatingBase({})
+    # Nothing about solis supplied, plus an unrelated shared setting that must not be
+    # mistaken for solis configuration.
+    unconfigured_base = _GatingBase({"days_previous": [7]})
     components_module.Components(unconfigured_base).initialize(only="solis", phase=1)
     if any("Skipping Solis Cloud API interface" in message for message in unconfigured_base.log_messages):
         print("ERROR: Unconfigured Solis component should be skipped without a warning")
         return True
 
-    configured_base = _GatingBase({"solis_auth_method": "oauth"})
+    # An empty credential: the component is still skipped, but the user clearly meant to
+    # configure it, so the warning must fire.
+    configured_base = _GatingBase({"solis_api_key": ""})
     components_module.Components(configured_base).initialize(only="solis", phase=1)
     expected = "Warn: Skipping Solis Cloud API interface, needs at least one of: solis_api_key, solis_access_token"
     if expected not in configured_base.log_messages:


### PR DESCRIPTION
Follow-up to #4737, which I authored — a review after it merged found two flaws in the noise guard. The first is user-visible on a default config, so worth landing promptly.

## 1. Every non-GivEnergy user now gets a spurious warning on every startup

The guard counted **every** arg a component declares:

```python
component_configured = any(configured_args.get(arg_info["config"]) for arg_info in component_info["args"].values())
```

`gecloud_data` declares the general-purpose `days_previous` (components.py:172), and the shipped `apps.yaml:487` sets `days_previous: [7]` for everyone. So any user without `ge_cloud_key` — i.e. every non-GivEnergy user on a stock config — now sees this on every startup:

```
Warn: Skipping GivEnergy Cloud Data interface, missing required configuration: ge_cloud_data, ge_cloud_key
```

They never configured GivEnergy Cloud. That is exactly the noise #4737 set out to avoid, aimed at the whole user base — my mistake in the original PR.

Fix: restrict the check to the args that actually gate activation (`required`, `required_true`, `required_or`). Incidental shared settings no longer imply the user was setting the component up.

## 2. An empty credential stays silent, which is the case that most needs the warning

The guard tested truthiness, so a setting supplied as `""`, `0` or `False` counted as absent:

```yaml
solis_api_key: ""
```

The `required_or` gate rejects the empty key, so Solis is skipped — and the guard also considers it unconfigured, so nothing is logged. A secret or environment substitution that unexpectedly resolves to an empty string is precisely when a user needs telling.

Fix: test key **presence** rather than truthiness.

## Verification

Simulated every component in `COMPONENT_LIST` against the shipped `apps.yaml`:

- Before: `gecloud_data` warns. After: **no component warns on a default config.**
- A partly configured component still warns — e.g. an energy provider with its key set but its account id missing still reports `missing required configuration: <key>`.

## Tests

The existing test is updated to cover both fixes rather than adding a new one:

- the silent case now also supplies an unrelated shared setting (`days_previous`), which would have failed under the old guard
- the warning case now uses an empty credential (`solis_api_key: ""`), which would have been silent under the old guard
