### PR TITLE
fix(octopus): compare a dispatch's real start, not its rounded settlement block, for 'already underway'

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -3072,7 +3072,6 @@ class Octopus:
         slots_added_set = set()
         plan_interval_minutes = self.plan_interval_minutes
         saved_slots = set()  # For logging purposes, track which slots we actually applied as low rate
-        current_block = (self.minutes_now // 30) * 30
 
         # #4482: Octopus often grants more daytime dispatch slots than the car actually needs - it
         # can't see the car's real SoC, only Predbat can (car_charging_soc/car_charging_limit).
@@ -3095,6 +3094,11 @@ class Octopus:
             # Add in IO slots
             for slot in octopus_slots:
                 start_minutes, end_minutes, kwh, source, location, kwh_valid = self.decode_octopus_slot(car_n, slot, raw=True)
+                # The dispatch's real (unrounded) start, kept apart from the 30-min-rounded
+                # start_minutes below - used only for the "already underway" check (#4808) so a
+                # dispatch starting partway through the current settlement period isn't treated as
+                # already started from the top of that period.
+                raw_start_minutes = start_minutes
 
                 # Ignore bump-charge slots as their cost won't change
                 if source != "bump-charge" and source != "BOOST" and (not location or location == "AT_HOME"):
@@ -3138,7 +3142,13 @@ class Octopus:
                         # slot already underway or completed is trusted regardless of what
                         # car_charging_slots now says about future need, and the fixed window is
                         # never affected since it's guaranteed cheap by the tariff itself.
-                        needed = (not limit_future_slots) or (slot_start <= current_block) or (slot_start in expected_blocks) or self.minute_in_iog_fixed_window(slot_start)
+                        #
+                        # "Already underway" compares the dispatch's real start (#4808, review
+                        # follow-up on #4483 from Speshman) rather than its 30-min-rounded
+                        # slot_start, so a dispatch starting partway through the current
+                        # settlement period isn't trusted early just because the period itself has
+                        # begun.
+                        needed = (not limit_future_slots) or (raw_start_minutes <= self.minutes_now) or (slot_start in expected_blocks) or self.minute_in_iog_fixed_window(slot_start)
 
                         # Whether this dispatch entry actually delivers charge to the car. A
                         # zero-kWh entry (e.g. a plug-independent SMART grid-flex event - #4483

--- a/apps/predbat/tests/test_rate_add_io_slots.py
+++ b/apps/predbat/tests/test_rate_add_io_slots.py
@@ -409,6 +409,22 @@ def run_rate_add_io_slots_tests(my_predbat):
     expected_rates_21 = {minute: 4.0 for minute in range(570, 600)}  # 09:30-10:00
     failed |= run_rate_add_io_slots_test("test21_current_dispatch_stays_low_rate", my_predbat, slots_21, True, 12, expected_rates_21)
 
+    # Test 21b (#4808, review follow-up on #4483 from Speshman): a dispatch starting partway
+    # through the current settlement period must not be treated as already underway just because
+    # the period itself has started - only compares the dispatch's real start against minutes_now,
+    # not the 30-min-rounded slot_start against the rounded current block.
+    print("\n**** Test 21b: A dispatch starting later in the current period is not yet underway ****")
+    my_predbat.octopus_intelligent_limit_future_slots = True
+    now_minutes_21b = my_predbat.minutes_now  # whatever "now" actually is - built relative to it, not a hardcoded wall-clock time
+    slot_start_21b = midnight_utc + timedelta(minutes=now_minutes_21b + 20)  # 20 minutes into the current period - genuinely still future
+    slot_end_21b = slot_start_21b + timedelta(minutes=30)
+    slots_21b = [{"start": slot_start_21b.strftime(TIME_FORMAT), "end": slot_end_21b.strftime(TIME_FORMAT), "charge_in_kwh": 2.5, "source": "smart-charge", "location": "AT_HOME"}]
+    my_predbat.car_charging_slots[0] = []  # Car doesn't need it
+    rounded_start_21b = (now_minutes_21b // 30) * 30
+    rounded_end_21b = ((now_minutes_21b + 20 + 30 + 29) // 30) * 30
+    expected_rates_21b = {minute: 10.0 for minute in range(rounded_start_21b, rounded_end_21b)}  # rejected, not yet started, not needed
+    failed |= run_rate_add_io_slots_test("test21b_mid_period_future_dispatch_not_yet_underway", my_predbat, slots_21b, True, 12, expected_rates_21b)
+
     # Test 22: feature disabled - existing (unconditional) behaviour is unchanged even with an
     # empty car_charging_slots that would otherwise have excluded every block.
     print("\n**** Test 22: Switch off restores unconditional low rate ****")


### PR DESCRIPTION
Stacked on #4810 (which is stacked on #4483) - fixes #4808.

`rate_add_io_slots()`'s exemption from the #4482 future-need check compared the 30-min-rounded `slot_start` against a similarly rounded `current_block`, so a dispatch starting partway through the current settlement period (e.g. 10:20, checked at 10:05) read as already-underway from the top of that period (10:00), before it had actually started.

This captures the dispatch's real, unrounded start separately (`raw_start_minutes`) and compares that against `minutes_now` instead. `current_block` is no longer needed and is removed.

## Test plan
- [x] New test (`test21b_mid_period_future_dispatch_not_yet_underway`) for a dispatch starting later in the current settlement period - fails without this commit, passes with it. Built relative to `my_predbat.minutes_now` at test time rather than a hardcoded wall-clock value, so it stays correct under the pre-existing test-clock drift between `now_utc`/`midnight_utc` that surfaces when the full suite runs in registry order (not something this PR introduces or fixes)
- [x] `./run_all --quick` full suite passes
- [x] `run_pre_commit` clean