### PR TITLE
Spike: Add dockerised dev environment

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -111,6 +111,7 @@ desync
 desynced
 devcontainer
 devcontainers
+devdevdev
 dexport
 deye
 deyecloud
@@ -215,6 +216,7 @@ hasattr
 hass
 hassapi
 hassio
+healthcheck
 heatingactive
 heatingtemp
 heatpump
@@ -304,6 +306,7 @@ minb
 minmax
 minsoc
 minsocongrid
+mintable
 minuteb
 misclick
 misdetect
@@ -531,6 +534,7 @@ timestep
 timestr
 timezone
 tmpfs
+tmpl
 tmrw
 tojson
 tottime
@@ -557,6 +561,8 @@ unpushed
 unsmoothed
 unstaged
 urandom
+urllib
+urlopen
 urlsafe
 useid
 userinterface

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,15 @@ Thumbs.db
 dev_code
 sigenergy_mqtt_key
 
+# Predbat dev container runtime state (dev/README.md) - Home Assistant writes a lot
+# more than just .storage/*.db into dev/ha_config at runtime (blueprints, .HA_VERSION,
+# .ha_run.lock, tts/, log files, ...), so ignore everything there except what we author.
+dev/ha_config/*
+!dev/ha_config/configuration.yaml
+!dev/ha_config/packages/
+dev/shared/*
+!dev/shared/.gitkeep
+
 # Python cache files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     args: [--markdown-linebreak-ext=md]
   - id: end-of-file-fixer
   - id: check-yaml
-    exclude: (example_chart.yml)
+    exclude: (example_chart.yml|dev/ha_config/configuration.yaml)
   - id: check-json
     exclude: ^(\.cspell\.json|\.devcontainer\/devcontainer\.json)$
 - repo: https://gitlab.com/bmares/check-json5

--- a/dev/Dockerfile.bootstrap
+++ b/dev/Dockerfile.bootstrap
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir aiohttp
+
+COPY dev/bootstrap.py /bootstrap.py
+
+ENTRYPOINT ["python3", "/bootstrap.py"]

--- a/dev/Dockerfile.predbat
+++ b/dev/Dockerfile.predbat
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY apps/predbat/ /app/predbat/
+COPY dev/apps.dev.yaml.tmpl /app/apps.dev.yaml.tmpl
+COPY dev/predbat-entrypoint.sh /app/predbat-entrypoint.sh
+RUN chmod +x /app/predbat-entrypoint.sh
+
+EXPOSE 5052
+
+ENTRYPOINT ["/app/predbat-entrypoint.sh"]

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,55 @@
+# Predbat dev environment
+
+Runs Predbat from this checkout against a disposable Home Assistant instance,
+pre-populated with dummy inverter entities, with onboarding and the long-lived
+access token created automatically - no manual setup.
+
+## Usage
+
+```sh
+dev/up.py
+```
+
+or, without the auto browser-open:
+
+```sh
+docker compose -f docker-compose.dev.yml up --build
+```
+
+- Home Assistant: <http://localhost:8123/> (login `dev` / `devdevdev1`)
+- Predbat web UI: <http://localhost:5052/>
+
+Dummy entities (battery SOC, charge/discharge rate, inverter mode, today's
+energy sensors, etc.) live under `dev/ha_config/packages/predbat_dummy.yaml` -
+edit their `initial` values, or change them live under Developer Tools > States
+in the HA UI, to exercise different scenarios. Predbat's config for the
+container is `dev/apps.dev.yaml.tmpl`.
+
+## Hot reload
+
+`apps/predbat/` is bind-mounted into the predbat container, and Predbat's own
+standalone runner (`hass.py`) watches those files and exits when one changes.
+The container is set to restart automatically, so editing and saving a `.py`
+file picks up the change within a few seconds - no rebuild needed.
+
+## Resetting
+
+`dev/ha_config` and `dev/shared` are bind-mounted so HA's onboarding state and
+the minted token persist across restarts (`docker compose up` again just re-mints
+a token). For a fully clean instance:
+
+```sh
+docker compose -f docker-compose.dev.yml down -v
+rm -rf dev/ha_config/.storage dev/ha_config/*.log dev/ha_config/*.db dev/shared
+```
+
+## Known limitations
+
+- Onboarding is driven through Home Assistant's private (undocumented)
+  `/api/onboarding` + websocket `auth/long_lived_access_token` sequence, in
+  `dev/bootstrap.py`. It's the same flow the HA frontend uses, but if a future
+  HA release changes it, that's the file to fix.
+- There's currently no way to replay a user's bug-report `predbat_debug.yaml`
+  into this container - that file only captures Predbat's own derived state,
+  not raw HA entity states. Reproducing a bug through this dev HA instance is a
+  planned follow-up.

--- a/dev/apps.dev.yaml.tmpl
+++ b/dev/apps.dev.yaml.tmpl
@@ -1,0 +1,76 @@
+# Predbat config for the dev container - points at the dummy entities defined in
+# dev/ha_config/packages/predbat_dummy.yaml. {{HA_URL}}/{{HA_KEY}} are substituted
+# by dev/predbat-entrypoint.sh once dev/shared/ha_token.json exists.
+
+pred_bat:
+  module: predbat
+  class: PredBat
+  prefix: predbat
+  timezone: Europe/London
+
+  ha_url: "{{HA_URL}}"
+  ha_key: "{{HA_KEY}}"
+
+  currency_symbols:
+    - "£"
+    - "p"
+
+  threads: auto
+
+  inverter_type: GE
+  num_inverters: 1
+
+  load_today:
+    - input_number.predbat_dummy_load_energy_today
+  import_today:
+    - input_number.predbat_dummy_import_energy_today
+  export_today:
+    - input_number.predbat_dummy_export_energy_today
+  pv_today:
+    - input_number.predbat_dummy_pv_energy_today
+
+  charge_rate:
+    - input_number.predbat_dummy_charge_rate
+  discharge_rate:
+    - input_number.predbat_dummy_discharge_rate
+  battery_power:
+    - input_number.predbat_dummy_battery_power
+  pv_power:
+    - input_number.predbat_dummy_pv_power
+  load_power:
+    - input_number.predbat_dummy_load_power
+  grid_power:
+    - input_number.predbat_dummy_grid_power
+  soc_kw:
+    - input_number.predbat_dummy_soc_kw
+  soc_max:
+    - input_number.predbat_dummy_soc_max
+  reserve:
+    - input_number.predbat_dummy_reserve
+  inverter_mode:
+    - select.predbat_dummy_inverter_mode
+  charge_start_time:
+    - select.predbat_dummy_charge_start_time
+  charge_end_time:
+    - select.predbat_dummy_charge_end_time
+  charge_limit:
+    - input_number.predbat_dummy_charge_limit
+  charge_limit_enable:
+    - input_boolean.predbat_dummy_charge_limit_enable
+  scheduled_charge_enable:
+    - switch.predbat_dummy_scheduled_charge_enable
+  scheduled_discharge_enable:
+    - switch.predbat_dummy_scheduled_discharge_enable
+  discharge_start_time:
+    - select.predbat_dummy_discharge_start_time
+  discharge_end_time:
+    - select.predbat_dummy_discharge_end_time
+
+  inverter_limit:
+    - 3600
+
+  # Flat rates - no Octopus/Kraken account needed for the dev container
+  rates_import:
+    - rate: 15
+  rates_export:
+    - rate: 5

--- a/dev/bootstrap.py
+++ b/dev/bootstrap.py
@@ -1,0 +1,171 @@
+"""One-shot Home Assistant provisioning for the Predbat dev container.
+
+Talks to a fresh, un-onboarded Home Assistant instance and, with no human in the
+loop, completes onboarding and mints a long-lived access token for Predbat to use.
+This drives the same private `/api/onboarding` + `/auth/token` + websocket
+`auth/long_lived_access_token` sequence the HA frontend itself uses during the
+first-run wizard - it is not an officially documented API, so if a future HA
+release changes it, this is the file to fix.
+
+Idempotent: if the instance is already onboarded (e.g. a restart re-using the
+bind-mounted dev/ha_config volume), it skips straight to minting a fresh token.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import time
+
+import aiohttp
+
+HA_URL = os.environ.get("HA_URL", "http://homeassistant:8123")
+DEV_USERNAME = os.environ.get("HA_DEV_USERNAME", "dev")
+DEV_PASSWORD = os.environ.get("HA_DEV_PASSWORD", "devdevdev1")
+DEV_NAME = os.environ.get("HA_DEV_NAME", "Predbat Dev")
+TOKEN_FILE = os.environ.get("TOKEN_FILE", "/shared/ha_token.json")
+CLIENT_ID = HA_URL.rstrip("/") + "/"
+POLL_INTERVAL = 2
+POLL_TIMEOUT = 180
+
+
+async def wait_for_ha(session):
+    """Poll HA until it answers, up to POLL_TIMEOUT seconds.
+
+    Returns the onboarding steps list if onboarding is still in progress (HTTP 200),
+    or None once onboarding is complete (HA unloads the onboarding views, so this
+    starts 404ing - any other non-200/404 status just keeps us polling/retrying).
+    """
+    print("Waiting for Home Assistant at {}...".format(HA_URL), flush=True)
+    for _ in range(POLL_TIMEOUT // POLL_INTERVAL):
+        try:
+            async with session.get(HA_URL + "/api/onboarding", timeout=aiohttp.ClientTimeout(total=5)) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+                if resp.status == 404:
+                    return None
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            pass
+        await asyncio.sleep(POLL_INTERVAL)
+    raise RuntimeError("Home Assistant did not become reachable at {} within {}s".format(HA_URL, POLL_TIMEOUT))
+
+
+async def onboard(session):
+    """Run the owner-creation + core_config/integration onboarding steps. Returns a short-lived access token."""
+    print("Creating owner user...", flush=True)
+    async with session.post(
+        HA_URL + "/api/onboarding/users",
+        json={
+            "client_id": CLIENT_ID,
+            "name": DEV_NAME,
+            "username": DEV_USERNAME,
+            "password": DEV_PASSWORD,
+            "language": "en",
+        },
+    ) as resp:
+        resp.raise_for_status()
+        auth_code = (await resp.json())["auth_code"]
+
+    print("Exchanging auth code for an access token...", flush=True)
+    async with session.post(
+        HA_URL + "/auth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": auth_code,
+            "client_id": CLIENT_ID,
+        },
+    ) as resp:
+        resp.raise_for_status()
+        access_token = (await resp.json())["access_token"]
+
+    headers = {"Authorization": "Bearer " + access_token}
+
+    print("Completing core_config/analytics/integration onboarding steps...", flush=True)
+    for step, payload in (
+        ("core_config", {}),
+        ("analytics", {}),
+        ("integration", {"client_id": CLIENT_ID, "redirect_uri": CLIENT_ID}),
+    ):
+        async with session.post(HA_URL + "/api/onboarding/" + step, json=payload, headers=headers) as resp:
+            if resp.status not in (200, 400):
+                # 400 here usually means "already done" on a re-run - anything else is worth seeing.
+                print("Warn: onboarding step {} returned {}: {}".format(step, resp.status, await resp.text()), flush=True)
+
+    return access_token
+
+
+async def login(session):
+    """Instance is already onboarded - log in with the dev credentials instead."""
+    print("Already onboarded, logging in as {}...".format(DEV_USERNAME), flush=True)
+    async with session.post(
+        HA_URL + "/auth/login_flow",
+        json={"client_id": CLIENT_ID, "handler": ["homeassistant", None], "redirect_uri": CLIENT_ID},
+    ) as resp:
+        resp.raise_for_status()
+        flow = await resp.json()
+
+    async with session.post(
+        HA_URL + "/auth/login_flow/" + flow["flow_id"],
+        json={"username": DEV_USERNAME, "password": DEV_PASSWORD, "client_id": CLIENT_ID},
+    ) as resp:
+        resp.raise_for_status()
+        result = await resp.json()
+        auth_code = result["result"]
+
+    async with session.post(
+        HA_URL + "/auth/token",
+        data={"grant_type": "authorization_code", "code": auth_code, "client_id": CLIENT_ID},
+    ) as resp:
+        resp.raise_for_status()
+        return (await resp.json())["access_token"]
+
+
+async def mint_long_lived_token(session, access_token):
+    """Long-lived tokens are only mintable over the websocket API, not REST."""
+    print("Minting a long-lived access token over the websocket API...", flush=True)
+    ws_url = HA_URL.replace("http://", "ws://").replace("https://", "wss://") + "/api/websocket"
+    async with session.ws_connect(ws_url) as ws:
+        await ws.receive_json()  # auth_required
+        await ws.send_json({"type": "auth", "access_token": access_token})
+        auth_result = await ws.receive_json()
+        if auth_result.get("type") != "auth_ok":
+            raise RuntimeError("Websocket auth failed: {}".format(auth_result))
+
+        # client_name must be unique per token on a re-run (e.g. after a restart that
+        # kept the HA volume but not dev/shared) - HA errors minting a second token
+        # under a name that's already in use, so timestamp it.
+        await ws.send_json(
+            {
+                "id": 1,
+                "type": "auth/long_lived_access_token",
+                "client_name": "predbat-dev-container-{}".format(int(time.time())),
+                "lifespan": 3650,
+            }
+        )
+        result = await ws.receive_json()
+        if not result.get("success"):
+            raise RuntimeError("Failed to mint long-lived access token: {}".format(result))
+        return result["result"]
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        onboarding_status = await wait_for_ha(session)
+
+        already_onboarded = onboarding_status is None or all(step.get("done") for step in onboarding_status)
+        access_token = await login(session) if already_onboarded else await onboard(session)
+
+        ha_key = await mint_long_lived_token(session, access_token)
+
+    os.makedirs(os.path.dirname(TOKEN_FILE), exist_ok=True)
+    with open(TOKEN_FILE, "w") as f:
+        json.dump({"ha_url": HA_URL, "ha_key": ha_key}, f)
+    print("Wrote {}".format(TOKEN_FILE), flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except Exception as e:
+        print("Error: dev HA bootstrap failed: {}".format(e), file=sys.stderr, flush=True)
+        sys.exit(1)

--- a/dev/ha_config/configuration.yaml
+++ b/dev/ha_config/configuration.yaml
@@ -1,0 +1,19 @@
+# Minimal Home Assistant config for the Predbat dev container.
+# Dummy inverter/entity definitions live in packages/predbat_dummy.yaml.
+
+default_config:
+
+homeassistant:
+  name: Predbat Dev
+  latitude: 51.5074
+  longitude: -0.1278
+  elevation: 20
+  unit_system: metric
+  time_zone: Europe/London
+  currency: GBP
+  packages: !include_dir_named packages
+
+# Onboarding is scripted by the ha-bootstrap container, not the browser wizard,
+# so it needs the frontend/API reachable on the container's default port.
+http:
+  server_port: 8123

--- a/dev/ha_config/packages/predbat_dummy.yaml
+++ b/dev/ha_config/packages/predbat_dummy.yaml
@@ -1,0 +1,270 @@
+# Dummy single-inverter "GivTCP-shaped" entities for the Predbat dev container.
+# Predbat is pointed at these via inverter_type: GE with no givtcp_rest set, so
+# every read/write goes through plain HA services - see dev/apps.dev.yaml.tmpl.
+#
+# Predbat only accepts entity_ids in the switch/select/input_number/number/time/
+# input_datetime domains for fields it writes to. So the writable time-slot/mode/
+# enable entities below are `select`/`switch` template entities (the same domains
+# a real GivTCP integration exposes) that wrap a hidden input_select/input_boolean
+# "_store" helper, which is what actually persists the value.
+
+input_number:
+  predbat_dummy_soc_kw:
+    name: Dummy Battery SOC
+    min: 0
+    max: 10
+    step: 0.1
+    initial: 5
+    unit_of_measurement: kWh
+  predbat_dummy_soc_max:
+    name: Dummy Battery Capacity
+    min: 0
+    max: 10
+    step: 0.1
+    initial: 10
+    unit_of_measurement: kWh
+  predbat_dummy_charge_rate:
+    name: Dummy Battery Charge Rate
+    min: 0
+    max: 3600
+    step: 100
+    initial: 3600
+    unit_of_measurement: W
+  predbat_dummy_discharge_rate:
+    name: Dummy Battery Discharge Rate
+    min: 0
+    max: 3600
+    step: 100
+    initial: 3600
+    unit_of_measurement: W
+  predbat_dummy_reserve:
+    name: Dummy Battery Reserve
+    min: 0
+    max: 100
+    step: 1
+    initial: 4
+    unit_of_measurement: "%"
+  predbat_dummy_charge_limit:
+    name: Dummy Charge Limit
+    min: 0
+    max: 100
+    step: 1
+    initial: 100
+    unit_of_measurement: "%"
+  predbat_dummy_battery_power:
+    name: Dummy Battery Power
+    min: -3600
+    max: 3600
+    step: 10
+    initial: 0
+    unit_of_measurement: W
+  predbat_dummy_pv_power:
+    name: Dummy PV Power
+    min: 0
+    max: 5000
+    step: 10
+    initial: 500
+    unit_of_measurement: W
+  predbat_dummy_load_power:
+    name: Dummy Load Power
+    min: 0
+    max: 5000
+    step: 10
+    initial: 300
+    unit_of_measurement: W
+  predbat_dummy_grid_power:
+    name: Dummy Grid Power
+    min: -5000
+    max: 5000
+    step: 10
+    initial: 0
+    unit_of_measurement: W
+  predbat_dummy_load_energy_today:
+    name: Dummy Load Energy Today
+    min: 0
+    max: 100
+    step: 0.01
+    initial: 4
+    unit_of_measurement: kWh
+  predbat_dummy_import_energy_today:
+    name: Dummy Import Energy Today
+    min: 0
+    max: 100
+    step: 0.01
+    initial: 2
+    unit_of_measurement: kWh
+  predbat_dummy_export_energy_today:
+    name: Dummy Export Energy Today
+    min: 0
+    max: 100
+    step: 0.01
+    initial: 0.5
+    unit_of_measurement: kWh
+  predbat_dummy_pv_energy_today:
+    name: Dummy PV Energy Today
+    min: 0
+    max: 100
+    step: 0.01
+    initial: 3
+    unit_of_measurement: kWh
+
+input_select:
+  predbat_dummy_inverter_mode_store:
+    name: Dummy Inverter Mode Store
+    options:
+      - Eco
+      - Timed Export
+    initial: Eco
+  predbat_dummy_charge_start_time_store:
+    name: Dummy Charge Start Time Store
+    options: &time_slots
+      - "00:00:00"
+      - "00:30:00"
+      - "01:00:00"
+      - "01:30:00"
+      - "02:00:00"
+      - "02:30:00"
+      - "03:00:00"
+      - "03:30:00"
+      - "04:00:00"
+      - "04:30:00"
+      - "05:00:00"
+      - "05:30:00"
+      - "06:00:00"
+      - "06:30:00"
+      - "07:00:00"
+      - "07:30:00"
+      - "08:00:00"
+      - "08:30:00"
+      - "09:00:00"
+      - "09:30:00"
+      - "10:00:00"
+      - "10:30:00"
+      - "11:00:00"
+      - "11:30:00"
+      - "12:00:00"
+      - "12:30:00"
+      - "13:00:00"
+      - "13:30:00"
+      - "14:00:00"
+      - "14:30:00"
+      - "15:00:00"
+      - "15:30:00"
+      - "16:00:00"
+      - "16:30:00"
+      - "17:00:00"
+      - "17:30:00"
+      - "18:00:00"
+      - "18:30:00"
+      - "19:00:00"
+      - "19:30:00"
+      - "20:00:00"
+      - "20:30:00"
+      - "21:00:00"
+      - "21:30:00"
+      - "22:00:00"
+      - "22:30:00"
+      - "23:00:00"
+      - "23:30:00"
+    initial: "00:00:00"
+  predbat_dummy_charge_end_time_store:
+    name: Dummy Charge End Time Store
+    options: *time_slots
+    initial: "05:00:00"
+  predbat_dummy_discharge_start_time_store:
+    name: Dummy Discharge Start Time Store
+    options: *time_slots
+    initial: "16:00:00"
+  predbat_dummy_discharge_end_time_store:
+    name: Dummy Discharge End Time Store
+    options: *time_slots
+    initial: "19:00:00"
+
+input_boolean:
+  predbat_dummy_charge_limit_enable:
+    name: Dummy Enable Charge Target
+    initial: true
+  predbat_dummy_scheduled_charge_enable_store:
+    name: Dummy Enable Charge Schedule Store
+    initial: true
+  predbat_dummy_scheduled_discharge_enable_store:
+    name: Dummy Enable Discharge Schedule Store
+    initial: false
+
+# select/switch wrappers around the _store helpers above, in domains Predbat's
+# apps.yaml validator actually accepts for writable fields (see note at top).
+template:
+  - select:
+      - name: Predbat Dummy Inverter Mode
+        unique_id: predbat_dummy_inverter_mode
+        state: "{{ states('input_select.predbat_dummy_inverter_mode_store') }}"
+        options: "{{ state_attr('input_select.predbat_dummy_inverter_mode_store', 'options') }}"
+        select_option:
+          - action: input_select.select_option
+            target:
+              entity_id: input_select.predbat_dummy_inverter_mode_store
+            data:
+              option: "{{ option }}"
+      - name: Predbat Dummy Charge Start Time
+        unique_id: predbat_dummy_charge_start_time
+        state: "{{ states('input_select.predbat_dummy_charge_start_time_store') }}"
+        options: "{{ state_attr('input_select.predbat_dummy_charge_start_time_store', 'options') }}"
+        select_option:
+          - action: input_select.select_option
+            target:
+              entity_id: input_select.predbat_dummy_charge_start_time_store
+            data:
+              option: "{{ option }}"
+      - name: Predbat Dummy Charge End Time
+        unique_id: predbat_dummy_charge_end_time
+        state: "{{ states('input_select.predbat_dummy_charge_end_time_store') }}"
+        options: "{{ state_attr('input_select.predbat_dummy_charge_end_time_store', 'options') }}"
+        select_option:
+          - action: input_select.select_option
+            target:
+              entity_id: input_select.predbat_dummy_charge_end_time_store
+            data:
+              option: "{{ option }}"
+      - name: Predbat Dummy Discharge Start Time
+        unique_id: predbat_dummy_discharge_start_time
+        state: "{{ states('input_select.predbat_dummy_discharge_start_time_store') }}"
+        options: "{{ state_attr('input_select.predbat_dummy_discharge_start_time_store', 'options') }}"
+        select_option:
+          - action: input_select.select_option
+            target:
+              entity_id: input_select.predbat_dummy_discharge_start_time_store
+            data:
+              option: "{{ option }}"
+      - name: Predbat Dummy Discharge End Time
+        unique_id: predbat_dummy_discharge_end_time
+        state: "{{ states('input_select.predbat_dummy_discharge_end_time_store') }}"
+        options: "{{ state_attr('input_select.predbat_dummy_discharge_end_time_store', 'options') }}"
+        select_option:
+          - action: input_select.select_option
+            target:
+              entity_id: input_select.predbat_dummy_discharge_end_time_store
+            data:
+              option: "{{ option }}"
+  - switch:
+      - name: Predbat Dummy Scheduled Charge Enable
+        unique_id: predbat_dummy_scheduled_charge_enable
+        state: "{{ states('input_boolean.predbat_dummy_scheduled_charge_enable_store') }}"
+        turn_on:
+          - action: input_boolean.turn_on
+            target:
+              entity_id: input_boolean.predbat_dummy_scheduled_charge_enable_store
+        turn_off:
+          - action: input_boolean.turn_off
+            target:
+              entity_id: input_boolean.predbat_dummy_scheduled_charge_enable_store
+      - name: Predbat Dummy Scheduled Discharge Enable
+        unique_id: predbat_dummy_scheduled_discharge_enable
+        state: "{{ states('input_boolean.predbat_dummy_scheduled_discharge_enable_store') }}"
+        turn_on:
+          - action: input_boolean.turn_on
+            target:
+              entity_id: input_boolean.predbat_dummy_scheduled_discharge_enable_store
+        turn_off:
+          - action: input_boolean.turn_off
+            target:
+              entity_id: input_boolean.predbat_dummy_scheduled_discharge_enable_store

--- a/dev/predbat-entrypoint.sh
+++ b/dev/predbat-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Waits for the ha-bootstrap container to publish a token, renders apps.yaml from
+# the dev/apps.dev.yaml.tmpl template, then hands off to Predbat's standalone runner.
+set -eu
+
+TOKEN_FILE="${TOKEN_FILE:-/shared/ha_token.json}"
+APPS_TEMPLATE="${APPS_TEMPLATE:-/app/apps.dev.yaml.tmpl}"
+APPS_FILE="${PREDBAT_APPS_FILE:-/app/apps.yaml}"
+
+echo "Waiting for ${TOKEN_FILE}..."
+until [ -f "$TOKEN_FILE" ]; do
+    sleep 1
+done
+
+python3 - "$TOKEN_FILE" "$APPS_TEMPLATE" "$APPS_FILE" <<'EOF'
+import json
+import sys
+
+token_file, template_file, out_file = sys.argv[1:4]
+
+with open(token_file) as f:
+    token = json.load(f)
+
+with open(template_file) as f:
+    rendered = f.read()
+
+rendered = rendered.replace("{{HA_URL}}", token["ha_url"]).replace("{{HA_KEY}}", token["ha_key"])
+
+with open(out_file, "w") as f:
+    f.write(rendered)
+EOF
+
+echo "Wrote ${APPS_FILE}, starting Predbat..."
+export PREDBAT_APPS_FILE="$APPS_FILE"
+cd /app
+exec python3 predbat/hass.py

--- a/dev/up.py
+++ b/dev/up.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Brings up the Predbat dev environment (dummy Home Assistant + auto-provisioned
+token + Predbat) and opens both web UIs once they're ready.
+
+Usage: dev/up.py   (run from anywhere - it cd's to the repo root for you)
+"""
+
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPOSE_FILE = "docker-compose.dev.yml"
+
+
+def wait_for_url(url, timeout_seconds):
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(url, timeout=5)
+            return True
+        except (urllib.error.URLError, ConnectionError, TimeoutError):
+            time.sleep(2)
+    return False
+
+
+def main():
+    subprocess.run(["docker", "compose", "-f", COMPOSE_FILE, "up", "-d", "--build"], cwd=REPO_ROOT, check=True)
+
+    print("Waiting for Home Assistant...")
+    if not wait_for_url("http://localhost:8123/", 120):
+        print("Warn: Home Assistant did not come up within 120s - check: docker compose -f docker-compose.dev.yml logs homeassistant", file=sys.stderr)
+
+    print("Waiting for Predbat...")
+    if not wait_for_url("http://localhost:5052/", 180):
+        print("Warn: Predbat did not come up within 180s - check: docker compose -f docker-compose.dev.yml logs predbat ha-bootstrap", file=sys.stderr)
+
+    webbrowser.open("http://localhost:8123/")
+    webbrowser.open("http://localhost:5052/")
+
+    print("Home Assistant: http://localhost:8123/  (dev / devdevdev1)")
+    print("Predbat web UI: http://localhost:5052/")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError:
+        print("docker compose up failed", file=sys.stderr)
+        sys.exit(1)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,47 @@
+# Disposable dev environment: a throwaway Home Assistant instance pre-populated
+# with dummy inverter entities, auto-onboarded, and Predbat running against it.
+#
+# Usage: dev/up.py, or plain `docker compose -f docker-compose.dev.yml up`.
+# Reset to a clean instance with `docker compose -f docker-compose.dev.yml down -v`.
+
+services:
+  homeassistant:
+    image: homeassistant/home-assistant:stable
+    volumes:
+      - ./dev/ha_config:/config
+    ports:
+      - "8123:8123"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8123/')\" || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  ha-bootstrap:
+    build:
+      context: .
+      dockerfile: dev/Dockerfile.bootstrap
+    environment:
+      HA_URL: "http://homeassistant:8123"
+    volumes:
+      - ./dev/shared:/shared
+    depends_on:
+      homeassistant:
+        condition: service_healthy
+
+  predbat:
+    build:
+      context: .
+      dockerfile: dev/Dockerfile.predbat
+    environment:
+      TOKEN_FILE: "/shared/ha_token.json"
+    volumes:
+      - ./dev/shared:/shared
+      - ./apps/predbat:/app/predbat
+    ports:
+      - "5052:5052"
+    restart: unless-stopped
+    depends_on:
+      ha-bootstrap:
+        condition: service_completed_successfully


### PR DESCRIPTION
@springfall2008 I've done a quick spike and was wondering if you think something like this would be useful at all.

Essentially it will bring up a few docker containers to allow you to quickly test a change you're making in a real home assistant, you just run dev/up.py and it'll get everything running, onboard home assistant and open two browser tabs to home assistant and predbat. I timed startup to 23 seconds after you have built and downloaded the docker containers, it also support hot loading ish so editing files is picked up by predbat, but obviously it will restart.

I'm imagining you could bring up a container with entities for each of the example yamls, so you can test solis, givenergy, etc. separately. But right now it's just super basic.