### PR TITLE
fix(sigenergy): apply the configured export rate to discharge commands

### DIFF
--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -2178,6 +2178,7 @@ class SigenergyAPI(ComponentBase):
                 new_mode = "export"
                 active_mode = SIGENERGY_ACTIVE_MODE_DISCHARGE
                 discharge_priority_type = "PV"
+                charge_power_kw = export_rate_w / 1000.0
         elif charge_window and charge_start_dt and charge_end_dt:
             duration_min = max(1, int((charge_end_dt - now).total_seconds() / 60))
             effective_target = max(charge_target_soc, reserve_soc)

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -1285,6 +1285,7 @@ def test_sigenergy_apply_controls_export_mode(my_predbat):
     bat_cmds = [c for c in commands_sent if c[0] == "battery_cmd"]
     assert len(bat_cmds) >= 1, "send_battery_command called for export"
     assert bat_cmds[0][2] == SIGENERGY_ACTIVE_MODE_DISCHARGE, "discharge mode sent for export"
+    assert bat_cmds[0][4] == 3.0, "configured export rate (3000W) sent as charging_power_kw, got {}".format(bat_cmds[0][4])
 
     return failed
 


### PR DESCRIPTION
`apply_controls()` computed `export_rate_w` from the user's export control config but never used it - found while auditing unused variables for #2198 (ruff F841 flagged it as dead).

## Summary
The charge branch correctly set `charge_power_kw = charge_rate_w / 1000.0` before calling `send_battery_command()`. The export/discharge branch left `charge_power_kw` at its `None` default, so no `chargingPower` field was sent to the Sigenergy API at all during export - that field is documented as governing both charging *and* discharging power, so this meant discharge ran unrate-limited regardless of what the user configured.

Not a lint cleanup - a real behaviour fix on live hardware, so pulled out of the #2198 ruff-rule PR stack into its own PR.

## Test plan
- [x] Extended the existing `test_sigenergy_apply_controls_export_mode` with an assertion on the rate (it previously only checked `active_mode`) - fails without the fix, passes with it
- [x] Full `sigenergy` test module passes