### PR TITLE
chore(lint): enable ruff F841 (unused local variable)

### DIFF
--- a/apps/predbat/alertfeed.py
+++ b/apps/predbat/alertfeed.py
@@ -150,7 +150,6 @@ class AlertFeed(ComponentBase):
         """
         alert_active_keep = {}
         active_alert_text = ""
-        active_alert = False
 
         if alerts:
             for alert in alerts:
@@ -159,7 +158,6 @@ class AlertFeed(ComponentBase):
                 severity = alert.get("severity", "")
                 certainty = alert.get("certainty", "")
                 urgency = alert.get("urgency", "")
-                area = alert.get("areaDesc", "")
 
                 if onset and expires:
                     onset_minutes = int((onset - midnight_utc).total_seconds() / 60)
@@ -173,7 +171,6 @@ class AlertFeed(ComponentBase):
                                 alert_active_keep[minute] = max(alert_active_keep[minute], keep)
                             if minute == minutes_now:
                                 active_alert_text = alert.get("event") + " until " + str(expires)
-                                active_alert = True
 
         alert_keep = alert_active_keep.get(minutes_now, 0)
         alert_show = []

--- a/apps/predbat/carbon.py
+++ b/apps/predbat/carbon.py
@@ -76,7 +76,7 @@ class CarbonAPI(ComponentBase):
                                                 # Use TIME_FORMAT_CARBON to parse time strings
                                                 from_time = datetime.strptime(from_time, TIME_FORMAT_CARBON).replace(tzinfo=timezone.utc)
                                                 to_time = datetime.strptime(to_time, TIME_FORMAT_CARBON).replace(tzinfo=timezone.utc)
-                                            except Exception as e:
+                                            except Exception:
                                                 from_time = None
                                                 to_time = None
                                             if from_time and to_time and intensity is not None:

--- a/apps/predbat/compare.py
+++ b/apps/predbat/compare.py
@@ -73,7 +73,7 @@ class Compare:
         if "rates_import_octopus_url" in tariff:
             # Fixed URL for rate import
             import_url = pb.resolve_arg("rates_import_octopus_url", tariff["rates_import_octopus_url"], indirect=False)
-            pb.rate_import = pb.download_octopus_rates(pb.resolve_arg("rates_import_octopus_url", tariff["rates_import_octopus_url"], indirect=False))
+            pb.rate_import = pb.download_octopus_rates(import_url)
         elif "metric_octopus_import" in tariff:
             # Octopus import rates
             entity_id = pb.resolve_arg("metric_octopus_import", tariff["metric_octopus_import"], indirect=False)

--- a/apps/predbat/db_engine.py
+++ b/apps/predbat/db_engine.py
@@ -164,7 +164,6 @@ class DatabaseEngine:
             last_state = last_record[1]
             last_attributes = last_record[2]
             last_system = last_record[3]
-            last_keep = last_record[4]
             if last_state == state and last_attributes == attributes_record_json and last_system == system_json:
                 return
 

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -1522,8 +1522,6 @@ class Fetch:
         """
         minute = -24 * 60
         rate_last = 0
-        rate_first = 0
-        rate_first_valid = False
         rate_last_valid = False  # Track if we've seen any real rates yet
         adjusted_rates = {}
         replicated_rates = {}
@@ -1583,9 +1581,6 @@ class Fetch:
             else:
                 rate_last = rates[minute]
                 rate_last_valid = True
-                if not rate_first_valid:
-                    rate_first = rate_last
-                    rate_first_valid = True
             minute += 1
 
         return rates, replicated_rates
@@ -2094,7 +2089,6 @@ class Fetch:
         found_rates = []
         lowest = 99
         highest = -99
-        upcoming_period = self.minutes_now + 4 * 60
 
         while True:
             rate_low_start, rate_low_end, rate_low_average = self.find_charge_window(rates, minute, threshold_rate, find_high, alt_rates=alt_rates, pv_light_dark=pv_light_dark)

--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -1767,8 +1767,6 @@ class FoxAPI(ComponentBase, OAuthMixin):
         entity_name_sensor = f"sensor.{self.prefix}_fox"
         entity_name_number = f"number.{self.prefix}_fox"
         entity_name_select = f"select.{self.prefix}_fox"
-        entity_name_switch = f"switch.{self.prefix}_fox"
-        entity_name_binary_sensor = f"binary_sensor.{self.prefix}_fox"
         for device in self.device_list:
             sn = device.get("deviceSN", None)
             detail = self.device_detail.get(sn, {})

--- a/apps/predbat/futurerate.py
+++ b/apps/predbat/futurerate.py
@@ -231,9 +231,7 @@ class FutureRate:
             self.record_status("Warn: Error downloading futurerate data from cloud, no multiAreaEntries", debug=url, had_errors=True)
             return {}, {}
 
-        prev_time_date_start = None
         prev_time_date_end = None
-        prev_duration = 0
         prev_rate_import = 0
         prev_rate_export = 0
 
@@ -290,9 +288,7 @@ class FutureRate:
                     extracted_keys.append(time_date_start)
                     extracted_data[time_date_start] = item
 
-            prev_time_date_start = time_date_start
             prev_time_date_end = time_date_end
-            prev_duration = minutes_end - minutes_start
             prev_rate_import = rate_import
             prev_rate_export = rate_export
 

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -2346,10 +2346,10 @@ class GECloudData(ComponentBase):
                         return {}, None
                     try:
                         data = await response.json()
-                    except (aiohttp.ContentTypeError, json.JSONDecodeError) as e:
+                    except (aiohttp.ContentTypeError, json.JSONDecodeError):
                         record_api_call("givenergy", False, "decode_error")
                         return {}, None
-        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError):
             record_api_call("givenergy", False, "connection_error")
             return {}, None
 

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1860,7 +1860,7 @@ class Inverter:
 
         try:
             current_rate = int(current_rate)
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError):
             self.base.log("Error: Inverter {} charge discharge {} is not a number, setting to {}W".format(current_rate, self.id, self.battery_rate_max_raw))
             current_rate = self.battery_rate_max_raw
 
@@ -1879,7 +1879,7 @@ class Inverter:
                 current_rate = self.base.get_arg("charge_rate", index=self.id, default=self.battery_rate_max_raw, required_unit="W")
         try:
             current_rate = int(current_rate)
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError):
             self.base.log("Error: Inverter {} charge rate {} is not a number, setting to {}W".format(current_rate, self.id, self.battery_rate_max_raw))
             current_rate = self.battery_rate_max_raw
 
@@ -2718,7 +2718,7 @@ class Inverter:
                 current = self.base.get_arg("discharge_target_soc", index=self.id, required_unit="%")
                 try:
                     current = float(current)
-                except (ValueError, TypeError) as e:
+                except (ValueError, TypeError):
                     current = None
                 if current is None:
                     self.log("Inverter {} No current discharge target to read, export target not written".format(self.id))

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -306,8 +306,6 @@ class Inverter:
         if self.rest_data and ("Battery_Details" in self.rest_data):
             average_temp = 0
             battery_count = 0
-            battery_capacity = 0
-            battery_voltage = 0
             for battery in self.rest_data["Battery_Details"]:
                 battery_details = self.rest_data["Battery_Details"][battery]
                 if "BMS_Temperature" in battery_details:
@@ -3385,7 +3383,7 @@ class Inverter:
         data = {"state": "enable" if enable else "disable"}
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             new_value = self.rest_data["Control"].get("Enable_Charge_Target", "disable")
             if isinstance(new_value, str):
@@ -3408,7 +3406,7 @@ class Inverter:
         url = self.rest_api + "/setChargeTarget"
         data = {"chargeToPercent": target}
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             if float(self.rest_data["Control"]["Target_SOC"]) == target:
                 self.count_register_writes += 1
@@ -3428,7 +3426,7 @@ class Inverter:
         url = self.rest_api + "/setChargeRate"
         data = {"chargeRate": rate}
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             new = int(self.rest_data["Control"]["Battery_Charge_Rate"])
             if abs(new - rate) < (self.battery_rate_max_charge * MINUTE_WATT / 12):
@@ -3449,7 +3447,7 @@ class Inverter:
         url = self.rest_api + "/setDischargeRate"
         data = {"dischargeRate": rate}
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             new = int(self.rest_data["Control"]["Battery_Discharge_Rate"])
             if abs(new - rate) < (self.battery_rate_max_discharge * MINUTE_WATT / 25):
@@ -3470,7 +3468,7 @@ class Inverter:
         data = {"mode": inverter_mode}
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             if inverter_mode == self.rest_data["Control"]["Mode"]:
                 self.count_register_writes += 1
@@ -3490,7 +3488,7 @@ class Inverter:
         data = {"state": pause_mode}
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             if pause_mode == self.rest_data["Control"]["Battery_pause_mode"]:
                 self.count_register_writes += 1
@@ -3511,7 +3509,7 @@ class Inverter:
         url = self.rest_api + "/setBatteryReserve"
         data = {"reservePercent": target}
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             result = int(float(self.rest_data["Control"]["Battery_Power_Reserve"]))
             if result == target:
@@ -3532,7 +3530,7 @@ class Inverter:
         data = {"state": "enable" if enable else "disable"}
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             new_value = self.rest_data["Control"]["Enable_Charge_Schedule"]
             if isinstance(new_value, str):
@@ -3558,7 +3556,7 @@ class Inverter:
         data = {"state": "enable" if enable else "disable"}
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             new_value = self.rest_data["Control"]["Enable_Discharge_Schedule"]
             if isinstance(new_value, str):
@@ -3584,7 +3582,7 @@ class Inverter:
         data = {"start": start[:5], "finish": finish[:5]}
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             if self.rest_data["Timeslots"]["Battery_pause_start_time_slot"] == start and self.rest_data["Timeslots"]["Battery_pause_end_time_slot"] == finish:
                 self.count_register_writes += 1
@@ -3604,7 +3602,7 @@ class Inverter:
         data = {"start": start[:5], "finish": finish[:5]}
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             if self.rest_data["Timeslots"]["Charge_start_time_slot_1"] == start and self.rest_data["Timeslots"]["Charge_end_time_slot_1"] == finish:
                 self.count_register_writes += 1
@@ -3661,7 +3659,7 @@ class Inverter:
         result = None
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             # GivTCP's write handler updates Control.Discharge_Target_SOC_1 synchronously the
             # moment it accepts the command (confirmed against GivTCP's own source - write.py's
             # setDischargeTarget() calls updateControlCache() straight after the Modbus write), so
@@ -3695,7 +3693,7 @@ class Inverter:
         data = {"start": start[:5], "finish": finish[:5]}
 
         for retry in range(INVERTER_MAX_RETRY_REST):
-            r = self.rest_postCommand(url, json=data)
+            self.rest_postCommand(url, json=data)
             self.rest_data = self.rest_runAll(self.rest_data)
             if self.rest_data["Timeslots"]["Discharge_start_time_slot_1"] == start and self.rest_data["Timeslots"]["Discharge_end_time_slot_1"] == finish:
                 self.count_register_writes += 1

--- a/apps/predbat/load_ml_component.py
+++ b/apps/predbat/load_ml_component.py
@@ -1089,7 +1089,6 @@ class LoadMLComponent(ComponentBase):
         reset_amount = 0
         load_today_h1 = 0
         load_today_h8 = 0
-        load_today_now = 0
         power_today_now = 0
         power_today_h1 = 0
         power_today_h8 = 0

--- a/apps/predbat/load_predictor.py
+++ b/apps/predbat/load_predictor.py
@@ -1260,7 +1260,6 @@ class LoadPredictor:
         X_train_norm = X_train
 
         X_val_norm = self._normalize_features(X_val, fit=False, in_place=True)
-        y_val_norm = self._normalize_targets(y_val, fit=False)
 
         # Initialise weights if needed
         if not self.model_initialized or (is_initial and self.weights is None):

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2329,9 +2329,7 @@ class Octopus:
         """
 
         if res:
-            dayname = res.group(1)
             daynumber = res.group(2)
-            daysymbol = res.group(3)
             month = res.group(4)
             time_from = res.group(5)
             time_to = res.group(6)
@@ -2510,7 +2508,6 @@ class Octopus:
                     start_hour = int(match.group(1))
                     end_hour = int(match.group(2))
                     period = match.group(3).lower()
-                    day_of_week = match.group(4)
                     day_num = int(match.group(5))
                     month = match.group(6)
 

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -2380,7 +2380,7 @@ class Octopus:
                 timestamp_start = timestamp_start.replace(hour=int(time_from))
                 timestamp_end = timestamp_end.replace(hour=int(time_to))
                 free_sessions.append({"start": timestamp_start.strftime(TIME_FORMAT), "end": timestamp_end.strftime(TIME_FORMAT), "rate": 0.0})
-            except (ValueError, TypeError) as e:
+            except (ValueError, TypeError):
                 pass
 
     def download_octopus_free_func(self, url):

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -653,7 +653,6 @@ class OhmeAPI(ComponentBase):
         self.dashboard_item(entity_name_number + "_preconditioning", state=preconditioning, attributes=ohme_attribute_table.get("preconditioning", {}), app="ohme")
 
         # Publish slot information
-        num_slots = len(slots) if slots else 0
         slot_attributes = ohme_attribute_table.get("slots", {}).copy()
 
         planned_dispatches = []
@@ -1172,7 +1171,7 @@ class OhmeApiClient:
         """Set the vehicle to be charged."""
         for vehicle in self._cars:
             if vehicle_to_name(vehicle) == selected_name:
-                result = await self._make_request("PUT", f"/v1/car/{vehicle['id']}/select")
+                await self._make_request("PUT", f"/v1/car/{vehicle['id']}/select")
 
                 return True
         return False

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -1222,13 +1222,6 @@ class Output:
 
             soc_percent = calc_percent_limit(self.predict_soc_best.get(minute_relative_start, 0.0), self.soc_max)
             soc_percent_end = calc_percent_limit(self.predict_soc_best.get(minute_relative_slot_end, 0.0), self.soc_max)
-            soc_min = self.soc_max
-            soc_max = 0
-            for minute_check in range(minute_relative_start, minute_relative_end + PREDICT_STEP, PREDICT_STEP):
-                soc_min = min(self.predict_soc_best.get(minute_check, 0), soc_min)
-                soc_max = max(self.predict_soc_best.get(minute_check, 0), soc_max)
-            soc_percent_min = calc_percent_limit(soc_min, self.soc_max)
-            soc_percent_max = calc_percent_limit(soc_max, self.soc_max)
             soc_min_window = self.soc_max
             soc_max_window = 0
             for minute_check in range(minute_relative_start, minute_relative_end + PREDICT_STEP, PREDICT_STEP):
@@ -1532,7 +1525,6 @@ class Output:
             iboost_amount_str = "&#9866;"
             iboost_color = "#FFFFFF"
             if self.iboost_enable:
-                iboost_slot_end = minute_relative_slot_end
                 iboost_amount = self.predict_iboost_best.get(minute_relative_start, 0)
                 iboost_amount_end = self.predict_iboost_best.get(minute_relative_slot_end, 0)
                 iboost_amount_prev = self.predict_iboost_best.get(minute_relative_slot_end - PREDICT_STEP, 0)
@@ -3154,7 +3146,6 @@ class Output:
         export_today_now = self.export_today_now
         pv_today_now = self.pv_today_now
         carbon_today_sofar = self.carbon_today_sofar
-        soc_kw = self.soc_kw
         car_charging_hold = self.car_charging_hold
         iboost_energy_subtract = self.iboost_energy_subtract
         load_minutes_now = self.load_minutes_now

--- a/apps/predbat/plan.py
+++ b/apps/predbat/plan.py
@@ -862,7 +862,6 @@ class Plan:
             soc_percent = calc_percent_limit(self.predict_soc_best.get(minute_relative_start, 0.0), self.soc_max)
             soc_percent_end = calc_percent_limit(self.predict_soc_best.get(minute_relative_end, 0.0), self.soc_max)
             soc_percent_max = max(soc_percent, soc_percent_end)
-            soc_percent_min = min(soc_percent, soc_percent_end)
 
             if charge_window_n >= 0 and export_window_n >= 0:
                 value = "Chrg/Exp"
@@ -3414,7 +3413,6 @@ class Plan:
                         window_start_orig = self.export_window_best[window_n].get("start_orig", window_start)
                         window_start_from_now = max(window_start, self.minutes_now)
                         window_length = self.export_window_best[window_n]["end"] - window_start_from_now
-                        window_length_orig = self.export_window_best[window_n]["end"] - window_start_orig
                         export_limit = self.export_limits_best[window_n]
                         window_day = self.export_window_best[window_n]["start"] // 1440
 
@@ -4066,7 +4064,6 @@ class Plan:
             self.charge_window_best[:record_charge_windows], self.export_window_best[:record_export_windows], calculate_import_low_export=self.calculate_import_low_export, calculate_export_high_import=self.calculate_export_high_import
         )
 
-        best_soc = self.soc_max
         best_cost = best_metric
         best_keep = metric_keep
         best_cycle = 0

--- a/apps/predbat/predheat.py
+++ b/apps/predbat/predheat.py
@@ -411,7 +411,6 @@ class PredHeat:
                     heat_power_in = heat_power_out / (self.heat_cop * cop_adjust)
 
                 energy_now_in = heat_power_in * PREDICT_STEP / 60.0 / 1000.0
-                energy_now_out = heat_power_out * PREDICT_STEP / 60.0 / 1000.0
 
                 cost += energy_now_in * self.rate_import.get(minute_absolute, 0)
                 heat_energy += energy_now_in

--- a/apps/predbat/prediction.py
+++ b/apps/predbat/prediction.py
@@ -817,7 +817,6 @@ class Prediction(PredictionBatch):
             # Iboost
             iboost_rate_okay = True
             iboost_amount = 0
-            iboost_freeze = False
 
             # IBoost energy rate control
             if self.iboost_enable:
@@ -852,7 +851,6 @@ class Prediction(PredictionBatch):
 
                 # Freeze discharge on iboost
                 if iboost_amount > 0 and self.iboost_prevent_discharge and set_charge_window:
-                    iboost_freeze = True
                     discharge_rate_now = battery_rate_min  # 0
 
                 # Iboost running

--- a/apps/predbat/tests/test_fox_api.py
+++ b/apps/predbat/tests/test_fox_api.py
@@ -778,7 +778,7 @@ def test_compute_schedule_scheduler_enabled_charge(my_predbat):
     fox.local_schedule[deviceSN] = {"reserve": 10}
 
     # Call compute_schedule (sync wrapper since it's now a regular method)
-    result = asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
+    asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
 
     # Verify charge schedule was extracted
     assert deviceSN in fox.local_schedule
@@ -825,7 +825,7 @@ def test_compute_schedule_scheduler_enabled_discharge(my_predbat):
     fox.fdpwr_max[deviceSN] = 8000
     fox.local_schedule[deviceSN] = {"reserve": 10}
 
-    result = asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
+    asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
 
     # Verify discharge schedule was extracted
     assert deviceSN in fox.local_schedule
@@ -864,7 +864,7 @@ def test_compute_schedule_scheduler_disabled_battery_times(my_predbat):
     fox.fdpwr_max[deviceSN] = 8000
     fox.local_schedule[deviceSN] = {"reserve": 10}
 
-    result = asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
+    asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
 
     # Verify charge schedule was created from battery times
     assert deviceSN in fox.local_schedule
@@ -921,7 +921,7 @@ def test_compute_schedule_both_charge_and_discharge(my_predbat):
     fox.device_settings[deviceSN] = {"MinSocOnGrid": {"value": 10}}
     fox.fdpwr_max[deviceSN] = 8000
     fox.local_schedule[deviceSN] = {"reserve": 10}
-    result = asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
+    asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
 
     # Verify both schedules were extracted
     assert "charge" in fox.local_schedule[deviceSN]
@@ -973,7 +973,7 @@ def test_compute_schedule_no_enabled_windows(my_predbat):
     fox.fdpwr_max[deviceSN] = 8000
     fox.local_schedule[deviceSN] = {"reserve": 10}
 
-    result = asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
+    asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
 
     # Verify no charge or discharge schedules were created
     assert "charge" not in fox.local_schedule[deviceSN]
@@ -1013,7 +1013,7 @@ def test_compute_schedule_end_time_midnight(my_predbat):
     fox.fdpwr_max[deviceSN] = 8000
     fox.local_schedule[deviceSN] = {"reserve": 10}
 
-    result = asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
+    asyncio.run(FoxAPI.compute_schedule(fox, deviceSN))
 
     # Verify charge schedule with midnight handling
     charge = fox.local_schedule[deviceSN]["charge"]
@@ -1547,7 +1547,7 @@ def test_api_get_device_detail(my_predbat):
         },
     )
 
-    result = asyncio.run(fox.get_device_detail(deviceSN))
+    asyncio.run(fox.get_device_detail(deviceSN))
 
     assert deviceSN in fox.device_detail
     assert fox.device_detail[deviceSN]["deviceType"] == "KH8"
@@ -2311,7 +2311,7 @@ def test_api_set_scheduler(my_predbat):
         }
     ]
 
-    result = asyncio.run(fox.set_scheduler(deviceSN, groups))
+    asyncio.run(fox.set_scheduler(deviceSN, groups))
 
     # Verify request was made
     assert len(fox.request_log) == 1
@@ -2336,7 +2336,7 @@ def test_api_set_scheduler_enabled(my_predbat):
 
     fox.set_mock_response("/op/v1/device/scheduler/set/flag", {})
 
-    result = asyncio.run(fox.set_scheduler_enabled(deviceSN, True))
+    asyncio.run(fox.set_scheduler_enabled(deviceSN, True))
 
     # Verify request was made
     assert len(fox.request_log) == 1
@@ -2865,7 +2865,7 @@ def test_api_get_real_time_data(my_predbat):
         ],
     )
 
-    result = asyncio.run(fox.get_real_time_data(deviceSN))
+    asyncio.run(fox.get_real_time_data(deviceSN))
 
     assert deviceSN in fox.device_values
     assert fox.device_values[deviceSN]["pvPower"]["value"] == 3.5
@@ -2893,7 +2893,7 @@ def test_api_get_device_production_year(my_predbat):
         ],
     )
 
-    result = asyncio.run(fox.get_device_production_year(deviceSN))
+    asyncio.run(fox.get_device_production_year(deviceSN))
 
     assert deviceSN in fox.device_production_year
     assert len(fox.device_production_year[deviceSN]) == 3
@@ -2977,7 +2977,7 @@ def test_api_get_device_production_month(my_predbat):
         ],
     )
 
-    result = asyncio.run(fox.get_device_production_year(deviceSN))
+    asyncio.run(fox.get_device_production_year(deviceSN))
 
     assert deviceSN in fox.device_production_year
     assert len(fox.device_production_year[deviceSN]) == 3
@@ -2996,7 +2996,7 @@ def test_api_get_device_power_generation(my_predbat):
 
     fox.set_mock_response("/op/v0/device/generation", {"month": 867.6, "today": 17.7, "cumulative": 5765.7})
 
-    result = asyncio.run(fox.get_device_power_generation(deviceSN))
+    asyncio.run(fox.get_device_power_generation(deviceSN))
 
     assert deviceSN in fox.device_power_generation
     assert fox.device_power_generation[deviceSN]["today"] == 17.7
@@ -3093,7 +3093,7 @@ def test_api_set_scheduler_no_change(my_predbat):
     # Setup existing scheduler with same groups
     fox.device_scheduler[deviceSN] = {"enable": True, "groups": groups.copy()}
 
-    result = asyncio.run(fox.set_scheduler(deviceSN, groups))
+    asyncio.run(fox.set_scheduler(deviceSN, groups))
 
     # Should not have made any API request since schedule is the same
     assert len(fox.request_log) == 0
@@ -3116,7 +3116,7 @@ def test_api_set_scheduler_disable_when_empty(my_predbat):
     fox.set_mock_response("/op/v1/device/scheduler/set/flag", {})
 
     # Call with empty groups
-    result = asyncio.run(fox.set_scheduler(deviceSN, []))
+    asyncio.run(fox.set_scheduler(deviceSN, []))
 
     # Should have called set_scheduler_enabled to disable
     assert len(fox.request_log) == 1
@@ -3157,7 +3157,7 @@ def test_api_get_schedule_settings_ha(my_predbat):
     fox.set_mock_ha_state("number.predbat_fox_test123456_battery_schedule_discharge_power", 5000)
     fox.set_mock_ha_state("switch.predbat_fox_test123456_battery_schedule_discharge_enable", "on")
 
-    result = asyncio.run(fox.get_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.get_schedule_settings_ha(deviceSN))
 
     # Verify reserve was read at top level
     assert fox.local_schedule[deviceSN]["reserve"] == 15
@@ -3197,7 +3197,7 @@ def test_api_get_schedule_settings_ha_defaults(my_predbat):
 
     # Don't set any mock HA states - should use defaults
 
-    result = asyncio.run(fox.get_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.get_schedule_settings_ha(deviceSN))
 
     # Reserve should default to minSocOnGrid (10) since 0 < 10
     assert fox.local_schedule[deviceSN]["reserve"] == 10
@@ -3238,7 +3238,7 @@ def test_api_get_schedule_settings_ha_reserve_clamped(my_predbat):
     # Set reserve to a value below minSocOnGrid
     fox.set_mock_ha_state("number.predbat_fox_test123456_battery_schedule_reserve", 5)
 
-    result = asyncio.run(fox.get_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.get_schedule_settings_ha(deviceSN))
 
     # Reserve should be clamped to minSocOnGrid (15), not 5
     assert fox.local_schedule[deviceSN]["reserve"] == 15
@@ -3264,7 +3264,7 @@ def test_api_get_schedule_settings_ha_enable_off(my_predbat):
     fox.set_mock_ha_state("switch.predbat_fox_test123456_battery_schedule_charge_enable", "off")
     fox.set_mock_ha_state("switch.predbat_fox_test123456_battery_schedule_discharge_enable", "off")
 
-    result = asyncio.run(fox.get_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.get_schedule_settings_ha(deviceSN))
 
     # Enable should be 0 for both charge and discharge
     assert fox.local_schedule[deviceSN]["charge"]["enable"] == 0
@@ -3290,7 +3290,7 @@ def test_api_get_schedule_settings_ha_invalid_values(my_predbat):
     # Set invalid numeric value for reserve
     fox.set_mock_ha_state("number.predbat_fox_test123456_battery_schedule_reserve", "invalid")
 
-    result = asyncio.run(fox.get_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.get_schedule_settings_ha(deviceSN))
 
     # Reserve should fall back to minSocOnGrid (10) since invalid value becomes 0, then clamped to 10
     assert fox.local_schedule[deviceSN]["reserve"] == 10
@@ -3331,7 +3331,7 @@ def test_api_publish_schedule_settings_ha(my_predbat):
         },
     }
 
-    result = asyncio.run(fox.publish_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.publish_schedule_settings_ha(deviceSN))
 
     # Verify reserve entity was published
     reserve_entity = "number.predbat_fox_test123456_battery_schedule_reserve"
@@ -3407,7 +3407,7 @@ def test_api_publish_schedule_settings_ha_no_battery(my_predbat):
     # Setup device without battery
     fox.device_detail[deviceSN] = {"hasBattery": False}
 
-    result = asyncio.run(fox.publish_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.publish_schedule_settings_ha(deviceSN))
 
     # No dashboard items should have been published
     assert len(fox.dashboard_items) == 0
@@ -3430,7 +3430,7 @@ def test_api_publish_schedule_settings_ha_defaults(my_predbat):
     fox.fdpwr_max[deviceSN] = 8000
     fox.local_schedule[deviceSN] = {}
 
-    result = asyncio.run(fox.publish_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.publish_schedule_settings_ha(deviceSN))
 
     # Verify reserve defaults to 0
     reserve_entity = "number.predbat_fox_test123456_battery_schedule_reserve"
@@ -3483,7 +3483,7 @@ def test_api_publish_schedule_settings_ha_enable_off(my_predbat):
         },
     }
 
-    result = asyncio.run(fox.publish_schedule_settings_ha(deviceSN))
+    asyncio.run(fox.publish_schedule_settings_ha(deviceSN))
 
     # Verify charge enable is "off"
     charge_enable = "switch.predbat_fox_test123456_battery_schedule_charge_enable"
@@ -3522,7 +3522,7 @@ def test_api_publish_schedule_settings_ha_invalid_time(my_predbat):
         },
     }
 
-    result = run_async(fox.publish_schedule_settings_ha(deviceSN))
+    run_async(fox.publish_schedule_settings_ha(deviceSN))
 
     # Invalid time should be replaced with "00:00:00"
     charge_start = "select.predbat_fox_test123456_battery_schedule_charge_start_time"
@@ -3586,7 +3586,6 @@ class MockFoxAPIWithHTTPSimulation(MockFoxAPIWithRequests):
         # Simulate successful response with potential Fox API errors
         if status_code in [200, 201]:
             errno = response.get("errno", 0)
-            msg = response.get("msg", "")
 
             if errno != 0:
                 self.failures_total += 1
@@ -4306,7 +4305,7 @@ def test_request_get_rate_limiting_prevents_retry(my_predbat):
             return create_aiohttp_mock_session(mock_response)
 
         with patch("fox.aiohttp.ClientSession", side_effect=session_side_effect):
-            with patch("fox.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            with patch("fox.asyncio.sleep", new_callable=AsyncMock):
                 result = run_async(fox.request_get("/op/v0/device/list"))
 
     # Verify NO retry occurred due to rate limiting
@@ -6635,7 +6634,7 @@ def test_fox_rate_limiting_midnight_reset(my_predbat):
     for key in FOX_CACHE_KEYS:
         fox.data_age[key] = day2_time
 
-    with patch("fox.datetime") as mock_datetime, patch.object(fox, "log") as mock_log, patch.object(fox, "should_allow_retry", return_value=True):
+    with patch("fox.datetime") as mock_datetime, patch.object(fox, "log"), patch.object(fox, "should_allow_retry", return_value=True):
         # Mock datetime.now() to return day2_time
         mock_datetime.now.return_value = day2_time
         # Mock datetime.now(timezone.utc) calls inside run()

--- a/apps/predbat/tests/test_hahistory.py
+++ b/apps/predbat/tests/test_hahistory.py
@@ -260,7 +260,7 @@ def test_hahistory_get_history_fetch_and_cache(my_predbat=None):
 
     # Test 2: Get from cache (should not call HAInterface again)
     initial_call_count = len(mock_ha.get_history_calls)
-    result2 = ha_history.get_history(entity_id, days=30, tracked=True)
+    ha_history.get_history(entity_id, days=30, tracked=True)
 
     if len(mock_ha.get_history_calls) != initial_call_count:
         print("ERROR: Should use cache, not call HAInterface again")
@@ -269,7 +269,7 @@ def test_hahistory_get_history_fetch_and_cache(my_predbat=None):
         print("✓ Used cache instead of fetching again")
 
     # Test 3: Request more days (should fetch again)
-    result3 = ha_history.get_history(entity_id, days=60, tracked=True)
+    ha_history.get_history(entity_id, days=60, tracked=True)
     if len(mock_ha.get_history_calls) == initial_call_count:
         print("ERROR: Should fetch when requesting more days")
         failed += 1

--- a/apps/predbat/tests/test_hainterface_api.py
+++ b/apps/predbat/tests/test_hainterface_api.py
@@ -124,7 +124,7 @@ def test_hainterface_api_call_supervisor(my_predbat=None):
         mock_env.return_value = "supervisor_token"
         mock_get.return_value = create_mock_requests_response(200, {"supervisor": "data"})
 
-        result = ha_interface.api_call("/addons/self/info", core=False)
+        ha_interface.api_call("/addons/self/info", core=False)
 
         # Verify supervisor URL used
         if not mock_get.called:
@@ -266,7 +266,7 @@ def test_hainterface_api_call_silent_mode(my_predbat=None):
         mock_get.return_value = mock_response
 
         # Call with silent=True
-        result = ha_interface.api_call("/api/states", silent=True)
+        ha_interface.api_call("/api/states", silent=True)
 
         # Verify warning not logged
         if log_called[0]:
@@ -296,7 +296,7 @@ def test_hainterface_api_call_error_limit(my_predbat=None):
     with patch("ha.requests.get") as mock_get:
         mock_get.side_effect = requests.Timeout("Connection timeout")
 
-        result = ha_interface.api_call("/api/states")
+        ha_interface.api_call("/api/states")
 
         # Verify fatal error triggered
         if not fatal_called[0]:
@@ -320,7 +320,7 @@ def test_hainterface_api_call_error_reset(my_predbat=None):
     with patch("ha.requests.get") as mock_get:
         mock_get.return_value = create_mock_requests_response(200, {"result": "success"})
 
-        result = ha_interface.api_call("/api/states")
+        ha_interface.api_call("/api/states")
 
         # Verify error count reset
         if ha_interface.api_errors != 0:
@@ -524,7 +524,7 @@ def test_hainterface_get_history_from_time(my_predbat=None):
     with patch("ha.requests.get") as mock_get:
         mock_get.return_value = create_mock_requests_response(200, [[]])
 
-        result = ha_interface.get_history("sensor.battery", now, from_time=from_time)
+        ha_interface.get_history("sensor.battery", now, from_time=from_time)
 
         # Verify API called with from_time in path
         if not mock_get.called:

--- a/apps/predbat/tests/test_hainterface_lifecycle.py
+++ b/apps/predbat/tests/test_hainterface_lifecycle.py
@@ -284,8 +284,6 @@ def test_hainterface_wait_api_started_timeout(my_predbat=None):
             return
 
     with patch("ha.time.sleep", side_effect=mock_sleep):
-        # Set max count to trigger timeout quickly
-        original_count = 0
         result = ha_interface.wait_api_started()
         # After 240 iterations without api_started, should return False
 

--- a/apps/predbat/tests/test_hainterface_service.py
+++ b/apps/predbat/tests/test_hainterface_service.py
@@ -32,7 +32,7 @@ def test_hainterface_call_service_websocket(my_predbat=None):
 
     ha_interface.call_service_websocket_command = mock_call_service_websocket_command
 
-    result = ha_interface.call_service("switch/turn_on", entity_id="switch.test")
+    ha_interface.call_service("switch/turn_on", entity_id="switch.test")
 
     if not call_service_websocket_command_called:
         print("ERROR: call_service_websocket_command should be called")
@@ -69,7 +69,7 @@ def test_hainterface_call_service_loopback(my_predbat=None):
         mock_base.trigger_callback_calls.append(data)
     mock_base.trigger_callback = mock_trigger_callback
 
-    result = ha_interface.call_service("number/set_value", entity_id="number.test", value=42)
+    ha_interface.call_service("number/set_value", entity_id="number.test", value=42)
 
     if not mock_base.trigger_callback_calls:
         print("ERROR: trigger_callback should be called")
@@ -291,7 +291,6 @@ def test_hainterface_async_call_service_exception(my_predbat=None):
     ha_interface.ws_pending_lock = threading.Lock()
 
     # Patch threading.Event.wait to simulate instant timeout
-    original_wait = threading.Event.wait
     def mock_wait(self, timeout=None):
         return False  # Simulate timeout
 

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -591,7 +591,6 @@ class UserInterface:
 
         if enable:
             enabled_value = self.get_arg(enable, default=False)
-            citem = self.config_index.get(enable, None)
             if enable_condition:
                 # Evaluate the condition in python
                 try:

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -392,7 +392,6 @@ def minute_data(
     adata = {}
     io_adjusted = {}
     newest_state = 0
-    prev_state = 0
     newest_age = 999999
 
     # Bounds on the data we store
@@ -546,7 +545,6 @@ def minute_data(
 
         if minutes < newest_age:
             newest_age = minutes
-            prev_state = newest_state
             newest_state = state
 
         # Power to Energy

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -349,7 +349,7 @@ def history_attribute_to_minute_data(now_utc, data, backwards=True):
         try:
             timestamp_key = str2time(key)
             oldest_date = min(oldest_date, timestamp_key)
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError):
             continue
 
         value = data[key]

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -5618,7 +5618,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                 stack.append({"file": code.co_filename, "line": line_no, "name": code.co_name, "code": line_code})
 
                             task_info["stack"] = stack
-                except Exception as e:
+                except Exception:
                     # If we can't get the coroutine stack, just skip it
                     pass
 

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -4644,7 +4644,6 @@ chart.render();
             from components import COMPONENT_LIST
 
             component_info = COMPONENT_LIST.get(component_name, {})
-            component = self.base.components.get_component(component_name)
             is_alive = self.base.components.is_alive(component_name)
             can_restart = self.base.components.can_restart(component_name)
             is_active = component_name in active_components

--- a/apps/predbat/web_mcp.py
+++ b/apps/predbat/web_mcp.py
@@ -226,6 +226,7 @@ class PredbatMCPServer(ComponentBase):
                 # Try to decode without verification to see what's in the token (for debugging)
                 try:
                     unverified = pyjwt.decode(token, options={"verify_signature": False})
+                    self.log(f"MCP: Token claims (unverified): {unverified}")
                 except Exception as e2:
                     self.log(f"MCP: Could not even decode without verification: {e2}")
 
@@ -724,7 +725,6 @@ class PredbatMCPServer(ComponentBase):
         """Handle authorization_code grant type"""
         code = data.get("code")
         client_id = data.get("client_id")
-        client_secret = data.get("client_secret")
         redirect_uri = data.get("redirect_uri")
         code_verifier = data.get("code_verifier")  # For PKCE
         resource = data.get("resource")  # RECOMMENDED by MCP spec (RFC 8707)


### PR DESCRIPTION
Enables ruff's F841 rule (local variable assigned but never used) and fixes all 132 sites it caught. Stacked on #4780, last in the rule-by-rule cleanup from #2198.

Closes #2198

## Summary
- 9 were ruff's own `--fix` (unused exception-binding `as e`)
- The rest fall into a few patterns, checked individually rather than blanket-deleted:
  - Side-effecting calls whose return value was never used (mock/REST/API calls) - dropped the assignment, kept the call
  - Dead initialisers whose sibling variables in the same block *are* used elsewhere (verified each one really is never read before deleting)
  - One genuine duplicate call in `compare.py` (`import_url` computed then immediately recomputed inline) - reused instead of dropped
  - One incomplete debug aid in `web_mcp.py` (`unverified` JWT decode) - added the log line its own comment promised, instead of deleting it
  - `web_mcp.py`'s `client_secret` is unused by design: that OAuth endpoint is PKCE-only per the MCP spec, not a confidential-client flow

Touches `inverter.py`, `plan.py`, `output.py`, `octopus.py`, `fetch.py`, `fox.py`, `futurerate.py`, `ohme.py`, `predheat.py`, `prediction.py`, `db_engine.py`, `compare.py`, `userinterface.py`, `utils.py`, `web.py`, `web_mcp.py`, `load_ml_component.py`, `load_predictor.py`, and several test files.

While auditing this rule I also found a real bug in `sigenergy.py` (a configured export rate that was silently never applied) - pulled that out into its own PR (#4782) rather than bundling a behaviour change into this lint stack.

## Test plan
- [x] `./run_pre_commit` passes
- [x] Full quick test suite passes, including targeted runs for every touched module (inverter, plan/optimise_levels/random-scenario regression, octopus, HA interface, fox_api, predheat, ohme, load_ml, web) after each change