### PR TITLE
Dark mode follows OS/browser prefers-color-scheme when unset

### DIFF
--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -519,5 +519,10 @@ def run_web_dark_mode_preference_tests(my_predbat):
         print("  ERROR: expected a matchMedia change listener so the page follows OS theme switches live")
         failed += 1
 
+    print("Test: the live listener falls back to addListener() for browsers without MediaQueryList.addEventListener")
+    if "darkModeMediaQuery.addListener" not in header:
+        print("  ERROR: expected a fallback to the deprecated addListener() for older Safari/Chrome")
+        failed += 1
+
     print("**** Web dark mode preference tests completed ****")
     return failed

--- a/apps/predbat/tests/test_web_functions.py
+++ b/apps/predbat/tests/test_web_functions.py
@@ -477,3 +477,47 @@ def run_web_logo_image_tests(my_predbat):
 
     print("**** Web logo image tests completed ****")
     return failed
+
+
+def run_web_dark_mode_preference_tests(my_predbat):
+    """Unit tests for dark mode falling back to the OS/browser prefers-color-scheme setting (issue #4800)."""
+    failed = 0
+    print("**** Running web dark mode preference tests ****")
+
+    from web_helper import get_header_html
+
+    header = get_header_html("Test", False, "./dash", [], "v1.0", "")
+
+    print("Test: a shared preference helper checks prefers-color-scheme when no explicit choice is stored")
+    helper_pos = header.find("function getDarkModePreference()")
+    media_query_pos = header.find("matchMedia('(prefers-color-scheme: dark)')")
+    stored_check_pos = header.find("localStorage.getItem('darkMode')")
+    if helper_pos < 0 or media_query_pos < 0 or stored_check_pos < 0:
+        print("  ERROR: expected getDarkModePreference() to check both localStorage and prefers-color-scheme")
+        failed += 1
+
+    print("Test: the pre-CSS flash-prevention script and applyDarkMode() both use the shared helper")
+    pre_css_call_pos = header.find("if (getDarkModePreference())")
+    apply_dark_mode_call_pos = header.find("const darkModeEnabled = getDarkModePreference();")
+    if pre_css_call_pos < 0 or apply_dark_mode_call_pos < 0:
+        print("  ERROR: expected both the pre-CSS script and applyDarkMode() to call getDarkModePreference()")
+        failed += 1
+    elif not (helper_pos < pre_css_call_pos):
+        print("  ERROR: getDarkModePreference() must be defined before it is first called")
+        failed += 1
+
+    print("Test: an explicit stored preference is not overridden by prefers-color-scheme")
+    helper_body_start = header.find("function getDarkModePreference()")
+    helper_body_end = header.find("\n}", helper_body_start)
+    helper_body = header[helper_body_start:helper_body_end]
+    if "storedDarkMode === 'true'" not in helper_body or "storedDarkMode !== null" not in helper_body:
+        print("  ERROR: an explicit localStorage value should be honoured ahead of the OS preference")
+        failed += 1
+
+    print("Test: a live listener re-applies the theme if the OS preference changes with no explicit choice stored")
+    if "addEventListener('change'" not in header or "prefers-color-scheme: dark" not in header:
+        print("  ERROR: expected a matchMedia change listener so the page follows OS theme switches live")
+        failed += 1
+
+    print("**** Web dark mode preference tests completed ****")
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -111,7 +111,7 @@ from tests.test_web_debug_history_routes import test_web_debug_history_routes
 from tests.test_web_mcp import run_web_mcp_tests
 from tests.test_debug_history_client_js import test_debug_history_client_js
 from tests.test_metrics_dashboard_soc_refresh import test_soc_chart_center_text_reads_live_data
-from tests.test_web_functions import run_web_functions_tests, run_web_logo_image_tests
+from tests.test_web_functions import run_web_functions_tests, run_web_logo_image_tests, run_web_dark_mode_preference_tests
 from tests.test_web_power_flow import run_web_power_flow_tests
 from tests.test_web_history_table import run_web_history_table_tests
 from tests.test_web_charts import run_web_charts_tests
@@ -469,6 +469,7 @@ def main():
         ("web_functions", run_web_functions_tests, "Web function unit tests", False),
         ("web_power_flow", run_web_power_flow_tests, "Power flow diagram car charging tests", False),
         ("web_logo_image", run_web_logo_image_tests, "Local logo image route tests (issue #4562)", False),
+        ("web_dark_mode_preference", run_web_dark_mode_preference_tests, "Dark mode follows OS prefers-color-scheme when unset (issue #4800)", False),
         ("web_annual", test_web_annual, "Annual web tab prefill tests", False),
         ("web_annual_form", test_web_annual_form, "Annual web tab form tests", False),
         ("web_annual_fast_mode", test_web_annual_fast_mode, "Annual web tab fast mode tests", False),

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -7717,7 +7717,15 @@ def get_header_html(title, calculating, default_page, arg_errors, THIS_VERSION, 
     text += """
 <script>
 // Apply dark mode immediately before CSS is parsed to prevent flash of white
-if (localStorage.getItem('darkMode') === 'true') {
+// Falls back to the OS/browser prefers-color-scheme setting when the user hasn't made an explicit choice (batpred#4800)
+function getDarkModePreference() {
+    const storedDarkMode = localStorage.getItem('darkMode');
+    if (storedDarkMode !== null) {
+        return storedDarkMode === 'true';
+    }
+    return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+}
+if (getDarkModePreference()) {
     document.documentElement.classList.add('dark-mode');
     document.addEventListener('DOMContentLoaded', function() {
         if (document.body) {
@@ -8037,7 +8045,7 @@ window.onload = function() {
     applyDarkMode();
 };
 function applyDarkMode() {
-    const darkModeEnabled = localStorage.getItem('darkMode') === 'true';
+    const darkModeEnabled = getDarkModePreference();
     if (darkModeEnabled) {
         document.body.classList.add('dark-mode');
         document.documentElement.classList.add('dark-mode');
@@ -8057,6 +8065,15 @@ function applyDarkMode() {
         }
     }
 };
+
+// Re-apply if the OS/browser theme changes while no explicit preference is stored (batpred#4800)
+if (window.matchMedia) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+        if (localStorage.getItem('darkMode') === null) {
+            applyDarkMode();
+        }
+    });
+}
 
 function toggleDarkMode() {
     const isDarkMode = document.body.classList.toggle('dark-mode');

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -8068,11 +8068,18 @@ function applyDarkMode() {
 
 // Re-apply if the OS/browser theme changes while no explicit preference is stored (batpred#4800)
 if (window.matchMedia) {
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+    const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleDarkModePreferenceChange = function() {
         if (localStorage.getItem('darkMode') === null) {
             applyDarkMode();
         }
-    });
+    };
+    // Safari < 14 and Chrome < 39 only implement the older, deprecated addListener() method
+    if (darkModeMediaQuery.addEventListener) {
+        darkModeMediaQuery.addEventListener('change', handleDarkModePreferenceChange);
+    } else if (darkModeMediaQuery.addListener) {
+        darkModeMediaQuery.addListener(handleDarkModePreferenceChange);
+    }
 }
 
 function toggleDarkMode() {


### PR DESCRIPTION
This is an automated draft PR generated from issue #4800 — a maintainer should review it before merging.

Fixes #4800

## Summary

The manual dark mode toggle stayed light on first visit regardless of the OS/browser theme, since it only ever checked `localStorage['darkMode']`. Adds a shared `getDarkModePreference()` helper (used both by the pre-CSS flash-prevention script and by `applyDarkMode()`) that falls back to `window.matchMedia('(prefers-color-scheme: dark)')` when no explicit choice has been stored, and a `matchMedia` `change` listener that re-applies the theme live if the OS preference changes while no explicit choice is stored. An explicit manual toggle (which always writes `'true'`/`'false'`) continues to override the OS setting, as before.

This covers ask #1 from the issue (follow OS/browser setting). Ask #2 (sync with Home Assistant's own theme setting) is a separate, larger change — the Predbat web UI is served standalone rather than reading HA's frontend theme state — and is intentionally out of scope here, per the triage comment.

## Testing

- `cd coverage && ./run_pre_commit` — all lint checks (ruff, black, cspell, markdownlint) and the full unit test suite passed.
- `tools/triage_test.sh web_dark_mode_preference` — new test module, passed.
- `tools/triage_test.sh web_functions` and `tools/triage_test.sh web_logo_image` — existing related web tests, no regressions.

## Notes

Per this repo's own convention for testing embedded page JS (Node isn't available in the test sandbox), the new test asserts on the JS source text returned by `get_header_html()`, following the same pattern as the existing `#2256` flash-of-white regression test in `test_web_functions.py`.