### PR TITLE
chore(lint): enable ruff F821 (undefined name)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   hooks:
   # Run the linter.
   - id: ruff
-    args: [--select=F401,E713,F811,E722, --fix]
+    args: [--select=F401,E713,F811,E722,F821, --fix]
 - repo: https://github.com/psf/black
   rev: 23.11.0
   hooks:

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -687,6 +687,7 @@ class Output:
         rate_amount_min = rate_amount
         rate_amount_max = rate_amount
         start_minute = self.minutes_now
+        rate_range = "({}{})".format(rate_amount_min, self.currency_symbols[1])
 
         for minute in range(self.minutes_now, end_plan):
             if export:

--- a/apps/predbat/tests/test_rate_text_scan.py
+++ b/apps/predbat/tests/test_rate_text_scan.py
@@ -1,0 +1,55 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+
+def test_rate_text_scan(my_predbat):
+    """
+    Test rate_text_scan across a multi-band tariff, checking that each band's
+    reported min/max range covers exactly the rates within that band and not
+    a neighbouring one.
+    """
+    failed = False
+    print("**** Testing rate_text_scan ****")
+
+    my_predbat.minutes_now = 0
+    my_predbat.end_record = 9
+    my_predbat.forecast_minutes = 9
+    my_predbat.rate_min = 4.0
+    my_predbat.rate_max = 43.09
+
+    # Band A (cheap, minutes 0-2): varies 4.0/10.0/6.0
+    # Band B (expensive, minutes 3-5): varies 20.0/28.7/22.0
+    # Band C (very expensive, minutes 6-8): flat 43.1
+    my_predbat.rate_import = {
+        0: 4.0,
+        1: 10.0,
+        2: 6.0,
+        3: 20.0,
+        4: 28.7,
+        5: 22.0,
+        6: 43.1,
+        7: 43.1,
+        8: 43.1,
+    }
+
+    result = my_predbat.rate_text_scan(export=False)
+
+    expected = [
+        {"start": 0, "end": 3, "rate": "cheap", "range": "(4.0p - 10.0p)"},
+        {"start": 3, "end": 6, "rate": "expensive", "range": "(20.0p - 28.7p)"},
+        {"start": 6, "end": 9, "rate": "very expensive", "range": "(43.1p)"},
+    ]
+
+    if result != expected:
+        print(f"  ERROR: rate_text_scan mismatch\n  got:      {result}\n  expected: {expected}")
+        failed = True
+
+    print("**** rate_text_scan tests completed ****")
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -253,6 +253,7 @@ from tests.test_temperature import test_temperature
 from tests.test_oauth_mixin import run_oauth_mixin_tests
 from tests.test_fox_oauth import run_fox_oauth_tests
 from tests.test_band_rate_text import test_band_rate_text
+from tests.test_rate_text_scan import test_rate_text_scan
 from tests.test_kraken import run_kraken_tests
 from tests.test_kraken_auth_mixin import run_kraken_auth_mixin_tests
 from tests.test_clip_export_slots import run_clip_export_slots_tests
@@ -613,6 +614,7 @@ def main():
         # External Temperature API tests
         ("temperature", test_temperature, "External Temperature API tests (initialization, zone.home fallback, timezone conversion, caching)", False),
         ("band_rate_text", test_band_rate_text, "Band rate text tests (flat rate, Cosy, Flux import/export)", False),
+        ("rate_text_scan", test_rate_text_scan, "Rate text scan tests (multi-band min/max range grouping)", False),
         # OAuth infrastructure tests
         ("oauth_mixin", run_oauth_mixin_tests, "OAuth mixin tests (token refresh, expiry, 401 handling, env var fallback)", False),
         ("fox_oauth", run_fox_oauth_tests, "Fox API OAuth tests (dual auth headers, 401 retry, initialize params)", False),


### PR DESCRIPTION
Enables ruff's F821 rule (undefined name) and fixes the 1 site it caught. Stacked on #4779, part of the rule-by-rule cleanup from #2198.

## Summary
`output.py`'s `rate_text_scan()` read `rate_range` on a band-transition append before that iteration had assigned it - relying on the *previous* iteration's value having been set. I verified the function's min/max grouping logic is actually correct (2000 randomised trials against a naive ground-truth implementation, zero mismatches) - the invariant that saves it is that `get_rate_text(minutes_now)` always equals the initial `rate_text`, so the append branch never fires on iteration 1. Ruff can't see that invariant, so this is a lint fix, not a behaviour change: initialised `rate_range` before the loop.

The function had no test coverage at all, so added `tests/test_rate_text_scan.py` covering a 3-band tariff.

## Test plan
- [x] New `rate_text_scan` test passes
- [x] `./run_pre_commit` passes
- [x] Full quick test suite passes