### PR TITLE
fix: backfill InDay chart's Predicted line for elapsed minutes under Load ML

### DIFF
--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -815,7 +815,6 @@ class Fetch:
             load_ml_forecast = self.fetch_ml_load_forecast(self.now_utc)
             if load_ml_forecast:
                 self.load_forecast_only = True  # Use only ML forecast for load if enabled and we have data
-                self.load_ml_forecast_active = True  # Load ML is genuinely the active source this cycle, not just running in the background
 
         # Fetch extra load forecast
         self.load_forecast, self.load_forecast_array = self.fetch_extra_load_forecast(self.now_utc, load_ml_forecast)
@@ -1137,8 +1136,10 @@ class Fetch:
                 self.log("Using weighted-bucket historical load forecast over {} days".format(min(self.load_minutes_age, self.max_days_previous - 1)))
 
         # Where Load ML genuinely supplied this cycle's forecast, backfill the elapsed part of today
-        # with its own past predictions (the weighted-bucket forecast above is skipped in that case)
-        self.apply_load_ml_forecast_history(self.now_utc)
+        # with its own past predictions (the weighted-bucket forecast above is skipped in that case).
+        # load_ml_forecast is this cycle's own fetch result from earlier in this function, so there is
+        # no cross-cycle state that could leave a stale "ML was active" reading behind (#4762 review).
+        self.apply_load_ml_forecast_history(self.now_utc, load_ml_forecast)
 
         # Load today vs actual
         if self.load_minutes:
@@ -2524,21 +2525,23 @@ class Fetch:
         load_forecast[horizon_end] = dp4(cumulative)
         return load_forecast
 
-    def apply_load_ml_forecast_history(self, now_utc):
+    def apply_load_ml_forecast_history(self, now_utc, ml_forecast=None):
         """
         Backfill the elapsed part of today with genuine past Load ML predictions.
 
-        Only takes effect when Load ML is genuinely the active forecast source this cycle
-        (self.load_ml_forecast_active) - a Load ML component running in the background without
-        being selected as the forecast source (load_ml_enable/load_ml_source) must not influence
-        the chart, so it has no effect and the weighted-bucket historical forecast above (skipped
-        while Load ML owns load_forecast_only) is what would apply instead. Load ML's own forecast
-        entity only ever publishes predictions from "now" onward (load_ml_component.py
-        _publish_entity), so without this the already-elapsed part of today has no forecast data
-        at all and load_today_comparison's Predicted chart series sits at zero from midnight until
-        "now" (batpred#4750).
+        Only takes effect when Load ML is genuinely the active forecast source this cycle, which is
+        exactly "fetch_sensor_data() fetched a non-empty ml_forecast this cycle" - a Load ML component
+        running in the background without being selected as the forecast source
+        (load_ml_enable/load_ml_source) must not influence the chart, so it has no effect and the
+        weighted-bucket historical forecast above (skipped while Load ML owns load_forecast_only) is
+        what would apply instead. This is passed in rather than held on self so there is no cycle-scoped
+        flag whose correctness depends on fetch_config_options() always running first (#4762 review).
+        Load ML's own forecast entity only ever publishes predictions from "now" onward
+        (load_ml_component.py _publish_entity), so without this the already-elapsed part of today has no
+        forecast data at all and load_today_comparison's Predicted chart series sits at zero from
+        midnight until "now" (batpred#4750).
         """
-        if not self.load_ml_forecast_active:
+        if not ml_forecast:
             return
         h1_forecast = self.fetch_ml_load_forecast_history(now_utc)
         for minute, value in h1_forecast.items():
@@ -2696,7 +2699,6 @@ class Fetch:
         self.holiday_days_left = self.get_arg("holiday_days_left")
         self.holiday_load_scaling = self.get_arg("holiday_load_scaling", 0.7)
         self.load_forecast_only = self.get_arg("load_forecast_only", False)
-        self.load_ml_forecast_active = False  # Set True in fetch_sensor_data() only when Load ML genuinely supplies this cycle's forecast
 
         self.days_previous = self.get_arg("days_previous", [7])
         self.days_previous_weight = self.get_arg("days_previous_weight", [1 for i in range(len(self.days_previous))])

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -815,6 +815,7 @@ class Fetch:
             load_ml_forecast = self.fetch_ml_load_forecast(self.now_utc)
             if load_ml_forecast:
                 self.load_forecast_only = True  # Use only ML forecast for load if enabled and we have data
+                self.load_ml_forecast_active = True  # Load ML is genuinely the active source this cycle, not just running in the background
 
         # Fetch extra load forecast
         self.load_forecast, self.load_forecast_array = self.fetch_extra_load_forecast(self.now_utc, load_ml_forecast)
@@ -1134,6 +1135,10 @@ class Fetch:
                     self.load_forecast[minute] = self.load_forecast.get(minute, 0) + value
                 self.load_forecast_array.append(hist_forecast)
                 self.log("Using weighted-bucket historical load forecast over {} days".format(min(self.load_minutes_age, self.max_days_previous - 1)))
+
+        # Where Load ML genuinely supplied this cycle's forecast, backfill the elapsed part of today
+        # with its own past predictions (the weighted-bucket forecast above is skipped in that case)
+        self.apply_load_ml_forecast_history(self.now_utc)
 
         # Load today vs actual
         if self.load_minutes:
@@ -2319,6 +2324,54 @@ class Fetch:
                     return load_forecast
         return {}
 
+    def fetch_ml_load_forecast_history(self, now_utc):
+        """
+        Reconstruct a genuine past Load ML forecast for the elapsed part of today.
+
+        sensor.<prefix>_load_ml_stats publishes a load_today_h1 attribute every cycle: the model's
+        cumulative-load-since-midnight prediction for 60 minutes after that cycle ran. Shifting each
+        recorded reading's timestamp forward by that same 60-minute lead turns the entity's history
+        into a genuine record of what the model predicted for each past target minute - unlike a
+        same-time-of-day historical average, this is the model's own past output (batpred#4750).
+
+        Covers 2 days of history so a reading from shortly before local midnight (whose target minute
+        falls just after midnight) is included, rather than leaving the first hour of the day as a gap.
+        """
+        entity_id = "sensor." + self.prefix + "_load_ml_stats"
+        history = self.get_history_wrapper(entity_id, days=2, required=False)
+        if not history:
+            return {}
+
+        data_array = []
+        for record in history[0]:
+            attributes = record.get("attributes") or {}
+            value = attributes.get("load_today_h1")
+            last_updated = record.get("last_updated")
+            if value is None or not last_updated:
+                continue
+            try:
+                shifted_time = str2time(last_updated) + timedelta(minutes=60)
+            except (ValueError, TypeError):
+                continue
+            data_array.append({"energy": value, "last_updated": shifted_time.isoformat()})
+
+        if not data_array:
+            return {}
+
+        load_forecast, _ = minute_data(
+            data_array,
+            self.forecast_days + 1,
+            self.midnight_utc,
+            "energy",
+            "last_updated",
+            backwards=False,
+            clean_increment=False,
+            smoothing=True,
+            divide_by=1.0,
+            scale=1.0,
+        )
+        return load_forecast or {}
+
     def get_holiday_minutes(self, now_utc, num_days):
         """
         Build a per-minute history of the holiday_days_left value (indexed by minutes-ago) from the recorded
@@ -2471,6 +2524,27 @@ class Fetch:
         load_forecast[horizon_end] = dp4(cumulative)
         return load_forecast
 
+    def apply_load_ml_forecast_history(self, now_utc):
+        """
+        Backfill the elapsed part of today with genuine past Load ML predictions.
+
+        Only takes effect when Load ML is genuinely the active forecast source this cycle
+        (self.load_ml_forecast_active) - a Load ML component running in the background without
+        being selected as the forecast source (load_ml_enable/load_ml_source) must not influence
+        the chart, so it has no effect and the weighted-bucket historical forecast above (skipped
+        while Load ML owns load_forecast_only) is what would apply instead. Load ML's own forecast
+        entity only ever publishes predictions from "now" onward (load_ml_component.py
+        _publish_entity), so without this the already-elapsed part of today has no forecast data
+        at all and load_today_comparison's Predicted chart series sits at zero from midnight until
+        "now" (batpred#4750).
+        """
+        if not self.load_ml_forecast_active:
+            return
+        h1_forecast = self.fetch_ml_load_forecast_history(now_utc)
+        for minute, value in h1_forecast.items():
+            if minute < self.minutes_now:
+                self.load_forecast[minute] = value
+
     def fetch_extra_load_forecast(self, now_utc, ml_forecast=None):
         """
         Fetch extra load forecast, this is future load data
@@ -2622,6 +2696,7 @@ class Fetch:
         self.holiday_days_left = self.get_arg("holiday_days_left")
         self.holiday_load_scaling = self.get_arg("holiday_load_scaling", 0.7)
         self.load_forecast_only = self.get_arg("load_forecast_only", False)
+        self.load_ml_forecast_active = False  # Set True in fetch_sensor_data() only when Load ML genuinely supplies this cycle's forecast
 
         self.days_previous = self.get_arg("days_previous", [7])
         self.days_previous_weight = self.get_arg("days_previous_weight", [1 for i in range(len(self.days_previous))])
@@ -2639,11 +2714,13 @@ class Fetch:
             # runs unconditionally every cycle regardless of whether the weighted-bucket forecast
             # actually gets used: Load ML (or any other source that sets load_forecast_only) takes
             # precedence and skips it entirely (fetch_sensor_data(), guarded by
-            # "not self.load_forecast_only"). The "using weighted-bucket..." wording previously
-            # here read as if it was happening every cycle regardless, which is what actually gets
-            # logged only when the forecast is genuinely used (fetch_sensor_data()'s own "Using
-            # weighted-bucket historical load forecast over N days" line) - confusing on a Load ML
-            # setup where this fallback is rarely/never actually invoked (#4496 follow-up).
+            # "not self.load_forecast_only") - apply_load_ml_forecast_history() backfills the
+            # elapsed part of today from Load ML's own history instead in that case (batpred#4750).
+            # The "using weighted-bucket..." wording previously here read as if it was happening
+            # every cycle regardless, which is what actually gets logged only when the forecast is
+            # genuinely used (fetch_sensor_data()'s own "Using weighted-bucket historical load
+            # forecast over N days" line) - confusing on a Load ML setup where this fallback is
+            # rarely/never actually invoked (#4496 follow-up).
             self.log("days_previous_auto enabled - will fall back to a weighted-bucket historical load forecast over up to {} days if no other load forecast source takes precedence".format(window_days))
             self.max_days_previous = window_days + 1
         elif self.holiday_days_left > 0:

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -621,6 +621,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.octopus_url_cache_loaded = False
         self.github_url_cache_loaded = False
         self.load_forecast_history = False
+        self.load_ml_forecast_active = False
         self.prediction_kernel_enable = False
 
         for root in CONFIG_ROOTS:

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -621,7 +621,6 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.octopus_url_cache_loaded = False
         self.github_url_cache_loaded = False
         self.load_forecast_history = False
-        self.load_ml_forecast_active = False
         self.prediction_kernel_enable = False
 
         for root in CONFIG_ROOTS:

--- a/apps/predbat/tests/test_load_forecast_history.py
+++ b/apps/predbat/tests/test_load_forecast_history.py
@@ -407,6 +407,101 @@ def test_load_forecast_history(my_predbat):
         print("Tomorrow slot matches same-time-of-day today (constant rate): {:.5f}".format(energy_tomorrow))
 
     # ---------------------------------------------------------------
+    # Test 9: fetch_ml_load_forecast_history time-shifts load_today_h1 history (batpred#4750)
+    # ---------------------------------------------------------------
+    print("Test 9: fetch_ml_load_forecast_history time-shifts load_today_h1 history by its 60-minute lead")
+    setup_predbat(my_predbat, now_utc)
+    my_predbat.prefix = "predbat"
+    my_predbat.forecast_days = 2
+    my_predbat.midnight_utc = now_utc  # now_utc is exactly local midnight in this test file
+    original_get_history_wrapper = my_predbat.get_history_wrapper
+
+    # A reading recorded yesterday at 23:30 predicts (via load_today_h1) the cumulative load at
+    # 00:30 today; a reading recorded today at 09:00 predicts the cumulative load at 10:00 today.
+    # A third, later reading (09:30) follows so 10:00 is an interior point of the reconstructed
+    # series rather than its tail - minute_data's smoothing tail-fill only settles on a point's
+    # true value once a later reading exists to interpolate towards, which is always the case in
+    # real usage since Load ML's most recent reading always predicts 60 minutes into the future.
+    yesterday_2330 = (now_utc - timedelta(minutes=30)).isoformat()
+    today_0900 = (now_utc + timedelta(hours=9)).isoformat()
+    today_0930 = (now_utc + timedelta(hours=9, minutes=30)).isoformat()
+    history_records = [
+        {"attributes": {"load_today_h1": 10.0}, "last_updated": yesterday_2330},
+        {"attributes": {"load_today_h1": 25.0}, "last_updated": today_0900},
+        {"attributes": {"load_today_h1": 26.0}, "last_updated": today_0930},
+    ]
+    captured_history_call = {}
+
+    def fake_get_history_wrapper(entity_id, days=30, required=True, tracked=True):
+        """Record the entity/days requested and return the fixed history_records."""
+        captured_history_call["entity_id"] = entity_id
+        captured_history_call["days"] = days
+        return [history_records]
+
+    my_predbat.get_history_wrapper = fake_get_history_wrapper
+
+    forecast = my_predbat.fetch_ml_load_forecast_history(now_utc)
+
+    if captured_history_call.get("entity_id") != "sensor.predbat_load_ml_stats":
+        print("ERROR: fetched history for wrong entity: {}".format(captured_history_call.get("entity_id")))
+        failed = True
+    elif captured_history_call.get("days", 0) < 2:
+        print("ERROR: history lookback should cover at least 2 days to include yesterday, got {}".format(captured_history_call.get("days")))
+        failed = True
+    elif abs(forecast.get(30, -1) - 10.0) > 1e-6:
+        print("ERROR: minute 30 (00:30 today, from yesterday 23:30 reading) expected 10.0, got {}".format(forecast.get(30)))
+        failed = True
+    elif abs(forecast.get(600, -1) - 25.0) > 1e-6:
+        print("ERROR: minute 600 (10:00 today, from today 09:00 reading) expected 25.0, got {}".format(forecast.get(600)))
+        failed = True
+    else:
+        print("PASS: past load_today_h1 readings correctly time-shifted onto their target minute ({} at 00:30, {} at 10:00)".format(forecast.get(30), forecast.get(600)))
+
+    # No history at all -> empty dict, not an error
+    my_predbat.get_history_wrapper = lambda entity_id, days=30, required=True, tracked=True: None
+    if my_predbat.fetch_ml_load_forecast_history(now_utc) != {}:
+        print("ERROR: missing history should return an empty forecast")
+        failed = True
+    else:
+        print("PASS: missing history returns an empty forecast rather than raising")
+
+    my_predbat.get_history_wrapper = original_get_history_wrapper
+
+    # ---------------------------------------------------------------
+    # Test 10: apply_load_ml_forecast_history gates on load_ml_forecast_active (batpred#4750)
+    # ---------------------------------------------------------------
+    print("Test 10: apply_load_ml_forecast_history overrides elapsed minutes only when Load ML is genuinely active")
+    my_predbat.minutes_now = 600
+
+    # Case A: Load ML not active this cycle (e.g. running in the background but not selected as
+    # the forecast source) - must NOT touch self.load_forecast even if h1 history exists.
+    my_predbat.load_ml_forecast_active = False
+    my_predbat.load_forecast = {300: 1.0, 600: 20.0}
+    my_predbat.fetch_ml_load_forecast_history = lambda now_utc: {300: 99.0}  # should be ignored entirely
+    my_predbat.apply_load_ml_forecast_history(now_utc)
+    if my_predbat.load_forecast != {300: 1.0, 600: 20.0}:
+        print("ERROR: load_forecast should be untouched when load_ml_forecast_active is False, got {}".format(my_predbat.load_forecast))
+        failed = True
+    else:
+        print("PASS: inactive Load ML leaves load_forecast untouched (falls through to the weighted-bucket baseline)")
+
+    # Case B: Load ML active - overrides the weighted-bucket baseline for elapsed minutes only,
+    # leaves future (>= minutes_now) minutes from the live ML forecast untouched.
+    my_predbat.load_ml_forecast_active = True
+    my_predbat.load_forecast = {300: 1.0, 600: 20.0, 900: 30.0}  # 300 = weighted-bucket baseline; 600/900 = live ML
+    my_predbat.fetch_ml_load_forecast_history = lambda now_utc: {300: 9.5, 900: 999.0}  # 900 is future, must not apply
+    my_predbat.apply_load_ml_forecast_history(now_utc)
+    expected = {300: 9.5, 600: 20.0, 900: 30.0}
+    if my_predbat.load_forecast != expected:
+        print("ERROR: expected {} got {}".format(expected, my_predbat.load_forecast))
+        failed = True
+    else:
+        print("PASS: active Load ML overrides only elapsed minutes with genuine past forecasts ({})".format(my_predbat.load_forecast))
+
+    del my_predbat.fetch_ml_load_forecast_history  # remove instance override, restoring the real bound method
+    my_predbat.load_ml_forecast_active = False
+
+    # ---------------------------------------------------------------
     # Restore mocks/state
     # ---------------------------------------------------------------
     my_predbat.get_holiday_minutes = original_get_holiday_minutes

--- a/apps/predbat/tests/test_load_forecast_history.py
+++ b/apps/predbat/tests/test_load_forecast_history.py
@@ -469,33 +469,41 @@ def test_load_forecast_history(my_predbat):
         my_predbat.get_history_wrapper = original_get_history_wrapper
 
     # ---------------------------------------------------------------
-    # Test 10: apply_load_ml_forecast_history gates on load_ml_forecast_active (batpred#4750)
+    # Test 10: apply_load_ml_forecast_history gates on the ml_forecast passed in (batpred#4750, #4762)
     # ---------------------------------------------------------------
     print("Test 10: apply_load_ml_forecast_history overrides elapsed minutes only when Load ML is genuinely active")
     my_predbat.minutes_now = 600
     original_fetch_ml_load_forecast_history = my_predbat.fetch_ml_load_forecast_history
-    original_load_ml_forecast_active = my_predbat.load_ml_forecast_active
     original_load_forecast = my_predbat.load_forecast
 
     try:
         # Case A: Load ML not active this cycle (e.g. running in the background but not selected as
-        # the forecast source) - must NOT touch self.load_forecast even if h1 history exists.
-        my_predbat.load_ml_forecast_active = False
+        # the forecast source, so fetch_sensor_data's own load_ml_forecast stayed empty) - must NOT
+        # touch self.load_forecast even if h1 history exists.
         my_predbat.load_forecast = {300: 1.0, 600: 20.0}
         my_predbat.fetch_ml_load_forecast_history = lambda now_utc: {300: 99.0}  # should be ignored entirely
-        my_predbat.apply_load_ml_forecast_history(now_utc)
+        my_predbat.apply_load_ml_forecast_history(now_utc, {})
         if my_predbat.load_forecast != {300: 1.0, 600: 20.0}:
-            print("ERROR: load_forecast should be untouched when load_ml_forecast_active is False, got {}".format(my_predbat.load_forecast))
+            print("ERROR: load_forecast should be untouched when no ML forecast was fetched this cycle, got {}".format(my_predbat.load_forecast))
             failed = True
         else:
             print("PASS: inactive Load ML leaves load_forecast untouched (falls through to the weighted-bucket baseline)")
 
+        # Case A2: the gate is a required precondition, not something a caller can skip by omitting
+        # the argument - the default must be inert rather than "assume ML was active".
+        my_predbat.load_forecast = {300: 1.0, 600: 20.0}
+        my_predbat.apply_load_ml_forecast_history(now_utc)
+        if my_predbat.load_forecast != {300: 1.0, 600: 20.0}:
+            print("ERROR: load_forecast should be untouched when ml_forecast is omitted, got {}".format(my_predbat.load_forecast))
+            failed = True
+        else:
+            print("PASS: omitted ml_forecast defaults to inactive rather than backfilling")
+
         # Case B: Load ML active - overrides the weighted-bucket baseline for elapsed minutes only,
         # leaves future (>= minutes_now) minutes from the live ML forecast untouched.
-        my_predbat.load_ml_forecast_active = True
         my_predbat.load_forecast = {300: 1.0, 600: 20.0, 900: 30.0}  # 300 = weighted-bucket baseline; 600/900 = live ML
         my_predbat.fetch_ml_load_forecast_history = lambda now_utc: {300: 9.5, 900: 999.0}  # 900 is future, must not apply
-        my_predbat.apply_load_ml_forecast_history(now_utc)
+        my_predbat.apply_load_ml_forecast_history(now_utc, {600: 20.0, 900: 30.0})  # this cycle's live ML forecast
         expected = {300: 9.5, 600: 20.0, 900: 30.0}
         if my_predbat.load_forecast != expected:
             print("ERROR: expected {} got {}".format(expected, my_predbat.load_forecast))
@@ -504,7 +512,6 @@ def test_load_forecast_history(my_predbat):
             print("PASS: active Load ML overrides only elapsed minutes with genuine past forecasts ({})".format(my_predbat.load_forecast))
     finally:
         my_predbat.fetch_ml_load_forecast_history = original_fetch_ml_load_forecast_history
-        my_predbat.load_ml_forecast_active = original_load_ml_forecast_active
         my_predbat.load_forecast = original_load_forecast
 
     # ---------------------------------------------------------------

--- a/apps/predbat/tests/test_load_forecast_history.py
+++ b/apps/predbat/tests/test_load_forecast_history.py
@@ -416,90 +416,96 @@ def test_load_forecast_history(my_predbat):
     my_predbat.midnight_utc = now_utc  # now_utc is exactly local midnight in this test file
     original_get_history_wrapper = my_predbat.get_history_wrapper
 
-    # A reading recorded yesterday at 23:30 predicts (via load_today_h1) the cumulative load at
-    # 00:30 today; a reading recorded today at 09:00 predicts the cumulative load at 10:00 today.
-    # A third, later reading (09:30) follows so 10:00 is an interior point of the reconstructed
-    # series rather than its tail - minute_data's smoothing tail-fill only settles on a point's
-    # true value once a later reading exists to interpolate towards, which is always the case in
-    # real usage since Load ML's most recent reading always predicts 60 minutes into the future.
-    yesterday_2330 = (now_utc - timedelta(minutes=30)).isoformat()
-    today_0900 = (now_utc + timedelta(hours=9)).isoformat()
-    today_0930 = (now_utc + timedelta(hours=9, minutes=30)).isoformat()
-    history_records = [
-        {"attributes": {"load_today_h1": 10.0}, "last_updated": yesterday_2330},
-        {"attributes": {"load_today_h1": 25.0}, "last_updated": today_0900},
-        {"attributes": {"load_today_h1": 26.0}, "last_updated": today_0930},
-    ]
-    captured_history_call = {}
+    try:
+        # A reading recorded yesterday at 23:30 predicts (via load_today_h1) the cumulative load at
+        # 00:30 today; a reading recorded today at 09:00 predicts the cumulative load at 10:00 today.
+        # A third, later reading (09:30) follows so 10:00 is an interior point of the reconstructed
+        # series rather than its tail - minute_data's smoothing tail-fill only settles on a point's
+        # true value once a later reading exists to interpolate towards, which is always the case in
+        # real usage since Load ML's most recent reading always predicts 60 minutes into the future.
+        yesterday_2330 = (now_utc - timedelta(minutes=30)).isoformat()
+        today_0900 = (now_utc + timedelta(hours=9)).isoformat()
+        today_0930 = (now_utc + timedelta(hours=9, minutes=30)).isoformat()
+        history_records = [
+            {"attributes": {"load_today_h1": 10.0}, "last_updated": yesterday_2330},
+            {"attributes": {"load_today_h1": 25.0}, "last_updated": today_0900},
+            {"attributes": {"load_today_h1": 26.0}, "last_updated": today_0930},
+        ]
+        captured_history_call = {}
 
-    def fake_get_history_wrapper(entity_id, days=30, required=True, tracked=True):
-        """Record the entity/days requested and return the fixed history_records."""
-        captured_history_call["entity_id"] = entity_id
-        captured_history_call["days"] = days
-        return [history_records]
+        def fake_get_history_wrapper(entity_id, days=30, required=True, tracked=True):
+            """Record the entity/days requested and return the fixed history_records."""
+            captured_history_call["entity_id"] = entity_id
+            captured_history_call["days"] = days
+            return [history_records]
 
-    my_predbat.get_history_wrapper = fake_get_history_wrapper
+        my_predbat.get_history_wrapper = fake_get_history_wrapper
 
-    forecast = my_predbat.fetch_ml_load_forecast_history(now_utc)
+        forecast = my_predbat.fetch_ml_load_forecast_history(now_utc)
 
-    if captured_history_call.get("entity_id") != "sensor.predbat_load_ml_stats":
-        print("ERROR: fetched history for wrong entity: {}".format(captured_history_call.get("entity_id")))
-        failed = True
-    elif captured_history_call.get("days", 0) < 2:
-        print("ERROR: history lookback should cover at least 2 days to include yesterday, got {}".format(captured_history_call.get("days")))
-        failed = True
-    elif abs(forecast.get(30, -1) - 10.0) > 1e-6:
-        print("ERROR: minute 30 (00:30 today, from yesterday 23:30 reading) expected 10.0, got {}".format(forecast.get(30)))
-        failed = True
-    elif abs(forecast.get(600, -1) - 25.0) > 1e-6:
-        print("ERROR: minute 600 (10:00 today, from today 09:00 reading) expected 25.0, got {}".format(forecast.get(600)))
-        failed = True
-    else:
-        print("PASS: past load_today_h1 readings correctly time-shifted onto their target minute ({} at 00:30, {} at 10:00)".format(forecast.get(30), forecast.get(600)))
+        if captured_history_call.get("entity_id") != "sensor.predbat_load_ml_stats":
+            print("ERROR: fetched history for wrong entity: {}".format(captured_history_call.get("entity_id")))
+            failed = True
+        elif captured_history_call.get("days", 0) < 2:
+            print("ERROR: history lookback should cover at least 2 days to include yesterday, got {}".format(captured_history_call.get("days")))
+            failed = True
+        elif abs(forecast.get(30, -1) - 10.0) > 1e-6:
+            print("ERROR: minute 30 (00:30 today, from yesterday 23:30 reading) expected 10.0, got {}".format(forecast.get(30)))
+            failed = True
+        elif abs(forecast.get(600, -1) - 25.0) > 1e-6:
+            print("ERROR: minute 600 (10:00 today, from today 09:00 reading) expected 25.0, got {}".format(forecast.get(600)))
+            failed = True
+        else:
+            print("PASS: past load_today_h1 readings correctly time-shifted onto their target minute ({} at 00:30, {} at 10:00)".format(forecast.get(30), forecast.get(600)))
 
-    # No history at all -> empty dict, not an error
-    my_predbat.get_history_wrapper = lambda entity_id, days=30, required=True, tracked=True: None
-    if my_predbat.fetch_ml_load_forecast_history(now_utc) != {}:
-        print("ERROR: missing history should return an empty forecast")
-        failed = True
-    else:
-        print("PASS: missing history returns an empty forecast rather than raising")
-
-    my_predbat.get_history_wrapper = original_get_history_wrapper
+        # No history at all -> empty dict, not an error
+        my_predbat.get_history_wrapper = lambda entity_id, days=30, required=True, tracked=True: None
+        if my_predbat.fetch_ml_load_forecast_history(now_utc) != {}:
+            print("ERROR: missing history should return an empty forecast")
+            failed = True
+        else:
+            print("PASS: missing history returns an empty forecast rather than raising")
+    finally:
+        my_predbat.get_history_wrapper = original_get_history_wrapper
 
     # ---------------------------------------------------------------
     # Test 10: apply_load_ml_forecast_history gates on load_ml_forecast_active (batpred#4750)
     # ---------------------------------------------------------------
     print("Test 10: apply_load_ml_forecast_history overrides elapsed minutes only when Load ML is genuinely active")
     my_predbat.minutes_now = 600
+    original_fetch_ml_load_forecast_history = my_predbat.fetch_ml_load_forecast_history
+    original_load_ml_forecast_active = my_predbat.load_ml_forecast_active
+    original_load_forecast = my_predbat.load_forecast
 
-    # Case A: Load ML not active this cycle (e.g. running in the background but not selected as
-    # the forecast source) - must NOT touch self.load_forecast even if h1 history exists.
-    my_predbat.load_ml_forecast_active = False
-    my_predbat.load_forecast = {300: 1.0, 600: 20.0}
-    my_predbat.fetch_ml_load_forecast_history = lambda now_utc: {300: 99.0}  # should be ignored entirely
-    my_predbat.apply_load_ml_forecast_history(now_utc)
-    if my_predbat.load_forecast != {300: 1.0, 600: 20.0}:
-        print("ERROR: load_forecast should be untouched when load_ml_forecast_active is False, got {}".format(my_predbat.load_forecast))
-        failed = True
-    else:
-        print("PASS: inactive Load ML leaves load_forecast untouched (falls through to the weighted-bucket baseline)")
+    try:
+        # Case A: Load ML not active this cycle (e.g. running in the background but not selected as
+        # the forecast source) - must NOT touch self.load_forecast even if h1 history exists.
+        my_predbat.load_ml_forecast_active = False
+        my_predbat.load_forecast = {300: 1.0, 600: 20.0}
+        my_predbat.fetch_ml_load_forecast_history = lambda now_utc: {300: 99.0}  # should be ignored entirely
+        my_predbat.apply_load_ml_forecast_history(now_utc)
+        if my_predbat.load_forecast != {300: 1.0, 600: 20.0}:
+            print("ERROR: load_forecast should be untouched when load_ml_forecast_active is False, got {}".format(my_predbat.load_forecast))
+            failed = True
+        else:
+            print("PASS: inactive Load ML leaves load_forecast untouched (falls through to the weighted-bucket baseline)")
 
-    # Case B: Load ML active - overrides the weighted-bucket baseline for elapsed minutes only,
-    # leaves future (>= minutes_now) minutes from the live ML forecast untouched.
-    my_predbat.load_ml_forecast_active = True
-    my_predbat.load_forecast = {300: 1.0, 600: 20.0, 900: 30.0}  # 300 = weighted-bucket baseline; 600/900 = live ML
-    my_predbat.fetch_ml_load_forecast_history = lambda now_utc: {300: 9.5, 900: 999.0}  # 900 is future, must not apply
-    my_predbat.apply_load_ml_forecast_history(now_utc)
-    expected = {300: 9.5, 600: 20.0, 900: 30.0}
-    if my_predbat.load_forecast != expected:
-        print("ERROR: expected {} got {}".format(expected, my_predbat.load_forecast))
-        failed = True
-    else:
-        print("PASS: active Load ML overrides only elapsed minutes with genuine past forecasts ({})".format(my_predbat.load_forecast))
-
-    del my_predbat.fetch_ml_load_forecast_history  # remove instance override, restoring the real bound method
-    my_predbat.load_ml_forecast_active = False
+        # Case B: Load ML active - overrides the weighted-bucket baseline for elapsed minutes only,
+        # leaves future (>= minutes_now) minutes from the live ML forecast untouched.
+        my_predbat.load_ml_forecast_active = True
+        my_predbat.load_forecast = {300: 1.0, 600: 20.0, 900: 30.0}  # 300 = weighted-bucket baseline; 600/900 = live ML
+        my_predbat.fetch_ml_load_forecast_history = lambda now_utc: {300: 9.5, 900: 999.0}  # 900 is future, must not apply
+        my_predbat.apply_load_ml_forecast_history(now_utc)
+        expected = {300: 9.5, 600: 20.0, 900: 30.0}
+        if my_predbat.load_forecast != expected:
+            print("ERROR: expected {} got {}".format(expected, my_predbat.load_forecast))
+            failed = True
+        else:
+            print("PASS: active Load ML overrides only elapsed minutes with genuine past forecasts ({})".format(my_predbat.load_forecast))
+    finally:
+        my_predbat.fetch_ml_load_forecast_history = original_fetch_ml_load_forecast_history
+        my_predbat.load_ml_forecast_active = original_load_ml_forecast_active
+        my_predbat.load_forecast = original_load_forecast
 
     # ---------------------------------------------------------------
     # Restore mocks/state


### PR DESCRIPTION
## Summary
- With Load ML enabled, `sensor.<prefix>_load_ml_forecast` only ever publishes predictions from "now" onward, so `load_today_comparison()`'s Predicted series sat at zero for every already-elapsed minute of the day, visibly misaligning the InDay chart's Predicted line against Actual/Adjusted.
- `sensor.<prefix>_load_ml_stats` already publishes a `load_today_h1` attribute every cycle — the model's own cumulative-load prediction for 60 minutes ahead. Shifting each recorded reading's timestamp forward by that lead time reconstructs a genuine record of what Load ML predicted for each past minute, and now backfills the elapsed portion of the chart with the model's own real past output (instead of a same-time-of-day average).
- This only takes effect when Load ML is genuinely the active forecast source this cycle (`load_ml_enable`/`load_ml_source`) — a Load ML component merely running in the background does not affect the chart.

## Test plan
- [x] New unit tests in `test_load_forecast_history.py` (Test 9/10): time-shift reconstruction from mocked `load_ml_stats` history, missing-history fallback, and gating on `load_ml_forecast_active` (inactive Load ML leaves data untouched; active Load ML overrides only elapsed minutes, future minutes from the live ML forecast untouched)
- [x] `./run_all --quick` — all 853 tests pass
- [x] `pre-commit` (ruff, black, cspell) clean on changed files
- [x] `interrogate` docstring coverage clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)