### PR TITLE
BOT_REVIEW and BOT_CLEANUP flows for pull requests

### DIFF
--- a/.claude/skills/pr-cleanup/SKILL.md
+++ b/.claude/skills/pr-cleanup/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pr-cleanup
+description: Address code review feedback and CI failures on a batpred pull request, then commit and push the fixes back to its branch.
+allowed-tools: You can view and edit files in this repo, write code and tests, run local tests and pre-commit, commit and push to the PR's own branch, and reply to review comments with 'gh'. Do not merge, close, or push to main.
+---
+
+# PR Cleanup
+
+You are addressing outstanding feedback and CI failures on one pull request on `springfall2008/batpred`, then committing and pushing the fixes back to its branch. The working directory is the same dedicated local clone the triage skill uses.
+
+Before implementing anything, load the `superpowers:receiving-code-review` skill and follow its evaluation discipline for every piece of feedback you act on: verify against the codebase before implementing, push back with technical reasoning on anything that seems wrong or unclear, and never perform agreement ("You're absolutely right!", "Great point!"). That skill assumes a live human partner to ask when something is unclear — you don't have one here. Wherever it says to stop and ask your human partner, instead post one comment on the PR explaining what's unclear and stop (see step 6).
+
+Arguments: `<pr-number> [scratch=<dir>]`, same convention as `/issue-triage`. If no `scratch=` is given (an interactive invocation), use `/tmp/predbat-triage/<pr-number>` and `mkdir -p` it yourself.
+
+## 1. Check out the PR's branch
+
+```bash
+gh pr checkout <pr-number>
+git fetch origin main
+```
+
+Work on the PR's own branch, not a new one — you're pushing back to it directly, not opening a separate PR.
+
+## 2. Gather everything to address
+
+- All feedback on the PR, not just a prior bot review if there was one: `gh pr view <pr-number> --json comments` for top-level comments, and `gh api repos/springfall2008/batpred/pulls/<pr-number>/comments` for inline review-thread comments — `gh pr view` does not surface these.
+- CI status: `gh pr checks <pr-number>`. For any failing check, read its actual log (`gh run view <run-id> --job <job-id> --log`, or fetch the job log directly) to find the real failure, not just the pass/fail summary.
+- Skip anything already resolved: a review thread that already has a reply from you addressing it, or a check that's since gone green.
+
+If there is genuinely nothing new to address — every thread already has a reply, every check is green — say so in a brief comment and stop; this is a normal, successful outcome, not a failure.
+
+## 3. Evaluate before implementing
+
+Per `receiving-code-review`: for each remaining item, verify it's technically correct for this codebase before touching anything. Some feedback will be wrong, outdated, or already addressed elsewhere in the diff — say so in a thread reply rather than implementing it anyway.
+
+## 4. Implement confirmed fixes
+
+Same conventions as `/issue-pr`: `CLAUDE.md` (already loaded automatically for this session), `lower_case_with_underscores` naming, 256-character line length, a one-line docstring on every new function or class, and a unit test for any new code.
+
+## 5. Quality gate
+
+Both of these must pass before you commit anything. `run_pre_commit` must run with `coverage/` as the working directory (it sources `coverage/setup.csh` internally); `tools/triage_test.sh` must run from the repo root:
+
+```bash
+cd coverage
+./run_pre_commit
+cd ..
+tools/triage_test.sh <name> <scratch>/test.log
+```
+
+Use the test module the changed area maps to in `TEST_REGISTRY` (`apps/predbat/unit_test.py`), or `./run_all --quick` (from `coverage/`, same as above) if there's no clean single-module mapping. If either still fails after your fixes, go to step 6 and report what's still broken — do not commit or push a change that doesn't pass its own quality gate.
+
+## 6. Commit, push, and reply
+
+```bash
+git add <changed files>
+git commit -m "<one-line summary of the fixes>"
+git push
+```
+
+Reply to each review thread you addressed, in the thread itself, not as a new top-level comment:
+
+```bash
+gh api repos/springfall2008/batpred/pulls/<pr-number>/comments/<comment-id>/replies -f body="..."
+```
+
+State what changed, or push back with your reasoning if you didn't implement the suggestion — never a bare "done" with no explanation. If anything is unclear, technically wrong, or you can't verify a suggestion, say so in the reply rather than guessing or implementing something you don't understand.
+
+If step 5's quality gate never passed, post one summary comment via `gh pr comment <pr-number> --body "..."` explaining what's still failing and why you didn't push, instead of doing the commit/push/reply steps above.
+
+## Guardrails
+
+- Never push to `main` or force-push. Only push to the PR's own branch.
+- Never merge or close the PR.
+- Never remove a label a human applied.
+- Never perform agreement ("You're absolutely right!", "Great point!", "Thanks for catching that!") — state the fix or the pushback plainly, per `receiving-code-review`.
+- If a command you needed was blocked by permissions, say so plainly rather than implying a step completed.

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -406,11 +406,46 @@ class PermissionModelTests(unittest.TestCase):
         review = set(triage_daemon.DISALLOWED_TOOLS_REVIEW.split(","))
         self.assertEqual(base - review, {"Bash(gh api*)"})
 
-    def test_review_allowed_tools_adds_only_the_scoped_api_grant(self):
-        """The review flow adds nothing but gh api scoped to this repo - no write/push/commit access."""
-        base = set(triage_daemon.ALLOWED_TOOLS.split(","))
+    def test_review_allowed_tools_does_not_inherit_the_broad_gh_grant(self):
+        """Regression test for the actual bug: with "Bash(gh *)" present, removing the
+        blanket gh api denial would un-restrict gh api entirely (any repo, any
+        endpoint, including merge/close via REST) - a narrower allow gets no
+        precedence over a broader one, only deny-wins-over-allow is a real rule.
+        The scoped gh api grant only means something if this entry is absent."""
+        review = triage_daemon.ALLOWED_TOOLS_REVIEW.split(",")
+        self.assertNotIn("Bash(gh *)", review)
+
+    def test_review_allowed_tools_does_not_grant_formal_review_actions(self):
+        """No "gh pr review*": that would also allow --approve/--request-changes,
+        a governance action beyond "post a comment"."""
+        review = triage_daemon.ALLOWED_TOOLS_REVIEW.split(",")
+        self.assertNotIn("Bash(gh pr review*)", review)
+
+    def test_review_allowed_tools_still_covers_the_read_only_base(self):
+        """Dropping the broad gh grant must not drop the non-gh read tools (git
+        history, file reads, the scoped Edit rules) every other flow still has."""
+        non_gh = set(triage_daemon._ALLOWED_TOOLS_NON_GH)
         review = set(triage_daemon.ALLOWED_TOOLS_REVIEW.split(","))
-        self.assertEqual(review - base, {"Bash(gh api repos/springfall2008/batpred/*)"})
+        self.assertTrue(non_gh.issubset(review))
+
+    def test_review_allowed_tools_grants_exactly_the_expected_gh_entries(self):
+        """The complete, curated gh surface for the review flow - specific
+        subcommands plus the scoped api grant, nothing broader."""
+        review = set(triage_daemon.ALLOWED_TOOLS_REVIEW.split(","))
+        gh_entries = {entry for entry in review if entry.startswith("Bash(gh")}
+        self.assertEqual(
+            gh_entries,
+            {
+                "Bash(gh pr view*)",
+                "Bash(gh pr diff*)",
+                "Bash(gh pr list*)",
+                "Bash(gh pr comment*)",
+                "Bash(gh issue view*)",
+                "Bash(gh issue list*)",
+                "Bash(gh search*)",
+                "Bash(gh api repos/springfall2008/batpred/*)",
+            },
+        )
 
     def test_cleanup_disallowed_tools_still_blocks_dangerous_gh_subcommands(self):
         """The BOT_CLEANUP flow keeps every dangerous gh subcommand denied."""
@@ -434,12 +469,61 @@ class PermissionModelTests(unittest.TestCase):
         self.assertTrue(any("force" in entry for entry in cleanup_denied), cleanup_denied)
         self.assertTrue(any("-f" in entry for entry in cleanup_denied), cleanup_denied)
 
-    def test_cleanup_allowed_tools_matches_pr_flow_plus_scoped_api(self):
-        """Cleanup gets exactly the PR flow's write access plus the scoped gh api grant - nothing more."""
-        pr = set(triage_daemon.ALLOWED_TOOLS_PR.split(","))
+    def test_cleanup_allowed_tools_does_not_inherit_the_broad_gh_grant(self):
+        """Same regression as the review flow: "Bash(gh *)" must be absent, or the
+        scoped gh api grant would do nothing once the blanket gh api denial is lifted."""
+        cleanup = triage_daemon.ALLOWED_TOOLS_CLEANUP.split(",")
+        self.assertNotIn("Bash(gh *)", cleanup)
+
+    def test_cleanup_allowed_tools_does_not_grant_pr_create(self):
+        """Cleanup pushes to the existing PR's branch - it never opens a new one, so
+        it must not inherit "gh pr create*" the way the BOT_PR flow does."""
+        cleanup = triage_daemon.ALLOWED_TOOLS_CLEANUP.split(",")
+        self.assertNotIn("Bash(gh pr create*)", cleanup)
+        self.assertIn("Bash(gh pr create*)", triage_daemon.DISALLOWED_TOOLS_CLEANUP.split(","))
+
+    def test_cleanup_allowed_tools_still_covers_the_read_only_base(self):
+        """Dropping the broad gh grant must not drop the non-gh read tools (git
+        history, file reads, the scoped Edit rules) every other flow still has."""
+        non_gh = set(triage_daemon._ALLOWED_TOOLS_NON_GH)
         cleanup = set(triage_daemon.ALLOWED_TOOLS_CLEANUP.split(","))
-        self.assertEqual(cleanup - pr, {"Bash(gh api repos/springfall2008/batpred/*)"})
-        self.assertEqual(pr - cleanup, set())
+        self.assertTrue(non_gh.issubset(cleanup))
+
+    def test_cleanup_allowed_tools_grants_exactly_the_expected_gh_entries(self):
+        """The complete, curated gh surface for the cleanup flow: the review flow's
+        read access, plus checkout/checks/run-log access and the scoped api grant."""
+        cleanup = set(triage_daemon.ALLOWED_TOOLS_CLEANUP.split(","))
+        gh_entries = {entry for entry in cleanup if entry.startswith("Bash(gh")}
+        self.assertEqual(
+            gh_entries,
+            {
+                "Bash(gh pr view*)",
+                "Bash(gh pr diff*)",
+                "Bash(gh pr list*)",
+                "Bash(gh pr comment*)",
+                "Bash(gh issue view*)",
+                "Bash(gh issue list*)",
+                "Bash(gh search*)",
+                "Bash(gh pr checkout*)",
+                "Bash(gh pr checks*)",
+                "Bash(gh run view*)",
+                "Bash(gh run list*)",
+                "Bash(gh api repos/springfall2008/batpred/*)",
+            },
+        )
+
+    def test_cleanup_allowed_tools_grants_write_access(self):
+        """Commit/push/pre-commit, matching the PR flow's write capability."""
+        cleanup = set(triage_daemon.ALLOWED_TOOLS_CLEANUP.split(","))
+        self.assertTrue(
+            {
+                "Bash(git add*)",
+                "Bash(git commit*)",
+                "Bash(git push*)",
+                "Bash(./run_pre_commit*)",
+                "Bash(./run_pre_commit)",
+            }.issubset(cleanup)
+        )
 
 
 class SyncRepoTests(unittest.TestCase):

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -67,6 +67,14 @@ class IssueUrlTests(unittest.TestCase):
         self.assertEqual(triage_daemon.issue_url(4720), "https://github.com/springfall2008/batpred/issues/4720")
 
 
+class PrUrlTests(unittest.TestCase):
+    """Tests for pr_url(), new - used to print an openable link when work starts."""
+
+    def test_builds_the_github_pr_url(self):
+        """Returns the standard GitHub PR URL for the configured repo."""
+        self.assertEqual(triage_daemon.pr_url(4720), "https://github.com/springfall2008/batpred/pull/4720")
+
+
 class FetchNewIssuesTests(unittest.TestCase):
     """Characterisation tests for fetch_new_issues() - pre-existing, except for also
     requesting the title field (used to print an openable link when work starts)."""
@@ -373,6 +381,65 @@ class PermissionModelTests(unittest.TestCase):
         pr_denied = triage_daemon.DISALLOWED_TOOLS_PR.split(",")
         self.assertTrue(any("force" in entry for entry in pr_denied), pr_denied)
         self.assertTrue(any("-f" in entry for entry in pr_denied), pr_denied)
+
+    def test_review_disallowed_tools_still_blocks_dangerous_gh_subcommands(self):
+        """The BOT_REVIEW-on-PR flow keeps every dangerous gh subcommand denied,
+        including generic gh api calls against another repo."""
+        still_denied = [
+            "Bash(gh pr merge*)",
+            "Bash(gh pr close*)",
+            "Bash(gh pr create*)",
+            "Bash(gh repo*)",
+            "Bash(gh release*)",
+            "Bash(gh workflow*)",
+            "Bash(gh auth*)",
+            "Bash(gh secret*)",
+            "mcp__*",
+        ]
+        review_denied = triage_daemon.DISALLOWED_TOOLS_REVIEW.split(",")
+        for entry in still_denied:
+            self.assertIn(entry, review_denied)
+
+    def test_review_disallowed_tools_carves_out_only_gh_api(self):
+        """Only the blanket gh api denial is removed - everything else stays denied."""
+        base = set(triage_daemon.DISALLOWED_TOOLS.split(","))
+        review = set(triage_daemon.DISALLOWED_TOOLS_REVIEW.split(","))
+        self.assertEqual(base - review, {"Bash(gh api*)"})
+
+    def test_review_allowed_tools_adds_only_the_scoped_api_grant(self):
+        """The review flow adds nothing but gh api scoped to this repo - no write/push/commit access."""
+        base = set(triage_daemon.ALLOWED_TOOLS.split(","))
+        review = set(triage_daemon.ALLOWED_TOOLS_REVIEW.split(","))
+        self.assertEqual(review - base, {"Bash(gh api repos/springfall2008/batpred/*)"})
+
+    def test_cleanup_disallowed_tools_still_blocks_dangerous_gh_subcommands(self):
+        """The BOT_CLEANUP flow keeps every dangerous gh subcommand denied."""
+        still_denied = [
+            "Bash(gh pr merge*)",
+            "Bash(gh pr close*)",
+            "Bash(gh repo*)",
+            "Bash(gh release*)",
+            "Bash(gh workflow*)",
+            "Bash(gh auth*)",
+            "Bash(gh secret*)",
+            "mcp__*",
+        ]
+        cleanup_denied = triage_daemon.DISALLOWED_TOOLS_CLEANUP.split(",")
+        for entry in still_denied:
+            self.assertIn(entry, cleanup_denied)
+
+    def test_cleanup_disallowed_tools_still_blocks_force_push_variants(self):
+        """Same defense-in-depth as the PR flow: force-push stays denied even though push is allowed."""
+        cleanup_denied = triage_daemon.DISALLOWED_TOOLS_CLEANUP.split(",")
+        self.assertTrue(any("force" in entry for entry in cleanup_denied), cleanup_denied)
+        self.assertTrue(any("-f" in entry for entry in cleanup_denied), cleanup_denied)
+
+    def test_cleanup_allowed_tools_matches_pr_flow_plus_scoped_api(self):
+        """Cleanup gets exactly the PR flow's write access plus the scoped gh api grant - nothing more."""
+        pr = set(triage_daemon.ALLOWED_TOOLS_PR.split(","))
+        cleanup = set(triage_daemon.ALLOWED_TOOLS_CLEANUP.split(","))
+        self.assertEqual(cleanup - pr, {"Bash(gh api repos/springfall2008/batpred/*)"})
+        self.assertEqual(pr - cleanup, set())
 
 
 class SyncRepoTests(unittest.TestCase):
@@ -689,6 +756,221 @@ class ProcessBotReviewIssueTests(unittest.TestCase):
         printed = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
         self.assertIn("Old ticket needing review", printed)
         self.assertIn("https://github.com/springfall2008/batpred/issues/3100", printed)
+
+
+class FetchBotReviewPrsTests(unittest.TestCase):
+    """Tests for fetch_bot_review_prs(), new - the BOT_REVIEW-on-PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_queries_open_prs_labelled_bot_review(self, mock_run):
+        """Calls gh pr list scoped to the BOT_REVIEW label and returns the parsed PRs."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 4742, "title": "Add confirmed findings"}]))
+        result = triage_daemon.fetch_bot_review_prs()
+        self.assertEqual(result, [{"number": 4742, "title": "Add confirmed findings"}])
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args[:3], ["gh", "pr", "list"])
+        self.assertIn("--label", args)
+        self.assertEqual(args[args.index("--label") + 1], "BOT_REVIEW")
+        self.assertIn("--limit", args)
+
+
+class FetchBotCleanupPrsTests(unittest.TestCase):
+    """Tests for fetch_bot_cleanup_prs(), new - the BOT_CLEANUP flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_queries_open_prs_labelled_bot_cleanup(self, mock_run):
+        """Calls gh pr list scoped to the BOT_CLEANUP label and returns the parsed PRs."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 4742, "title": "Add confirmed findings"}]))
+        result = triage_daemon.fetch_bot_cleanup_prs()
+        self.assertEqual(result, [{"number": 4742, "title": "Add confirmed findings"}])
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args[:3], ["gh", "pr", "list"])
+        self.assertIn("--label", args)
+        self.assertEqual(args[args.index("--label") + 1], "BOT_CLEANUP")
+        self.assertIn("--limit", args)
+
+
+class RemovePrReviewLabelTests(unittest.TestCase):
+    """Tests for remove_pr_review_label(), new - the BOT_REVIEW-on-PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_removes_bot_review_label_from_the_pr(self, mock_run):
+        """Removes BOT_REVIEW via gh pr edit, scoped to the configured repo."""
+        triage_daemon.remove_pr_review_label(4742)
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "pr", "edit", "4742", "--repo", "springfall2008/batpred", "--remove-label", "BOT_REVIEW"])
+
+
+class MarkPrReviewFailedTests(unittest.TestCase):
+    """Tests for mark_pr_review_failed(), new - the BOT_REVIEW-on-PR flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_comments_then_swaps_labels(self, mock_run):
+        """Posts an explanatory comment, then swaps BOT_REVIEW for BOT_FAILED, both on the PR."""
+        triage_daemon.mark_pr_review_failed(4742)
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        self.assertEqual(calls[0][:3], ["gh", "pr", "comment"])
+        self.assertIn("--repo", calls[0])
+        self.assertEqual(
+            calls[1],
+            ["gh", "pr", "edit", "4742", "--repo", "springfall2008/batpred", "--remove-label", "BOT_REVIEW", "--add-label", "BOT_FAILED"],
+        )
+
+
+class ReviewPrTests(DaemonPathsTestCase):
+    """Tests for review_pr(), new - runs /code-review under the comment-only permission set."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_invokes_claude_with_the_review_permission_set(self, mock_run):
+        """Runs /code-review at the high effort level with --comment, under the
+        review-only allow/deny lists - no write/push/commit access."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.review_pr(4742)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/code-review 4742 high --comment", cmd[2])
+        self.assertIn(triage_daemon.ALLOWED_TOOLS_REVIEW, cmd)
+        self.assertIn(triage_daemon.DISALLOWED_TOOLS_REVIEW, cmd)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_raises_on_a_non_zero_exit(self, mock_run):
+        """Matches triage()/triage_followup(): a failed invocation raises."""
+        mock_run.return_value = MagicMock(returncode=1)
+        with self.assertRaises(subprocess.CalledProcessError):
+            triage_daemon.review_pr(4742)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_writes_a_log_file(self, mock_run):
+        """A per-PR review log file is created under LOG_DIR."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.review_pr(4742)
+        self.assertTrue((self.log_dir / "pr-4742-review.log").exists())
+
+
+class ProcessBotReviewPrTests(unittest.TestCase):
+    """Tests for process_bot_review_pr(), new - the BOT_REVIEW-on-PR orchestrator."""
+
+    def setUp(self):
+        """Patch every collaborator process_bot_review_pr() calls."""
+        self.patches = {}
+        for name in ["sync_repo", "reset_scratch", "review_pr", "remove_pr_review_label", "mark_pr_review_failed"]:
+            patcher = patch.object(triage_daemon, name)
+            self.patches[name] = patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_reviews_then_removes_the_label(self):
+        """A successful review syncs, reviews, then removes BOT_REVIEW."""
+        triage_daemon.process_bot_review_pr({"number": 4742, "title": "Add confirmed findings"})
+        self.patches["sync_repo"].assert_called_once()
+        self.patches["reset_scratch"].assert_called_once()
+        self.patches["review_pr"].assert_called_once_with(4742)
+        self.patches["remove_pr_review_label"].assert_called_once_with(4742)
+        self.patches["mark_pr_review_failed"].assert_not_called()
+
+    def test_failed_review_marks_failed_instead_of_removing_the_label(self):
+        """A review_pr() failure swaps to BOT_FAILED rather than retrying next poll."""
+        self.patches["review_pr"].side_effect = subprocess.CalledProcessError(1, ["claude"])
+        triage_daemon.process_bot_review_pr({"number": 4742, "title": "Add confirmed findings"})
+        self.patches["mark_pr_review_failed"].assert_called_once_with(4742)
+        self.patches["remove_pr_review_label"].assert_not_called()
+
+    @patch("builtins.print")
+    def test_prints_the_title_and_link_before_doing_anything(self, mock_print):
+        """Prints the PR's title and an openable GitHub link as soon as work starts."""
+        triage_daemon.process_bot_review_pr({"number": 4742, "title": "Add confirmed findings"})
+        printed = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
+        self.assertIn("Add confirmed findings", printed)
+        self.assertIn("https://github.com/springfall2008/batpred/pull/4742", printed)
+
+
+class RemovePrCleanupLabelTests(unittest.TestCase):
+    """Tests for remove_pr_cleanup_label(), new - the BOT_CLEANUP flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_removes_bot_cleanup_label_from_the_pr(self, mock_run):
+        """Removes BOT_CLEANUP via gh pr edit, scoped to the configured repo."""
+        triage_daemon.remove_pr_cleanup_label(4742)
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "pr", "edit", "4742", "--repo", "springfall2008/batpred", "--remove-label", "BOT_CLEANUP"])
+
+
+class MarkPrCleanupFailedTests(unittest.TestCase):
+    """Tests for mark_pr_cleanup_failed(), new - the BOT_CLEANUP flow."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_comments_then_swaps_labels(self, mock_run):
+        """Posts an explanatory comment, then swaps BOT_CLEANUP for BOT_FAILED, both on the PR."""
+        triage_daemon.mark_pr_cleanup_failed(4742)
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        self.assertEqual(calls[0][:3], ["gh", "pr", "comment"])
+        self.assertIn("--repo", calls[0])
+        self.assertEqual(
+            calls[1],
+            ["gh", "pr", "edit", "4742", "--repo", "springfall2008/batpred", "--remove-label", "BOT_CLEANUP", "--add-label", "BOT_FAILED"],
+        )
+
+
+class CleanupPrTests(DaemonPathsTestCase):
+    """Tests for cleanup_pr(), new - runs /pr-cleanup under the write-capable cleanup permission set."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_invokes_claude_with_the_cleanup_permission_set(self, mock_run):
+        """Runs /pr-cleanup under the write-capable cleanup allow/deny lists."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.cleanup_pr(4742)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/pr-cleanup 4742", cmd[2])
+        self.assertIn(triage_daemon.ALLOWED_TOOLS_CLEANUP, cmd)
+        self.assertIn(triage_daemon.DISALLOWED_TOOLS_CLEANUP, cmd)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_raises_on_a_non_zero_exit(self, mock_run):
+        """Matches triage()/triage_followup()/review_pr(): a failed invocation raises."""
+        mock_run.return_value = MagicMock(returncode=1)
+        with self.assertRaises(subprocess.CalledProcessError):
+            triage_daemon.cleanup_pr(4742)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_writes_a_log_file(self, mock_run):
+        """A per-PR cleanup log file is created under LOG_DIR."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.cleanup_pr(4742)
+        self.assertTrue((self.log_dir / "pr-4742-cleanup.log").exists())
+
+
+class ProcessBotCleanupPrTests(unittest.TestCase):
+    """Tests for process_bot_cleanup_pr(), new - the BOT_CLEANUP orchestrator."""
+
+    def setUp(self):
+        """Patch every collaborator process_bot_cleanup_pr() calls."""
+        self.patches = {}
+        for name in ["sync_repo", "reset_scratch", "cleanup_pr", "remove_pr_cleanup_label", "mark_pr_cleanup_failed"]:
+            patcher = patch.object(triage_daemon, name)
+            self.patches[name] = patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_cleans_up_then_removes_the_label(self):
+        """A successful cleanup syncs, cleans up, then removes BOT_CLEANUP."""
+        triage_daemon.process_bot_cleanup_pr({"number": 4742, "title": "Add confirmed findings"})
+        self.patches["sync_repo"].assert_called_once()
+        self.patches["reset_scratch"].assert_called_once()
+        self.patches["cleanup_pr"].assert_called_once_with(4742)
+        self.patches["remove_pr_cleanup_label"].assert_called_once_with(4742)
+        self.patches["mark_pr_cleanup_failed"].assert_not_called()
+
+    def test_failed_cleanup_marks_failed_instead_of_removing_the_label(self):
+        """A cleanup_pr() failure swaps to BOT_FAILED rather than retrying next poll."""
+        self.patches["cleanup_pr"].side_effect = subprocess.CalledProcessError(1, ["claude"])
+        triage_daemon.process_bot_cleanup_pr({"number": 4742, "title": "Add confirmed findings"})
+        self.patches["mark_pr_cleanup_failed"].assert_called_once_with(4742)
+        self.patches["remove_pr_cleanup_label"].assert_not_called()
+
+    @patch("builtins.print")
+    def test_prints_the_title_and_link_before_doing_anything(self, mock_print):
+        """Prints the PR's title and an openable GitHub link as soon as work starts."""
+        triage_daemon.process_bot_cleanup_pr({"number": 4742, "title": "Add confirmed findings"})
+        printed = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
+        self.assertIn("Add confirmed findings", printed)
+        self.assertIn("https://github.com/springfall2008/batpred/pull/4742", printed)
 
 
 if __name__ == "__main__":

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -190,6 +190,19 @@ _PR_REMOVED_DENIALS = {"Bash(git push*)", "Bash(git commit*)", "Bash(gh pr creat
 # matching can't parse flags, so this is a heuristic, not a guarantee.
 _PR_FORCE_PUSH_DENIALS = ["Bash(git push*--force*)", "Bash(git push*-f*)"]
 DISALLOWED_TOOLS_PR = ",".join([item for item in _DISALLOWED_TOOLS_BASE if item not in _PR_REMOVED_DENIALS] + _PR_FORCE_PUSH_DENIALS)
+# /code-review posts findings as inline PR comments, which needs gh api against the
+# PR-comments endpoint - carve just that back out, scoped to this repo only. No
+# write/push/commit access at all: BOT_REVIEW-on-PR is comment-only.
+_REVIEW_REMOVED_DENIALS = {"Bash(gh api*)"}
+_REVIEW_EXTRA_ALLOWED = [f"Bash(gh api repos/{REPO}/*)"]
+ALLOWED_TOOLS_REVIEW = ",".join(_ALLOWED_TOOLS_BASE + _REVIEW_EXTRA_ALLOWED)
+DISALLOWED_TOOLS_REVIEW = ",".join(item for item in _DISALLOWED_TOOLS_BASE if item not in _REVIEW_REMOVED_DENIALS)
+# BOT_CLEANUP needs everything the PR flow has (commit/push/pre-commit) plus the same
+# scoped gh api access as the review flow - to read inline review-thread comments
+# (gh pr view only surfaces top-level comments) and reply in-thread.
+ALLOWED_TOOLS_CLEANUP = ",".join(_ALLOWED_TOOLS_BASE + _ALLOWED_TOOLS_PR_EXTRA + _REVIEW_EXTRA_ALLOWED)
+_CLEANUP_REMOVED_DENIALS = _PR_REMOVED_DENIALS | _REVIEW_REMOVED_DENIALS
+DISALLOWED_TOOLS_CLEANUP = ",".join([item for item in _DISALLOWED_TOOLS_BASE if item not in _CLEANUP_REMOVED_DENIALS] + _PR_FORCE_PUSH_DENIALS)
 
 
 def load_state():
@@ -211,6 +224,11 @@ def save_state(state):
 def issue_url(issue_number):
     """Return the GitHub URL for an issue, for easy opening from the daemon's log."""
     return f"https://github.com/{REPO}/issues/{issue_number}"
+
+
+def pr_url(pr_number):
+    """Return the GitHub URL for a PR, for easy opening from the daemon's log."""
+    return f"https://github.com/{REPO}/pull/{pr_number}"
 
 
 def fetch_new_issues(since_number):
@@ -524,6 +542,28 @@ def fetch_bot_review_issues():
     return json.loads(result.stdout)
 
 
+def fetch_bot_review_prs():
+    """Return open PRs currently labelled BOT_REVIEW, each with its title."""
+    result = subprocess.run(
+        ["gh", "pr", "list", "--repo", REPO, "--state", "open", "--label", "BOT_REVIEW", "--json", "number,title", "--limit", "100"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def fetch_bot_cleanup_prs():
+    """Return open PRs currently labelled BOT_CLEANUP, each with its title."""
+    result = subprocess.run(
+        ["gh", "pr", "list", "--repo", REPO, "--state", "open", "--label", "BOT_CLEANUP", "--json", "number,title", "--limit", "100"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
 def remove_review_label(issue_number):
     """Remove BOT_REVIEW once the issue is confirmed triaged, so it isn't reprocessed."""
     subprocess.run(["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--remove-label", "BOT_REVIEW"], check=True)
@@ -549,6 +589,62 @@ def mark_review_failed(issue_number):
     )
     subprocess.run(
         ["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--remove-label", "BOT_REVIEW", "--add-label", "BOT_FAILED"],
+        check=True,
+    )
+
+
+def remove_pr_review_label(pr_number):
+    """Remove BOT_REVIEW from a PR once the review has been posted, so it isn't reprocessed."""
+    subprocess.run(["gh", "pr", "edit", str(pr_number), "--repo", REPO, "--remove-label", "BOT_REVIEW"], check=True)
+
+
+def mark_pr_review_failed(pr_number):
+    """Post a note and swap BOT_REVIEW for BOT_FAILED on a PR, so a failing review isn't
+    retried every poll cycle. Remove BOT_FAILED and re-add BOT_REVIEW to retry.
+    """
+    subprocess.run(
+        [
+            "gh",
+            "pr",
+            "comment",
+            str(pr_number),
+            "--repo",
+            REPO,
+            "--body",
+            "Automated review failed to complete for this PR - see the triage bot's logs for details. " "Not retrying automatically; remove `BOT_FAILED` and re-add `BOT_REVIEW` to try again.",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["gh", "pr", "edit", str(pr_number), "--repo", REPO, "--remove-label", "BOT_REVIEW", "--add-label", "BOT_FAILED"],
+        check=True,
+    )
+
+
+def remove_pr_cleanup_label(pr_number):
+    """Remove BOT_CLEANUP once fixes have been committed and pushed, so it isn't reprocessed."""
+    subprocess.run(["gh", "pr", "edit", str(pr_number), "--repo", REPO, "--remove-label", "BOT_CLEANUP"], check=True)
+
+
+def mark_pr_cleanup_failed(pr_number):
+    """Post a note and swap BOT_CLEANUP for BOT_FAILED on a PR, so a failing cleanup
+    isn't retried every poll cycle. Remove BOT_FAILED and re-add BOT_CLEANUP to retry.
+    """
+    subprocess.run(
+        [
+            "gh",
+            "pr",
+            "comment",
+            str(pr_number),
+            "--repo",
+            REPO,
+            "--body",
+            "Automated cleanup failed to complete for this PR - see the triage bot's logs for details. " "Not retrying automatically; remove `BOT_FAILED` and re-add `BOT_CLEANUP` to try again.",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["gh", "pr", "edit", str(pr_number), "--repo", REPO, "--remove-label", "BOT_CLEANUP", "--add-label", "BOT_FAILED"],
         check=True,
     )
 
@@ -591,6 +687,113 @@ def process_bot_review_issue(issue):
     remove_review_label(issue_number)
 
 
+def review_pr(pr_number):
+    """Run /code-review against a PR at the "high" effort level, posting findings as
+    inline PR comments. Read-only otherwise: no code changes, no push, no PR actions.
+    """
+    cmd = [
+        "claude",
+        "-p",
+        f"/code-review {pr_number} high --comment",
+        "--permission-mode",
+        "dontAsk",
+        "--allowedTools",
+        ALLOWED_TOOLS_REVIEW,
+        "--disallowedTools",
+        DISALLOWED_TOOLS_REVIEW,
+        "--verbose",
+        "--add-dir",
+        str(SCRATCH_DIR),
+        "--max-turns",
+        "100",
+        "--max-budget-usd",
+        "20.00",
+    ]
+    log_path = LOG_DIR / f"pr-{pr_number}-review.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"[review-pr] PR #{pr_number}: starting, logging to {log_path}", flush=True)
+    with log_path.open("a") as log_handle:
+        log_handle.write(f"\n==== PR #{pr_number} review started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
+        log_handle.flush()
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        log_handle.write(f"==== PR #{pr_number} review exited {result.returncode} ====\n")
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, cmd)
+    print(f"[review-pr] PR #{pr_number}: exited {result.returncode}", flush=True)
+
+
+def process_bot_review_pr(pr):
+    """Run the BOT_REVIEW flow for one PR: /code-review posts findings as comments,
+    nothing here ever touches the PR's code. On success, remove BOT_REVIEW - the
+    posted review is the artifact, there's no separate "done" state to track. A
+    failed invocation swaps to BOT_FAILED instead, with an explanatory comment.
+    """
+    pr_number = pr["number"]
+    print(f'[review-pr] PR #{pr_number}: "{pr["title"]}" - {pr_url(pr_number)}', flush=True)
+    sync_repo()
+    reset_scratch()
+    try:
+        review_pr(pr_number)
+    except subprocess.CalledProcessError as exc:
+        print(f"[review-pr] PR #{pr_number}: review failed: {exc}", flush=True)
+        mark_pr_review_failed(pr_number)
+        return
+    remove_pr_review_label(pr_number)
+
+
+def cleanup_pr(pr_number):
+    """Run the /pr-cleanup skill against a PR: address review feedback and CI
+    failures, then commit and push - under the write-capable cleanup permission set.
+    """
+    cmd = [
+        "claude",
+        "-p",
+        f"/pr-cleanup {pr_number} scratch={SCRATCH_DIR}",
+        "--permission-mode",
+        "dontAsk",
+        "--allowedTools",
+        ALLOWED_TOOLS_CLEANUP,
+        "--disallowedTools",
+        DISALLOWED_TOOLS_CLEANUP,
+        "--verbose",
+        "--add-dir",
+        str(SCRATCH_DIR),
+        "--max-turns",
+        "150",
+        "--max-budget-usd",
+        "25.00",
+    ]
+    log_path = LOG_DIR / f"pr-{pr_number}-cleanup.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"[cleanup-pr] PR #{pr_number}: starting, logging to {log_path}", flush=True)
+    with log_path.open("a") as log_handle:
+        log_handle.write(f"\n==== PR #{pr_number} cleanup started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
+        log_handle.flush()
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        log_handle.write(f"==== PR #{pr_number} cleanup exited {result.returncode} ====\n")
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, cmd)
+    print(f"[cleanup-pr] PR #{pr_number}: exited {result.returncode}", flush=True)
+
+
+def process_bot_cleanup_pr(pr):
+    """Run the BOT_CLEANUP flow for one PR: address review feedback and CI failures,
+    then remove the trigger label. A failed run swaps to BOT_FAILED instead, with an
+    explanatory comment.
+    """
+    pr_number = pr["number"]
+    print(f'[cleanup-pr] PR #{pr_number}: "{pr["title"]}" - {pr_url(pr_number)}', flush=True)
+    sync_repo()
+    reset_scratch()
+    try:
+        cleanup_pr(pr_number)
+    except subprocess.CalledProcessError as exc:
+        print(f"[cleanup-pr] PR #{pr_number}: cleanup failed: {exc}", flush=True)
+        mark_pr_cleanup_failed(pr_number)
+        return
+    remove_pr_cleanup_label(pr_number)
+
+
 def main():
     if not CLONE_DIR.exists():
         raise SystemExit(f"Expected a git clone at {CLONE_DIR} - see setup steps before running this daemon.")
@@ -609,6 +812,10 @@ def main():
                 process_bot_pr_issue(issue)
             for issue in fetch_bot_review_issues():
                 process_bot_review_issue(issue)
+            for pr in fetch_bot_review_prs():
+                process_bot_review_pr(pr)
+            for pr in fetch_bot_cleanup_prs():
+                process_bot_cleanup_pr(pr)
         except subprocess.CalledProcessError as exc:
             print(f"[triage] error: {exc}", flush=True)
         time.sleep(POLL_SECONDS)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -82,9 +82,7 @@ POLL_SECONDS = 300
 
 EDIT_SCOPE = f"//{CLONE_DIR.relative_to('/')}/**"
 SCRATCH_SCOPE = f"//{SCRATCH_DIR.relative_to('/')}/**"
-_ALLOWED_TOOLS_BASE = [
-    # Read the issue, search for duplicates, post the triage comment
-    "Bash(gh *)",
+_ALLOWED_TOOLS_NON_GH = [
     # Git history, and the re-sync/discard the skill does before investigating
     "Bash(git log*)",
     "Bash(git diff*)",
@@ -150,6 +148,8 @@ _ALLOWED_TOOLS_BASE = [
     "Grep",
     "Glob",
 ]
+# Read the issue, search for duplicates, post the triage comment
+_ALLOWED_TOOLS_BASE = ["Bash(gh *)"] + _ALLOWED_TOOLS_NON_GH
 ALLOWED_TOOLS = ",".join(_ALLOWED_TOOLS_BASE)
 # The /issue-pr invocation needs everything the read-only triage flow has, plus
 # committing/pushing its branch, opening the PR, and running pre-commit as a quality gate.
@@ -190,18 +190,44 @@ _PR_REMOVED_DENIALS = {"Bash(git push*)", "Bash(git commit*)", "Bash(gh pr creat
 # matching can't parse flags, so this is a heuristic, not a guarantee.
 _PR_FORCE_PUSH_DENIALS = ["Bash(git push*--force*)", "Bash(git push*-f*)"]
 DISALLOWED_TOOLS_PR = ",".join([item for item in _DISALLOWED_TOOLS_BASE if item not in _PR_REMOVED_DENIALS] + _PR_FORCE_PUSH_DENIALS)
+# The review and cleanup flows do NOT inherit the broad "Bash(gh *)" grant: with it
+# present, carving a scoped exception out of the gh api denial below would do nothing,
+# since "Bash(gh *)" already allows every gh api call once that denial is lifted, and
+# a narrower allow gets no precedence over a broader one - only "deny wins over allow"
+# is a real rule here. Instead, list the specific gh subcommands actually needed, so
+# there is no catch-all for the scoped gh api grant to hide behind.
+_ALLOWED_GH_PR_READ = [
+    "Bash(gh pr view*)",
+    "Bash(gh pr diff*)",
+    "Bash(gh pr list*)",
+    "Bash(gh pr comment*)",
+    "Bash(gh issue view*)",
+    "Bash(gh issue list*)",
+    "Bash(gh search*)",
+]
 # /code-review posts findings as inline PR comments, which needs gh api against the
-# PR-comments endpoint - carve just that back out, scoped to this repo only. No
-# write/push/commit access at all: BOT_REVIEW-on-PR is comment-only.
+# PR-comments endpoint - scoped to this repo only. No write/push/commit access, and
+# deliberately no "gh pr review*" either: that would also allow --approve/
+# --request-changes, a governance action beyond "post a comment."
 _REVIEW_REMOVED_DENIALS = {"Bash(gh api*)"}
 _REVIEW_EXTRA_ALLOWED = [f"Bash(gh api repos/{REPO}/*)"]
-ALLOWED_TOOLS_REVIEW = ",".join(_ALLOWED_TOOLS_BASE + _REVIEW_EXTRA_ALLOWED)
+ALLOWED_TOOLS_REVIEW = ",".join(_ALLOWED_GH_PR_READ + _ALLOWED_TOOLS_NON_GH + _REVIEW_EXTRA_ALLOWED)
 DISALLOWED_TOOLS_REVIEW = ",".join(item for item in _DISALLOWED_TOOLS_BASE if item not in _REVIEW_REMOVED_DENIALS)
-# BOT_CLEANUP needs everything the PR flow has (commit/push/pre-commit) plus the same
-# scoped gh api access as the review flow - to read inline review-thread comments
-# (gh pr view only surfaces top-level comments) and reply in-thread.
-ALLOWED_TOOLS_CLEANUP = ",".join(_ALLOWED_TOOLS_BASE + _ALLOWED_TOOLS_PR_EXTRA + _REVIEW_EXTRA_ALLOWED)
-_CLEANUP_REMOVED_DENIALS = _PR_REMOVED_DENIALS | _REVIEW_REMOVED_DENIALS
+# BOT_CLEANUP needs the review flow's read access and scoped gh api grant, plus
+# committing/pushing/pre-commit and checking out the PR's own branch (the review flow
+# never needs a local checkout, and never gh pr checks/run view - it doesn't touch CI).
+# Deliberately not the full _ALLOWED_TOOLS_PR_EXTRA: no "gh pr create*" - cleanup
+# pushes to the existing PR's branch, it never opens a new one.
+_CLEANUP_EXTRA_GH = ["Bash(gh pr checkout*)", "Bash(gh pr checks*)", "Bash(gh run view*)", "Bash(gh run list*)"]
+_CLEANUP_EXTRA_WRITE = [
+    "Bash(git add*)",
+    "Bash(git commit*)",
+    "Bash(git push*)",
+    "Bash(./run_pre_commit*)",
+    "Bash(./run_pre_commit)",
+]
+ALLOWED_TOOLS_CLEANUP = ",".join(_ALLOWED_GH_PR_READ + _CLEANUP_EXTRA_GH + _ALLOWED_TOOLS_NON_GH + _CLEANUP_EXTRA_WRITE + _REVIEW_EXTRA_ALLOWED)
+_CLEANUP_REMOVED_DENIALS = {"Bash(git push*)", "Bash(git commit*)"} | _REVIEW_REMOVED_DENIALS
 DISALLOWED_TOOLS_CLEANUP = ",".join([item for item in _DISALLOWED_TOOLS_BASE if item not in _CLEANUP_REMOVED_DENIALS] + _PR_FORCE_PUSH_DENIALS)
 
 


### PR DESCRIPTION
## Summary

Extends the triage bot's label-driven flows to pull requests, reusing all existing daemon infrastructure (polling, permission-set derivation, label-based state, failure handling).

- **`BOT_REVIEW` on a PR** (a second meaning — on an issue it's unchanged) runs the built-in `/code-review <pr> high --comment`, posting findings as inline PR comments. Comment-only: the review permission set adds nothing but a scoped `gh api` grant, no write/push/commit access at all.
- **`BOT_CLEANUP` on a PR** (new) runs a new `.claude/skills/pr-cleanup/SKILL.md` skill that addresses outstanding review feedback (from any source — human reviewers, Copilot, a prior bot review) and CI failures. It's built on `superpowers:receiving-code-review`'s evaluation discipline: verify before implementing, push back with reasoning on anything wrong or unclear. That skill assumes a live human partner to consult; where it says to stop and ask, the daemon version posts a comment explaining what's unclear and stops instead. Runs `./run_pre_commit` + the relevant test as a quality gate before committing, then pushes to the PR's own branch and replies in-thread (not as new top-level comments) to addressed review comments.

Both flows need `gh api` access — inline PR review comments aren't visible via `gh pr view` (I hit this gap myself reviewing PR #4740 interactively), and thread replies need the REST endpoint directly (`.../pulls/{pr}/comments/{id}/replies`). Every existing flow currently blocks `gh api` entirely, so this carves out a narrow exception scoped to this repo only (`Bash(gh api repos/springfall2008/batpred/*)`), the same technique already used to carve `git push`/`git commit` out of the base denial list for the `/issue-pr` flow.

Same label lifecycle as everything else: success removes the trigger label; a failed invocation swaps to the existing `BOT_FAILED` with an explanatory comment rather than retrying every poll cycle.

## Before this is usable

The `BOT_CLEANUP` label needs creating on the repo (`BOT_REVIEW`/`BOT_FAILED` already exist from earlier work). `/code-review`'s exact CLI argument syntax (`/code-review <pr> high --comment`) is my best inference from its description — it's a built-in command with no readable source, so this needs a live end-to-end check before relying on it.

## Test plan

- [x] `python3 tools/test_triage_daemon.py -v` — 84/84 passing
- [x] `./run_pre_commit` (full suite) — clean
- [x] `coverage/venv` quick suite (`unit_test.py --quick`) — clean, 0 failures
- [ ] End-to-end: add `BOT_REVIEW` to a real PR and confirm `/code-review`'s argument syntax and comment-posting actually work as invoked
- [ ] End-to-end: add `BOT_CLEANUP` to a real PR with outstanding feedback and confirm the fix/push/reply flow