### PR TITLE
chore(lint): enable ruff E713 (not-in style)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   hooks:
   # Run the linter.
   - id: ruff
-    args: [--select=F401, --fix]
+    args: [--select=F401,E713, --fix]
 - repo: https://github.com/psf/black
   rev: 23.11.0
   hooks:

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1201,7 +1201,7 @@ class Inverter:
                                 this_soc = soc_percent.get(target_minute, 0)
                                 if not discharge and (predbat_status.get(target_minute, "") != "Charging" or charge_rate.get(target_minute, 0) < max_power_scaled or battery_power.get(target_minute, 0) >= 0):
                                     break
-                                if discharge and (not ((predbat_status.get(target_minute, "") in ["Exporting", "Discharging"])) or charge_rate.get(target_minute, 0) < max_power_scaled or battery_power.get(target_minute, 0) <= 0):
+                                if discharge and (predbat_status.get(target_minute, "") not in ["Exporting", "Discharging"] or charge_rate.get(target_minute, 0) < max_power_scaled or battery_power.get(target_minute, 0) <= 0):
                                     break
 
                                 if (discharge and (this_soc > data_point)) or (not discharge and (this_soc < data_point)):

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -1607,7 +1607,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
                                 if "float" in sensor_types and self.validate_is_float(sensor) and not spec.get("modify", False):
                                     # Allow fixed float values
                                     continue
-                                if "string" in sensor_types and isinstance(sensor, str) and not spec.get("modify", False) and not "." in sensor:
+                                if "string" in sensor_types and isinstance(sensor, str) and not spec.get("modify", False) and "." not in sensor:
                                     # Allow fixed string values
                                     continue
 


### PR DESCRIPTION
Enables ruff's E713 rule (`not x in y` → `x not in y`) and fixes the 2 sites it caught. First of a stack progressively turning on the rules from #2198, one rule per PR.

## Summary
- 2 sites in `inverter.py` and `predbat.py` rewritten to the idiomatic `not in` form - purely style, semantically identical.

## Test plan
- [x] `./run_pre_commit` passes (ruff, black, cspell, docstrings)
- [x] Full quick test suite passes