### PR TITLE
feat(mcp): add get_log and get_state tools, redact credentials from get_apps

### DIFF
--- a/apps/predbat/tests/test_web_mcp.py
+++ b/apps/predbat/tests/test_web_mcp.py
@@ -1,0 +1,519 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""Tests for the MCP server's log and apps.yaml tools (#4768).
+
+Covers the new get_log tool, get_apps' credential redaction, the widened
+mask_secret_args() key match, and the log-filter helpers now shared between the
+MCP tool and the web log view.
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta
+
+import web
+import web_mcp
+from web import WebInterface
+from web_mcp import MCPServerWrapper, LOG_FILTER_TYPES, MCP_LOG_DEFAULT_LINES, MCP_LOG_MAX_LINES, parse_bool_argument
+from utils import mask_secret_args, is_secret_key, read_predbat_log, classify_log_line, log_line_included, parse_log_timestamp
+
+
+class FakeRequest:
+    """A minimal aiohttp-request stand-in exposing only the query string a handler reads."""
+
+    def __init__(self, query=None):
+        """Store the query string a handler will read."""
+        self.query = query or {}
+
+
+def _stamp(minutes_ago):
+    """Return a predbat.log-style timestamp prefix for a line written N minutes ago."""
+    return "{}: ".format(datetime.now() - timedelta(minutes=minutes_ago))
+
+
+def _sample_log():
+    """Return a small synthetic predbat.log, newest line last, spanning three days."""
+    lines = [
+        _stamp(60 * 48) + "Info: Predbat starting up two days ago",
+        _stamp(60 * 48) + "Warn: An old warning from before the window",
+        _stamp(60 * 3) + "Info: Fetched Octopus rates",
+        _stamp(60 * 2) + "Warn: battery_rate_max_charge clamped to 3.0",
+        _stamp(60) + "Error: Failed to write charge window to inverter",
+        "Traceback (most recent call last):",  # a continuation line, written without its own stamp
+        _stamp(30) + "Fetched 48 slots of solar forecast",
+        _stamp(10) + "Warn: iboost target not reached",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _make_mcp(my_predbat):
+    """Build an MCPServerWrapper bound to my_predbat without starting any server."""
+    return MCPServerWrapper(my_predbat, log_func=my_predbat.log)
+
+
+def _make_web(my_predbat):
+    """Build a minimal WebInterface bound to my_predbat, bypassing ComponentBase.__init__
+    (which would stand up the real aiohttp app) - same pattern as test_web_debug_history_routes.py.
+    """
+    w = WebInterface.__new__(WebInterface)
+    w.base = my_predbat
+    w.log = my_predbat.log
+    w.prefix = my_predbat.prefix
+    return w
+
+
+def _call_tool(mcp, name, arguments=None):
+    """Run one tool through the MCP tools/call path and return the decoded JSON result."""
+    result = asyncio.run(mcp._handle_tools_call({"name": name, "arguments": arguments or {}}))
+    return json.loads(result["content"][0]["text"]), result.get("isError", False)
+
+
+def test_mask_secret_args(my_predbat):
+    """Credential-like apps.yaml keys are redacted, including the *_secret and *_token names
+    the original "_key"/"password" match missed (#4768), while timestamps stay readable.
+    """
+    failed = False
+    print("**** Testing mask_secret_args key matching ****")
+
+    args = {
+        "ha_key": "ha-key-value",
+        "octopus_api_key": "octopus-key-value",
+        "deye_password": "deye-password-value",
+        "sigenergy_app_secret": "sigenergy-secret-value",
+        "solis_api_secret": "solis-secret-value",
+        "solis_access_token": "solis-token-value",
+        "gateway_mqtt_token": "mqtt-token-value",
+        "mcp_secret": "mcp-secret-value",
+        "solis_token_expires_at": "2026-08-27T09:00:00",
+        "fox_token_expires_at": "2026-08-27T09:00:00",
+        "battery_rate_max_charge": 3.0,
+        "inverter_type": "GE",
+        "keyword_notes": "not a credential",
+    }
+    masked = mask_secret_args(args)
+
+    for key in ["ha_key", "octopus_api_key", "deye_password", "sigenergy_app_secret", "solis_api_secret", "solis_access_token", "gateway_mqtt_token", "mcp_secret"]:
+        if masked.get(key) != "xxx":
+            print("  ERROR: expected {} to be masked, got {!r}".format(key, masked.get(key)))
+            failed = True
+
+    for key in ["solis_token_expires_at", "fox_token_expires_at", "battery_rate_max_charge", "inverter_type", "keyword_notes"]:
+        if masked.get(key) != args[key]:
+            print("  ERROR: expected {} to be left alone, got {!r}".format(key, masked.get(key)))
+            failed = True
+
+    # The original dict must not be touched - it is the live self.args
+    if args["ha_key"] != "ha-key-value":
+        print("  ERROR: mask_secret_args mutated the caller's dict")
+        failed = True
+
+    if is_secret_key("SOLIS_API_SECRET") is not True:
+        print("  ERROR: is_secret_key should be case-insensitive")
+        failed = True
+    if is_secret_key("forecast_hours") is not False:
+        print("  ERROR: is_secret_key matched a non-credential key")
+        failed = True
+
+    return failed
+
+
+def test_read_predbat_log(my_predbat):
+    """read_predbat_log() concatenates the rotated log ahead of the live one, and copes with
+    either or both files being absent.
+    """
+    failed = False
+    print("**** Testing read_predbat_log ****")
+
+    tmpdir = tempfile.mkdtemp(prefix="predbat_test_mcp_log_")
+    live = os.path.join(tmpdir, "predbat.log")
+    prev = os.path.join(tmpdir, "predbat.1.log")
+
+    if read_predbat_log(logfile=live, logfile_prev=prev) != "":
+        print("  ERROR: expected an empty string when neither log file exists")
+        failed = True
+
+    with open(live, "w") as f:
+        f.write("newer\n")
+    if read_predbat_log(logfile=live, logfile_prev=prev) != "newer\n":
+        print("  ERROR: expected only the live log when no rotated log exists")
+        failed = True
+
+    with open(prev, "w") as f:
+        f.write("older\n")
+    data = read_predbat_log(logfile=live, logfile_prev=prev)
+    if data != "older\n\nnewer\n":
+        print("  ERROR: expected the rotated log first, got {!r}".format(data))
+        failed = True
+
+    return failed
+
+
+def test_log_filter_helpers(my_predbat):
+    """The severity classifier and per-view include rules keep the semantics the web log view
+    had inline before they were shared with the MCP get_log tool.
+    """
+    failed = False
+    print("**** Testing log filter helpers ****")
+
+    cases = [
+        ("2026-08-27 09:00:00.000000: Error: something broke", "error"),
+        ("2026-08-27 09:00:00.000000: Warn: something odd", "warning"),
+        ("2026-08-27 09:00:00.000000: Info: something happened", "info"),
+        ("2026-08-27 09:00:00.000000: just a line", "log"),
+    ]
+    for line, expected in cases:
+        line_type = classify_log_line(line)
+        if line_type != expected:
+            print("  ERROR: expected {!r} to classify as {}, got {}".format(line, expected, line_type))
+            failed = True
+
+    # Errors show everywhere; warnings on all/warnings; info on all/info; plain lines on all only
+    expected_matrix = {
+        ("error", "all"): True,
+        ("error", "info"): True,
+        ("error", "warnings"): True,
+        ("error", "errors"): True,
+        ("warning", "all"): True,
+        ("warning", "warnings"): True,
+        ("warning", "info"): False,
+        ("warning", "errors"): False,
+        ("info", "all"): True,
+        ("info", "info"): True,
+        ("info", "warnings"): False,
+        ("info", "errors"): False,
+        ("log", "all"): True,
+        ("log", "info"): False,
+        ("log", "warnings"): False,
+        ("log", "errors"): False,
+    }
+    for (line_type, filter_type), expected in expected_matrix.items():
+        got = log_line_included(line_type, filter_type)
+        if got != expected:
+            print("  ERROR: log_line_included({}, {}) expected {}, got {}".format(line_type, filter_type, expected, got))
+            failed = True
+
+    stamped = parse_log_timestamp("2026-08-27 09:15:30.123456: Info: hello")
+    if stamped != datetime(2026, 8, 27, 9, 15, 30, 123456):
+        print("  ERROR: failed to parse a microsecond timestamp, got {!r}".format(stamped))
+        failed = True
+
+    # str(datetime) drops ".000000", so whole-second lines are 19 characters not 26
+    stamped = parse_log_timestamp("2026-08-27 09:15:30: Info: hello")
+    if stamped != datetime(2026, 8, 27, 9, 15, 30):
+        print("  ERROR: failed to parse a whole-second timestamp, got {!r}".format(stamped))
+        failed = True
+
+    if parse_log_timestamp("Traceback (most recent call last):") is not None:
+        print("  ERROR: expected None for a line with no timestamp")
+        failed = True
+    if parse_log_timestamp("") is not None:
+        print("  ERROR: expected None for an empty line")
+        failed = True
+
+    return failed
+
+
+def test_mcp_get_apps(my_predbat):
+    """get_apps redacts credentials by default, honours an explicit masked=false opt-out, still
+    filters by regex, and never mutates the live args (#4768).
+    """
+    failed = False
+    print("**** Testing MCP get_apps redaction ****")
+
+    mcp = _make_mcp(my_predbat)
+    saved_args = my_predbat.args
+    try:
+        my_predbat.args = {"ha_key": "supersecret", "mcp_secret": "mcp-secret-value", "battery_rate_max_charge": 3.0, "inverter_type": "GE"}
+
+        result, _ = _call_tool(mcp, "get_apps")
+        if not result.get("success"):
+            print("  ERROR: get_apps failed: {}".format(result.get("error")))
+            failed = True
+        data = result.get("data") or {}
+        if data.get("ha_key") != "xxx" or data.get("mcp_secret") != "xxx":
+            print("  ERROR: expected credentials to be masked by default, got {!r}".format(data))
+            failed = True
+        if data.get("battery_rate_max_charge") != 3.0:
+            print("  ERROR: masking should leave ordinary settings alone, got {!r}".format(data.get("battery_rate_max_charge")))
+            failed = True
+        if result.get("masked") is not True:
+            print("  ERROR: expected the response to report masked=True")
+            failed = True
+        if my_predbat.args["ha_key"] != "supersecret":
+            print("  ERROR: get_apps mutated the live args")
+            failed = True
+
+        print("Test: masked=false returns the raw values")
+        result, _ = _call_tool(mcp, "get_apps", {"masked": False})
+        if (result.get("data") or {}).get("ha_key") != "supersecret":
+            print("  ERROR: expected the unmasked key with masked=false, got {!r}".format(result.get("data")))
+            failed = True
+        if result.get("masked") is not False:
+            print("  ERROR: expected the response to report masked=False")
+            failed = True
+
+        print("Test: a string 'false' from a client that can't send booleans is honoured")
+        result, _ = _call_tool(mcp, "get_apps", {"masked": "false"})
+        if (result.get("data") or {}).get("ha_key") != "supersecret":
+            print("  ERROR: expected string 'false' to disable masking")
+            failed = True
+
+        print("Test: the filter regex still applies, and its results are masked too")
+        result, _ = _call_tool(mcp, "get_apps", {"filter": "^ha_key$"})
+        data = result.get("data") or {}
+        if list(data.keys()) != ["ha_key"] or data.get("ha_key") != "xxx":
+            print("  ERROR: expected only a masked ha_key, got {!r}".format(data))
+            failed = True
+    finally:
+        my_predbat.args = saved_args
+
+    if parse_bool_argument(None, default=True) is not True:
+        print("  ERROR: parse_bool_argument should fall back to its default for None")
+        failed = True
+    for value in [False, "false", "False", "0", "no", "off", ""]:
+        if parse_bool_argument(value, default=True) is not False:
+            print("  ERROR: parse_bool_argument({!r}) should be False".format(value))
+            failed = True
+    for value in [True, "true", "1", 1, "yes"]:
+        if parse_bool_argument(value, default=False) is not True:
+            print("  ERROR: parse_bool_argument({!r}) should be True".format(value))
+            failed = True
+
+    return failed
+
+
+def test_mcp_get_log(my_predbat):
+    """get_log filters by level, search term and age, caps the number of lines returned, and
+    reports the log oldest-first (#4768).
+    """
+    failed = False
+    print("**** Testing MCP get_log ****")
+
+    mcp = _make_mcp(my_predbat)
+    saved_reader = web_mcp.read_predbat_log
+    try:
+        web_mcp.read_predbat_log = lambda: _sample_log()
+
+        print("Test: the default warnings view returns warnings and errors only")
+        result, _ = _call_tool(mcp, "get_log")
+        if not result.get("success"):
+            print("  ERROR: get_log failed: {}".format(result.get("error")))
+            return True
+        data = result["data"]
+        types = [line["type"] for line in data["lines"]]
+        if sorted(set(types)) != ["error", "warning"]:
+            print("  ERROR: expected only warnings and errors by default, got {}".format(sorted(set(types))))
+            failed = True
+        if data["filter"] != "warnings":
+            print("  ERROR: expected the default filter to be warnings, got {}".format(data["filter"]))
+            failed = True
+
+        print("Test: lines come back oldest-first")
+        stamps = [parse_log_timestamp(line["line"]) for line in data["lines"]]
+        if stamps != sorted(stamps):
+            print("  ERROR: expected oldest-first ordering, got {}".format(stamps))
+            failed = True
+
+        print("Test: the errors view drops warnings")
+        result, _ = _call_tool(mcp, "get_log", {"filter": "errors"})
+        types = [line["type"] for line in result["data"]["lines"]]
+        if types != ["error"]:
+            print("  ERROR: expected a single error line, got {}".format(types))
+            failed = True
+
+        print("Test: the all view includes untyped lines such as tracebacks")
+        result, _ = _call_tool(mcp, "get_log", {"filter": "all"})
+        if not any(line["type"] == "log" for line in result["data"]["lines"]):
+            print("  ERROR: expected plain log lines in the all view")
+            failed = True
+        if result["data"]["returned_lines"] != 8:
+            print("  ERROR: expected all 8 sample lines, got {}".format(result["data"]["returned_lines"]))
+            failed = True
+
+        print("Test: search narrows to matching lines, case-insensitively")
+        result, _ = _call_tool(mcp, "get_log", {"filter": "all", "search": "IBOOST"})
+        lines = result["data"]["lines"]
+        if len(lines) != 1 or "iboost" not in lines[0]["line"]:
+            print("  ERROR: expected one iboost line, got {}".format(lines))
+            failed = True
+
+        print("Test: hours drops entries older than the window")
+        result, _ = _call_tool(mcp, "get_log", {"filter": "all", "hours": 4})
+        lines = result["data"]["lines"]
+        if any("two days ago" in line["line"] or "before the window" in line["line"] for line in lines):
+            print("  ERROR: expected the two-day-old lines to be excluded, got {}".format([line["line"] for line in lines]))
+            failed = True
+        if len(lines) != 6:
+            print("  ERROR: expected 6 lines within 4 hours, got {}".format(len(lines)))
+            failed = True
+
+        print("Test: a traceback line with no timestamp of its own is kept with the entry above it")
+        if not any("Traceback" in line["line"] for line in lines):
+            print("  ERROR: expected the traceback continuation line to be retained")
+            failed = True
+
+        print("Test: max_lines keeps the most recent lines and flags the truncation")
+        result, _ = _call_tool(mcp, "get_log", {"filter": "all", "max_lines": 2})
+        data = result["data"]
+        if data["returned_lines"] != 2 or not data["truncated"]:
+            print("  ERROR: expected 2 truncated lines, got {}".format(data))
+            failed = True
+        if data["matched_lines"] != 8:
+            print("  ERROR: expected matched_lines to count all 8 matches, got {}".format(data["matched_lines"]))
+            failed = True
+        if "iboost" not in data["lines"][-1]["line"]:
+            print("  ERROR: expected the newest line to survive truncation, got {}".format(data["lines"][-1]["line"]))
+            failed = True
+
+        print("Test: max_lines is clamped to the protocol cap and to at least one line")
+        result, _ = _call_tool(mcp, "get_log", {"filter": "all", "max_lines": MCP_LOG_MAX_LINES * 100})
+        if result["data"]["truncated"]:
+            print("  ERROR: an oversized max_lines should still return the whole sample log")
+            failed = True
+        result, _ = _call_tool(mcp, "get_log", {"filter": "all", "max_lines": 0})
+        if result["data"]["returned_lines"] != 1:
+            print("  ERROR: expected max_lines=0 to be clamped up to 1, got {}".format(result["data"]["returned_lines"]))
+            failed = True
+
+        print("Test: an unknown filter is rejected rather than silently returning everything")
+        result, _ = _call_tool(mcp, "get_log", {"filter": "everything"})
+        if result.get("success") or "everything" not in (result.get("error") or ""):
+            print("  ERROR: expected an error naming the bad filter, got {}".format(result))
+            failed = True
+
+        print("Test: an empty log is reported as success with no lines")
+        web_mcp.read_predbat_log = lambda: ""
+        result, _ = _call_tool(mcp, "get_log", {"filter": "all"})
+        if not result.get("success") or result["data"]["returned_lines"] != 0:
+            print("  ERROR: expected an empty but successful result, got {}".format(result))
+            failed = True
+
+        print("Test: a reader failure is reported rather than raised")
+
+        def _boom():
+            """Stand-in reader that fails the way an unreadable log file would."""
+            raise IOError("log file unreadable")
+
+        web_mcp.read_predbat_log = _boom
+        result, _ = _call_tool(mcp, "get_log")
+        if result.get("success") or "unreadable" not in (result.get("error") or ""):
+            print("  ERROR: expected a failure result naming the error, got {}".format(result))
+            failed = True
+    finally:
+        web_mcp.read_predbat_log = saved_reader
+
+    return failed
+
+
+def test_mcp_tools_list(my_predbat):
+    """get_log is advertised by tools/list with a usable schema, and tools/call routes to it."""
+    failed = False
+    print("**** Testing MCP tools/list registration ****")
+
+    mcp = _make_mcp(my_predbat)
+    tools = asyncio.run(mcp._handle_tools_list({}))["tools"]
+    by_name = {tool["name"]: tool for tool in tools}
+
+    if "get_log" not in by_name:
+        print("  ERROR: get_log is missing from tools/list")
+        return True
+
+    schema = by_name["get_log"]["inputSchema"]
+    for prop in ["filter", "search", "hours", "max_lines"]:
+        if prop not in schema["properties"]:
+            print("  ERROR: get_log schema is missing the {} property".format(prop))
+            failed = True
+    if schema.get("required"):
+        print("  ERROR: get_log should have no required arguments")
+        failed = True
+    if schema["properties"]["filter"].get("enum") != list(LOG_FILTER_TYPES):
+        print("  ERROR: get_log filter enum should list every supported view, got {}".format(schema["properties"]["filter"].get("enum")))
+        failed = True
+    if str(MCP_LOG_DEFAULT_LINES) not in schema["properties"]["max_lines"]["description"]:
+        print("  ERROR: the max_lines description should name the default")
+        failed = True
+
+    if "masked" not in by_name["get_apps"]["inputSchema"]["properties"]:
+        print("  ERROR: get_apps schema is missing the masked property")
+        failed = True
+
+    print("Test: an unknown tool is still rejected")
+    result = asyncio.run(mcp._handle_tools_call({"name": "get_logs", "arguments": {}}))
+    if not result.get("isError"):
+        print("  ERROR: expected an error for an unknown tool name")
+        failed = True
+
+    return failed
+
+
+def test_web_api_log_unchanged(my_predbat):
+    """The web log API still filters exactly as it did before it moved onto the shared helpers,
+    including its HTML escaping and search highlighting.
+    """
+    failed = False
+    print("**** Testing /api/log after the shared-helper refactor ****")
+
+    w = _make_web(my_predbat)
+    saved_reader = web.read_predbat_log
+    try:
+        web.read_predbat_log = lambda: _sample_log() + _stamp(5) + "Info: <b>escape me</b>\n"
+
+        response = asyncio.run(w.html_api_get_log(FakeRequest({"filter": "errors"})))
+        data = json.loads(response.text)
+        if data["status"] != "success":
+            print("  ERROR: expected a successful response, got {}".format(data))
+            return True
+        if [line["type"] for line in data["lines"]] != ["error"]:
+            print("  ERROR: expected only the error line on the errors tab, got {}".format([line["type"] for line in data["lines"]]))
+            failed = True
+
+        response = asyncio.run(w.html_api_get_log(FakeRequest({"filter": "warnings"})))
+        types = sorted(set(line["type"] for line in json.loads(response.text)["lines"]))
+        if types != ["error", "warning"]:
+            print("  ERROR: expected warnings and errors on the warnings tab, got {}".format(types))
+            failed = True
+
+        response = asyncio.run(w.html_api_get_log(FakeRequest({"filter": "all"})))
+        data = json.loads(response.text)
+        if not any(line["type"] == "log" for line in data["lines"]):
+            print("  ERROR: expected untyped lines on the all tab")
+            failed = True
+        if not any("&lt;b&gt;escape me&lt;/b&gt;" in line["full_line"] for line in data["lines"]):
+            print("  ERROR: expected HTML in log lines to still be escaped")
+            failed = True
+
+        response = asyncio.run(w.html_api_get_log(FakeRequest({"filter": "all", "search": "iboost"})))
+        data = json.loads(response.text)
+        if data.get("search_matches") != 1:
+            print("  ERROR: expected a single search match, got {}".format(data.get("search_matches")))
+            failed = True
+        if not any("search-highlight" in line["full_line"] for line in data["lines"]):
+            print("  ERROR: expected the search term to be highlighted")
+            failed = True
+    finally:
+        web.read_predbat_log = saved_reader
+
+    return failed
+
+
+def run_web_mcp_tests(my_predbat):
+    """Run every MCP log/apps.yaml test, returning True if any of them failed."""
+    failed = False
+    failed |= test_mask_secret_args(my_predbat)
+    failed |= test_read_predbat_log(my_predbat)
+    failed |= test_log_filter_helpers(my_predbat)
+    failed |= test_mcp_get_apps(my_predbat)
+    failed |= test_mcp_get_log(my_predbat)
+    failed |= test_mcp_tools_list(my_predbat)
+    failed |= test_web_api_log_unchanged(my_predbat)
+    return failed

--- a/apps/predbat/tests/test_web_mcp.py
+++ b/apps/predbat/tests/test_web_mcp.py
@@ -24,8 +24,20 @@ from datetime import datetime, timedelta
 import web
 import web_mcp
 from web import WebInterface
-from web_mcp import MCPServerWrapper, LOG_FILTER_TYPES, MCP_LOG_DEFAULT_LINES, MCP_LOG_MAX_LINES, parse_bool_argument
-from utils import mask_secret_args, is_secret_key, read_predbat_log, classify_log_line, log_line_included, parse_log_timestamp
+from web_mcp import (
+    MCPServerWrapper,
+    LOG_FILTER_TYPES,
+    MCP_LOG_DEFAULT_LINES,
+    MCP_LOG_MAX_LINES,
+    parse_bool_argument,
+    json_safe_value,
+    summarise_state_value,
+    measure_state_value,
+    MCP_STATE_DEFAULT_MAX_BYTES,
+    MCP_STATE_LARGE_COLLECTION,
+    MCP_STATE_MAX_BYTES_LIMIT,
+)
+from utils import mask_secret_args, is_secret_key, is_debug_excluded_key, read_predbat_log, classify_log_line, log_line_included, parse_log_timestamp
 
 
 class FakeRequest:
@@ -415,6 +427,289 @@ def test_mcp_get_log(my_predbat):
     return failed
 
 
+class FakeBase:
+    """A stand-in for the PredBat instance, carrying only the attributes get_state walks."""
+
+    def __init__(self, log_func):
+        """Populate a mix of small, large, excluded and awkward state variables."""
+        self.log = log_func
+        self.prefix = "predbat"
+        self.plan_interval_minutes = 30
+
+        # Small scalars - the bulk of a real dump, and what get_state exists to return
+        self.current_status = "Charging"
+        self.soc_max = 9.52
+        self.num_cars = 1
+        self.carbon_enable = False
+        self.charge_limit_best = [9.52, 4.0]
+
+        # A per-minute series - too long to serialise, must be described instead
+        self.load_minutes = {minute: minute * 0.01 for minute in range(2880)}
+
+        # Short but bulky - rejected on byte size rather than entry count
+        self.html_plan = "x" * (MCP_STATE_DEFAULT_MAX_BYTES + 500)
+
+        # Values a plain json.dumps would choke on
+        self.midnight_utc = datetime(2026, 8, 27, 0, 0, 0)
+        self.inverter_object = object()
+
+        # Legitimately-None state - a great deal of Predbat's is, so None must not double as
+        # the "too large to return" sentinel
+        self.plan_last_updated = None
+        self.previous_status = None
+        self.empty_dict = {}
+
+        # Must never be returned: credentials and live object graphs
+        self.ha_key = "ha-key-value"
+        self.mcp_secret = "mcp-secret-value"
+        self.solis_access_token = "solis-token-value"
+        self.ha_interface = object()
+        self.components = object()
+        self.octopus_url_cache = {"https://example.invalid": "cached"}
+        self.db_connection = object()
+        self.args = {"ha_key": "ha-key-value", "battery_rate_max_charge": 3.0}
+
+    def is_running(self):
+        """Callables are skipped by get_state - present so that path is exercised."""
+        return True
+
+
+def test_state_value_helpers(my_predbat):
+    """json_safe_value coerces anything json.dumps would reject, and summarise_state_value
+    describes a value's shape well enough to decide whether to ask for it.
+    """
+    failed = False
+    print("**** Testing get_state value helpers ****")
+
+    safe = json_safe_value({"when": datetime(2026, 8, 27, 9, 0, 0), "nested": [1, {"deep": object()}], "ok": 2.5, "flag": True})
+    try:
+        json.dumps(safe)
+    except TypeError as error:
+        print("  ERROR: json_safe_value left a value json.dumps cannot encode: {}".format(error))
+        failed = True
+    if safe["when"] != "2026-08-27T09:00:00":
+        print("  ERROR: expected a datetime to become an ISO string, got {!r}".format(safe["when"]))
+        failed = True
+    if safe["ok"] != 2.5 or safe["flag"] is not True:
+        print("  ERROR: plain values should pass through untouched, got {!r}".format(safe))
+        failed = True
+
+    print("Test: deeply nested values stop recursing rather than blowing the stack")
+    deep = {}
+    node = deep
+    for _ in range(40):
+        node["next"] = {}
+        node = node["next"]
+    try:
+        json.dumps(json_safe_value(deep))
+    except (TypeError, ValueError, RecursionError) as error:
+        print("  ERROR: deep nesting was not handled: {}".format(error))
+        failed = True
+
+    print("Test: a numeric series is summarised with its range")
+    summary = summarise_state_value({minute: float(minute) for minute in range(1000)})
+    if summary.get("type") != "dict" or summary.get("length") != 1000:
+        print("  ERROR: expected a dict of 1000 entries, got {}".format(summary))
+        failed = True
+    if summary.get("min") != 0.0 or summary.get("max") != 999.0:
+        print("  ERROR: expected min/max over the values, got {}".format(summary))
+        failed = True
+    if len(summary.get("sample_keys", [])) != 3:
+        print("  ERROR: expected three sample keys, got {}".format(summary.get("sample_keys")))
+        failed = True
+
+    print("Test: measure_state_value reports fit separately from the value itself")
+    fits, safe, size = measure_state_value(None, MCP_STATE_DEFAULT_MAX_BYTES)
+    if not fits or safe is not None or size != len("null"):
+        print("  ERROR: None should fit and come back as None, got fits={} safe={!r} size={}".format(fits, safe, size))
+        failed = True
+    fits, safe, _ = measure_state_value({minute: minute for minute in range(MCP_STATE_LARGE_COLLECTION + 1)}, MCP_STATE_DEFAULT_MAX_BYTES)
+    if fits or safe is not None:
+        print("  ERROR: a long collection should not fit, got fits={}".format(fits))
+        failed = True
+    fits, _, _ = measure_state_value("z" * (MCP_STATE_DEFAULT_MAX_BYTES + 1), MCP_STATE_DEFAULT_MAX_BYTES)
+    if fits:
+        print("  ERROR: an oversized string should not fit")
+        failed = True
+
+    print("Test: a long string is summarised with a preview, not its full contents")
+    summary = summarise_state_value("y" * 5000)
+    if summary.get("length") != 5000 or len(summary.get("preview", "")) != 200:
+        print("  ERROR: expected a 200 character preview of a 5000 character string, got {}".format({k: v for k, v in summary.items() if k != "preview"}))
+        failed = True
+
+    return failed
+
+
+def test_debug_excluded_keys(my_predbat):
+    """The state query and the debug yaml share one exclusion filter, so a variable that never
+    reaches a debug dump can't be read over MCP either.
+    """
+    failed = False
+    print("**** Testing is_debug_excluded_key ****")
+
+    for key in ["ha_interface", "components", "secrets", "octopus_url_cache", "github_url_cache", "inverters", "CONFIG_ITEMS", "logfile"]:
+        if not is_debug_excluded_key(key):
+            print("  ERROR: expected {} to be excluded".format(key))
+            failed = True
+
+    print("Test: credentials are excluded via the shared secret matcher, including secrets and tokens")
+    for key in ["ha_key", "octopus_api_key", "mcp_secret", "solis_access_token", "deye_password"]:
+        if not is_debug_excluded_key(key):
+            print("  ERROR: expected the credential {} to be excluded".format(key))
+            failed = True
+
+    print("Test: database internals and double-underscore names are excluded by prefix")
+    for key in ["db_connection", "db_manage", "__class__"]:
+        if not is_debug_excluded_key(key):
+            print("  ERROR: expected {} to be excluded by prefix".format(key))
+            failed = True
+
+    print("Test: ordinary diagnostic state is not excluded")
+    for key in ["soc_max", "charge_limit_best", "load_minutes", "current_status", "dashboard_values", "solis_token_expires_at"]:
+        if is_debug_excluded_key(key):
+            print("  ERROR: expected {} to be readable".format(key))
+            failed = True
+
+    return failed
+
+
+def test_mcp_get_state(my_predbat):
+    """get_state returns the small variables, describes the large ones instead of returning them,
+    honours keys/filter/max_bytes, and never leaks a credential or a live object graph (#4768).
+    """
+    failed = False
+    print("**** Testing MCP get_state ****")
+
+    mcp = _make_mcp(my_predbat)
+    mcp.base = FakeBase(my_predbat.log)
+
+    print("Test: with no arguments the small variables come back and the big ones are described")
+    result, _ = _call_tool(mcp, "get_state")
+    if not result.get("success"):
+        print("  ERROR: get_state failed: {}".format(result.get("error")))
+        return True
+    data = result["data"]
+    state, omitted = data["state"], data["omitted"]
+
+    for key in ["current_status", "soc_max", "num_cars", "carbon_enable", "charge_limit_best"]:
+        if key not in state:
+            print("  ERROR: expected the small variable {} to be returned".format(key))
+            failed = True
+    if state.get("soc_max") != 9.52 or state.get("carbon_enable") is not False:
+        print("  ERROR: small values came back altered: {!r}".format({k: state.get(k) for k in ["soc_max", "carbon_enable"]}))
+        failed = True
+
+    print("Test: None-valued state is returned as null, not reported as omitted")
+    for key in ["plan_last_updated", "previous_status"]:
+        if key in omitted:
+            print("  ERROR: {} is None, not too large - it must not be listed as omitted".format(key))
+            failed = True
+        if key not in state or state[key] is not None:
+            print("  ERROR: expected {} to come back as null, got {!r}".format(key, state.get(key)))
+            failed = True
+    if "empty_dict" not in state or state["empty_dict"] != {}:
+        print("  ERROR: expected an empty collection to be returned, got {!r}".format(state.get("empty_dict")))
+        failed = True
+
+    print("Test: a per-minute series is described, not returned")
+    if "load_minutes" in state:
+        print("  ERROR: the 2880 entry series should not have been returned in full")
+        failed = True
+    if omitted.get("load_minutes", {}).get("length") != 2880:
+        print("  ERROR: expected load_minutes to be described with its length, got {}".format(omitted.get("load_minutes")))
+        failed = True
+    if "max" not in omitted.get("load_minutes", {}):
+        print("  ERROR: expected a numeric summary for load_minutes, got {}".format(omitted.get("load_minutes")))
+        failed = True
+
+    print("Test: a bulky string is rejected on size even though it is a single value")
+    if "html_plan" in state or "html_plan" not in omitted:
+        print("  ERROR: expected html_plan to be described rather than returned")
+        failed = True
+
+    print("Test: credentials and live object graphs never appear, in state or in omitted")
+    for key in ["ha_key", "mcp_secret", "solis_access_token", "ha_interface", "components", "octopus_url_cache", "db_connection"]:
+        if key in state or key in omitted:
+            print("  ERROR: excluded key {} was exposed".format(key))
+            failed = True
+    blob = json.dumps(data)
+    for secret in ["ha-key-value", "mcp-secret-value", "solis-token-value"]:
+        if secret in blob:
+            print("  ERROR: the secret {!r} leaked into the response".format(secret))
+            failed = True
+
+    print("Test: args is masked if it is returned at all")
+    if "args" in state and state["args"].get("ha_key") != "xxx":
+        print("  ERROR: expected args to be masked, got {!r}".format(state.get("args")))
+        failed = True
+
+    print("Test: values json.dumps could not encode are coerced rather than failing the call")
+    if state.get("midnight_utc") != "2026-08-27T00:00:00":
+        print("  ERROR: expected the datetime to be returned as an ISO string, got {!r}".format(state.get("midnight_utc")))
+        failed = True
+    if not isinstance(state.get("inverter_object"), str):
+        print("  ERROR: expected an opaque object to become a string, got {!r}".format(state.get("inverter_object")))
+        failed = True
+
+    print("Test: methods are skipped")
+    if "is_running" in state or "is_running" in omitted:
+        print("  ERROR: callables should not be reported as state")
+        failed = True
+
+    print("Test: keys= returns just those variables, and reports the ones that don't exist")
+    result, _ = _call_tool(mcp, "get_state", {"keys": ["soc_max", "num_cars", "not_a_real_key"]})
+    data = result["data"]
+    if sorted(data["state"].keys()) != ["num_cars", "soc_max"]:
+        print("  ERROR: expected only the two named keys, got {}".format(sorted(data["state"].keys())))
+        failed = True
+    if data.get("unknown_keys") != ["not_a_real_key"]:
+        print("  ERROR: expected the unknown key to be reported back, got {}".format(data.get("unknown_keys")))
+        failed = True
+
+    print("Test: a single key may be given as a bare string")
+    result, _ = _call_tool(mcp, "get_state", {"keys": "soc_max"})
+    if list(result["data"]["state"].keys()) != ["soc_max"]:
+        print("  ERROR: expected a bare string key to work, got {}".format(result["data"]["state"]))
+        failed = True
+
+    print("Test: asking for an excluded key by name still refuses it")
+    result, _ = _call_tool(mcp, "get_state", {"keys": ["ha_key", "mcp_secret", "ha_interface"]})
+    data = result["data"]
+    if data["state"] or data["omitted"]:
+        print("  ERROR: naming an excluded key explicitly must not return it, got {}".format(data))
+        failed = True
+
+    print("Test: filter narrows by variable name")
+    result, _ = _call_tool(mcp, "get_state", {"filter": "^charge_"})
+    if list(result["data"]["state"].keys()) != ["charge_limit_best"]:
+        print("  ERROR: expected only charge_ variables, got {}".format(list(result["data"]["state"].keys())))
+        failed = True
+
+    print("Test: raising max_bytes lets a previously omitted value through")
+    result, _ = _call_tool(mcp, "get_state", {"keys": ["html_plan"], "max_bytes": MCP_STATE_DEFAULT_MAX_BYTES + 2000})
+    if "html_plan" not in result["data"]["state"]:
+        print("  ERROR: expected html_plan to fit once max_bytes was raised")
+        failed = True
+
+    print("Test: max_bytes cannot be raised past the protocol cap, and a long series still won't fit")
+    result, _ = _call_tool(mcp, "get_state", {"keys": ["load_minutes"], "max_bytes": MCP_STATE_MAX_BYTES_LIMIT * 100})
+    if result["data"]["max_bytes"] != MCP_STATE_MAX_BYTES_LIMIT:
+        print("  ERROR: expected max_bytes to be clamped to the cap, got {}".format(result["data"]["max_bytes"]))
+        failed = True
+    if "load_minutes" in result["data"]["state"]:
+        print("  ERROR: a {} entry collection should be refused on entry count regardless of max_bytes".format(MCP_STATE_LARGE_COLLECTION))
+        failed = True
+
+    print("Test: a non-list keys argument is rejected with a clear error")
+    result, _ = _call_tool(mcp, "get_state", {"keys": {"soc_max": True}})
+    if result.get("success") or "keys" not in (result.get("error") or ""):
+        print("  ERROR: expected an error naming the bad argument, got {}".format(result))
+        failed = True
+
+    return failed
+
+
 def test_mcp_tools_list(my_predbat):
     """get_log is advertised by tools/list with a usable schema, and tools/call routes to it."""
     failed = False
@@ -427,6 +722,21 @@ def test_mcp_tools_list(my_predbat):
     if "get_log" not in by_name:
         print("  ERROR: get_log is missing from tools/list")
         return True
+    if "get_state" not in by_name:
+        print("  ERROR: get_state is missing from tools/list")
+        return True
+
+    state_schema = by_name["get_state"]["inputSchema"]
+    for prop in ["keys", "filter", "max_bytes"]:
+        if prop not in state_schema["properties"]:
+            print("  ERROR: get_state schema is missing the {} property".format(prop))
+            failed = True
+    if state_schema["properties"]["keys"].get("type") != "array":
+        print("  ERROR: get_state keys should be declared as an array")
+        failed = True
+    if state_schema.get("required"):
+        print("  ERROR: get_state should have no required arguments")
+        failed = True
 
     schema = by_name["get_log"]["inputSchema"]
     for prop in ["filter", "search", "hours", "max_lines"]:
@@ -514,6 +824,9 @@ def run_web_mcp_tests(my_predbat):
     failed |= test_log_filter_helpers(my_predbat)
     failed |= test_mcp_get_apps(my_predbat)
     failed |= test_mcp_get_log(my_predbat)
+    failed |= test_state_value_helpers(my_predbat)
+    failed |= test_debug_excluded_keys(my_predbat)
+    failed |= test_mcp_get_state(my_predbat)
     failed |= test_mcp_tools_list(my_predbat)
     failed |= test_web_api_log_unchanged(my_predbat)
     return failed

--- a/apps/predbat/tests/test_web_mcp.py
+++ b/apps/predbat/tests/test_web_mcp.py
@@ -36,6 +36,9 @@ from web_mcp import (
     MCP_STATE_DEFAULT_MAX_BYTES,
     MCP_STATE_LARGE_COLLECTION,
     MCP_STATE_MAX_BYTES_LIMIT,
+    MCPArgumentError,
+    parse_number_argument,
+    compile_filter_argument,
 )
 from utils import mask_secret_args, is_secret_key, is_debug_excluded_key, read_predbat_log, classify_log_line, log_line_included, parse_log_timestamp
 
@@ -108,6 +111,10 @@ def test_mask_secret_args(my_predbat):
         "mcp_secret": "mcp-secret-value",
         "solis_token_expires_at": "2026-08-27T09:00:00",
         "fox_token_expires_at": "2026-08-27T09:00:00",
+        "partner_token_expiry": "2026-08-27T09:00:00",
+        "session_token_expires": "2026-08-27T09:00:00",
+        "auth_token_expiration": "2026-08-27T09:00:00",
+        "client_token_birth": 1756280000.0,
         "battery_rate_max_charge": 3.0,
         "inverter_type": "GE",
         "keyword_notes": "not a credential",
@@ -119,7 +126,9 @@ def test_mask_secret_args(my_predbat):
             print("  ERROR: expected {} to be masked, got {!r}".format(key, masked.get(key)))
             failed = True
 
-    for key in ["solis_token_expires_at", "fox_token_expires_at", "battery_rate_max_charge", "inverter_type", "keyword_notes"]:
+    # Timing metadata about a token is not itself a secret, and is what you want to see when a
+    # cloud integration stops working - Copilot review of PR #4775
+    for key in ["solis_token_expires_at", "fox_token_expires_at", "partner_token_expiry", "session_token_expires", "auth_token_expiration", "client_token_birth", "battery_rate_max_charge", "inverter_type", "keyword_notes"]:
         if masked.get(key) != args[key]:
             print("  ERROR: expected {} to be left alone, got {!r}".format(key, masked.get(key)))
             failed = True
@@ -565,8 +574,8 @@ def test_debug_excluded_keys(my_predbat):
             print("  ERROR: expected {} to be excluded by prefix".format(key))
             failed = True
 
-    print("Test: ordinary diagnostic state is not excluded")
-    for key in ["soc_max", "charge_limit_best", "load_minutes", "current_status", "dashboard_values", "solis_token_expires_at"]:
+    print("Test: ordinary diagnostic state is not excluded, token timing metadata included")
+    for key in ["soc_max", "charge_limit_best", "load_minutes", "current_status", "dashboard_values", "solis_token_expires_at", "partner_token_expiry", "client_token_birth"]:
         if is_debug_excluded_key(key):
             print("  ERROR: expected {} to be readable".format(key))
             failed = True
@@ -710,6 +719,133 @@ def test_mcp_get_state(my_predbat):
     return failed
 
 
+def test_mcp_argument_validation(my_predbat):
+    """Bad tool arguments come back as a named argument error rather than a raw Python exception,
+    across every tool that takes one - Copilot review of PR #4775.
+    """
+    failed = False
+    print("**** Testing MCP argument validation ****")
+
+    print("Test: parse_number_argument clamps in range but rejects non-numbers")
+    if parse_number_argument(None, "max_lines", 500, minimum=1, maximum=5000) != 500:
+        print("  ERROR: expected the default to be used when the argument is absent")
+        failed = True
+    if parse_number_argument(99999, "max_lines", 500, minimum=1, maximum=5000) != 5000:
+        print("  ERROR: expected an oversized value to be clamped to the maximum")
+        failed = True
+    if parse_number_argument(0, "max_lines", 500, minimum=1, maximum=5000) != 1:
+        print("  ERROR: expected an undersized value to be clamped to the minimum")
+        failed = True
+    if parse_number_argument("250", "max_lines", 500, minimum=1, maximum=5000) != 250:
+        print("  ERROR: expected a numeric string to be accepted")
+        failed = True
+    if parse_number_argument(None, "hours", None) is not None:
+        print("  ERROR: expected an absent optional argument with no default to stay None")
+        failed = True
+    if parse_number_argument("1.5", "hours", None, as_float=True) != 1.5:
+        print("  ERROR: expected a float argument to be parsed")
+        failed = True
+    for bad in ["abc", "", [1], {"a": 1}, True]:
+        try:
+            parse_number_argument(bad, "max_lines", 500)
+            print("  ERROR: expected {!r} to be rejected as a number".format(bad))
+            failed = True
+        except MCPArgumentError as error:
+            if "max_lines" not in str(error):
+                print("  ERROR: the error should name the argument, got {}".format(error))
+                failed = True
+
+    print("Test: compile_filter_argument returns a usable pattern or a named error")
+    if compile_filter_argument(None) is not None or compile_filter_argument("") is not None:
+        print("  ERROR: an absent filter should compile to None")
+        failed = True
+    pattern = compile_filter_argument("^soc_")
+    if not pattern.search("soc_max") or pattern.search("battery_soc"):
+        print("  ERROR: the compiled pattern did not anchor as written")
+        failed = True
+    for bad in ["[unclosed", "*", 42]:
+        try:
+            compile_filter_argument(bad, "filter")
+            print("  ERROR: expected {!r} to be rejected as a regex".format(bad))
+            failed = True
+        except MCPArgumentError as error:
+            if "filter" not in str(error):
+                print("  ERROR: the error should name the argument, got {}".format(error))
+                failed = True
+
+    print("Test: every filtering tool reports a bad regex the same way")
+    mcp = _make_mcp(my_predbat)
+    saved_args = my_predbat.args
+    saved_reader = web_mcp.read_predbat_log
+    try:
+        my_predbat.args = {"battery_rate_max_charge": 3.0}
+        web_mcp.read_predbat_log = lambda: _sample_log()
+        for tool in ["get_apps", "get_config", "get_entities", "get_state"]:
+            result, _ = _call_tool(mcp, tool, {"filter": "[unclosed"})
+            if result.get("success"):
+                print("  ERROR: {} accepted an invalid regex".format(tool))
+                failed = True
+            elif "not a valid regular expression" not in (result.get("error") or ""):
+                print("  ERROR: {} gave an unhelpful error: {}".format(tool, result.get("error")))
+                failed = True
+
+        print("Test: get_log reports bad max_lines and hours by name")
+        for argument, value in [("max_lines", "lots"), ("hours", "yesterday")]:
+            result, _ = _call_tool(mcp, "get_log", {argument: value})
+            if result.get("success") or argument not in (result.get("error") or ""):
+                print("  ERROR: expected get_log to name the bad {} argument, got {}".format(argument, result.get("error")))
+                failed = True
+
+        print("Test: get_state reports a bad max_bytes by name")
+        result, _ = _call_tool(mcp, "get_state", {"max_bytes": "plenty"})
+        if result.get("success") or "max_bytes" not in (result.get("error") or ""):
+            print("  ERROR: expected get_state to name the bad max_bytes argument, got {}".format(result.get("error")))
+            failed = True
+
+        print("Test: a valid filter still works everywhere after the change")
+        result, _ = _call_tool(mcp, "get_apps", {"filter": "^battery_"})
+        if not result.get("success") or list((result.get("data") or {}).keys()) != ["battery_rate_max_charge"]:
+            print("  ERROR: a valid regex filter stopped working, got {}".format(result.get("data")))
+            failed = True
+    finally:
+        my_predbat.args = saved_args
+        web_mcp.read_predbat_log = saved_reader
+
+    return failed
+
+
+def test_log_encoding(my_predbat):
+    """A non-UTF-8 byte in the log is replaced rather than raising UnicodeDecodeError and taking
+    out both /api/log and get_log - Copilot review of PR #4775.
+    """
+    failed = False
+    print("**** Testing log decoding robustness ****")
+
+    tmpdir = tempfile.mkdtemp(prefix="predbat_test_mcp_encoding_")
+    live = os.path.join(tmpdir, "predbat.log")
+    prev = os.path.join(tmpdir, "predbat.1.log")
+
+    # A latin-1 encoded degree sign is not valid UTF-8 - exactly what an inverter API error
+    # message can carry into the log
+    with open(live, "wb") as f:
+        f.write("2026-08-27 09:00:00.000000: Warn: inverter reported 21".encode("utf-8") + b"\xb0" + "C\n".encode("utf-8"))
+
+    try:
+        data = read_predbat_log(logfile=live, logfile_prev=prev)
+    except UnicodeDecodeError as error:
+        print("  ERROR: a non-UTF-8 byte raised instead of being replaced: {}".format(error))
+        return True
+
+    if "inverter reported 21" not in data:
+        print("  ERROR: the readable part of the line was lost, got {!r}".format(data))
+        failed = True
+    if chr(0xFFFD) not in data:
+        print("  ERROR: expected the undecodable byte to become a replacement character, got {!r}".format(data))
+        failed = True
+
+    return failed
+
+
 def test_mcp_tools_list(my_predbat):
     """get_log is advertised by tools/list with a usable schema, and tools/call routes to it."""
     failed = False
@@ -751,6 +887,14 @@ def test_mcp_tools_list(my_predbat):
         failed = True
     if str(MCP_LOG_DEFAULT_LINES) not in schema["properties"]["max_lines"]["description"]:
         print("  ERROR: the max_lines description should name the default")
+        failed = True
+    # The tool keeps the most recent matches but returns them oldest-first; the schema said
+    # "most recent first", which misdescribed the output - Copilot review of PR #4775
+    if "oldest-first" not in schema["properties"]["max_lines"]["description"]:
+        print("  ERROR: the max_lines description must say which order lines come back in, got {!r}".format(schema["properties"]["max_lines"]["description"]))
+        failed = True
+    if "oldest-first" not in by_name["get_log"]["description"]:
+        print("  ERROR: the get_log description should state the return order")
         failed = True
 
     if "masked" not in by_name["get_apps"]["inputSchema"]["properties"]:
@@ -827,6 +971,8 @@ def run_web_mcp_tests(my_predbat):
     failed |= test_state_value_helpers(my_predbat)
     failed |= test_debug_excluded_keys(my_predbat)
     failed |= test_mcp_get_state(my_predbat)
+    failed |= test_mcp_argument_validation(my_predbat)
+    failed |= test_log_encoding(my_predbat)
     failed |= test_mcp_tools_list(my_predbat)
     failed |= test_web_api_log_unchanged(my_predbat)
     return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -107,6 +107,7 @@ from tests.test_history_chunking import run_history_chunking_tests
 from tests.test_web_if import run_test_web_if
 from tests.test_web_chart_currency import test_rates_chart_series_names_use_currency_symbol
 from tests.test_web_debug_history_routes import test_web_debug_history_routes
+from tests.test_web_mcp import run_web_mcp_tests
 from tests.test_debug_history_client_js import test_debug_history_client_js
 from tests.test_metrics_dashboard_soc_refresh import test_soc_chart_center_text_reads_live_data
 from tests.test_web_functions import run_web_functions_tests, run_web_logo_image_tests
@@ -459,6 +460,7 @@ def main():
         ("web_if", run_test_web_if, "Web interface tests", False),
         ("web_chart_currency", test_rates_chart_series_names_use_currency_symbol, "Rates chart series names follow currency_symbols tests", False),
         ("web_debug_history_routes", test_web_debug_history_routes, "Debug-history web routes tests (#4438 review items 4, 6, 21)", False),
+        ("web_mcp", run_web_mcp_tests, "MCP get_log and apps.yaml redaction tests (issue #4768)", False),
         ("debug_history_client_js", test_debug_history_client_js, "Debug-history client-side JS structure tests (#4438 review item 22)", False),
         ("metrics_dashboard_soc_refresh", test_soc_chart_center_text_reads_live_data, "Metrics dashboard SoC chart live-refresh tests", False),
         ("web_functions", run_web_functions_tests, "Web function unit tests", False),

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -19,7 +19,7 @@ service calls) to the appropriate handlers.
 
 import os
 from datetime import timedelta
-from utils import get_override_time_from_string, mask_secret_args
+from utils import get_override_time_from_string, mask_secret_args, is_debug_excluded_key
 import json
 import yaml
 import re
@@ -31,27 +31,6 @@ from const import (
 )
 from config import APPS_SCHEMA, CONFIG_API_OVERRIDE
 from predbat import THIS_VERSION, THIS_VERSION_DISPLAY
-
-DEBUG_EXCLUDE_LIST = [
-    "ha_interface",
-    "components",
-    "prediction",
-    "logfile",
-    "predheat",
-    "inverters",
-    "run_list",
-    "threads",
-    "EVENT_LISTEN_LIST",
-    "local_tz",
-    "CONFIG_ITEMS",
-    "config_index",
-    "comparison",
-    "plugin_system",
-    "ge_url_cache",
-    "github_url_cache",
-    "octopus_url_cache",
-    "secrets",
-]
 
 
 class UserInterface:
@@ -789,7 +768,7 @@ class UserInterface:
         # Store all predbat member variables into debug
         for key in self.__dict__:
             if not key.startswith("__") and not callable(getattr(self, key)):
-                if (key.startswith("db")) or ("_key" in key) or key in DEBUG_EXCLUDE_LIST:
+                if is_debug_excluded_key(key):
                     pass
                 else:
                     if key == "args":

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -36,9 +36,10 @@ PREDBAT_LOG_FILE_PREV = "predbat.1.log"
 # mcp_secret were all being served in the clear.
 SECRET_KEY_SUBSTRINGS = ("_key", "password", "secret", "token")
 
-# Key suffixes that match a credential substring but hold no secret. A token expiry time is
-# what you want to see when debugging "my cloud integration stopped working", so keep it.
-SECRET_KEY_EXEMPT_SUFFIXES = ("_expires_at",)
+# Key suffixes that match a credential substring but hold no secret - timing metadata about a
+# token rather than the token itself. An expiry time is exactly what you want to see when
+# debugging "my cloud integration stopped working", so keep it readable.
+SECRET_KEY_EXEMPT_SUFFIXES = ("_expires_at", "_expires", "_expiry", "_expiration", "_birth")
 
 # Use datetime.fromisoformat in str2time rather than strptime, set False to revert to strptime
 STR2TIME_USE_FROMISOFORMAT = True
@@ -162,12 +163,15 @@ def read_predbat_log(logfile=PREDBAT_LOG_FILE, logfile_prev=PREDBAT_LOG_FILE_PRE
     """
     Return the contents of predbat.log, prefixed with the rotated previous log when one exists.
     """
+    # Decoded explicitly rather than with the platform default: a single non-UTF-8 byte anywhere
+    # in the log - an inverter API error message carrying one, say - would otherwise raise
+    # UnicodeDecodeError and take out both /api/log and the get_log MCP tool.
     logdata = ""
     if os.path.exists(logfile):
-        with open(logfile, "r") as f:
+        with open(logfile, "r", encoding="utf-8", errors="replace") as f:
             logdata = f.read()
     if os.path.exists(logfile_prev):
-        with open(logfile_prev, "r") as f:
+        with open(logfile_prev, "r", encoding="utf-8", errors="replace") as f:
             logdata = f.read() + "\n" + logdata
     return logdata
 

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -17,12 +17,28 @@ and historical data extraction from incrementing energy counters.
 """
 
 import array
+import os
 from datetime import datetime, timedelta, timezone, time
 from functools import lru_cache
 from const import LOW_POWER_PV_THRESHOLD, MINUTE_WATT, PREDICT_STEP, TIME_FORMAT, TIME_FORMAT_SECONDS, TIME_FORMAT_OCTOPUS, MAX_INCREMENT, TIME_FORMAT_DAILY
 import copy
 
 DAY_OF_WEEK_MAP = {"mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6}
+
+# The live log and the one rotated out from under it - both read whole when serving logs.
+PREDBAT_LOG_FILE = "predbat.log"
+PREDBAT_LOG_FILE_PREV = "predbat.1.log"
+
+# Key-name substrings that mark an apps.yaml value as a credential, for mask_secret_args().
+# "_key" and "password" were the original pair; "secret" and "token" were added for #4768,
+# which promotes apps.yaml over MCP as the config-review route and so hands it to a cloud AI -
+# sigenergy_app_secret, solis_api_secret, solis_access_token, gateway_mqtt_token and
+# mcp_secret were all being served in the clear.
+SECRET_KEY_SUBSTRINGS = ("_key", "password", "secret", "token")
+
+# Key suffixes that match a credential substring but hold no secret. A token expiry time is
+# what you want to see when debugging "my cloud integration stopped working", so keep it.
+SECRET_KEY_EXEMPT_SUFFIXES = ("_expires_at",)
 
 # Use datetime.fromisoformat in str2time rather than strptime, set False to revert to strptime
 STR2TIME_USE_FROMISOFORMAT = True
@@ -83,15 +99,85 @@ class MinuteArray:
         return new
 
 
+def is_secret_key(key):
+    """
+    Return True when an apps.yaml key name looks like it holds a credential.
+    """
+    key_lower = str(key).lower()
+    if key_lower.endswith(SECRET_KEY_EXEMPT_SUFFIXES):
+        return False
+    return any(substring in key_lower for substring in SECRET_KEY_SUBSTRINGS)
+
+
 def mask_secret_args(args):
     """
     Return a deep copy of an apps.yaml-style args dict with credential-like keys redacted.
     """
     masked = copy.deepcopy(args)
     for key in masked:
-        if ("_key" in key.lower()) or ("password" in key.lower()):
+        if is_secret_key(key):
             masked[key] = "xxx"
     return masked
+
+
+def read_predbat_log(logfile=PREDBAT_LOG_FILE, logfile_prev=PREDBAT_LOG_FILE_PREV):
+    """
+    Return the contents of predbat.log, prefixed with the rotated previous log when one exists.
+    """
+    logdata = ""
+    if os.path.exists(logfile):
+        with open(logfile, "r") as f:
+            logdata = f.read()
+    if os.path.exists(logfile_prev):
+        with open(logfile_prev, "r") as f:
+            logdata = f.read() + "\n" + logdata
+    return logdata
+
+
+def classify_log_line(line):
+    """
+    Return the severity bucket ("error", "warning", "info" or "log") for one predbat.log line.
+    """
+    line_lower = line.lower()
+    if "error" in line_lower:
+        return "error"
+    if "warn" in line_lower:
+        return "warning"
+    if "info" in line_lower:
+        return "info"
+    return "log"
+
+
+def log_line_included(line_type, filter_type):
+    """
+    Return True when a log line of the given severity belongs in the requested view.
+
+    Errors appear on every view; warnings on "all" and "warnings"; info on "all" and
+    "info"; everything else only on "all".
+    """
+    if line_type == "error":
+        return True
+    if line_type == "warning":
+        return filter_type in ("all", "warnings")
+    if line_type == "info":
+        return filter_type in ("all", "info")
+    return filter_type == "all"
+
+
+def parse_log_timestamp(line):
+    """
+    Return the datetime a predbat.log line was written, or None when it carries no timestamp.
+
+    Lines are written as "{datetime.now()}: {message}", so the stamp is the leading 26
+    characters - or 19 when the microseconds happened to be zero and str() dropped them.
+    """
+    for length, time_format in ((26, "%Y-%m-%d %H:%M:%S.%f"), (19, "%Y-%m-%d %H:%M:%S")):
+        if len(line) >= length:
+            try:
+                return datetime.strptime(line[0:length], time_format)
+            except ValueError:
+                continue
+    return None
 
 
 # Helper to make dict hashable for caching

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -99,6 +99,44 @@ class MinuteArray:
         return new
 
 
+# Predbat member variables never included in a debug dump or served over MCP - live object
+# graphs, the HA interface, loaded secrets and the URL caches. Shared with is_debug_excluded_key().
+DEBUG_EXCLUDE_LIST = [
+    "ha_interface",
+    "components",
+    "prediction",
+    "logfile",
+    "predheat",
+    "inverters",
+    "run_list",
+    "threads",
+    "EVENT_LISTEN_LIST",
+    "local_tz",
+    "CONFIG_ITEMS",
+    "config_index",
+    "comparison",
+    "plugin_system",
+    "ge_url_cache",
+    "github_url_cache",
+    "octopus_url_cache",
+    "secrets",
+]
+
+
+def is_debug_excluded_key(key):
+    """
+    Return True when a Predbat member variable must be kept out of a debug dump or state query.
+
+    The "db" prefix drops the database internals and "_key" drops credentials; both predate
+    is_secret_key(), which is applied on top so secrets and tokens are caught here too (#4768).
+    """
+    if key.startswith("__") or key.startswith("db"):
+        return True
+    if key in DEBUG_EXCLUDE_LIST:
+        return True
+    return is_secret_key(key)
+
+
 def is_secret_key(key):
     """
     Return True when an apps.yaml key name looks like it holds a credential.

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -69,7 +69,7 @@ from web_helper import (
     get_dashboard_collapsible_js,
 )
 
-from utils import calc_percent_limit, str2time, dp0, dp2, dp4, format_time_ago, get_override_time_from_string, history_attribute, prune_today, mask_secret_args
+from utils import calc_percent_limit, str2time, dp0, dp2, dp4, format_time_ago, get_override_time_from_string, history_attribute, prune_today, mask_secret_args, read_predbat_log, classify_log_line, log_line_included
 from const import TIME_FORMAT, TIME_FORMAT_DAILY, TIME_FORMAT_HA
 from predbat import THIS_VERSION_DISPLAY
 from component_base import ComponentBase
@@ -2267,16 +2267,7 @@ chart.render();
             return "".join(result_parts)
 
         try:
-            logfile = "predbat.log"
-            logfile_1 = "predbat.1.log"
-            logdata = ""
-
-            if os.path.exists(logfile):
-                with open(logfile, "r") as f:
-                    logdata = f.read()
-            if os.path.exists(logfile_1):
-                with open(logfile_1, "r") as f:
-                    logdata = f.read() + "\n" + logdata
+            logdata = read_predbat_log()
 
             # Get query parameters
             args = request.query
@@ -2304,22 +2295,10 @@ chart.render();
                     lineno -= 1
                     continue
 
-                # Apply log level filtering first
-                include_line = False
-                line_type = "log"
-
-                if "error" in line_lower:  # any error log lines will appear on all, info, warning and error tabs
-                    line_type = "error"
-                    include_line = True
-                elif "warn" in line_lower:  # warning log lines appear on all and warning tabs
-                    line_type = "warning"
-                    include_line = filter_type in ["all", "warnings"]
-                elif "info" in line_lower:  # info log lines appear on all and info tabs
-                    line_type = "info"
-                    include_line = filter_type in ["all", "info"]
-                else:  # all other log lines appear on just the all tab
-                    line_type = "log"
-                    include_line = filter_type == "all"
+                # Apply log level filtering first - shared with the get_log MCP tool so the
+                # two views of the same log can't drift apart (#4768)
+                line_type = classify_log_line(line)
+                include_line = log_line_included(line_type, filter_type)
 
                 # Apply search filter if search term is provided
                 if include_line and search_term:

--- a/apps/predbat/web_mcp.py
+++ b/apps/predbat/web_mcp.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 from typing import Any, Dict
 from datetime import datetime, timezone, timedelta
-from utils import calc_percent_limit, get_override_time_from_string, mask_secret_args, read_predbat_log, classify_log_line, log_line_included, parse_log_timestamp
+from utils import calc_percent_limit, get_override_time_from_string, mask_secret_args, read_predbat_log, classify_log_line, log_line_included, parse_log_timestamp, is_debug_excluded_key
 import re
 from aiohttp import web
 import secrets
@@ -49,6 +49,97 @@ LOG_FILTER_TYPES = ("all", "info", "warnings", "errors")
 # the cap stops a "max_lines": 999999 request pulling a 10MB log through the protocol (#4768)
 MCP_LOG_DEFAULT_LINES = 500
 MCP_LOG_MAX_LINES = 5000
+
+
+# get_state size guards. A real debug dump is ~5MB, but 272 of its 313 top-level keys are under
+# 1KB and total under 10KB between them - the whole scalar state of Predbat. The per-key budget
+# returns those freely while the handful of per-minute series (load_minutes, rate_import, ...)
+# are described rather than serialised (#4768).
+MCP_STATE_DEFAULT_MAX_BYTES = 2048
+MCP_STATE_MAX_BYTES_LIMIT = 262144
+MCP_STATE_TOTAL_BYTES_LIMIT = 262144
+
+# Collections longer than this are summarised without serialising them first - measuring a 2880
+# entry per-minute dict by encoding it would cost more than the tool call is worth.
+MCP_STATE_LARGE_COLLECTION = 200
+
+# How many entries of a large collection to show in its summary
+MCP_STATE_SAMPLE_ENTRIES = 3
+
+
+def json_safe_value(value, depth=0):
+    """
+    Convert a Predbat state value into something json.dumps can encode.
+
+    Tool results are serialised with a plain json.dumps, so a stray datetime or inverter object
+    would fail the whole call - anything unrecognised becomes its str() rather than an error.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if depth >= 6:
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): json_safe_value(item, depth + 1) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [json_safe_value(item, depth + 1) for item in value]
+    return str(value)
+
+
+def summarise_state_value(value):
+    """
+    Describe a state value that is too large to return in full, so the caller can still see its
+    shape and decide whether to ask for it another way.
+    """
+    summary = {"type": type(value).__name__}
+    try:
+        summary["length"] = len(value)
+    except TypeError:
+        pass
+
+    if isinstance(value, dict):
+        keys = list(value.keys())[:MCP_STATE_SAMPLE_ENTRIES]
+        summary["sample_keys"] = [str(key) for key in keys]
+        numbers = [item for item in value.values() if isinstance(item, (int, float)) and not isinstance(item, bool)]
+    elif isinstance(value, (list, tuple, set)):
+        numbers = [item for item in value if isinstance(item, (int, float)) and not isinstance(item, bool)]
+        summary["sample_entries"] = [json_safe_value(item, depth=5) for item in list(value)[:MCP_STATE_SAMPLE_ENTRIES]]
+    elif isinstance(value, str):
+        summary["preview"] = value[:200]
+        numbers = []
+    else:
+        numbers = []
+
+    if numbers:
+        summary["min"] = min(numbers)
+        summary["max"] = max(numbers)
+        summary["mean"] = sum(numbers) / len(numbers)
+
+    return summary
+
+
+def measure_state_value(value, max_bytes):
+    """
+    Return (fits, safe_value, size_bytes) for a state value.
+
+    fits is a separate flag rather than a None safe_value because plenty of Predbat state is
+    legitimately None, and a None sentinel would report every one of those as omitted.
+
+    Long collections are rejected on their entry count alone so the per-minute series are never
+    serialised just to discover they don't fit.
+    """
+    if isinstance(value, (dict, list, tuple, set)) and len(value) > MCP_STATE_LARGE_COLLECTION:
+        return False, None, None
+    safe = json_safe_value(value)
+    try:
+        size = len(json.dumps(safe))
+    except (TypeError, ValueError):
+        safe = str(value)
+        size = len(safe) + 2
+    if size > max_bytes:
+        return False, None, None
+    return True, safe, size
 
 
 def parse_bool_argument(value, default=False):
@@ -1112,6 +1203,81 @@ class MCPServerWrapper:
         except Exception as e:
             return {"success": False, "error": f"Error retrieving Predbat apps.yaml data: {str(e)}", "data": None}
 
+    async def _execute_get_state(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the get_state tool"""
+        try:
+            requested = arguments.get("keys", None)
+            if isinstance(requested, str):
+                requested = [requested]
+            if requested is not None and not isinstance(requested, list):
+                return {"success": False, "error": "'keys' must be a list of state variable names", "data": None}
+
+            key_filter = arguments.get("filter", None)
+            max_bytes = int(arguments.get("max_bytes", MCP_STATE_DEFAULT_MAX_BYTES))
+            max_bytes = max(1, min(max_bytes, MCP_STATE_MAX_BYTES_LIMIT))
+
+            state = {}
+            omitted = {}
+            total_bytes = 0
+            budget_exhausted = False
+            unknown_keys = []
+
+            # Snapshot the key list up front - the plan thread can add attributes while we walk it
+            available = list(self.base.__dict__.keys())
+            if requested is not None:
+                unknown_keys = [key for key in requested if key not in available]
+                candidates = [key for key in requested if key in available]
+            else:
+                candidates = available
+
+            for key in candidates:
+                # Same filter the debug yaml uses, so this can never return what a debug dump won't
+                if is_debug_excluded_key(key):
+                    continue
+                if key_filter and not re.search(key_filter, key):
+                    continue
+                try:
+                    value = self.base.__dict__[key]
+                except KeyError:
+                    continue
+                if callable(value):
+                    continue
+                if key == "args":
+                    value = mask_secret_args(value)
+
+                fits, safe, size = measure_state_value(value, max_bytes)
+                if not fits:
+                    # Too large to return, but say what it is so the caller isn't guessing
+                    omitted[key] = summarise_state_value(value)
+                    continue
+                if total_bytes + size > MCP_STATE_TOTAL_BYTES_LIMIT:
+                    budget_exhausted = True
+                    omitted[key] = summarise_state_value(value)
+                    continue
+                state[key] = safe
+                total_bytes += size
+
+            data = {
+                "state": state,
+                "omitted": omitted,
+                "returned_keys": len(state),
+                "omitted_keys": len(omitted),
+                "approx_bytes": total_bytes,
+                "max_bytes": max_bytes,
+            }
+            if unknown_keys:
+                data["unknown_keys"] = unknown_keys
+
+            description = "Predbat internal state - {} variables returned".format(len(state))
+            if omitted:
+                description += ", {} described in 'omitted' instead of being returned in full (ask for one by name, or raise max_bytes)".format(len(omitted))
+            if budget_exhausted:
+                description += ". The overall response budget was reached, so narrow the request with 'keys' or 'filter'"
+            return {"success": True, "error": None, "data": data, "timestamp": datetime.now().isoformat(), "description": description}
+
+        except Exception as e:
+            return {"success": False, "error": f"Error retrieving state data: {str(e)}", "data": None}
+
     async def _execute_get_log(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the get_log tool"""
         try:
@@ -1318,6 +1484,19 @@ class MCPServerWrapper:
                     },
                 },
                 {
+                    "name": "get_state",
+                    "description": "Get Predbat's internal state variables - the same data a debug yaml carries, one key at a time. Called with no arguments it returns every small variable and describes the large ones (per-minute series) without returning them.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "keys": {"type": "array", "items": {"type": "string"}, "description": "Specific state variable names to return (optional - omit for every small variable)"},
+                            "filter": {"type": "string", "description": "Only return variables whose name matches this Python regex (optional)"},
+                            "max_bytes": {"type": "integer", "description": "Per-variable size budget before it is described rather than returned (default {}, maximum {})".format(MCP_STATE_DEFAULT_MAX_BYTES, MCP_STATE_MAX_BYTES_LIMIT)},
+                        },
+                        "required": [],
+                    },
+                },
+                {
                     "name": "get_log",
                     "description": "Get the Predbat log (predbat.log), filtered by level, search term and age - use this to diagnose warnings and errors",
                     "inputSchema": {
@@ -1381,6 +1560,8 @@ class MCPServerWrapper:
                 result = await self._execute_get_config(arguments)
             elif tool_name == "get_log":
                 result = await self._execute_get_log(arguments)
+            elif tool_name == "get_state":
+                result = await self._execute_get_state(arguments)
             elif tool_name == "get_entities":
                 result = await self._execute_get_entities(arguments)
             elif tool_name == "set_config":

--- a/apps/predbat/web_mcp.py
+++ b/apps/predbat/web_mcp.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 from typing import Any, Dict
 from datetime import datetime, timezone, timedelta
-from utils import calc_percent_limit, get_override_time_from_string
+from utils import calc_percent_limit, get_override_time_from_string, mask_secret_args, read_predbat_log, classify_log_line, log_line_included, parse_log_timestamp
 import re
 from aiohttp import web
 import secrets
@@ -40,6 +40,28 @@ Example usage in VSCode with OAuth
 		}
 	}
 """
+
+
+# Log filter levels accepted by the get_log tool, matching the web log view's tabs
+LOG_FILTER_TYPES = ("all", "info", "warnings", "errors")
+
+# get_log line budget - the default keeps a response small enough for an AI context window,
+# the cap stops a "max_lines": 999999 request pulling a 10MB log through the protocol (#4768)
+MCP_LOG_DEFAULT_LINES = 500
+MCP_LOG_MAX_LINES = 5000
+
+
+def parse_bool_argument(value, default=False):
+    """
+    Coerce an MCP tool argument to a bool, tolerating the strings some clients send.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() not in ("false", "0", "no", "off", "")
 
 
 class PredbatMCPServer(ComponentBase):
@@ -1068,7 +1090,11 @@ class MCPServerWrapper:
     async def _execute_get_apps(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the get_apps tool"""
         try:
-            configuration = self.base.args
+            # Credentials are redacted unless the caller explicitly opts out - apps.yaml carries
+            # API keys, secrets and tokens, and this tool exists to hand the configuration to an
+            # AI assistant for review (#4768). Matches the web UI's own apps.yaml download.
+            masked = parse_bool_argument(arguments.get("masked", True), default=True)
+            configuration = mask_secret_args(self.base.args) if masked else self.base.args
             return_configuration = {}
             config_id_filter = arguments.get("filter", None)
             for key, value in configuration.items():
@@ -1078,10 +1104,88 @@ class MCPServerWrapper:
                 else:
                     return_configuration[key] = value
 
-            return {"success": True, "error": None, "data": return_configuration, "timestamp": datetime.now().isoformat(), "description": "The contents of the Predbat apps.yaml configuration"}
+            description = "The contents of the Predbat apps.yaml configuration"
+            if masked:
+                description += " (credential-like values redacted as 'xxx')"
+            return {"success": True, "error": None, "data": return_configuration, "masked": masked, "timestamp": datetime.now().isoformat(), "description": description}
 
         except Exception as e:
             return {"success": False, "error": f"Error retrieving Predbat apps.yaml data: {str(e)}", "data": None}
+
+    async def _execute_get_log(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the get_log tool"""
+        try:
+            filter_type = str(arguments.get("filter", "warnings")).lower()
+            if filter_type not in LOG_FILTER_TYPES:
+                return {"success": False, "error": "Unknown filter '{}', expected one of {}".format(filter_type, ", ".join(LOG_FILTER_TYPES)), "data": None}
+
+            search_term = str(arguments.get("search", "") or "").lower().strip()
+            max_lines = int(arguments.get("max_lines", MCP_LOG_DEFAULT_LINES))
+            max_lines = max(1, min(max_lines, MCP_LOG_MAX_LINES))
+            hours = arguments.get("hours", None)
+            hours = float(hours) if hours is not None else None
+
+            loglines = read_predbat_log().split("\n")
+            total_lines = len(loglines)
+
+            # Cut-off for the hours filter. Lines with no parseable stamp (tracebacks and other
+            # continuation lines) inherit the timestamp of the newer line above them, so a
+            # multi-line entry is kept or dropped as a whole.
+            cutoff = (datetime.now() - timedelta(hours=hours)) if hours else None
+            last_timestamp = None
+
+            result_lines = []
+            truncated = False
+            matched_lines = 0
+
+            # Walk newest-first so max_lines keeps the most recent entries, as the web log view does
+            for lineno in range(total_lines - 1, -1, -1):
+                line = loglines[lineno]
+                if not line.strip():
+                    continue
+
+                timestamp = parse_log_timestamp(line)
+                if timestamp:
+                    last_timestamp = timestamp
+                if cutoff:
+                    effective_time = timestamp or last_timestamp
+                    if effective_time and effective_time < cutoff:
+                        # Everything below this point is older still
+                        break
+
+                line_type = classify_log_line(line)
+                if not log_line_included(line_type, filter_type):
+                    continue
+                if search_term and search_term not in line.lower():
+                    continue
+
+                matched_lines += 1
+                if len(result_lines) >= max_lines:
+                    truncated = True
+                    continue
+
+                result_lines.append({"line_number": lineno, "type": line_type, "line": line})
+
+            # Return oldest-first, which reads the way a log does
+            result_lines.reverse()
+
+            data = {
+                "lines": result_lines,
+                "total_lines": total_lines,
+                "returned_lines": len(result_lines),
+                "matched_lines": matched_lines,
+                "truncated": truncated,
+                "filter": filter_type,
+                "search": search_term,
+                "hours": hours,
+            }
+            description = "The Predbat log filtered to '{}' level".format(filter_type)
+            if truncated:
+                description += ", truncated to the most recent {} of {} matching lines".format(max_lines, matched_lines)
+            return {"success": True, "error": None, "data": data, "timestamp": datetime.now().isoformat(), "description": description}
+
+        except Exception as e:
+            return {"success": False, "error": f"Error retrieving log data: {str(e)}", "data": None}
 
     async def _execute_get_status(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the get_status tool"""
@@ -1203,8 +1307,29 @@ class MCPServerWrapper:
                 {"name": "get_status", "description": "Get the current Predbat system status and configuration", "inputSchema": {"type": "object", "properties": {}, "required": []}},
                 {
                     "name": "get_apps",
-                    "description": "Get predbat apps.yaml static configuration data",
-                    "inputSchema": {"type": "object", "properties": {"filter": {"type": "string", "description": "The configuration item name to filter on, as a Python regex (optional)"}}, "required": []},
+                    "description": "Get predbat apps.yaml static configuration data, with credentials redacted by default",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "filter": {"type": "string", "description": "The configuration item name to filter on, as a Python regex (optional)"},
+                            "masked": {"type": "boolean", "description": "Redact credential-like values such as API keys, secrets and passwords (default true)"},
+                        },
+                        "required": [],
+                    },
+                },
+                {
+                    "name": "get_log",
+                    "description": "Get the Predbat log (predbat.log), filtered by level, search term and age - use this to diagnose warnings and errors",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "filter": {"type": "string", "description": "Log level to return: all, info, warnings or errors (default warnings)", "enum": list(LOG_FILTER_TYPES)},
+                            "search": {"type": "string", "description": "Only return lines containing this text, case-insensitive (optional)"},
+                            "hours": {"type": "number", "description": "Only return lines written in the last N hours (optional)"},
+                            "max_lines": {"type": "integer", "description": "Maximum number of lines to return, most recent first (default {}, maximum {})".format(MCP_LOG_DEFAULT_LINES, MCP_LOG_MAX_LINES)},
+                        },
+                        "required": [],
+                    },
                 },
                 {
                     "name": "get_config",
@@ -1254,6 +1379,8 @@ class MCPServerWrapper:
                 result = await self._execute_get_apps(arguments)
             elif tool_name == "get_config":
                 result = await self._execute_get_config(arguments)
+            elif tool_name == "get_log":
+                result = await self._execute_get_log(arguments)
             elif tool_name == "get_entities":
                 result = await self._execute_get_entities(arguments)
             elif tool_name == "set_config":

--- a/apps/predbat/web_mcp.py
+++ b/apps/predbat/web_mcp.py
@@ -142,6 +142,52 @@ def measure_state_value(value, max_bytes):
     return True, safe, size
 
 
+class MCPArgumentError(ValueError):
+    """Raised when a tool argument is the wrong type or shape, so it can be reported clearly."""
+
+
+def parse_number_argument(value, name, default, minimum=None, maximum=None, as_float=False):
+    """
+    Coerce a numeric tool argument, clamping it into range.
+
+    Out-of-range values are clamped rather than rejected - a client asking for more than the cap
+    wants as much as it can have - but a value that is not a number at all is a mistake, and the
+    caller is an AI assistant that can only correct itself if told which argument was wrong.
+    """
+    if value is None:
+        value = default
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise MCPArgumentError("'{}' must be a number, not a boolean".format(name))
+    try:
+        value = float(value) if as_float else int(value)
+    except (TypeError, ValueError):
+        raise MCPArgumentError("'{}' must be a {}, got {!r}".format(name, "number" if as_float else "whole number", value))
+    if minimum is not None:
+        value = max(minimum, value)
+    if maximum is not None:
+        value = min(maximum, value)
+    return value
+
+
+def compile_filter_argument(value, name="filter"):
+    """
+    Compile a regex tool argument, or return None when no filter was given.
+
+    Compiling up front turns an invalid pattern into a named argument error instead of a bare
+    Python traceback, and avoids re-compiling it for every entry the caller filters over.
+    """
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise MCPArgumentError("'{}' must be a string regular expression, got {!r}".format(name, value))
+    try:
+        return re.compile(value)
+    except re.error as error:
+        raise MCPArgumentError("'{}' is not a valid regular expression: {}".format(name, error))
+
+
 def parse_bool_argument(value, default=False):
     """
     Coerce an MCP tool argument to a bool, tolerating the strings some clients send.
@@ -1077,7 +1123,7 @@ class MCPServerWrapper:
         Get current Predbat entities
         """
         try:
-            filter = arguments.get("filter", None)
+            filter = compile_filter_argument(arguments.get("filter", None))
             entities = self.base.dashboard_values
             returned_entities = []
             for entity in entities:
@@ -1086,7 +1132,7 @@ class MCPServerWrapper:
                 else:
                     entity_id = entity.get("entity_id", "")
                 if filter:
-                    if not re.search(filter, entity_id):
+                    if not filter.search(entity_id):
                         continue
                 if isinstance(entity, str):
                     value = {"entity_id": entity_id}
@@ -1107,6 +1153,8 @@ class MCPServerWrapper:
                 returned_entities.append(value)
             return {"success": True, "error": None, "data": returned_entities, "timestamp": datetime.now().isoformat(), "description": "The current Predbat entities and their states"}
 
+        except MCPArgumentError as e:
+            return {"success": False, "error": str(e), "data": None}
         except Exception as e:
             return {"success": False, "error": f"Error retrieving entities data: {str(e)}", "data": None}
 
@@ -1164,17 +1212,19 @@ class MCPServerWrapper:
         Get full HA configuration for Predbat
         """
         try:
-            entity_id_filter = arguments.get("filter", None)
+            entity_id_filter = compile_filter_argument(arguments.get("filter", None))
             config_return = []
             for item in self.base.CONFIG_ITEMS:
                 if entity_id_filter:
                     entity_id = item.get("entity", None)
-                    if entity_id and re.search(entity_id_filter, entity_id):
+                    if entity_id and entity_id_filter.search(entity_id):
                         config_return.append(item)
                 else:
                     config_return.append(item)
             return {"success": True, "error": None, "data": config_return, "timestamp": datetime.now().isoformat(), "description": "The contents of the Predbat configuration settings"}
 
+        except MCPArgumentError as e:
+            return {"success": False, "error": str(e), "data": None}
         except Exception as e:
             return {"success": False, "error": f"Error retrieving apps.yaml data: {str(e)}", "data": None}
 
@@ -1187,10 +1237,10 @@ class MCPServerWrapper:
             masked = parse_bool_argument(arguments.get("masked", True), default=True)
             configuration = mask_secret_args(self.base.args) if masked else self.base.args
             return_configuration = {}
-            config_id_filter = arguments.get("filter", None)
+            config_id_filter = compile_filter_argument(arguments.get("filter", None))
             for key, value in configuration.items():
                 if config_id_filter:
-                    if re.search(config_id_filter, key):
+                    if config_id_filter.search(key):
                         return_configuration[key] = value
                 else:
                     return_configuration[key] = value
@@ -1200,6 +1250,8 @@ class MCPServerWrapper:
                 description += " (credential-like values redacted as 'xxx')"
             return {"success": True, "error": None, "data": return_configuration, "masked": masked, "timestamp": datetime.now().isoformat(), "description": description}
 
+        except MCPArgumentError as e:
+            return {"success": False, "error": str(e), "data": None}
         except Exception as e:
             return {"success": False, "error": f"Error retrieving Predbat apps.yaml data: {str(e)}", "data": None}
 
@@ -1210,11 +1262,10 @@ class MCPServerWrapper:
             if isinstance(requested, str):
                 requested = [requested]
             if requested is not None and not isinstance(requested, list):
-                return {"success": False, "error": "'keys' must be a list of state variable names", "data": None}
+                raise MCPArgumentError("'keys' must be a list of state variable names, got {!r}".format(requested))
 
-            key_filter = arguments.get("filter", None)
-            max_bytes = int(arguments.get("max_bytes", MCP_STATE_DEFAULT_MAX_BYTES))
-            max_bytes = max(1, min(max_bytes, MCP_STATE_MAX_BYTES_LIMIT))
+            key_filter = compile_filter_argument(arguments.get("filter", None))
+            max_bytes = parse_number_argument(arguments.get("max_bytes", None), "max_bytes", MCP_STATE_DEFAULT_MAX_BYTES, minimum=1, maximum=MCP_STATE_MAX_BYTES_LIMIT)
 
             state = {}
             omitted = {}
@@ -1234,7 +1285,7 @@ class MCPServerWrapper:
                 # Same filter the debug yaml uses, so this can never return what a debug dump won't
                 if is_debug_excluded_key(key):
                     continue
-                if key_filter and not re.search(key_filter, key):
+                if key_filter and not key_filter.search(key):
                     continue
                 try:
                     value = self.base.__dict__[key]
@@ -1275,6 +1326,8 @@ class MCPServerWrapper:
                 description += ". The overall response budget was reached, so narrow the request with 'keys' or 'filter'"
             return {"success": True, "error": None, "data": data, "timestamp": datetime.now().isoformat(), "description": description}
 
+        except MCPArgumentError as e:
+            return {"success": False, "error": str(e), "data": None}
         except Exception as e:
             return {"success": False, "error": f"Error retrieving state data: {str(e)}", "data": None}
 
@@ -1286,10 +1339,8 @@ class MCPServerWrapper:
                 return {"success": False, "error": "Unknown filter '{}', expected one of {}".format(filter_type, ", ".join(LOG_FILTER_TYPES)), "data": None}
 
             search_term = str(arguments.get("search", "") or "").lower().strip()
-            max_lines = int(arguments.get("max_lines", MCP_LOG_DEFAULT_LINES))
-            max_lines = max(1, min(max_lines, MCP_LOG_MAX_LINES))
-            hours = arguments.get("hours", None)
-            hours = float(hours) if hours is not None else None
+            max_lines = parse_number_argument(arguments.get("max_lines", None), "max_lines", MCP_LOG_DEFAULT_LINES, minimum=1, maximum=MCP_LOG_MAX_LINES)
+            hours = parse_number_argument(arguments.get("hours", None), "hours", None, minimum=0, as_float=True)
 
             loglines = read_predbat_log().split("\n")
             total_lines = len(loglines)
@@ -1350,6 +1401,8 @@ class MCPServerWrapper:
                 description += ", truncated to the most recent {} of {} matching lines".format(max_lines, matched_lines)
             return {"success": True, "error": None, "data": data, "timestamp": datetime.now().isoformat(), "description": description}
 
+        except MCPArgumentError as e:
+            return {"success": False, "error": str(e), "data": None}
         except Exception as e:
             return {"success": False, "error": f"Error retrieving log data: {str(e)}", "data": None}
 
@@ -1498,14 +1551,17 @@ class MCPServerWrapper:
                 },
                 {
                     "name": "get_log",
-                    "description": "Get the Predbat log (predbat.log), filtered by level, search term and age - use this to diagnose warnings and errors",
+                    "description": "Get the Predbat log (predbat.log), filtered by level, search term and age - use this to diagnose warnings and errors. Lines are returned oldest-first.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
                             "filter": {"type": "string", "description": "Log level to return: all, info, warnings or errors (default warnings)", "enum": list(LOG_FILTER_TYPES)},
                             "search": {"type": "string", "description": "Only return lines containing this text, case-insensitive (optional)"},
                             "hours": {"type": "number", "description": "Only return lines written in the last N hours (optional)"},
-                            "max_lines": {"type": "integer", "description": "Maximum number of lines to return, most recent first (default {}, maximum {})".format(MCP_LOG_DEFAULT_LINES, MCP_LOG_MAX_LINES)},
+                            "max_lines": {
+                                "type": "integer",
+                                "description": "Maximum number of lines to return. The most recent matching lines are the ones kept, but they are returned oldest-first (default {}, maximum {})".format(MCP_LOG_DEFAULT_LINES, MCP_LOG_MAX_LINES),
+                            },
                         },
                         "required": [],
                     },

--- a/docs/components.md
+++ b/docs/components.md
@@ -189,6 +189,7 @@ Example usage in VSCode
 | `get_config` | Every Predbat setting, with its current value and its default |
 | `get_apps` | Your `apps.yaml` configuration, with credentials redacted |
 | `get_log` | Lines from `predbat.log`, filtered by level, search term and age |
+| `get_state` | Predbat's internal state variables - the same data a debug yaml carries |
 | `get_entities` | All Predbat entities and their states |
 | `set_config` | Change a Predbat setting |
 | `set_plan_override` | Override the plan for one 30 minute period |
@@ -209,9 +210,26 @@ look wrong"*, or *"find the warnings in the last 24 hours of my log and explain 
 | `hours` | Only return lines written in the last N hours |
 | `max_lines` | How many lines to return, most recent first (default 500, maximum 5000) |
 
-`get_apps` redacts credential-like values (anything whose name contains `_key`, `password`,
-`secret` or `token`) and replaces them with `xxx`, so your API keys are not sent to your AI
-provider. Pass `masked: false` if you deliberately want the raw values.
+`get_state` exposes the same internal state a `predbat_debug.yaml` carries, but a variable at a
+time rather than as a 5MB file. Called with no arguments it returns every variable small enough
+to be worth reading - a few hundred of them, together well under a page - and *describes* the
+handful of large ones (the per-minute series such as `load_minutes`, `rate_import` and
+`pv_today`) in an `omitted` section giving each one's type, length and value range. Ask for one
+of those by name with `keys`, narrow by name with `filter`, or raise the per-variable budget
+with `max_bytes`.
+
+| Argument | Description |
+| -------- | ----------- |
+| `keys` | Specific variable names to return (omit for every small variable) |
+| `filter` | Only return variables whose name matches this Python regex |
+| `max_bytes` | Per-variable size budget before a value is described instead of returned (default 2048, maximum 262144) |
+
+`get_state` and `get_apps` both redact credentials. `get_apps` replaces credential-like values
+(anything whose name contains `_key`, `password`, `secret` or `token`) with `xxx`, so your API
+keys are not sent to your AI provider; pass `masked: false` if you deliberately want the raw
+values. `get_state` applies the same rule *and* the debug yaml's exclusion list, so it can never
+return anything a debug dump would not - credentials, the Home Assistant interface, loaded
+secrets and the URL caches are not reachable through it at all.
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -182,12 +182,36 @@ Example usage in VSCode
 
 #### Available commands (mcp)
 
-- Get current system status
-- View and update configuration settings
-- Browse all entities
-- Retrieve battery plan data
-- Override plan for specific time periods
-- Access apps.yaml configuration
+| Tool | What it returns or does |
+| ---- | ----------------------- |
+| `get_status` | Current system status - mode, SoC, live power figures |
+| `get_plan` | The current battery plan, with forecasts and costs |
+| `get_config` | Every Predbat setting, with its current value and its default |
+| `get_apps` | Your `apps.yaml` configuration, with credentials redacted |
+| `get_log` | Lines from `predbat.log`, filtered by level, search term and age |
+| `get_entities` | All Predbat entities and their states |
+| `set_config` | Change a Predbat setting |
+| `set_plan_override` | Override the plan for one 30 minute period |
+
+#### Asking an AI assistant to review your setup (mcp)
+
+`get_config`, `get_apps` and `get_log` together give an assistant everything a bug report
+normally has to carry, so you can ask it to look over your setup without opening an issue -
+for example *"compare my Predbat settings against their defaults and tell me which changes
+look wrong"*, or *"find the warnings in the last 24 hours of my log and explain them"*.
+
+`get_log` takes optional arguments:
+
+| Argument | Description |
+| -------- | ----------- |
+| `filter` | `all`, `info`, `warnings` (the default) or `errors` |
+| `search` | Only return lines containing this text, case-insensitive |
+| `hours` | Only return lines written in the last N hours |
+| `max_lines` | How many lines to return, most recent first (default 500, maximum 5000) |
+
+`get_apps` redacts credential-like values (anything whose name contains `_key`, `password`,
+`secret` or `token`) and replaces them with `xxx`, so your API keys are not sent to your AI
+provider. Pass `masked: false` if you deliberately want the raw values.
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -208,7 +208,7 @@ look wrong"*, or *"find the warnings in the last 24 hours of my log and explain 
 | `filter` | `all`, `info`, `warnings` (the default) or `errors` |
 | `search` | Only return lines containing this text, case-insensitive |
 | `hours` | Only return lines written in the last N hours |
-| `max_lines` | How many lines to return, most recent first (default 500, maximum 5000) |
+| `max_lines` | How many lines to return - the most recent matches are the ones kept, but they come back oldest-first (default 500, maximum 5000) |
 
 `get_state` exposes the same internal state a `predbat_debug.yaml` carries, but a variable at a
 time rather than as a 5MB file. Called with no arguments it returns every variable small enough


### PR DESCRIPTION
This is an automated draft PR generated from issue #4768 — a maintainer should review it before merging.

Fixes #4768

## Summary

The MCP server already covered part of #4768 via `get_apps`/`get_config`, but had no way to reach `predbat.log` or Predbat's internal state — the artefacts a bug report normally has to carry. This adds both, and closes the credential leak that made pointing a cloud AI at `get_apps` unwise.

### `get_log`

Serves `predbat.log` (plus the rotated `predbat.1.log`), with optional `filter` (`all`/`info`/`warnings`/`errors`, default `warnings`), `search`, `hours` and `max_lines`. Lines come back oldest-first with severity tagged; `max_lines` defaults to 500 and is capped at 5000 so a request can't pull a 10MB log through the protocol. Continuation lines with no timestamp of their own (tracebacks) inherit the timestamp of the entry they belong to, so `hours` keeps or drops a multi-line entry as a whole.

### `get_state`

Deliberately **not** a debug-yaml download. Sizing a real dump ([`coverage/cases/predbat_debug_agile1.yaml`](coverage/cases/predbat_debug_agile1.yaml), 313 top-level keys, 5.3MB) shows 272 of those keys are under 1KB and total under 10KB between them, while 11 keys are 85% of the file and every one is a per-minute series. So the split is:

- Called with **no arguments**, `get_state` returns every variable within the per-variable budget — 371 keys / ~2.4KB (~590 tokens) on a fresh instance — and describes the rest.
- Large values go into an `omitted` section carrying type, length, sample keys and min/max/mean, so the caller can ask for one by name rather than guessing. A size guard, not a size limit.
- `keys`, `filter` (regex) and `max_bytes` narrow or widen the request. Collections over 200 entries are refused on entry count alone, so a 2,880-entry per-minute dict is never serialised just to discover it doesn't fit.
- Values `json.dumps` can't encode (datetimes, inverter objects) are coerced rather than failing the call.

### Credential handling

- **`get_apps` now redacts by default**, matching what the web UI's own apps.yaml download already did. Pass `masked: false` to opt out. Previously `_execute_get_apps` returned `self.base.args` verbatim.
- **`mask_secret_args` widened** to match `secret` and `token` alongside `_key`/`password`. `sigenergy_app_secret`, `solis_api_secret`, `deye_app_secret`, `alphaess_app_secret`, `solis_access_token`, `gateway_mqtt_token` and `mcp_secret` were all being served in the clear. `*_expires_at` is exempt — a token expiry is exactly what you want visible when debugging a dead cloud integration.
- **The debug yaml's exclusion list moved to `utils.is_debug_excluded_key`** and is now shared with `create_debug_yaml`, so `get_state` can never return anything a debug dump would not (`ha_interface`, `components`, `secrets`, the URL caches, `db*`, credentials). Verified against a live instance: the widened rule newly excludes **zero** attributes on a baseline config, so it costs debug dumps nothing and only bites on cloud-integration credentials.

### Shared filtering

Log level rules (`classify_log_line`/`log_line_included`) are now shared between `get_log` and `/api/log` so the two views of the same log can't drift. The web handler's behaviour is unchanged — its HTML escaping and search highlighting are pinned by a regression test.

### Docs

[`docs/components.md`](docs/components.md) lists every MCP tool in a table, documents `get_log`'s and `get_state`'s arguments and the redaction behaviour, and adds a short "ask an AI assistant to review your setup" section describing the workflow the issue asked for.

## Testing

- New [`apps/predbat/tests/test_web_mcp.py`](apps/predbat/tests/test_web_mcp.py) (registered as `web_mcp`), 10 groups: `mask_secret_args` key matching, `is_debug_excluded_key`, `read_predbat_log` rotation, the shared filter helpers and timestamp parsing, the `get_state` value helpers, `get_apps` redaction, `get_log`, `get_state`, `tools/list` registration, and a regression test that `/api/log` still filters, escapes and highlights as before.
- `get_state` was probed against a real `PredBat` instance, not just a fake. That surfaced a genuine bug the fake missed: `measure_state_value` used `None` as its "too large" sentinel, so the 14 state variables that are legitimately `None` were being reported as omitted. Fixed by returning an explicit `fits` flag, with a regression test.
- `tools/triage_test.sh web_mcp` — passed. `tools/triage_test.sh debug_cases` — passed (run explicitly since `create_debug_yaml`'s filter changed; it's marked slow and skipped by `--quick`).
- `cd coverage && ./run_pre_commit` — all hooks passed, and the `run_all --quick` suite it runs passed in full.
- `interrogate` fails at 89% on `main` today and is not a pre-commit hook; changed files each moved up or stayed level, and everything added here is documented.

## Notes

No debug-yaml download tool. An MCP server cannot write to the client's filesystem and everything it returns lands in the client's context, so a 5MB dump has no viable path through the protocol; `get_state` reaches the same data incrementally. The "button in the web UI" form of the request needs a billing/key-custody decision and is left for @springfall2008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)