### PR TITLE
fix(inverter): export window must tolerate an empty source like the charge window

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1629,14 +1629,28 @@ class Inverter:
         elif "discharge_start_time" in self.base.args:
             discharge_start = time_string_to_stamp(self.base.get_arg("discharge_start_time", index=self.id))
             discharge_end = time_string_to_stamp(self.base.get_arg("discharge_end_time", index=self.id))
+        elif self.rest_api or self.base.get_arg("ge_cloud_direct", False, indirect=False):
+            # Same reasoning as the charge window above, and it has to be here too or that fix is
+            # defeated: on a cloud fetch failure the charge window degrades gracefully and then
+            # this branch crashes the whole update loop on the very same cycle, so the inverter
+            # never recovers either way. A configured-but-empty source is transient, so fall
+            # through to the safe-defaults/retry handling below.
+            discharge_start = None
+            discharge_end = None
         else:
-            self.log("Error: Inverter {} unable to read Export window as neither REST or discharge_start_time are set".format(self.id))
-            self.base.record_status("Error: Inverter {} unable to read Export window as neither REST or discharge_start_time are set".format(self.id), had_errors=True)
-            raise ValueError
+            # No data source configured at all - a permanent setup gap, handled as such.
+            message = "Error: Inverter {} unable to read Export window - no source is configured (set givtcp_rest, ge_cloud_direct, or discharge_start_time in apps.yaml)".format(self.id)
+            self.log(message)
+            self.base.record_status(message, had_errors=True)
+            raise ValueError(message)
 
         if discharge_start is None or discharge_end is None:
-            self.log("Warn: Inverter {} unable to read Export window as discharge_start or discharge_end is None, will retry next update".format(self.id))
-            self.base.record_status("Warn: Inverter {} unable to read Export window, will retry next update".format(self.id), had_errors=True)
+            # Name the source that came back empty, as the charge window does - "discharge_start is
+            # None" sends users to apps.yaml, which is the one thing that is fine here.
+            source = "GE Cloud" if (not self.rest_api and self.base.get_arg("ge_cloud_direct", False, indirect=False)) else "REST"
+            hint = "check the {} credentials and that the account still has this inverter attached".format(source)
+            self.log("Warn: Inverter {} unable to read Export window - {} returned no data, {}, will retry next update".format(self.id, source, hint))
+            self.base.record_status("Warn: Inverter {} unable to read Export window - {} returned no data, {}".format(self.id, source, hint), had_errors=True)
             # Set safe defaults to allow graceful recovery on next update
             self.discharge_enable_time = False
             self.discharge_start_time_minutes = 0

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1623,13 +1623,20 @@ class Inverter:
         # Construct discharge window from GivTCP settings
         self.export_window = []
 
+        # Record which source we read from, rather than re-deriving it below. Three branches
+        # reach the empty-value handling and only one of them is REST, so a ternary over
+        # rest_api/ge_cloud_direct mislabels the configured-entity case and sends the user to
+        # check credentials for a source they are not using.
         if self.rest_data:
+            export_source = "REST"
             discharge_start = time_string_to_stamp(self.rest_data["Timeslots"]["Discharge_start_time_slot_1"])
             discharge_end = time_string_to_stamp(self.rest_data["Timeslots"]["Discharge_end_time_slot_1"])
         elif "discharge_start_time" in self.base.args:
+            export_source = "discharge_start_time"
             discharge_start = time_string_to_stamp(self.base.get_arg("discharge_start_time", index=self.id))
             discharge_end = time_string_to_stamp(self.base.get_arg("discharge_end_time", index=self.id))
         elif self.rest_api or self.base.get_arg("ge_cloud_direct", False, indirect=False):
+            export_source = "REST" if self.rest_api else "GE Cloud"
             # Same reasoning as the charge window above, and it has to be here too or that fix is
             # defeated: on a cloud fetch failure the charge window degrades gracefully and then
             # this branch crashes the whole update loop on the very same cycle, so the inverter
@@ -1647,14 +1654,22 @@ class Inverter:
         if discharge_start is None or discharge_end is None:
             # Name the source that came back empty, as the charge window does - "discharge_start is
             # None" sends users to apps.yaml, which is the one thing that is fine here.
-            source = "GE Cloud" if (not self.rest_api and self.base.get_arg("ge_cloud_direct", False, indirect=False)) else "REST"
-            hint = "check the {} credentials and that the account still has this inverter attached".format(source)
-            self.log("Warn: Inverter {} unable to read Export window - {} returned no data, {}, will retry next update".format(self.id, source, hint))
-            self.base.record_status("Warn: Inverter {} unable to read Export window - {} returned no data, {}".format(self.id, source, hint), had_errors=True)
-            # Set safe defaults to allow graceful recovery on next update
+            if export_source == "discharge_start_time":
+                hint = "check the discharge_start_time/discharge_end_time entities in apps.yaml are reporting"
+            else:
+                hint = "check the {} credentials and that the account still has this inverter attached".format(export_source)
+            self.log("Warn: Inverter {} unable to read Export window - {} returned no data, {}, will retry next update".format(self.id, export_source, hint))
+            self.base.record_status("Warn: Inverter {} unable to read Export window - {} returned no data, {}".format(self.id, export_source, hint), had_errors=True)
+            # Safe defaults must be INERT, not merely disabled. forecast_minutes parks the window
+            # beyond the horizon, exactly as the charge window does. The previous 0/0 is midnight,
+            # i.e. in the PAST: execute.py takes `discharge_start_time_minutes <= minutes_now` as
+            # "the window has begun", which is trivially true at 0, so a discharge command gets
+            # backdated to the start of the day. That was survivable while this path was reached
+            # only rarely; the transient branch above makes it reachable on any cloud hiccup, so
+            # the landing state has to be genuinely inert or this trades a crash for a bad write.
             self.discharge_enable_time = False
-            self.discharge_start_time_minutes = 0
-            self.discharge_end_time_minutes = 0
+            self.discharge_start_time_minutes = self.base.forecast_minutes
+            self.discharge_end_time_minutes = self.base.forecast_minutes
             self.track_discharge_start = "00:00:00"
             self.track_discharge_end = "00:00:00"
         else:

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1692,6 +1692,76 @@ def test_charge_window_ge_cloud_configured_but_no_data_yet(test_name, my_predbat
     return failed
 
 
+def test_export_window_ge_cloud_configured_but_no_data_yet(test_name, my_predbat, dummy_items):
+    """
+    The export window must tolerate a configured-but-empty source exactly as the charge window does.
+
+    The charge window gained that tolerance, but the export window a hundred lines below kept a bare
+    `raise ValueError`. Both read from the same cloud fetch, so on a GE Cloud failure the charge
+    window sets safe defaults and retries and then the export window kills the update loop on the
+    very same cycle - the charge-side fix never gets a chance to take effect. Seen live: a GivEnergy
+    instance logging "GE Cloud returned no data ... will retry next update" immediately followed by
+    the export window raising, every cycle, for two weeks.
+
+    The bare raise also carried no message, so predbat.status read "Error: Exception raised " with
+    nothing after it, telling support nothing at all.
+    """
+    failed = False
+    print(f"**** Running Test: {test_name} ****")
+
+    inv = Inverter(my_predbat, 0)
+    inv.sleep = dummy_sleep
+    inv.inv_has_charge_enable_time = True
+    inv.rest_api = None
+    inv.rest_data = None
+
+    # Drop both windows' args: ge_cloud_direct configures neither, so this is what a cloud-backed
+    # instance actually looks like when the fetch has come back empty.
+    original_charge_start_time = my_predbat.args.pop("charge_start_time", None)
+    original_charge_end_time = my_predbat.args.pop("charge_end_time", None)
+    original_discharge_start_time = my_predbat.args.pop("discharge_start_time", None)
+    original_discharge_end_time = my_predbat.args.pop("discharge_end_time", None)
+    original_ge_cloud_direct = my_predbat.args.get("ge_cloud_direct", None)
+    my_predbat.args["ge_cloud_direct"] = True
+    dummy_items["switch.scheduled_charge_enable"] = "on"
+
+    def restore():
+        """Restore the config this test mutated so later tests are unaffected."""
+        if original_charge_start_time is not None:
+            my_predbat.args["charge_start_time"] = original_charge_start_time
+        if original_charge_end_time is not None:
+            my_predbat.args["charge_end_time"] = original_charge_end_time
+        if original_discharge_start_time is not None:
+            my_predbat.args["discharge_start_time"] = original_discharge_start_time
+        if original_discharge_end_time is not None:
+            my_predbat.args["discharge_end_time"] = original_discharge_end_time
+        if original_ge_cloud_direct is None:
+            my_predbat.args.pop("ge_cloud_direct", None)
+        else:
+            my_predbat.args["ge_cloud_direct"] = original_ge_cloud_direct
+
+    try:
+        inv.update_status(my_predbat.minutes_now)
+    except ValueError as e:
+        print(f"ERROR: {test_name} - update_status should not raise while a configured GE Cloud source just hasn't returned data yet, got ValueError({e})")
+        restore()
+        return True
+
+    # Same safe defaults the discharge_start-is-None path already sets
+    if inv.discharge_enable_time != False:
+        print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
+        failed = True
+    if inv.discharge_start_time_minutes != 0:
+        print(f"ERROR: {test_name} - discharge_start_time_minutes should be 0, got {inv.discharge_start_time_minutes}")
+        failed = True
+    if inv.discharge_end_time_minutes != 0:
+        print(f"ERROR: {test_name} - discharge_end_time_minutes should be 0, got {inv.discharge_end_time_minutes}")
+        failed = True
+
+    restore()
+    return failed
+
+
 def test_discharge_window_none_illegal_time(test_name, my_predbat, dummy_items):
     """
     Test discharge window handling when time is illegal (e.g., 'unknown')
@@ -3444,6 +3514,7 @@ charge_start_service:
         return failed
 
     failed |= test_charge_window_ge_cloud_configured_but_no_data_yet("charge_window_ge_cloud_configured_but_no_data_yet", my_predbat, dummy_items)
+    failed |= test_export_window_ge_cloud_configured_but_no_data_yet("export_window_ge_cloud_configured_but_no_data_yet", my_predbat, dummy_items)
     if failed:
         return failed
 

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1751,11 +1751,71 @@ def test_export_window_ge_cloud_configured_but_no_data_yet(test_name, my_predbat
     if inv.discharge_enable_time != False:
         print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
         failed = True
-    if inv.discharge_start_time_minutes != 0:
-        print(f"ERROR: {test_name} - discharge_start_time_minutes should be 0, got {inv.discharge_start_time_minutes}")
+    # Inert, not merely disabled: 0 is midnight, which execute.py reads as "already started".
+    if inv.discharge_start_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - discharge_start_time_minutes should be {my_predbat.forecast_minutes} (inert), got {inv.discharge_start_time_minutes}")
         failed = True
-    if inv.discharge_end_time_minutes != 0:
-        print(f"ERROR: {test_name} - discharge_end_time_minutes should be 0, got {inv.discharge_end_time_minutes}")
+    if inv.discharge_end_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - discharge_end_time_minutes should be {my_predbat.forecast_minutes}, got {inv.discharge_end_time_minutes}")
+        failed = True
+
+    # The retry warning is what a user actually sees for this failure, so it must name GE Cloud
+    # rather than sending them to apps.yaml - the same misdirection the charge window fixed.
+    if "GE Cloud" not in my_predbat.current_status:
+        print(f"ERROR: {test_name} - status should name GE Cloud as the source that returned no data, got: {my_predbat.current_status}")
+        failed = True
+
+    restore()
+    return failed
+
+
+def test_export_window_no_source_configured_raises(test_name, my_predbat, dummy_items):
+    """With no source configured at all this is a real apps.yaml gap and must still raise.
+
+    The transient branch must not swallow a genuine setup gap - an instance that can never
+    produce an export window should say so, not retry silently forever.
+    """
+    failed = False
+    print(f"**** Running Test: {test_name} ****")
+
+    inv = Inverter(my_predbat, 0)
+    inv.sleep = dummy_sleep
+    inv.inv_has_charge_enable_time = True
+    inv.rest_api = None
+    inv.rest_data = None
+
+    original_charge_start_time = my_predbat.args.pop("charge_start_time", None)
+    original_charge_end_time = my_predbat.args.pop("charge_end_time", None)
+    original_discharge_start_time = my_predbat.args.pop("discharge_start_time", None)
+    original_discharge_end_time = my_predbat.args.pop("discharge_end_time", None)
+    original_ge_cloud_direct = my_predbat.args.pop("ge_cloud_direct", None)
+    dummy_items["switch.scheduled_charge_enable"] = "on"
+
+    def restore():
+        """Restore the config this test mutated so later tests are unaffected."""
+        for key, value in (
+            ("charge_start_time", original_charge_start_time),
+            ("charge_end_time", original_charge_end_time),
+            ("discharge_start_time", original_discharge_start_time),
+            ("discharge_end_time", original_discharge_end_time),
+            ("ge_cloud_direct", original_ge_cloud_direct),
+        ):
+            if value is not None:
+                my_predbat.args[key] = value
+
+    raised = False
+    try:
+        inv.update_status(my_predbat.minutes_now)
+    except ValueError as e:
+        raised = True
+        # The bare `raise ValueError` this replaces produced "Error: Exception raised " with
+        # nothing after it, which told support nothing at all.
+        if not str(e):
+            print(f"ERROR: {test_name} - the raise must carry a message, got an empty ValueError")
+            failed = True
+
+    if not raised:
+        print(f"ERROR: {test_name} - no source configured is a permanent setup gap and must raise")
         failed = True
 
     restore()
@@ -1786,11 +1846,12 @@ def test_discharge_window_none_illegal_time(test_name, my_predbat, dummy_items):
     if inv.discharge_enable_time != False:
         print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
         failed = True
-    if inv.discharge_start_time_minutes != 0:
-        print(f"ERROR: {test_name} - discharge_start_time_minutes should be 0, got {inv.discharge_start_time_minutes}")
+    # Inert, not merely disabled: 0 is midnight, which execute.py reads as "already started".
+    if inv.discharge_start_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - discharge_start_time_minutes should be {my_predbat.forecast_minutes} (inert), got {inv.discharge_start_time_minutes}")
         failed = True
-    if inv.discharge_end_time_minutes != 0:
-        print(f"ERROR: {test_name} - discharge_end_time_minutes should be 0, got {inv.discharge_end_time_minutes}")
+    if inv.discharge_end_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - discharge_end_time_minutes should be {my_predbat.forecast_minutes} (inert), got {inv.discharge_end_time_minutes}")
         failed = True
     if inv.track_discharge_start != "00:00:00":
         print(f"ERROR: {test_name} - track_discharge_start should be '00:00:00', got {inv.track_discharge_start}")
@@ -1865,11 +1926,12 @@ def test_discharge_window_invalid_format_time(test_name, my_predbat, dummy_items
     if inv.discharge_enable_time != False:
         print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
         failed = True
-    if inv.discharge_start_time_minutes != 0:
-        print(f"ERROR: {test_name} - discharge_start_time_minutes should be 0, got {inv.discharge_start_time_minutes}")
+    # Inert, not merely disabled: 0 is midnight, which execute.py reads as "already started".
+    if inv.discharge_start_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - discharge_start_time_minutes should be {my_predbat.forecast_minutes} (inert), got {inv.discharge_start_time_minutes}")
         failed = True
-    if inv.discharge_end_time_minutes != 0:
-        print(f"ERROR: {test_name} - discharge_end_time_minutes should be 0, got {inv.discharge_end_time_minutes}")
+    if inv.discharge_end_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - discharge_end_time_minutes should be {my_predbat.forecast_minutes} (inert), got {inv.discharge_end_time_minutes}")
         failed = True
     if inv.track_discharge_start != "00:00:00":
         print(f"ERROR: {test_name} - track_discharge_start should be '00:00:00', got {inv.track_discharge_start}")
@@ -1906,11 +1968,12 @@ def test_discharge_window_none_value(test_name, my_predbat, dummy_items):
     if inv.discharge_enable_time != False:
         print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
         failed = True
-    if inv.discharge_start_time_minutes != 0:
-        print(f"ERROR: {test_name} - discharge_start_time_minutes should be 0, got {inv.discharge_start_time_minutes}")
+    # Inert, not merely disabled: 0 is midnight, which execute.py reads as "already started".
+    if inv.discharge_start_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - discharge_start_time_minutes should be {my_predbat.forecast_minutes} (inert), got {inv.discharge_start_time_minutes}")
         failed = True
-    if inv.discharge_end_time_minutes != 0:
-        print(f"ERROR: {test_name} - discharge_end_time_minutes should be 0, got {inv.discharge_end_time_minutes}")
+    if inv.discharge_end_time_minutes != my_predbat.forecast_minutes:
+        print(f"ERROR: {test_name} - discharge_end_time_minutes should be {my_predbat.forecast_minutes} (inert), got {inv.discharge_end_time_minutes}")
         failed = True
     if inv.track_discharge_start != "00:00:00":
         print(f"ERROR: {test_name} - track_discharge_start should be '00:00:00', got {inv.track_discharge_start}")
@@ -3515,6 +3578,7 @@ charge_start_service:
 
     failed |= test_charge_window_ge_cloud_configured_but_no_data_yet("charge_window_ge_cloud_configured_but_no_data_yet", my_predbat, dummy_items)
     failed |= test_export_window_ge_cloud_configured_but_no_data_yet("export_window_ge_cloud_configured_but_no_data_yet", my_predbat, dummy_items)
+    failed |= test_export_window_no_source_configured_raises("export_window_no_source_configured_raises", my_predbat, dummy_items)
     if failed:
         return failed
 


### PR DESCRIPTION
## Problem

The charge window has four branches: REST data, a configured `charge_start_time`, **a configured-but-empty source** (`rest_api` or `ge_cloud_direct`) which sets safe defaults and retries, and finally a raise for a genuine apps.yaml gap.

The export window a hundred lines below has only three — the configured-but-empty branch is missing:

```python
else:
    self.log("Error: Inverter {} unable to read Export window as neither REST or discharge_start_time are set"...)
    self.base.record_status(...)
    raise ValueError          # bare, no message
```

Both windows are populated from the same fetch, so the charge-side tolerance cannot actually take effect. When GE Cloud returns nothing, the charge window recovers exactly as intended and then the export window kills the update loop on the very same cycle.

Seen live on a GivEnergy instance, these two lines back to back every cycle for two weeks:

```
Warn: Inverter 0 unable to read charge window time - GE Cloud returned no data,
      check the GE Cloud credentials and that the account still has this inverter attached,
      will retry next update
Error: Inverter 0 unable to read Export window as neither REST or discharge_start_time are set
```

The bare `raise ValueError` carried no message, so `record_status` wrote `"Error: Exception raised "` with nothing after it. The status entity is the main thing support reads, and it said nothing about what had failed — the underlying cause (expired GE Cloud credentials) was invisible from there.

## Fix

Mirror the charge window:

- Add the `elif self.rest_api or ge_cloud_direct:` branch so a configured-but-empty source falls through to the safe-defaults/retry path that already exists just below.
- Name the source that came back empty in the retry warning, as the charge window does — "discharge_start is None" sends users to apps.yaml, which is the one thing that is fine here.
- Give the remaining genuine-setup-gap raise a message, so the status entity says something useful.

The permanent-setup-gap behaviour is unchanged: no source configured at all still raises, it just says why now.

## Tests

Adds `test_export_window_ge_cloud_configured_but_no_data_yet`, mirroring the existing `test_charge_window_ge_cloud_configured_but_no_data_yet`. It drops both windows' args (which is what a cloud-backed instance actually looks like, since `ge_cloud_direct` configures neither) and asserts `update_status` does not raise and sets the safe defaults.

On `main` it fails with `ValueError()` — literally empty, which is the reported symptom exactly. It passes with the fix.

`inverter`, `inverter_multi`, `multi_inverter_status`, `ge_cloud`, `balance_inverters` and `inverter_config_sensor` all pass.