### PR TITLE
Size the thread pool to the container's CPU quota

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -219,6 +219,7 @@ generationmix
 generationpower
 geserial
 geseriale
+getaffinity
 getall
 getrusage
 Ginlong

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -34,11 +34,59 @@ import time
 PLAN_PASS_WINDOW_BUDGET = 8
 
 
+def available_cpu_count():
+    """Return how many CPUs this process may actually use.
+
+    cpu_count() reports the machine's cores, which is the wrong number inside a container. A Docker
+    --cpus or a Kubernetes CPU limit is a cgroup bandwidth quota, and the host's full core count
+    stays visible through both cpu_count() and sched_getaffinity() - so 'auto' sizes the pool to the
+    host and the CFS scheduler then throttles it. Measured on a Kubernetes pod with a 4-core limit on
+    a 12-core node: cpu_count() reports 12, cpu.max reports "400000 100000", and the pod sat pegged
+    at its quota with twelve lanes contending for four cores.
+
+    Falls back to cpu_count() on bare metal, in a container with no limit set, and on any platform
+    without cgroups, so behaviour outside a constrained container is unchanged.
+    """
+    quota = None
+
+    # cgroup v2: "$MAX $PERIOD", where $MAX is the string "max" when unlimited.
+    try:
+        with open("/sys/fs/cgroup/cpu.max") as handle:
+            field_max, field_period = handle.read().split()
+        if field_max != "max":
+            period = int(field_period)
+            if period > 0:
+                quota = int(field_max) / period
+    except (OSError, ValueError):
+        pass
+
+    # cgroup v1: a quota of -1 means unlimited.
+    if quota is None:
+        try:
+            with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as handle:
+                cfs_quota = int(handle.read())
+            with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us") as handle:
+                cfs_period = int(handle.read())
+            if cfs_quota > 0 and cfs_period > 0:
+                quota = cfs_quota / cfs_period
+        except (OSError, ValueError):
+            pass
+
+    host_count = max(cpu_count() or 1, 1)
+    if quota is None:
+        return host_count
+
+    # Round down - a 3.5-core quota sustains three fully-busy lanes - but never below one, and never
+    # above what the host actually has.
+    return max(1, min(host_count, int(quota)))
+
+
 def resolve_batch_threads(threads, cpu_count_value):
     """Map the threads setting onto how many kernel lanes one batch may use.
 
-    'auto' takes the core count and is deliberately not capped. On a fast machine the curve is very
-    flat and peaks slightly below the core count - measured on the 20-scenario benchmark, best of 3:
+    'auto' takes the usable core count - see available_cpu_count(), which is the host's cores except
+    inside a container with a CPU limit - and is deliberately not capped beyond that. On a fast
+    machine the curve is very flat and peaks slightly below the core count - measured on the 20-scenario benchmark, best of 3:
     serial 26.33s, 4 threads 24.89s, 6 threads 24.71s, 8 threads 24.91s, 16 threads 25.04s - so a cap
     looks attractive. But re-running with each job made eight times dearer, which is how a machine
     where the kernel dominates behaves, the curve stops turning over entirely: 48.92s serial, 32.03s
@@ -1422,7 +1470,7 @@ class Plan:
         # The kernel spreads one batched fan-out across threads with the GIL released for the whole
         # call, so these are real cores - unlike a Python ThreadPool, which peaked at 1.15x on two
         # threads and then degraded below serial (perf/threadpool-prototype).
-        self.prediction.batch_threads = resolve_batch_threads(self.get_arg("threads", "auto"), cpu_count())
+        self.prediction.batch_threads = resolve_batch_threads(self.get_arg("threads", "auto"), available_cpu_count())
         self.log("Prediction batch using {} kernel thread(s)".format(self.prediction.batch_threads))
         kernel_message, kernel_is_warning = kernel_status_summary(self.prediction)
         self.log("{}Prediction kernel: {}".format("Warn: " if kernel_is_warning else "", kernel_message))

--- a/apps/predbat/tests/test_prediction_batch.py
+++ b/apps/predbat/tests/test_prediction_batch.py
@@ -22,6 +22,10 @@ handle in a multi-job batch comes back with its own job's result rather than a n
 
 import random
 
+import builtins
+import io
+
+import plan
 import prediction_batch
 from const import PREDICT_STEP, PV_SCENARIO_NOMINAL, PV_SCENARIO_PV10
 from plan import resolve_batch_threads
@@ -512,6 +516,63 @@ def test_batch_results_match_their_own_job(my_predbat):
     return failed
 
 
+def test_available_cpu_count_respects_a_cgroup_quota():
+    """Check the usable CPU count follows a container's quota, returns True on failure.
+
+    cpu_count() reports the host's cores even inside a container with a CPU limit, so 'auto' would
+    size the pool to the host and then be throttled by the CFS scheduler. Measured on a Kubernetes
+    pod limited to 4 cores on a 12-core node: cpu_count() said 12 while cpu.max said "400000 100000".
+
+    The cgroup reads are stubbed rather than exercised against the real filesystem, so this gives the
+    same answer on a developer's laptop, inside a container, and in CI.
+    """
+    print("**** Running available CPU count tests ****")
+    failed = False
+
+    # (cgroup files the case exposes, host cores, expected, why)
+    cases = [
+        ({"/sys/fs/cgroup/cpu.max": "400000 100000"}, 12, 4, "a v2 quota caps the host count"),
+        ({"/sys/fs/cgroup/cpu.max": "max 100000"}, 12, 12, "an unlimited v2 quota falls back to the host"),
+        ({"/sys/fs/cgroup/cpu.max": "350000 100000"}, 12, 3, "a fractional quota rounds down"),
+        ({"/sys/fs/cgroup/cpu.max": "50000 100000"}, 12, 1, "a sub-core quota still leaves one lane"),
+        ({"/sys/fs/cgroup/cpu.max": "1600000 100000"}, 12, 12, "a quota above the host cannot exceed it"),
+        ({"/sys/fs/cgroup/cpu/cpu.cfs_quota_us": "200000", "/sys/fs/cgroup/cpu/cpu.cfs_period_us": "100000"}, 8, 2, "a v1 quota caps the host count"),
+        ({"/sys/fs/cgroup/cpu/cpu.cfs_quota_us": "-1", "/sys/fs/cgroup/cpu/cpu.cfs_period_us": "100000"}, 8, 8, "an unlimited v1 quota falls back to the host"),
+        ({}, 8, 8, "no cgroup files at all falls back to the host"),
+        ({"/sys/fs/cgroup/cpu.max": "garbage"}, 8, 8, "an unparsable quota falls back rather than raising"),
+    ]
+
+    real_open = builtins.open
+    real_cpu_count = plan.cpu_count
+
+    for files, cores, expected, why in cases:
+
+        def fake_open(path, *args, **kwargs):
+            """Serve this case's cgroup files and hide any it omits"""
+            name = str(path)
+            if name.startswith("/sys/fs/cgroup"):
+                if name in files:
+                    return io.StringIO(files[name])
+                raise FileNotFoundError(name)
+            return real_open(path, *args, **kwargs)
+
+        builtins.open = fake_open
+        plan.cpu_count = lambda count=cores: count
+        try:
+            got = plan.available_cpu_count()
+        finally:
+            builtins.open = real_open
+            plan.cpu_count = real_cpu_count
+
+        if got != expected:
+            print("ERROR: files={} cores={} gave {} CPUs, expected {} ({})".format(files, cores, got, expected, why))
+            failed = True
+
+    if not failed:
+        print("Available CPU count tests passed")
+    return failed
+
+
 def test_batch_thread_count_resolution():
     """Check how the threads setting maps onto kernel lanes, returns True on failure.
 
@@ -548,6 +609,7 @@ def run_prediction_batch_tests(my_predbat):
     """Run every batched prediction test, returns True on failure"""
     failed = test_export_trial_does_not_mutate_caller_window(my_predbat)
     failed |= test_batch_thread_count_resolution()
+    failed |= test_available_cpu_count_respects_a_cgroup_quota()
     failed |= test_batch_state_exists_without_a_base(my_predbat)
 
     available, required_failure = kernel_available()


### PR DESCRIPTION
## The problem

`threads: auto` sizes the batch pool from `cpu_count()`, which reports the machine's cores. Inside a container that is the wrong number: a Docker `--cpus` or a Kubernetes CPU limit is a cgroup *bandwidth quota*, and the host's full core count stays visible through both `cpu_count()` and `sched_getaffinity()`. Predbat sizes its pool to the host, and the CFS scheduler then throttles it.

I hit this running Predbat on Kubernetes with a 4-core limit on a 12-core node:

```
os.cpu_count()          -> 12
sched_getaffinity        -> 12
/sys/fs/cgroup/cpu.max   -> 400000 100000   # i.e. 4 cores
```

The pod sat pegged at its quota, CPU-throttled, for the whole of a 30-epoch ML fine-tune — twelve lanes contending for four cores, which is slower than four lanes would have been. Note `sched_getaffinity()` is *also* 12, so the usual affinity-based workaround does not help here; it has to be the quota.

## The change

`available_cpu_count()` reads the cgroup quota (v2 `cpu.max`, then v1 `cpu.cfs_quota_us`/`cpu.cfs_period_us`) and falls back to `cpu_count()` on bare metal, in a container with no limit set, and on any platform without cgroups. Behaviour outside a constrained container is unchanged.

**This deliberately does not touch the "auto is not capped" policy.** The reasoning in `resolve_batch_threads`'s docstring — that a cap costs 10.7% on a kernel-heavy machine against 1.3% for no cap — is about physical cores, and I read it as still correct. This only changes *which number* `auto` is uncapped against: the CPUs the process may actually use, rather than the ones it can see. A quota is a hard ceiling the scheduler enforces regardless, so exceeding it buys contention rather than throughput.

Rounding is down (a 3.5-core quota sustains three fully-busy lanes), never below 1, and never above the host count.

## Tests

Added to `test_prediction_batch.py` alongside the existing thread-resolution test, and registered in `run_prediction_batch_tests` so a regression fails the suite.

The cgroup reads are stubbed rather than exercised against the real filesystem, so the test gives the same answer on a laptop, inside a container, and in CI. Cases cover v2, v1, unlimited in both, fractional and sub-core quotas, a quota above the host count, no cgroup files at all, and an unparsable quota.

I checked the test **fails against the unfixed code** rather than only passing against the new code — reverting the quota branch produces four `ERROR:` lines and `failed = True`.

`black --line-length 256` clean; `flake8 --max-line-length 250` reports nothing new (the remaining `F841`/`C901` hits are pre-existing on `main`).

Happy to adjust the approach — including capping `auto` at the quota only when one is present and leaving everything else alone, if you would rather keep the change narrower.
