### PR TITLE
chore(lint): enable ruff E722 (bare except)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   hooks:
   # Run the linter.
   - id: ruff
-    args: [--select=F401,E713,F811, --fix]
+    args: [--select=F401,E713,F811,E722, --fix]
 - repo: https://github.com/psf/black
   rev: 23.11.0
   hooks:

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -1227,7 +1227,7 @@ class OhmeApiClient:
 
         try:
             self.cap_enabled = resp["userSettings"]["chargeSettings"][0]["enabled"]
-        except:
+        except Exception:
             pass
 
         device = resp["chargeDevices"][0]

--- a/apps/predbat/tests/test_load_ml.py
+++ b/apps/predbat/tests/test_load_ml.py
@@ -1545,7 +1545,7 @@ def _test_real_data_training():
                 plt.savefig(chart_path, dpi=150, bbox_inches="tight")
                 print(f"  Chart saved to {chart_path}")
                 break
-            except:
+            except Exception:
                 continue
 
         plt.close()
@@ -1807,7 +1807,7 @@ def _test_pretrained_model_prediction():
                 plt.savefig(chart_path, dpi=150, bbox_inches="tight")
                 print(f"  Chart saved to {chart_path}")
                 break
-            except:
+            except Exception:
                 continue
 
         plt.close()

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -5612,7 +5612,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                     import linecache
 
                                     line_code = linecache.getline(code.co_filename, line_no).strip()
-                                except:
+                                except Exception:
                                     line_code = ""
 
                                 stack.append({"file": code.co_filename, "line": line_no, "name": code.co_name, "code": line_code})
@@ -5791,7 +5791,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 except Exception as e:
                     try:
                         yaml_key = str(key)
-                    except:
+                    except Exception:
                         yaml_key = f"<unprintable_key_{hash(key)}>"
                     result[yaml_key] = f"<error: {type(e).__name__}>"
             # Remove from visited after processing to allow same object in different branches
@@ -5822,7 +5822,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if len(str_value) > 200:
                 return str_value[:200] + "..."
             return str_value
-        except:
+        except Exception:
             return f"<{type(obj).__name__}>"
 
     def _get_object_members(self, obj, path):
@@ -5927,7 +5927,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     display_value = str_value[:100] + "..."
                 else:
                     display_value = str_value
-            except:
+            except Exception:
                 display_value = f"<{value_type}>"
 
         # Build the full path for this item using :: as separator


### PR DESCRIPTION
Enables ruff's E722 rule (bare `except:`) and fixes the 7 sites it caught. Stacked on #4778, part of the rule-by-rule cleanup from #2198.

## Summary
- All 7 sites (`ohme.py`, `web.py` x4, `tests/test_load_ml.py` x2) are narrow best-effort blocks (parsing/display formatting) - broadened to `except Exception:`, since bare `except` also silently caught `SystemExit`/`KeyboardInterrupt`/`GeneratorExit`, which was never the intent.

## Test plan
- [x] `./run_pre_commit` passes
- [x] Full quick test suite passes