### PR TITLE
Add carbon_yesterday and a running carbon_total sensor

### DIFF
--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -3020,6 +3020,14 @@ class Output:
             self.savings_last_updated = self.now_utc
             return
 
+        # Unlike cost above, missing carbon_today history isn't fatal to this function - carbon is an
+        # optional add-on metric, so a user who has just turned it on (and so has no history for it yet)
+        # should still get their savings/plan history, just with carbon_yesterday reading 0 until a full
+        # day of predbat.carbon_today history has accumulated for it to read back.
+        carbon_today_data = self.get_history_wrapper(entity_id=self.prefix + ".carbon_today", days=2, required=False) if self.carbon_enable else None
+        if self.carbon_enable and not carbon_today_data:
+            self.log("Warn: Calculate yesterday: No history for {}.carbon_today yet, carbon_yesterday and carbon_total will read 0 until a day of history has built up".format(self.prefix))
+
         self.log("Calculating data from yesterday for savings calculation")
 
         # step_data_history() only fills in offsets up to self.forecast_minutes + plan_interval_minutes.
@@ -3095,6 +3103,17 @@ class Output:
         cost_data_per_kwh, _ = minute_data(cost_today_data[0], 2, self.now_utc, "p/kWh", "last_updated", attributes=True, backwards=True, clean_increment=False, smoothing=False, divide_by=1.0, scale=1.0)
         cost_yesterday = cost_data.get(minutes_back, 0.0)
         cost_yesterday_per_kwh = cost_data_per_kwh.get(minutes_back, 0.0)
+
+        # Get Carbon yesterday, read back the same way as cost above - predbat.carbon_today's own
+        # recorded history at 23:59 yesterday is its final value for the day, before it resets to 0.
+        # carbon_enable_real is captured now because self.carbon_enable is temporarily forced False
+        # further down (to keep the no-PV/battery baseline simulation from computing carbon too) for
+        # longer than this function's remaining "yesterday" publishing runs after it.
+        carbon_enable_real = self.carbon_enable
+        carbon_yesterday = 0.0
+        if carbon_today_data:
+            carbon_data, _ = minute_data(carbon_today_data[0], 2, self.now_utc, "state", "last_updated", backwards=True, clean_increment=False, smoothing=False, divide_by=1.0, scale=1.0)
+            carbon_yesterday = carbon_data.get(minutes_back, 0.0)
         cost_yesterday_array = {}
         for minute in range(0, end_record + self.minutes_now):
             cost_value = cost_data.get(minutes_back + 24 * 60 - minute - 5, 0.0)  # -5 gives 4 minutes into new data to allow for reset
@@ -3351,6 +3370,7 @@ class Output:
         self.savings_today_predbat_soc = final_soc
         self.savings_today_actual = cost_yesterday
         self.cost_yesterday_car = cost_yesterday_car
+        self.carbon_yesterday = carbon_yesterday
 
         # Save state
         self.dashboard_item(
@@ -3370,6 +3390,17 @@ class Output:
                 "json": plan_json_yesterday,
             },
         )
+        if carbon_enable_real:
+            self.dashboard_item(
+                self.prefix + ".carbon_yesterday",
+                state=dp2(carbon_yesterday),
+                attributes={
+                    "friendly_name": "Carbon yesterday",
+                    "state_class": "measurement",
+                    "unit_of_measurement": "g",
+                    "icon": "mdi:carbon-molecule",
+                },
+            )
         if num_cars > 0:
             self.dashboard_item(
                 self.prefix + ".cost_yesterday_car",

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -3026,7 +3026,7 @@ class Output:
         # day of predbat.carbon_today history has accumulated for it to read back.
         carbon_today_data = self.get_history_wrapper(entity_id=self.prefix + ".carbon_today", days=2, required=False) if self.carbon_enable else None
         if self.carbon_enable and not carbon_today_data:
-            self.log("Warn: Calculate yesterday: No history for {}.carbon_today yet, carbon_yesterday and carbon_total will read 0 until a day of history has built up".format(self.prefix))
+            self.log("Warn: Calculate yesterday: No history for {}.carbon_today yet, carbon_yesterday will read 0 and carbon_total can't increment until a day of history has built up".format(self.prefix))
 
         self.log("Calculating data from yesterday for savings calculation")
 

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -540,6 +540,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.savings_last_updated = None
         self.cost_yesterday_car = 0.0
         self.cost_total_car = 0.0
+        self.carbon_yesterday = 0.0
         self.rate_import = {}
         self.rate_import_replicated = {}
         self.rate_export = {}
@@ -1179,6 +1180,15 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
             else:
                 cost_total_car = 0
 
+            if self.carbon_enable:
+                carbon_total = self.load_previous_value_from_ha(self.prefix + ".carbon_total")
+                try:
+                    carbon_total = float(carbon_total)
+                except (ValueError, TypeError):
+                    carbon_total = 0.0
+            else:
+                carbon_total = 0.0
+
             # Increment total at 1am once we have today's data stable (cloud data can lag)
             if self.minutes_now > 60 and savings_total_last_updated and savings_total_last_updated != todays_date and scheduled and not self.set_read_only:
                 savings_total_predbat += self.savings_today_predbat
@@ -1187,6 +1197,8 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
                 savings_total_actual += self.savings_today_actual
                 savings_total_last_updated = todays_date
                 cost_total_car += self.cost_yesterday_car
+                if self.carbon_enable:
+                    carbon_total += self.carbon_yesterday
 
             self.dashboard_item(
                 self.prefix + ".savings_total_predbat",
@@ -1249,6 +1261,20 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
                         "unit_of_measurement": self.currency_symbols[1],
                         "pounds": dp2(cost_total_car / 100.0),
                         "icon": "mdi:cash-multiple",
+                        "start_date": savings_total_start_date,
+                        "last_updated": savings_total_last_updated,
+                    },
+                )
+            if self.carbon_enable:
+                self.dashboard_item(
+                    self.prefix + ".carbon_total",
+                    state=dp2(carbon_total),
+                    attributes={
+                        "friendly_name": "Total carbon emissions",
+                        "state_class": "measurement",
+                        "unit_of_measurement": "g",
+                        "kg": dp2(carbon_total / 1000.0),
+                        "icon": "mdi:carbon-molecule",
                         "start_date": savings_total_start_date,
                         "last_updated": savings_total_last_updated,
                     },

--- a/apps/predbat/tests/test_calculate_yesterday.py
+++ b/apps/predbat/tests/test_calculate_yesterday.py
@@ -1247,6 +1247,62 @@ def _test_missing_cost_today_history(my_predbat, failed):
     return failed
 
 
+def _test_carbon_yesterday(my_predbat, failed):
+    """Test: with carbon_enable on, carbon_yesterday is read back from predbat.carbon_today's
+    own history (#2830) the same way cost_yesterday reads predbat.cost_today, and published as
+    predbat.carbon_yesterday. With carbon_enable off, neither is computed nor published."""
+    print("calculate_yesterday: Test - carbon_yesterday read back from carbon_today history")
+    now_utc = _setup_base(my_predbat)
+    my_predbat.carbon_enable = True
+
+    carbon_hist = _make_constant_history(456.0, now_utc)
+    base_history = _make_history_mock(my_predbat, now_utc, cost_value=100.0, soc_value=5.0)
+
+    def _get_history_wrapper(entity_id, days=30, required=True, tracked=True):
+        if entity_id == my_predbat.prefix + ".carbon_today":
+            return carbon_hist
+        return base_history(entity_id, days=days, required=required, tracked=tracked)
+
+    captured_load, original_run_pred = _apply_mocks(my_predbat, now_utc, cost_value=100.0, soc_value=5.0)
+    my_predbat.get_history_wrapper = _get_history_wrapper
+
+    my_predbat.calculate_yesterday()
+
+    if my_predbat.carbon_yesterday != 456.0:
+        print("ERROR: carbon_yesterday should be 456.0, got {}".format(my_predbat.carbon_yesterday))
+        failed = True
+
+    entity_id = my_predbat.prefix + ".carbon_yesterday"
+    state = my_predbat.get_state_wrapper(entity_id)
+    if state != 456.0:
+        print("ERROR: entity {} should be 456.0, got {}".format(entity_id, state))
+        failed = True
+
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    my_predbat.ha_interface.dummy_items.pop(entity_id, None)
+
+    # Now with carbon_enable off - carbon_yesterday must not be recomputed from the (still
+    # present) mock history, and the entity must not be published.
+    my_predbat.carbon_enable = False
+    my_predbat.carbon_yesterday = 0.0
+    captured_load, original_run_pred = _apply_mocks(my_predbat, now_utc, cost_value=100.0, soc_value=5.0)
+    my_predbat.get_history_wrapper = _get_history_wrapper
+
+    my_predbat.calculate_yesterday()
+
+    if my_predbat.carbon_yesterday != 0.0:
+        print("ERROR: carbon_yesterday should stay 0.0 with carbon_enable off, got {}".format(my_predbat.carbon_yesterday))
+        failed = True
+    if my_predbat.get_state_wrapper(entity_id) is not None:
+        print("ERROR: entity {} should not be published with carbon_enable off".format(entity_id))
+        failed = True
+
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    return failed
+
+
 def _test_yesterday_slot_is_exporting(my_predbat, failed):
     """Test: yesterday_slot_is_exporting() recognises Cross-charging as export activity.
 
@@ -1298,6 +1354,7 @@ def test_calculate_yesterday(my_predbat):
     failed = _test_soc_not_mutated_and_override_passed(my_predbat, failed)
     failed = _test_soc_kw_h0_fallback(my_predbat, failed)
     failed = _test_missing_cost_today_history(my_predbat, failed)
+    failed = _test_carbon_yesterday(my_predbat, failed)
     failed = _test_yesterday_slot_is_exporting(my_predbat, failed)
     failed = _test_cross_charging_reconstructed_as_both_windows(my_predbat, failed)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -253,6 +253,7 @@ recorder:
       - sensor.predbat_temperature
   include:
     entities: #The history of these entities is used by Predbat
+      - predbat.carbon_today
       - predbat.cost_today
       - predbat.cost_today_car
       - predbat.cost_yesterday

--- a/docs/output-data.md
+++ b/docs/output-data.md
@@ -606,6 +606,8 @@ They are used in the carbon chart - see [creating the Predbat charts](creating-c
 - predbat.carbon_best - Predicted Carbon intensity in g for your home under the best plan based on grid imports, grid exports and the grid's projected carbon intensity
 - predbat.carbon_now - A sensor that gives the current Grid Carbon intensity in g/kWh
 - predbat.carbon_today - A sensor that tracks your home's Carbon impact today in g based on your grid import minus your grid export
+- predbat.carbon_yesterday - A sensor that gives your home's total Carbon impact in g for yesterday (00:00-23:59 on the previous day)
+- predbat.carbon_total - A running total in g of the above carbon_yesterday sensor, with attribute of the total in kg. Only published when **carbon_enable** is set
 
 ## Cost saving data
 


### PR DESCRIPTION
Fixes #2830 - closes the gap raised there: `predbat.carbon_today` resets to 0 at midnight, so the reporter's attempt to total it in a Home Assistant Utility Meter helper failed (it doesn't accept the value going backwards). `savings_total_predbat` already solves exactly this for cost - this mirrors that pattern for carbon.

## What this adds

**`predbat.carbon_yesterday`** - reads `predbat.carbon_today`'s own recorded HA history at 23:59 the previous day, the same technique `cost_yesterday` already uses for `cost_today`, rather than re-running any simulation.

**`predbat.carbon_total`** - a genuine persisted running total: loaded from HA on startup, incremented once a day at the same 1am rollover gate `savings_total_predbat` uses, with `start_date`/`last_updated` attributes so it can be reset the same way (as the original issue asked for - "reset at the beginning of 2026").

Both are gated on `carbon_enable` and add nothing for users who don't have it on.

## Two things caught while building this

- `calculate_yesterday()` temporarily zeroes `self.carbon_enable` for ~300 lines while it runs a no-PV/battery baseline simulation (so that inner sim doesn't needlessly compute carbon too). The first version of `carbon_yesterday`'s publish sat inside that window, so with carbon genuinely enabled the entity silently never got published. Caught by the new test, fixed by capturing the real flag before the temporary disable.
- `test_faq_recorder_config` (built for #4583) flagged that the new `get_history_wrapper(".carbon_today")` call left `docs/faq.md`'s recorder allowlist example stale. Added `predbat.carbon_today` there - a real fix independent of this feature, since anyone using that documented recorder config would otherwise have had it silently break.

## Tests

New `_test_carbon_yesterday` in `test_calculate_yesterday.py`, covering both the enabled path (value read back correctly, entity published) and the disabled path (neither happens) - deliberately the case that would have caught the bug above.

`./run_all --quick` and pre-commit both green.

## Docs

Added both new sensors to `docs/output-data.md`, and `predbat.carbon_today` to the recorder example in `docs/faq.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
