### PR TITLE
fix(web): correct inverted grid arrow and icon on Power Flow diagram

### DIFF
--- a/apps/predbat/tests/test_web_power_flow.py
+++ b/apps/predbat/tests/test_web_power_flow.py
@@ -272,6 +272,47 @@ def run_power_flow_colour_tests(my_predbat, web):
     return failed
 
 
+def run_grid_power_sign_tests(my_predbat, web):
+    """The grid arrow and icon follow the documented grid_power sign convention.
+
+    grid_power is positive while importing and negative while exporting (predbat_metrics.py:101),
+    the same way round as battery_power (positive while discharging). Getting this backwards drew
+    the grid arrow, and picked the grid icon, the wrong way round for every import/export state (#4797).
+    """
+    failed = 0
+    print("Test: the grid arrow and icon follow the documented grid_power sign convention")
+
+    saved = (my_predbat.grid_power, my_predbat.dashboard_index)
+    my_predbat.dashboard_index = ["dummy"]
+
+    cases = [
+        (1500, "Grid", "transmission-tower-import", "importing"),
+        (-1500, "House", "transmission-tower-export", "exporting"),
+    ]
+    for grid_power, expected_tail, icon_name, description in cases:
+        my_predbat.grid_power = grid_power
+        html = web.get_power_flow_diagram()
+        grid_lines = [line for colour, line in arrow_lines(html) if colour == "#757575"]
+        if not grid_lines:
+            print(f"  ERROR: no grid arm drawn while {description} (grid_power={grid_power})")
+            failed += 1
+            continue
+        x1, y1, x2, y2 = grid_lines[0]
+        tail_at_grid = distance((x1, y1), NODE_BY_COLOUR["#757575"][1]) < distance((x1, y1), HOUSE_CENTRE)
+        actual_tail = "Grid" if tail_at_grid else "House"
+        if actual_tail != expected_tail:
+            print(f"  ERROR: while {description} (grid_power={grid_power}) the grid arm starts at {actual_tail}, expected {expected_tail}")
+            failed += 1
+
+        icon_html = web.get_grid_power_icon()
+        if f"mdi-{icon_name}" not in icon_html:
+            print(f"  ERROR: while {description} (grid_power={grid_power}) expected the {icon_name} icon, got: {icon_html}")
+            failed += 1
+
+    (my_predbat.grid_power, my_predbat.dashboard_index) = saved
+    return failed
+
+
 def run_power_flow_geometry_tests(my_predbat, web):
     """The arms line up with the circles they join, in every flow direction."""
     failed = 0
@@ -281,11 +322,13 @@ def run_power_flow_geometry_tests(my_predbat, web):
 
     my_predbat.car_charging_power_configured = True
 
-    # Importing, battery discharging, PV generating, car charging
+    # Importing, battery discharging, PV generating, car charging. grid_power is positive while
+    # importing and negative while exporting (predbat_metrics.py), the same way round as
+    # battery_power, which is positive while discharging.
     my_predbat.pv_power = 2000
     my_predbat.load_power = 4000
     my_predbat.battery_power = 1500
-    my_predbat.grid_power = -1000
+    my_predbat.grid_power = 1000
     my_predbat.car_charging_power = 2000
     html = web.get_power_flow_diagram()
     failed += check_arm_geometry(html, "importing, battery discharging")
@@ -294,7 +337,7 @@ def run_power_flow_geometry_tests(my_predbat, web):
     # The opposite of every branch: exporting, battery charging, PV idle, car idle
     my_predbat.pv_power = 0
     my_predbat.battery_power = -1500
-    my_predbat.grid_power = 1000
+    my_predbat.grid_power = -1000
     my_predbat.car_charging_power = 0
     html = web.get_power_flow_diagram()
     failed += check_arm_geometry(html, "exporting, battery charging")
@@ -543,6 +586,7 @@ def run_web_power_flow_tests(my_predbat):
     failed += run_power_flow_icon_tests(my_predbat, web)
     failed += run_power_flow_colour_tests(my_predbat, web)
     failed += run_battery_icon_tests(my_predbat, web)
+    failed += run_grid_power_sign_tests(my_predbat, web)
     failed += run_power_flow_geometry_tests(my_predbat, web)
 
     my_predbat.args = original_args

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -611,9 +611,9 @@ class WebInterface(ComponentBase):
         house_power = max(0, load_power - car_power) if car_configured else load_power
 
         # Determine flow directions. battery_power is positive when the battery is DISCHARGING
-        # (gateway.py negates the firmware's sign for exactly this reason) and grid_power is
-        # negative when importing, so the reading and the arrow run opposite ways round.
-        grid_importing = grid_power <= -10  # Grid is importing power (negative value)
+        # (gateway.py negates the firmware's sign for exactly this reason). grid_power is positive
+        # for import and negative for export (predbat_metrics.py), the same way round as battery_power.
+        grid_importing = grid_power >= 10  # Grid is importing power (positive value)
 
         battery_to_house = battery_power >= 10  # Battery is discharging into the house
         battery_charging = battery_power <= -10  # Power is flowing into the battery
@@ -4440,9 +4440,9 @@ chart.render();
 
         power = self.base.grid_power
         if power >= 10:
-            icon_text = "transmission-tower-export"
-        elif power <= -10:
             icon_text = "transmission-tower-import"
+        elif power <= -10:
+            icon_text = "transmission-tower-export"
         else:
             icon_text = "transmission-tower-outline"
 


### PR DESCRIPTION
This is an automated draft PR generated from issue #4797 — a maintainer should review it before merging.

Fixes #4797

## Summary

`web.py`'s `render_power_flow` computed `grid_importing = grid_power <= -10`, but `grid_power` is positive while importing and negative while exporting (`predbat_metrics.py:101`) — the opposite convention, and the opposite of the sign the battery arm's equivalent fix (ef2f306) established for `battery_power`. This drew the grid arrow the wrong way round for every import/export state, and the comment introduced alongside that commit asserted the wrong convention. `get_grid_power_icon` had the same two icon names swapped (`transmission-tower-import`/`-export`).

Fixed both spots to `grid_power >= 10` / correct icon mapping, and corrected the misleading comment.

## Testing

- `cd coverage && ./run_pre_commit` — all hooks and the full unit test suite passed (`web_power_flow` included).
- `tools/triage_test.sh web_power_flow <log>` — passed after the fix.
- Verified the new `run_grid_power_sign_tests` regression test (added in `test_web_power_flow.py`, checks both arrow direction and icon against the documented sign convention) fails with clear errors against the pre-fix code, then re-ran clean after restoring the fix.
- Also corrected the existing geometry test's fixture, which paired `grid_power = -1000` with a comment labelled "Importing" — the same inverted convention as the bug, so it only ever checked arm geometry, never the sign mapping (as flagged in the triage comment).

## Notes

Root cause and both bug locations were identified in the issue's triage comment; this PR implements the one-line fix it suggested plus the swapped icon pair, and adds the sign-check regression test the triage comment recommended.