### PR TITLE
fix(web): draw the car from the Grid when the charger is outside the CT clamp

### DIFF
--- a/apps/predbat/tests/test_web_power_flow.py
+++ b/apps/predbat/tests/test_web_power_flow.py
@@ -16,11 +16,12 @@ from web import WebInterface
 
 # Where each node is drawn in the diagram's SVG, keyed by the colour of the arm that reaches it
 HOUSE_CENTRE = (300, 200)
+GRID_CENTRE = (450, 300)
 NODE_RADIUS = 50
 NODE_BY_COLOUR = {
     "#F9A825": ("PV", (150, 100)),
     "#43A047": ("Battery", (150, 300)),
-    "#757575": ("Grid", (450, 300)),
+    "#757575": ("Grid", GRID_CENTRE),
     "#E53935": ("Car", (450, 100)),
 }
 
@@ -61,7 +62,7 @@ def distance_from_line(point, line_start, line_end):
     return abs(cross) / math.hypot(run_x, run_y)
 
 
-def check_arm_geometry(html, state_description):
+def check_arm_geometry(html, state_description, car_anchor=("House", HOUSE_CENTRE)):
     """Every arm runs along the line joining the two circles, tail on one edge and point on the other.
 
     Drawn at any other angle the arrow leaves its circle off-centre and its head stops in open
@@ -71,18 +72,22 @@ def check_arm_geometry(html, state_description):
     The point of the arrow is ARROW_HEAD_LENGTH beyond the line's end vertex, so the line has to
     stop short by exactly that much. Ending it on the circle edge instead drives the arrowhead
     inside the circle it is pointing at.
+
+    Every arm joins its node to the House bar one: the car arm leaves the Grid instead when the
+    charger sits outside the CT clamp, so where its far end belongs is passed in as car_anchor.
     """
     failed = 0
     for colour, (x1, y1, x2, y2) in arrow_lines(html):
         name, node_centre = NODE_BY_COLOUR[colour]
+        anchor_name, anchor_centre = car_anchor if name == "Car" else ("House", HOUSE_CENTRE)
         start, end = (x1, y1), (x2, y2)
 
         # marker-end puts the arrowhead on (x2, y2), so the line is always drawn tail first and
         # an arm reversed by the flow direction swaps which circle each end belongs to
         tail, head = start, end
-        tail_at_node = distance(tail, node_centre) < distance(tail, HOUSE_CENTRE)
-        tail_centre, head_centre = (node_centre, HOUSE_CENTRE) if tail_at_node else (HOUSE_CENTRE, node_centre)
-        tail_name, head_name = (name, "House") if tail_at_node else ("House", name)
+        tail_at_node = distance(tail, node_centre) < distance(tail, anchor_centre)
+        tail_centre, head_centre = (node_centre, anchor_centre) if tail_at_node else (anchor_centre, node_centre)
+        tail_name, head_name = (name, anchor_name) if tail_at_node else (anchor_name, name)
 
         tail_gap = distance(tail, tail_centre) - NODE_RADIUS
         if abs(tail_gap) > 1.5:
@@ -103,11 +108,17 @@ def check_arm_geometry(html, state_description):
                 failed += 1
 
         for point in (tail, head):
-            offset = distance_from_line(point, node_centre, HOUSE_CENTRE)
+            offset = distance_from_line(point, node_centre, anchor_centre)
             if offset > 1.5:
-                print(f"  ERROR [{state_description}]: the {name} arm is {offset:.1f}px off the line joining {name} to the House, so it points the wrong way")
+                print(f"  ERROR [{state_description}]: the {name} arm is {offset:.1f}px off the line joining {name} to the {anchor_name}, so it points the wrong way")
                 failed += 1
     return failed
+
+
+def house_reading(html):
+    """The power figure printed inside the House circle, as it appears in the diagram."""
+    match = re.search(r'<text x="300" y="215" text-anchor="middle" dy="\.3em" fill="#fff">([^<]*)</text>', html)
+    return match.group(1) if match else None
 
 
 def power_labels(html):
@@ -278,8 +289,10 @@ def run_power_flow_geometry_tests(my_predbat, web):
     print("Test: every arm runs circle edge to circle edge, whichever way the power is flowing")
 
     saved = (my_predbat.pv_power, my_predbat.load_power, my_predbat.battery_power, my_predbat.grid_power, my_predbat.car_charging_power, my_predbat.car_charging_power_configured)
+    saved_reported = my_predbat.car_energy_reported_load
 
     my_predbat.car_charging_power_configured = True
+    my_predbat.car_energy_reported_load = True
 
     # Importing, battery discharging, PV generating, car charging
     my_predbat.pv_power = 2000
@@ -300,7 +313,21 @@ def run_power_flow_geometry_tests(my_predbat, web):
     failed += check_arm_geometry(html, "exporting, battery charging")
     failed += check_label_clearance(html, "exporting, battery charging")
 
+    # A charger outside the CT clamp hangs its arm off the Grid instead of the House (#4788), so
+    # that arm has a second pair of circles to line up with - checked both charging and idle,
+    # since the two write different label text and a wider label is the one that fouls the arm
+    my_predbat.car_energy_reported_load = False
+    my_predbat.pv_power = 2000
+    my_predbat.battery_power = 1500
+    my_predbat.grid_power = -1000
+    for car_power, description in ((7000, "car outside the CT clamp, charging"), (0, "car outside the CT clamp, idle")):
+        my_predbat.car_charging_power = car_power
+        html = web.get_power_flow_diagram()
+        failed += check_arm_geometry(html, description, car_anchor=("Grid", GRID_CENTRE))
+        failed += check_label_clearance(html, description)
+
     (my_predbat.pv_power, my_predbat.load_power, my_predbat.battery_power, my_predbat.grid_power, my_predbat.car_charging_power, my_predbat.car_charging_power_configured) = saved
+    my_predbat.car_energy_reported_load = saved_reported
     return failed
 
 
@@ -311,6 +338,10 @@ def run_web_power_flow_tests(my_predbat):
 
     original_args = my_predbat.args.copy()
     original_load_power = my_predbat.load_power
+    # The diagram branches on whether the charger sits inside the house CT clamp, and this PredBat
+    # instance is shared with the other test modules, so pin the switch rather than inherit it
+    original_car_energy_reported_load = my_predbat.car_energy_reported_load
+    my_predbat.car_energy_reported_load = True
     web = make_web(my_predbat)
 
     # -------------------------------------------------------------------------
@@ -526,11 +557,53 @@ def run_web_power_flow_tests(my_predbat):
     my_predbat.car_charging_power = 3000
     my_predbat.car_charging_power_configured = True
     html = web.get_power_flow_diagram()
-    if ">0 W<" not in html:
-        print("  ERROR: expected the House remainder to clamp at 0 W rather than go negative")
+    if house_reading(html) != "0 W":
+        print(f"  ERROR: expected the House remainder to clamp at 0 W rather than go negative, got '{house_reading(html)}'")
         failed += 1
     if "-2000 W" in html:
         print("  ERROR: the House circle must never show a negative load")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    # switch.predbat_car_energy_reported_load off means the charger sits outside the house CT
+    # clamp, so its power was never inside load_power in the first place. Subtracting it there
+    # takes the car off a figure that never held it and the clamp above then swallows the entire
+    # house load, showing 0 W next to a house genuinely drawing 542 W (#4788). The reporter's own
+    # readings are used here: a 7363 W charger against 542 W of real household load.
+    print("Test: a charger outside the CT clamp keeps the house load and is fed from the Grid")
+    my_predbat.car_energy_reported_load = False
+    my_predbat.load_power = 542
+    my_predbat.car_charging_power = 7363
+    my_predbat.car_charging_power_configured = True
+    html = web.get_power_flow_diagram()
+    if house_reading(html) != "542 W":
+        print(f"  ERROR: expected the House circle to keep its whole 542 W with the car outside the CT clamp, got '{house_reading(html)}'")
+        failed += 1
+    if ">7363 W<" not in html:
+        print("  ERROR: expected the car charging power to still be labelled on its own arm")
+        failed += 1
+    if "grid-car-path" not in html:
+        print("  ERROR: a charger outside the CT clamp draws from the incoming supply, so its arm should run from the Grid")
+        failed += 1
+    if "house-car-path" in html:
+        print("  ERROR: the car arm should not run from the House when the charger is outside the CT clamp")
+        failed += 1
+
+    # -------------------------------------------------------------------------
+    # The same household with the switch back on - the case the subtraction exists for
+    print("Test: a charger inside the CT clamp is still subtracted and drawn from the House")
+    my_predbat.car_energy_reported_load = True
+    my_predbat.load_power = 7905
+    my_predbat.car_charging_power = 7363
+    html = web.get_power_flow_diagram()
+    if house_reading(html) != "542 W":
+        print(f"  ERROR: expected 7905 - 7363 = 542 W in the House circle with the car inside the CT clamp, got '{house_reading(html)}'")
+        failed += 1
+    if "house-car-path" not in html:
+        print("  ERROR: the car arm should run from the House when the charger is behind the CT clamp")
+        failed += 1
+    if "grid-car-path" in html:
+        print("  ERROR: the car arm should not be hung off the Grid when the charger is behind the CT clamp")
         failed += 1
 
     # dashboard_item() records an entity in four separate stores, and a lingering
@@ -549,6 +622,7 @@ def run_web_power_flow_tests(my_predbat):
     my_predbat.load_power = original_load_power
     my_predbat.car_charging_power = 0
     my_predbat.car_charging_power_configured = False
+    my_predbat.car_energy_reported_load = original_car_energy_reported_load
 
     print("**** Web power flow car charging tests completed ****")
     return failed

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -602,13 +602,18 @@ class WebInterface(ComponentBase):
         load_power = self.base.load_power
 
         # Car charging only appears when a car_charging_power sensor is configured (execute.py
-        # update_car_charging_power). The charger sits on the house side of the meter, so its power
-        # is already inside load_power - subtract it so the House circle reads as the rest of the
+        # update_car_charging_power). Where the charger sits relative to the house CT clamp is what
+        # car_energy_reported_load records. With it on the charger is behind the clamp and its power
+        # is already inside load_power, so subtract it and the House circle reads as the rest of the
         # house rather than counting the car twice. Clamped at zero because the two readings come
         # from different meters and a slow-updating load sensor can briefly read below the car.
+        # With it off the charger is outside the clamp and was never in load_power, so subtracting
+        # would take the car off a figure that never held it and the clamp would then swallow the
+        # whole house load - leave the reading alone and feed the car from the Grid instead (#4788).
         car_configured = self.base.car_charging_power_configured
         car_power = self.base.car_charging_power
-        house_power = max(0, load_power - car_power) if car_configured else load_power
+        car_inside_clamp = self.base.car_energy_reported_load
+        house_power = max(0, load_power - car_power) if (car_configured and car_inside_clamp) else load_power
 
         # Determine flow directions. battery_power is positive when the battery is DISCHARGING
         # (gateway.py negates the firmware's sign for exactly this reason) and grid_power is
@@ -662,52 +667,69 @@ class WebInterface(ComponentBase):
             battery_icon, dp0(house_power)
         )
 
-        # Car charging arm - drawn top right, the corner left free by PV/battery/grid
+        # Car charging arm - drawn top right, the corner left free by PV/battery/grid. It runs from
+        # whichever node is actually feeding the charger: the House when the charger is behind the
+        # CT clamp, otherwise the Grid, since the incoming supply is then the only thing left that
+        # can be feeding it. Both run circle edge to circle edge, stopping short of the Car by the
+        # length of the arrowhead the marker draws past the end of the line.
         if car_configured:
             car_charging = car_power >= 10
+            if car_inside_clamp:
+                car_source = "House"
+                car_line = 'x1="342" y1="172" x2="391" y2="139"'
+                car_path = "M342,172 L391,139"
+                car_label = 'x="356" y="122"'
+            else:
+                car_source = "Grid"
+                car_line = 'x1="450" y1="250" x2="450" y2="170"'
+                car_path = "M450,250 L450,170"
+                car_label = 'x="485" y="205"'
+
             html += """
                 <!-- Car Circle -->
                 <circle cx="450" cy="100" r="50" fill="#E53935"><title>Car</title></circle>
                 <text x="450" y="100" text-anchor="middle" dy=".35em" font-family="Material Design Icons" font-size="44" fill="#fff">&#xF010B;</text>
 
                 <defs>
-                    <!-- House to Car path -->
-                    <path id="house-car-path" d="M342,172 L391,139" stroke="transparent" fill="none" />
+                    <!-- {source} to Car path -->
+                    <path id="{source_id}-car-path" d="{path}" stroke="transparent" fill="none" />
                     <marker id="car-arrow" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
                     <polygon points="0 0, 10 3.5, 0 7" fill="#E53935"/>
                     </marker>
                 </defs>
-            """
+            """.format(
+                source=car_source, source_id=car_source.lower(), path=car_path
+            )
             if car_charging:
                 # Calculate animation speed based on power flow - faster for higher power
                 car_speed = max(0.5, min(3.0, 2.0 - (abs(car_power) / 3000)))
 
                 html += """
-                <!-- House to Car Arrow -->
-                <line x1="342" y1="172" x2="391" y2="139" stroke="#E53935" stroke-width="2" marker-end="url(#car-arrow)" />
-                <text x="356" y="122" text-anchor="middle" fill="#E53935">{} W</text>
+                <!-- {source} to Car Arrow -->
+                <line {line} stroke="#E53935" stroke-width="2" marker-end="url(#car-arrow)" />
+                <text {label} text-anchor="middle" fill="#E53935">{power} W</text>
 
-                <!-- Moving dots for House to Car -->
+                <!-- Moving dots for {source} to Car -->
                 <circle r="4" fill="#E53935" opacity="0.8">
-                    <animateMotion dur="{}s" repeatCount="indefinite" path="M342,172 L391,139" />
+                    <animateMotion dur="{speed}s" repeatCount="indefinite" path="{path}" />
                 </circle>
                 <circle r="3" fill="#E53935" opacity="0.6">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="0.5s" path="M342,172 L391,139" />
+                    <animateMotion dur="{speed}s" repeatCount="indefinite" begin="0.5s" path="{path}" />
                 </circle>
                 <circle r="2" fill="#E53935" opacity="0.4">
-                    <animateMotion dur="{}s" repeatCount="indefinite" begin="1.0s" path="M342,172 L391,139" />
+                    <animateMotion dur="{speed}s" repeatCount="indefinite" begin="1.0s" path="{path}" />
                 </circle>
                 """.format(
-                    dp0(car_power), car_speed, car_speed, car_speed
+                    source=car_source, line=car_line, label=car_label, power=dp0(car_power), speed=car_speed, path=car_path
                 )
             else:
                 html += """
-                <!-- House to Car Arrow (dashed) -->
-                <line x1="342" y1="172" x2="391" y2="139" stroke="#E53935" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#car-arrow)" />
-                <text x="356" y="122" text-anchor="middle" fill="#E53935">{} W</text>
+                <!-- {source} to Car Arrow (dashed) -->
+                <line {line} stroke="#E53935" stroke-width="2" stroke-dasharray="5,5" marker-end="url(#car-arrow)" />
+                <text {label} text-anchor="middle" fill="#E53935">{power} W</text>
                 <!-- No moving dot when the car is not charging -->
                 """.format(
-                    dp0(car_power)
+                    source=car_source, line=car_line, label=car_label, power=dp0(car_power)
                 )
 
         # Draw arrows and labels

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -88,7 +88,10 @@ to multiply the **car_charging_energy** sensor data by if required (e.g. set to 
 This has been pre-defined as a regular expression that should auto-detect the appropriate Wallbox and Zappi car charger sensors, or edit as necessary in `apps.yaml` for your charger sensor.<BR>
 Unlike **car_charging_energy** this is display only - it has no effect at all on the Predbat plan. When it is set:
 
-- the [web interface](web-interface.md) power flow diagram gains a Car showing what the charger is drawing, and the House figure becomes the household load with the car charging subtracted from it
+- the [web interface](web-interface.md) power flow diagram gains a Car showing what the charger is drawing.
+What the Car is drawn as being fed from follows **switch.predbat_car_energy_reported_load**: with it on (the default) your charger sits inside the house CT clamp,
+so the Car hangs off the House and its power is subtracted from the House figure to stop the car being counted twice;
+with it off the charger is outside the clamp and was never part of your house load, so the Car hangs off the Grid instead and the House figure is left alone
 - Predbat publishes a **predbat.car_charging_power** sensor (in kW) which you can graph or use in your own automations
 
 Like car_charging_energy it can be a list of sensors, one per line, if you have more than one charger - they are added together:

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -38,8 +38,10 @@ The initial view is the Dash view which gives a summary of Predbat's status and 
 ![image](images/web-interface-dash-view.png)
 
 The power flow diagram shows the PV, battery, grid and house, with animated arrows whose speed reflects how much power is flowing.
-A car is also shown if you have set [car_charging_power](car-charging.md#configure-appsyaml-for-your-car-charging) in `apps.yaml` (this is automatic for the supported charger integrations);
-the car charging power is then subtracted from the House figure so that it shows the rest of your household load rather than counting the car twice.
+A car is also shown if you have set [car_charging_power](car-charging.md#configure-appsyaml-for-your-car-charging) in `apps.yaml` (this is automatic for the supported charger integrations).
+If **switch.predbat_car_energy_reported_load** is on (the default) then your charger sits inside the house CT clamp, so the car is drawn as being fed from the House
+and its power is subtracted from the House figure, which then shows the rest of your household load rather than counting the car twice.
+If the switch is off then the charger is outside the clamp and its power was never in your house load reading, so the car is drawn as being fed from the Grid and the House figure is shown as it is read.
 
 The Debug panel provides easy access to a number of files that are useful in diagnosing a problem and are usually required if you raise a [Predbat GitHub issue](https://github.com/springfall2008/batpred/issues):
 


### PR DESCRIPTION
The power flow diagram assumed the charger always sits behind the house CT clamp, so it subtracted car_charging_power from load_power and hung the car arm off the House. With switch.predbat_car_energy_reported_load off the car was never in load_power, so the subtraction took it off a figure that never held it and the max(0, ...) clamp then swallowed the entire house load, showing 0 W beside a house genuinely drawing 542 W.

Read the switch in get_power_flow_diagram(): with it off, leave the house reading alone and run the car arm from the Grid, which is the only thing left that can be feeding a charger outside the clamp.