### PR TITLE
Warn when apps.yaml has unmasked credentials

### DIFF
--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -76,7 +76,7 @@ from const import (
 )
 from config import APPS_SCHEMA, CONFIG_ITEMS
 import debug_history
-from utils import minutes_since_yesterday, dp1, dp2, dp3
+from utils import minutes_since_yesterday, dp1, dp2, dp3, find_unmasked_secret_paths
 from predheat import PredHeat
 from octopus import Octopus
 from energydataservice import Energidataservice
@@ -290,6 +290,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.db_manager = None
         self.plan_debug = False
         self.arg_errors = {}
+        self.arg_warnings = {}
         self.validate_config_retries_remaining = 0
         self.validate_config_next_retry_time = None
         self.ha_interface = None
@@ -1685,7 +1686,53 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         else:
             self.log("Validation of apps.yaml was successful")
 
+        self.check_apps_yaml_secrets()
+
         return errors
+
+    def check_apps_yaml_secrets(self, apps_yaml_path=None):
+        """
+        Re-read apps.yaml with the ruamel round-trip loader (the same one the web config
+        editors use) and warn about credential-like values stored in plain text instead of
+        via a '!secret' reference into secrets.yaml.
+
+        By the time apps.yaml reaches self.args, '!secret' has already been resolved to its
+        real value, so an inline key and a secrets.yaml reference are indistinguishable there -
+        this re-reads the raw file to recover that distinction. Populates self.arg_warnings
+        rather than self.arg_errors: an inline credential is not an invalid configuration, so
+        it should not turn the same red "apps.yaml has N errors" banner on for a large
+        fraction of existing installs.
+        """
+        self.arg_warnings = {}
+        try:
+            from ruamel.yaml import YAML
+        except ImportError:
+            return
+
+        if apps_yaml_path is None:
+            apps_yaml_path = hass.resolve_apps_yaml_path()
+        if not os.path.exists(apps_yaml_path):
+            return
+
+        try:
+            yaml_loader = YAML(typ="rt")
+            with open(apps_yaml_path, "r") as handle:
+                data = yaml_loader.load(handle)
+        except Exception as e:
+            self.log("Warn: Unable to re-read {} to check for unmasked secrets: {}".format(apps_yaml_path, e))
+            return
+
+        if not isinstance(data, dict):
+            return
+        root = data.get("pred_bat")
+        if not isinstance(root, dict):
+            return
+
+        for key_path in find_unmasked_secret_paths(root):
+            self.arg_warnings[key_path] = "Credential-like value is stored in plain text in apps.yaml - consider using '!secret' to reference secrets.yaml instead"
+
+        if self.arg_warnings:
+            self.log("Warn: apps.yaml has {} credential-like value(s) not using the !secret mechanism: {}".format(len(self.arg_warnings), ", ".join(sorted(self.arg_warnings))))
 
     def validate_config_schedule_retry(self, errors):
         """

--- a/apps/predbat/tests/test_validate_config.py
+++ b/apps/predbat/tests/test_validate_config.py
@@ -27,6 +27,9 @@ Types covered (see APPS_SCHEMA in config.py):
   sensor_list (with entries, modify, none|string sensor_type)
 """
 
+import os
+import tempfile
+
 
 def _run(my_predbat, extra_args, extra_states=None, expect_errors=(), expect_clean=()):
     """Inject args/states, run validate_config, assert per-field expectations.
@@ -391,6 +394,71 @@ def test_validate_config(my_predbat):
         _run(my_predbat, {name: "sensor.test_charger_typo"}, expect_errors=[name])
 
     print("**** test_validate_config PASSED ****")
+    return False
+
+
+def test_validate_config_secrets(my_predbat):
+    """
+    Tests check_apps_yaml_secrets() (#4787) - re-reads apps.yaml with the ruamel round-trip
+    loader and flags credential-like values that are stored in plain text rather than
+    referenced via the '!secret' mechanism.
+
+    Writes a real temp apps.yaml so the round-trip loader has something genuine to parse:
+    provenance (whether a value came from a '!secret' tag or was written inline) only
+    survives in the raw file, not in self.args, which is why the check has to re-read it
+    rather than working off the already-resolved config the rest of validate_config() uses.
+    check_apps_yaml_secrets() takes an explicit path so this is independent of
+    PREDBAT_APPS_FILE and the working directory the test suite happens to run from.
+    """
+    print("**** test_validate_config_secrets ****")
+
+    apps_yaml_content = """
+pred_bat:
+  module: predbat
+  class: PredBat
+  mcp_secret: !secret my_mcp_secret
+  ohme_password: plaintext_password
+  kraken_key: ""
+  forecast_solar:
+    api_key: plaintext_nested_key
+  gateway_mqtt_host: mqtt.example.com
+  rates_import:
+    - start: "00:00"
+      end: "05:00"
+      rate: 0.07
+"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        temp_path = f.name
+        f.write(apps_yaml_content)
+
+    try:
+        my_predbat.check_apps_yaml_secrets(apps_yaml_path=temp_path)
+        warnings = my_predbat.arg_warnings
+
+        print("  Inline credential value is flagged")
+        assert "ohme_password" in warnings, f"Expected inline ohme_password to be flagged, got {warnings}"
+
+        print("  Nested inline credential value is flagged")
+        assert "forecast_solar.api_key" in warnings, f"Expected nested forecast_solar.api_key to be flagged, got {warnings}"
+
+        print("  '!secret'-referenced value is not flagged")
+        assert "mcp_secret" not in warnings, f"'!secret'-referenced mcp_secret must not be flagged, got {warnings}"
+
+        print("  Empty credential-like value is not flagged")
+        assert "kraken_key" not in warnings, f"Empty string value must not be flagged, got {warnings}"
+
+        print("  Non-credential key is not flagged")
+        assert "gateway_mqtt_host" not in warnings, f"Non-credential key must not be flagged, got {warnings}"
+        assert not any(w.startswith("rates_import") for w in warnings), f"Non-credential nested list must not be flagged, got {warnings}"
+    finally:
+        os.remove(temp_path)
+
+    print("  A missing apps.yaml is handled without error")
+    my_predbat.check_apps_yaml_secrets(apps_yaml_path="/tmp/does_not_exist_predbat_test_4787.yaml")
+    assert my_predbat.arg_warnings == {}, f"Expected no warnings for a missing file, got {my_predbat.arg_warnings}"
+
+    print("**** test_validate_config_secrets PASSED ****")
     return False
 
 

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -229,7 +229,7 @@ from tests.test_integer_config import (
 )
 from tests.test_predbat_metrics_data_age import test_data_age_metrics_round_trip
 from tests.test_metrics_dashboard_control_conflicts import test_control_conflicts_metrics_round_trip, test_control_conflicts_dashboard_renders_section
-from tests.test_validate_config import test_validate_config, test_validate_config_retry
+from tests.test_validate_config import test_validate_config, test_validate_config_retry, test_validate_config_secrets
 from tests.test_get_arg_missing_index import test_get_arg_missing_index_uses_default_quietly
 from tests.test_plan_json_rate_adjust import run_test_plan_json_rate_adjust
 from tests.test_plan_why_reason import run_test_plan_why_reason
@@ -567,6 +567,7 @@ def main():
         ("validate_config", test_validate_config, "APPS_SCHEMA validator tests (string types, sensor boolean states)", False),
         ("get_arg_missing_index", test_get_arg_missing_index_uses_default_quietly, "get_arg missing (out-of-range index) vs malformed numeric coercion tests", False),
         ("validate_config_retry", test_validate_config_retry, "Config validation retry-after-failure tests (#4379)", False),
+        ("validate_config_secrets", test_validate_config_secrets, "check_apps_yaml_secrets() unmasked-credential detection tests (#4787)", False),
         ("expose_config_integer", test_expose_config_preserves_integer, "Expose config preserves integer tests", False),
         ("config_item_range_clamp", test_config_item_range_clamp, "Config item min/max range clamp tests", False),
         ("config_item_step_min_max_types", test_config_item_step_min_max_types_consistent, "Config item step/min/max type consistency tests", False),

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -159,6 +159,31 @@ def mask_secret_args(args):
     return masked
 
 
+def find_unmasked_secret_paths(node, path=""):
+    """
+    Recursively walk a ruamel round-trip-loaded apps.yaml section and yield the dotted path
+    of every credential-like key (per is_secret_key()) whose value is a plain scalar rather
+    than a '!secret' reference into secrets.yaml (loaded as a ruamel TaggedScalar).
+
+    Only usable against a document loaded with ruamel's round-trip loader - a plain
+    yaml.safe_load() has already resolved '!secret' tags to their real value and lost the
+    distinction this depends on.
+    """
+    from ruamel.yaml.comments import TaggedScalar
+
+    if isinstance(node, dict):
+        for key, value in node.items():
+            key_path = "{}.{}".format(path, key) if path else str(key)
+            if is_secret_key(key):
+                if value not in (None, "") and not isinstance(value, TaggedScalar):
+                    yield key_path
+            else:
+                yield from find_unmasked_secret_paths(value, key_path)
+    elif isinstance(node, list):
+        for index, item in enumerate(node):
+            yield from find_unmasked_secret_paths(item, "{}[{}]".format(path, index))
+
+
 def read_predbat_log(logfile=PREDBAT_LOG_FILE, logfile_prev=PREDBAT_LOG_FILE_PREV):
     """
     Return the contents of predbat.log, prefixed with the rotated previous log when one exists.

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -3585,6 +3585,8 @@ chart.render();
         if self.base.arg_errors:
             warning = "&#9888;"
         text += "{}<a href='./debug_apps'>apps.yaml</a> - has {} errors<br>\n".format(warning, len(self.base.arg_errors))
+        if self.base.arg_warnings:
+            text += "&#9888; apps.yaml has {} credential-like value(s) stored in plain text - consider using '!secret' to reference secrets.yaml: {}<br>\n".format(len(self.base.arg_warnings), html_module.escape(", ".join(sorted(self.base.arg_warnings))))
         text += "<table>\n"
         text += "<tr><th>Name</th><th>Value</th><th>Actions</th></tr>\n"
 

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -201,6 +201,8 @@ pred_bat:
   kraken_password: !secret kraken_password  # Kraken password (if using Kraken component)
 ```
 
+If a credential-like value (matching a key name containing `_key`, `password`, `secret` or `token`) is found written directly in `apps.yaml` instead of via `!secret`, Predbat logs a warning and lists the affected item(s) on the [web interface](web-interface.md) apps.yaml page. This is a warning rather than a validation error - the configuration still works, but moving the value into `secrets.yaml` keeps it out of `apps.yaml`, which is more likely to end up shared, backed up or attached to a bug report.
+
 When Predbat loads, it will automatically replace `!secret octopus_api_key` with the actual value from `secrets.yaml`.
 
 If a secret is referenced in `apps.yaml` but not found in `secrets.yaml`, Predbat will log a warning and the configuration item will be set to `None`.


### PR DESCRIPTION
This is an automated draft PR generated from issue #4787 — a maintainer should review it before merging.

Fixes #4787

## Summary

`apps.yaml` supports a `!secret` mechanism for keeping credentials out of the config file, but nothing warned when a user wrote a credential-like value (matching an `_key`/`password`/`secret`/`token` key name, minus `_expires_at`-style suffixes) inline instead. By the time apps.yaml reaches `self.args`, `!secret` has already been resolved to its real value, so the two are indistinguishable there — `check_apps_yaml_secrets()` re-reads the raw file with the ruamel round-trip loader (the same one the web config editors already use), where a `!secret` reference loads as a `TaggedScalar` and an inline value loads as a plain scalar, and recurses into nested structures (e.g. `forecast_solar.api_key`) so it isn't limited to top-level keys.

Findings are stored in a new `self.arg_warnings` dict, kept separate from `self.arg_errors` — an inline credential is not an invalid configuration, so it deliberately does not increment the count behind the existing red "apps.yaml has N errors" banner. Instead it logs a `Warn:` line and adds a small warning line to the `/apps` web page listing the affected item(s).

## Testing

- `cd coverage && ./run_pre_commit` — passed (black reformatted one line in `web.py`, included in this PR)
- `tools/triage_test.sh validate_config_secrets <log>` — new test, passed
- `tools/triage_test.sh validate_config <log>` and `tools/triage_test.sh validate_config_retry <log>` — existing `validate_config()` tests, still passed with the new call wired in

## Notes

Per the triage comment: the scan deliberately does not iterate `APPS_SCHEMA` (7 credential-like component args are missing from it) and does recurse into nested values — both gaps the triage investigation flagged as required for this to actually catch real cases. The `/debug_apps` per-row inline editor annotation and a "store in secrets.yaml" option on `html_component_config_save()` (`web.py:4952`) are left as possible follow-ups rather than folded into this change.