### PR TITLE
fix(solis): a real batteryType beats a "No Battery" batteryList entry

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1362,9 +1362,18 @@ class SolisAPI(ComponentBase, OAuthMixin):
         (batteryTypeCode is '0000' in this state, against '0001'/'0063' for real packs, but it is
         left out on purpose: a code that means "unknown" on some firmware would silently ignore a
         working battery, and the names above already cover every case seen.)
+
+        A top-level batteryType that names a real pack settles it on its own: batteryList is only
+        consulted when batteryType is absent. Accounts exist whose batteryType is 'PYLON_LV' with a
+        live, healthy pack while batteryList still carries a "No Battery" entry, and letting the
+        list win there drops a working battery. Both no-battery accounts observed so far state it
+        in batteryType as well, so nothing that motivated checking the list is lost by this.
         """
-        if str(detail.get("batteryType", "")).strip().lower() == "no battery":
+        battery_type = str(detail.get("batteryType", "")).strip()
+        if battery_type.lower() == "no battery":
             return True
+        if battery_type:
+            return False
         for entry in detail.get("batteryList") or []:
             if not isinstance(entry, dict):
                 continue

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -1298,6 +1298,35 @@ async def test_automatic_config_skips_no_battery_named_only_in_battery_list():
     return failed
 
 
+async def test_automatic_config_keeps_battery_when_battery_list_contradicts_battery_type():
+    """A real batteryType beats a "No Battery" batteryList entry - the pack is there.
+
+    Seen in the field: batteryType 'PYLON_LV' with SoC 72%, SoH 94% and 50.31V on the wire, while
+    batteryList still carried a "No Battery" entry. Believing the list drops the inverter, and a
+    dropped inverter means automatic_config sets no args at all - so Predbat then raises
+    "unable to read charge window time" every cycle and the installation is dead until someone
+    intervenes. Costly enough that a disagreement must resolve in favour of the battery existing.
+    """
+    failed = False
+    print("**** Testing automatic_config keeps a real battery when batteryList contradicts batteryType ****")
+
+    detail = {
+        "batteryType": "PYLON_LV",
+        "batteryTypeCode": "0001",
+        "batteryHealthSoh": 94.0,
+        "batteryList": [{"batteryTypeName": "No Battery", "battSn": "", "noBattery": True, "batteryVoltage": 0.0}],
+    }
+    recorded, _ = await _run_automatic_config({"6000000000000002": detail})
+
+    if recorded.get("num_inverters") != 1:
+        print("ERROR: batteryType 'PYLON_LV' must win over a 'No Battery' batteryList entry, got num_inverters={}".format(recorded.get("num_inverters")))
+        failed = True
+
+    if not failed:
+        print("PASSED: automatic_config keeps a real battery when batteryList contradicts batteryType")
+    return failed
+
+
 async def test_automatic_config_keeps_real_battery_reporting_zero_soh():
     """SoH 0 on a real pack is a valid SolisCloud response - such an inverter must stay enrolled."""
     failed = False
@@ -1337,6 +1366,7 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_automatic_config_skips_no_battery_inverter())
         failed |= asyncio.run(test_automatic_config_skips_no_battery_on_alt_firmware())
         failed |= asyncio.run(test_automatic_config_skips_no_battery_named_only_in_battery_list())
+        failed |= asyncio.run(test_automatic_config_keeps_battery_when_battery_list_contradicts_battery_type())
         failed |= asyncio.run(test_automatic_config_keeps_real_battery_reporting_zero_soh())
         failed |= asyncio.run(test_read_cid())
         failed |= asyncio.run(test_read_batch())


### PR DESCRIPTION
## Problem

`_reports_no_battery()` returns True for inverters that have a working battery, which drops them from `automatic_config()`. The log line it emits contradicts itself:

```
Solis API: Skipping inverter <SN> - Solis Cloud reports no battery attached (batteryType 'PYLON_LV'),
so it will not be managed as a battery inverter
```

`PYLON_LV` is a real Pylontech pack — one of the two values cited in 8ed7908 as a *positive* identification. Seen on two separate accounts, both `PYLON_LV`, both with healthy battery telemetry at the moment auto-config declared no battery: SoC 72%, SoH 94%, 50.31V, ~4 kWh charged that day.

Since `batteryType` names a real pack, the first check isn't what fires — the verdict comes from the `batteryList` loop, where an entry says `noBattery: true` / `batteryTypeName: "No Battery"` on an inverter whose battery is demonstrably present.

## Why the failure is total rather than degraded

`is_battery_inverter()` only withholds control writes, which is recoverable. But `automatic_config()` uses the same predicate for enrolment, and an empty `batteries` list means it returns having set **no args at all** — not just battery-related ones. So `charge_start_time` is never populated and `inverter.py` raises on every subsequent cycle:

```
Error: Inverter 0 unable to read charge window time - no source is configured
(set givtcp_rest, ge_cloud_direct, or charge_start_time/charge_start_hour in apps.yaml)
```

That path is deliberately fatal on the reasoning that it's a permanent apps.yaml gap. Here it isn't — and the message names `givtcp_rest` / `ge_cloud_direct`, neither of which a Solis Cloud user can act on. Auto-config also only runs on the first cycle, so nothing re-evaluates and a restart does not clear it.

## Fix

Let a top-level `batteryType` naming a real pack settle it on its own; consult `batteryList` only when `batteryType` is absent.

This keeps everything that motivated 8ed7908. Both no-battery accounts observed there state it in `batteryType` as well, so both fixtures still return True unchanged, as does the case where "No Battery" is named only inside `batteryList` (that fixture has no top-level `batteryType` at all, so it still falls through to the list).

## Tests

Adds `test_automatic_config_keeps_battery_when_battery_list_contradicts_battery_type` — the conflict case, which had no coverage. It fails on `main` (`num_inverters=None`, reproducing the production symptom exactly) and passes with the fix. The full Solis suite passes unchanged.

This complements the existing no-battery tests rather than replacing them; a disagreement between the two sources now resolves in favour of the battery existing, which is the cheaper way to be wrong.