### PR TITLE
chore(lint): enable ruff F841 (unused local variable)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   hooks:
   # Run the linter.
   - id: ruff
-    args: [--select=F401,E713,F811,E722,F821, --fix]
+    args: [--select=F401,E713,F811,E722,F821,F841, --fix]
 - repo: https://github.com/psf/black
   rev: 23.11.0
   hooks:

--- a/apps/predbat/tests/test_alert_feed.py
+++ b/apps/predbat/tests/test_alert_feed.py
@@ -53,8 +53,6 @@ def test_alert_feed(my_predbat):
     tz_offset = f"{tz_offset:02d}"
 
     birmingham = [52.4823, -1.8900]
-    bristol = [51.4545, -2.5879]
-    manchester = [53.4808, -2.2426]
     fife = [56.2082, -3.1495]
 
     alert_data = f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -498,7 +496,6 @@ def test_alert_feed(my_predbat):
         "event": "Yellow|Amber",
         "keep": 0.5,
     }
-    original_download_alert_data = alert_feed.download_alert_data
     alert_feed.alert_config = alert_config
     alert_feed.alert_xml = alert_data
     alerts, alert_active_keep = alert_feed.process_alerts(my_predbat.minutes_now, my_predbat.midnight_utc, testing=True)

--- a/apps/predbat/tests/test_alphaess_api.py
+++ b/apps/predbat/tests/test_alphaess_api.py
@@ -301,7 +301,6 @@ def test_alphaess_response_code_is_logged_even_with_debug_on():
     with patch("alphaess.aiohttp.ClientSession", return_value=session):
         run_async_local(client._post("update_charge_config", body={"sysSn": "AL70"}))
     # Check that the response code 6008 was logged (not masked as ***)
-    response_logs = [msg for msg in client.log_messages if "response" in msg.lower() or "6008" in msg]
     if not any("6008" in msg for msg in client.log_messages):
         print(f"ERROR: code 6008 not logged, got {client.log_messages}")
         failed = True

--- a/apps/predbat/tests/test_axle.py
+++ b/apps/predbat/tests/test_axle.py
@@ -1069,8 +1069,6 @@ def _test_axle_load_slot_export(my_predbat=None):
     end_minutes = 16 * 60  # 16:00 = 960 minutes
 
     original_rate_before = base.rate_export[start_minutes]
-    original_rate_during = base.rate_export[start_minutes + 30]  # 14:30
-    original_rate_after = base.rate_export[end_minutes]  # Should not be modified
 
     # Load the Axle export slot
     rate_replicate = {}

--- a/apps/predbat/tests/test_carbon.py
+++ b/apps/predbat/tests/test_carbon.py
@@ -188,7 +188,7 @@ def _test_fetch_carbon_data_success(my_predbat=None):
 
     with patch("carbon.aiohttp.ClientSession") as mock_session_class:
         mock_session_class.return_value = mock_session
-        result = run_async(api.fetch_carbon_data())
+        run_async(api.fetch_carbon_data())
 
         # Check data was collected (3 points per call * 2 calls)
         if len(api.carbon_data_points) != 6:

--- a/apps/predbat/tests/test_compare.py
+++ b/apps/predbat/tests/test_compare.py
@@ -408,7 +408,7 @@ def test_compare(my_predbat):
     cmp.recompute_car_charging = lambda slots: None
     cmp.run_scenario = lambda end_record: {"cost": 0, "metric": 0}
 
-    result = cmp.run_single({"name": "test_tariff", "id": "test"}, {}, {}, 48 * 60, fetch_sensor=False)
+    cmp.run_single({"name": "test_tariff", "id": "test"}, {}, {}, 48 * 60, fetch_sensor=False)
 
     if not tariff_plan_calls:
         print("ERROR T13: plan_iboost_smart() was not called during run_single()")

--- a/apps/predbat/tests/test_db_manager.py
+++ b/apps/predbat/tests/test_db_manager.py
@@ -183,7 +183,7 @@ def _test_db_manager_set_get_state(my_predbat=None):
             state2 = "15.3"
             attributes2 = {"unit_of_measurement": "kW"}
 
-            result2 = await loop.run_in_executor(None, db_mgr.set_state_db, entity_id2, state2, attributes2, custom_timestamp)
+            await loop.run_in_executor(None, db_mgr.set_state_db, entity_id2, state2, attributes2, custom_timestamp)
             retrieved2 = await loop.run_in_executor(None, db_mgr.get_state_db, entity_id2)
             assert retrieved2 is not None, "get_state_db returned None for entity2"
             assert retrieved2["state"] == state2, f"Expected state {state2}, got {retrieved2['state']}"
@@ -330,7 +330,7 @@ def _test_db_manager_entities_and_history(my_predbat=None):
                     try:
                         # Remove 'Z' suffix if present
                         ts = timestamp_str.rstrip("Z")
-                        parsed = datetime.strptime(ts, TIME_FORMAT_DB)
+                        datetime.strptime(ts, TIME_FORMAT_DB)
                         print(f"✓ Timestamp format correct: {timestamp_str}")
                         break
                     except ValueError as e:

--- a/apps/predbat/tests/test_debug_history.py
+++ b/apps/predbat/tests/test_debug_history.py
@@ -240,7 +240,7 @@ def test_debug_history(my_predbat):
     print("Test: 'latest' (and a falsy id) resolves to the newest snapshot")
     storage = FakeStorage()
     asyncio.run(capture_snapshot(storage, sample_yaml_text("first"), now, max_count=15))
-    newest_id = asyncio.run(capture_snapshot(storage, sample_yaml_text("newest"), now + datetime.timedelta(hours=1), max_count=15))
+    asyncio.run(capture_snapshot(storage, sample_yaml_text("newest"), now + datetime.timedelta(hours=1), max_count=15))
     if asyncio.run(load_snapshot(storage, "latest")) != sample_yaml_text("newest"):
         print("  ERROR: id='latest' should resolve to the newest snapshot")
         failed = True

--- a/apps/predbat/tests/test_dynamic_load.py
+++ b/apps/predbat/tests/test_dynamic_load.py
@@ -45,7 +45,7 @@ def test_dynamic_load_car_slot_cancellation(my_predbat):
     original_slot_1_kwh = my_predbat.car_charging_slots[1][0]["kwh"]
 
     # Call dynamic_load
-    status_changed = my_predbat.dynamic_load()
+    my_predbat.dynamic_load()
 
     # Verify high load status
     if my_predbat.load_last_status != "high":
@@ -71,7 +71,7 @@ def test_dynamic_load_car_slot_cancellation(my_predbat):
     my_predbat.car_charging_slots[1] = [{"start": my_predbat.minutes_now + 30, "end": my_predbat.minutes_now + 45, "kwh": 8.0}]
 
     # Call dynamic_load
-    status_changed = my_predbat.dynamic_load()
+    my_predbat.dynamic_load()
 
     # Verify low load status
     if my_predbat.load_last_status != "low":
@@ -99,7 +99,7 @@ def test_dynamic_load_car_slot_cancellation(my_predbat):
     my_predbat.car_charging_slots[1] = [{"start": my_predbat.minutes_now - 60, "end": my_predbat.minutes_now - 30, "kwh": 8.0}]
 
     # Call dynamic_load
-    status_changed = my_predbat.dynamic_load()
+    my_predbat.dynamic_load()
 
     if my_predbat.car_charging_slots[0][0]["kwh"] != 10.0:
         print(f"ERROR: Car slot 0 should not have been cancelled, kwh = {my_predbat.car_charging_slots[0][0]['kwh']}")
@@ -119,7 +119,7 @@ def test_dynamic_load_car_slot_cancellation(my_predbat):
     my_predbat.car_charging_slots[1] = [{"start": my_predbat.minutes_now - 60, "end": my_predbat.minutes_now - 30, "kwh": 8.0}]
 
     # Call dynamic_load
-    status_changed = my_predbat.dynamic_load()
+    my_predbat.dynamic_load()
 
     if my_predbat.car_charging_slots[0][0]["kwh"] != 0:
         print(f"ERROR: Car slot 0 should have been cancelled, kwh = {my_predbat.car_charging_slots[0][0]['kwh']}")
@@ -140,7 +140,7 @@ def test_dynamic_load_car_slot_cancellation(my_predbat):
     my_predbat.car_charging_slots[0] = [{"start": my_predbat.minutes_now, "end": my_predbat.minutes_now + 25, "kwh": 10.0}]
 
     # Call dynamic_load
-    status_changed = my_predbat.dynamic_load()
+    my_predbat.dynamic_load()
 
     # Verify slots were NOT cancelled (due to midnight exclusion)
     if my_predbat.car_charging_slots[0][0]["kwh"] != 10.0:
@@ -158,7 +158,7 @@ def test_dynamic_load_car_slot_cancellation(my_predbat):
     my_predbat.car_charging_slots[0] = [{"start": my_predbat.minutes_now - 5, "end": my_predbat.minutes_now + 25, "kwh": 10.0}]
 
     # Call dynamic_load
-    status_changed = my_predbat.dynamic_load()
+    my_predbat.dynamic_load()
 
     # Verify slots were NOT cancelled (feature disabled)
     if my_predbat.car_charging_slots[0][0]["kwh"] != 10.0:

--- a/apps/predbat/tests/test_energydataservice.py
+++ b/apps/predbat/tests/test_energydataservice.py
@@ -19,8 +19,6 @@ def test_energydataservice(my_predbat):
     failed = 0
 
     print("Test energy data service")
-
-    date_yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     today = datetime.now().strftime("%Y-%m-%d")
     tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
     tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)

--- a/apps/predbat/tests/test_find_battery_size.py
+++ b/apps/predbat/tests/test_find_battery_size.py
@@ -56,7 +56,6 @@ def create_test_history_data(my_predbat, num_days=2, battery_size_kwh=10.0):
         timestamp_str = timestamp.strftime("%Y-%m-%dT%H:%M:%S%z")
 
         hour = timestamp.hour
-        minute_of_hour = timestamp.minute
 
         # Determine if we're in a charging period
         # Morning charge: 2am-4am (120 minutes) - charges ~49% for 10kWh battery

--- a/apps/predbat/tests/test_find_charge_curve.py
+++ b/apps/predbat/tests/test_find_charge_curve.py
@@ -56,9 +56,6 @@ def create_test_history_data(my_predbat, num_days=7, slow=False):
 
     total_minutes = num_days * 24 * 60
 
-    # DEBUG: Counter for printing first few charging entries
-    debug_charging_count = 0
-
     # Generate data for each minute going backwards in time
     for minutes in range(0, total_minutes, 5):
         timestamp = base_time + timedelta(minutes=minutes)

--- a/apps/predbat/tests/test_infra.py
+++ b/apps/predbat/tests/test_infra.py
@@ -174,7 +174,6 @@ class TestHAInterface:
         state = 0.0
         for count in range(int(days * 24 * 60 / self.step)):
             point = start + timedelta(minutes=count * self.step)
-            point_str = point.strftime("%Y-%m-%dT%H:%M:%SZ")
             history.append({"state": state, "last_changed": point})
         self.history = history
 

--- a/apps/predbat/tests/test_load_ml.py
+++ b/apps/predbat/tests/test_load_ml.py
@@ -788,7 +788,7 @@ def _test_cold_start():
     load_data = _create_synthetic_load_data(n_days=1, now_utc=now_utc)
 
     # Training should fail or return None
-    val_mae = predictor.train(load_data, now_utc, pv_minutes=None, is_initial=True, epochs=5, time_decay_days=7)
+    predictor.train(load_data, now_utc, pv_minutes=None, is_initial=True, epochs=5, time_decay_days=7)
 
     # With only 1 day of data, we can't create a valid dataset for 48h prediction
     # The result depends on actual data coverage
@@ -805,9 +805,6 @@ def _test_fine_tune():
     np.random.seed(42)
     load_data = _create_synthetic_load_data(n_days=7, now_utc=now_utc)
     predictor.train(load_data, now_utc, pv_minutes=None, is_initial=True, epochs=5, time_decay_days=7)
-
-    # Store original weights
-    orig_weights = [w.copy() for w in predictor.weights]
 
     # Fine-tune with same data but as fine-tune mode
     # Note: Fine-tune uses is_finetune=True which only looks at last 24h

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -1017,7 +1017,6 @@ async def test_octopus_fetch_tariffs(my_predbat):
         print("PASS: FLUX-IMPORT rates stored correctly as export fallback")
 
     # Verify the URL constructed has FLUX-IMPORT, not FLUX-EXPORT
-    wrong_url_called = any(flux_export_product in url and "standard-unit-rates" in url and url != f"https://api.octopus.energy/v1/products/{flux_export_product}/electricity-tariffs/{flux_export_tariff}/standard-unit-rates/" for url in urls_called8)
     expected_flux_import_url = f"https://api.octopus.energy/v1/products/{flux_import_product}/electricity-tariffs/{flux_import_tariff}/standard-unit-rates/"
     if expected_flux_import_url not in urls_called8:
         print(f"ERROR: Expected exact URL {expected_flux_import_url}, got {urls_called8}")

--- a/apps/predbat/tests/test_octopus_rate_limit.py
+++ b/apps/predbat/tests/test_octopus_rate_limit.py
@@ -28,7 +28,7 @@ async def test_octopus_rate_limit(my_predbat):
     - Test 9: Expired token is automatically refreshed and query retried successfully
     """
     # Mock asyncio.sleep to prevent real delays during rate limit testing
-    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+    with patch("asyncio.sleep", new_callable=AsyncMock):
         print("**** Running Octopus API rate limit tests ****")
         failed = False
 

--- a/apps/predbat/tests/test_octopus_slots.py
+++ b/apps/predbat/tests/test_octopus_slots.py
@@ -93,7 +93,6 @@ def run_load_octopus_slots_tests(my_predbat):
         start_plus_15 = start + timedelta(minutes=15)
         start_minus_30 = start - timedelta(minutes=30)
         end = start + timedelta(minutes=60)
-        prev_soc = soc
         prev_soc2 = soc2
         soc += 5
         soc2 += 2.5

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -1284,7 +1284,7 @@ def _test_ohme_client_make_request_creates_session(my_predbat=None):
     mock_session_instance.request.return_value = mock_context
 
     with patch('aiohttp.ClientSession', return_value=mock_session_instance):
-        result = run_async(client._make_request("GET", "/v1/test"))
+        run_async(client._make_request("GET", "/v1/test"))
 
         # Verify session was created
         assert client._session is not None, "Expected session to be created"

--- a/apps/predbat/tests/test_previous_days_modal.py
+++ b/apps/predbat/tests/test_previous_days_modal.py
@@ -32,7 +32,6 @@ def test_previous_days_modal_filter(my_predbat):
     my_predbat.load_minutes_age = 7  # 7 days of data
     my_predbat.days_previous = [1, 2]  # Test with 3 days
     my_predbat.days_previous_weight = [1.0, 1.0]  # Equal weighting
-    number_of_days = 2
     my_predbat.load_filter_modal = True  # Enable modal filtering
     my_predbat.car_charging_hold = False
     my_predbat.car_charging_energy = None

--- a/apps/predbat/tests/test_rate_replicate_missing_slots.py
+++ b/apps/predbat/tests/test_rate_replicate_missing_slots.py
@@ -326,7 +326,7 @@ def _test_undefined_negative_minutes(my_predbat):
         try:
             # Simulate what publish_rates does: access rates[minute] directly
             test_minute = -1440
-            value = result[test_minute]  # This will raise KeyError
+            result[test_minute]  # This will raise KeyError
             print(f"    No KeyError at minute {test_minute} (unexpected!)")
         except KeyError as e:
             print(f"    ✓ Confirmed: KeyError accessing minute {test_minute}: {e}")

--- a/apps/predbat/tests/test_saving_session.py
+++ b/apps/predbat/tests/test_saving_session.py
@@ -151,7 +151,6 @@ def test_saving_session_null_octopoints(my_predbat):
     print("Test saving session with null octopoints_per_kwh (issue #3079)")
     ha = my_predbat.ha_interface
     failed = False
-    date_today = datetime.now().strftime("%Y-%m-%d")
     tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)
     tz_offset = f"{tz_offset:02d}"
 
@@ -1199,7 +1198,6 @@ def test_saving_session_default_rate(my_predbat):
     ha = my_predbat.ha_interface
     failed = False
     date_today = datetime.now().strftime("%Y-%m-%d")
-    date_yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)
     tz_offset = f"{tz_offset:02d}"
 

--- a/apps/predbat/tests/test_secrets.py
+++ b/apps/predbat/tests/test_secrets.py
@@ -61,9 +61,6 @@ def test_secrets_loading():
     with open("secrets.yaml", "w") as f:
         yaml.dump(secrets_data, f)
 
-    # Create a test apps.yaml with !secret tags
-    test_config = {"pred_bat": {"module": "predbat", "class": "PredBat", "api_key": "!secret test_api_key", "username": "!secret test_username"}}
-
     # Write YAML with !secret tags (manually to preserve the tag)
     with open("test_apps.yaml", "w") as f:
         f.write("pred_bat:\n")

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -650,8 +650,6 @@ def test_sigenergy_get_access_token_retry(my_predbat):
 
     call_log = []
 
-    original_class = __import__("sigenergy").aiohttp.ClientSession
-
     class SequencedSession:
         """Return failure sessions then success session."""
         def __init__(self, *args, **kwargs):

--- a/apps/predbat/tests/test_solax.py
+++ b/apps/predbat/tests/test_solax.py
@@ -4086,7 +4086,7 @@ async def test_query_plant_realtime_data_main():
 
     api3.fetch_single_result = mock_fetch_multiple
 
-    result1 = await api3.query_plant_realtime_data("plant_001")
+    await api3.query_plant_realtime_data("plant_001")
     result2 = await api3.query_plant_realtime_data("plant_002")
 
     if "plant_001" not in api3.realtime_data or "plant_002" not in api3.realtime_data:
@@ -4681,7 +4681,7 @@ async def test_query_device_realtime_data_all_main():
 
     api5.query_device_realtime_data = mock_query_log_types
 
-    result5 = await api5.query_device_realtime_data_all("plant5")
+    await api5.query_device_realtime_data_all("plant5")
 
     if len(device_type_log) != 3:
         print(f"**** ERROR: Expected 3 calls, got {len(device_type_log)} ****")
@@ -7059,7 +7059,7 @@ async def test_positive_or_negative_mode_main():
         endpoint = call_args[0][0]
         payload = call_args[0][1]
         command_name = call_args[0][2]
-        sn = call_args[0][3]
+        call_args[0][3]
 
         if endpoint != "/openapi/v2/device/inverter_vpp_mode/push_power/positive_or_negative_mode":
             print(f"**** ERROR: Wrong endpoint: {endpoint} ****")

--- a/apps/predbat/tests/test_solcast.py
+++ b/apps/predbat/tests/test_solcast.py
@@ -528,7 +528,7 @@ def test_cache_get_url_metrics_forecast_solar(my_predbat):
             return test_api.mock_aiohttp_session()
 
         with patch("solcast.aiohttp.ClientSession", side_effect=create_mock_session):
-            result = run_async(test_api.solar.cache_get_url(url, params, max_age=60))
+            run_async(test_api.solar.cache_get_url(url, params, max_age=60))
 
         # Should increment forecast_solar metrics, not solcast
         if test_api.solar.forecast_solar_requests_total != 1:
@@ -3142,9 +3142,6 @@ def test_pv_calibration_power_conversion(my_predbat):
     try:
         solar = test_api.solar
         base = test_api.mock_base
-
-        plan_interval = base.plan_interval_minutes  # 5
-        minutes_now = base.minutes_now  # 720 (12:00)
 
         # Build synthetic cumulative pv_today history.
         # We represent 5 previous days.  Each day, the panel produces 2 kWh between

--- a/apps/predbat/tests/test_temperature.py
+++ b/apps/predbat/tests/test_temperature.py
@@ -710,7 +710,7 @@ def _test_fetch_temperature_data_exponential_backoff(my_predbat):
 
         with patch('temperature.aiohttp.ClientSession', return_value=mock_session):
             with patch('temperature.asyncio.sleep', side_effect=mock_sleep):
-                result = await temp_component.fetch_temperature_data()
+                await temp_component.fetch_temperature_data()
 
                 # Should have 2 sleep calls (after 1st and 2nd attempts)
                 if len(sleep_times) != 2:
@@ -1008,7 +1008,7 @@ def _test_run_first_fresh_cache(my_predbat=None):
             with patch.object(temp_api, 'load_temperature_cache', side_effect=mock_load_cache):
                 with patch.object(temp_api, 'save_temperature_cache', new_callable=AsyncMock):
                     with patch.object(temp_api, 'fetch_temperature_data', side_effect=mock_fetch):
-                        result = await temp_api.run(seconds=0, first=True)
+                        await temp_api.run(seconds=0, first=True)
 
             if fetch_called[0]:
                 print("    ERROR: fetch_temperature_data should not be called (cache is 45 min old < 60)")
@@ -1052,7 +1052,7 @@ def _test_run_first_stale_cache(my_predbat=None):
             with patch.object(temp_api, 'load_temperature_cache', side_effect=mock_load_cache):
                 with patch.object(temp_api, 'save_temperature_cache', new_callable=AsyncMock) as mock_save:
                     with patch.object(temp_api, 'fetch_temperature_data', new_callable=AsyncMock, return_value=fresh_data):
-                        result = await temp_api.run(seconds=0, first=True)
+                        await temp_api.run(seconds=0, first=True)
 
             if temp_api.temperature_data != fresh_data:
                 print("    ERROR: temperature_data should be updated (cache was 90 min old >= 60)")


### PR DESCRIPTION
## Summary

#4781 fixed F841 (unused local variable) violations across production code and test files, but never actually added the rule to `.pre-commit-config.yaml`'s `--select` list - so it stayed unenforced. 37 new violations, all in test files, accumulated since: setup values computed and never read again.

All fixed by removing the dead assignment (keeping the call/expression where it has a side effect worth preserving, e.g. an `await`); a couple of now-orphaned comments were cleaned up alongside their variable.

Two are worth a closer look separately, not fixed here since it's out of scope for a lint-config PR:
- `test_load_ml.py`'s fine-tune test captured "original weights" but never compared them against the post-fine-tune weights - the test only asserts the model stayed initialized, not that fine-tuning actually changed anything.
- `test_octopus_misc.py`'s FLUX-IMPORT/EXPORT test computed whether the *wrong* URL was called but never asserted on it - only checks the right URL was called, which doesn't rule out the wrong one also being hit.

## Test plan

- [x] `ruff check --select=F401,E713,F811,E722,F821,F841` - clean
- [x] `./run_all --quick` - passes
- [x] `./run_pre_commit` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)