### PR TITLE
fix: trim debug_history_count default from 15 to 5

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -1213,7 +1213,7 @@ CONFIG_ITEMS = [
         "step": 1,
         "unit": "snapshots",
         "icon": "mdi:history",
-        "default": 15,
+        "default": 5,
     },
     {
         "name": "debug_history_interval",

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -840,10 +840,10 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         genuine capture attempt is never skipped just because the warning was
         recently logged.
         """
-        count = int(self.get_arg("debug_history_count", 15))
-        interval_hours = max(1, int(self.get_arg("debug_history_interval", 3)))
-        enabled = self.get_arg("debug_history_enable", True)
-        forced = self.get_arg("debug_history_force_capture", False)
+        count = int(self.get_arg("debug_history_count"))
+        interval_hours = max(1, int(self.get_arg("debug_history_interval")))
+        enabled = self.get_arg("debug_history_enable")
+        forced = self.get_arg("debug_history_force_capture")
         if not enabled and not forced:
             return
         if not forced:

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -854,8 +854,8 @@ mode: single
 Turning on `switch.predbat_debug_enable` only captures debug information from the moment you switch it on - not much help if you have already noticed a problem and want to see what Predbat was doing an hour or two ago. Predbat also keeps a small rolling history of debug snapshots automatically, independent of that switch, so there is always some recent history to look back at:
 
 - **switch.predbat_debug_history_enable** - turns the rolling history off entirely when off (default on). `debug_history_force_capture` still works even while this is off.
-- **input_number.predbat_debug_history_count** - how many snapshots to retain (default 15, minimum 1 - use the enable switch above to turn the feature off, not a count of 0).
-- **input_number.predbat_debug_history_interval** - how many hours between automatic snapshots (default 3). With the defaults, 15 snapshots at 3-hourly intervals covers just under 48 hours.
+- **input_number.predbat_debug_history_count** - how many snapshots to retain (default 5, minimum 1 - use the enable switch above to turn the feature off, not a count of 0).
+- **input_number.predbat_debug_history_interval** - how many hours between automatic snapshots (default 3). With the defaults, 5 snapshots at 3-hourly intervals covers 15 hours.
 - **switch.predbat_debug_history_force_capture** - turn this on to trigger an immediate snapshot rather than waiting for the next scheduled one, useful from an automation that has just spotted something worth investigating. Predbat resets the switch back off itself once the snapshot has been taken, and still takes the snapshot even if `debug_history_enable` is off.
 
 Retained snapshots can all be downloaded together as a single `.tgz` archive from a link on the web interface's dashboard **Debug** panel, or individually from the **Debug** column shown on the plan's **History** view (next to any time slot a snapshot was captured for exactly). An automation can also fetch the most recent snapshot directly without needing to know its exact timestamp, by calling `GET <predbat-url>/debug_history_download?id=latest` after turning `switch.predbat_debug_history_force_capture` on.


### PR DESCRIPTION
## Summary

Partial response to #4749 — that issue asks for `debug_history_enable` to default off entirely (24MB/install, 45h rolling buffer, whether or not anyone ever opens History). Rather than switching the feature off by default, this trims the buffer size instead, as a middle ground:

- `debug_history_count` default `15` → `5`. With the unchanged 3h `debug_history_interval`, that's a 15h rolling window instead of 45h, and roughly **~8MB instead of ~24MB** per install (still a meaningful cut, ~66%).
- The feature stays **on by default**, so the buffer keeps covering the "something looked off a few hours ago" case that #4417/#4438 originally built it for — it just no longer reaches back the full ~48h History-tab window.
- Also removed the duplicated `15`/`3`/`True`/`False` literals from the `get_arg()` calls in `_capture_debug_history()` (`predbat.py`) — they now resolve through `config_index` instead, so `config.py`'s `CONFIG_ITEMS` is the single source of truth for these defaults rather than needing to be kept in sync by hand at two call sites.
- Updated `docs/customisation.md` to match (default count, resulting window).

### Note for maintainer review

This is offered as a compromise, not a resolution — #4749 explicitly asks for default-off, and the earlier #4417/#4438 decision to default this on was deliberate. If the storage-cost concern in #4749 still isn't satisfied by a smaller buffer, the default-off change is a one-line follow-up (`config.py`'s `debug_history_enable` default plus the docs line) rather than something this PR needs to also do.

Closes/relates to #4749 (leaving to a maintainer to decide whether this satisfies the issue or whether default-off is still wanted).

## Test plan

- [x] `./run_all --test debug_history_capture` — passes (values are set explicitly via `expose_config()` in every test, so the default change doesn't affect them)
- [x] `./run_all --quick` — full quick suite passes, no regressions
- [x] `pre-commit run --files apps/predbat/config.py apps/predbat/predbat.py docs/customisation.md` — ruff/black/cspell all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)