### PR TITLE
fix: GE Cloud Data missing-config warning fires for everyone, not just GivEnergy users

### DIFF
--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -173,6 +173,11 @@ COMPONENT_LIST = {
                 "required": False,
                 "default": [7],
                 "config": "days_previous",
+                # days_previous is a global load-forecasting setting configured by virtually every
+                # installation regardless of inverter brand, so it must not count towards "did the
+                # user configure GE Cloud Data" - otherwise the missing ge_cloud_data/ge_cloud_key
+                # warning fires for everyone, not just people who tried to enable this component.
+                "shared_config": True,
             },
         },
         "phase": 1,
@@ -705,7 +710,7 @@ class Components:
                 configured_args = getattr(self.base, "args_from_apps_yaml", None)
                 if configured_args is None:
                     configured_args = self.base.args
-                component_configured = any(configured_args.get(arg_info["config"]) for arg_info in component_info["args"].values())
+                component_configured = any(configured_args.get(arg_info["config"]) for arg_info in component_info["args"].values() if not arg_info.get("shared_config", False))
                 if component_configured:
                     reasons = []
                     if missing_config:

--- a/apps/predbat/tests/test_components.py
+++ b/apps/predbat/tests/test_components.py
@@ -1,0 +1,86 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+# fmt on
+
+"""Tests for Components.initialize()'s "should we warn about a skipped component" heuristic."""
+
+from components import Components
+from mock_base import MockBase
+
+
+def _skip_warnings(base):
+    """Return the "Warn: Skipping ..." log lines recorded on a MockBase-backed run."""
+    return [message for message in base.log_messages if message.startswith("Warn: Skipping")]
+
+
+class LoggingMockBase(MockBase):
+    """MockBase that also records every log message, like the other component test mocks."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.log_messages = []
+
+    def log(self, message, quiet=True):
+        """Record a log message instead of printing it."""
+        self.log_messages.append(message)
+
+
+def test_gecloud_data_no_warning_from_global_days_previous(my_predbat):
+    """days_previous is a global load-forecasting setting nearly every installation sets.
+
+    Its presence alone must not be treated as evidence the user tried to enable GE Cloud
+    Data, or everyone who has never touched GE Cloud settings gets a spurious warning.
+    """
+    base = LoggingMockBase(days_previous=[7])
+    components = Components(base)
+    components.initialize(only="gecloud_data", phase=1)
+
+    assert _skip_warnings(base) == [], f"Unexpected warning(s) for a base that never configured GE Cloud Data: {_skip_warnings(base)}"
+    return False
+
+
+def test_gecloud_data_warns_when_actually_misconfigured(my_predbat):
+    """When the user genuinely starts configuring GE Cloud Data but leaves it incomplete, warn."""
+    base = LoggingMockBase(days_previous=[7], ge_cloud_data=True)
+    components = Components(base)
+    components.initialize(only="gecloud_data", phase=1)
+
+    warnings = _skip_warnings(base)
+    assert len(warnings) == 1, f"Expected exactly one warning, got: {warnings}"
+    assert "GivEnergy Cloud Data" in warnings[0]
+    assert "ge_cloud_key" in warnings[0]
+    return False
+
+
+def test_components_all(my_predbat):
+    """Run all components.py tests"""
+    tests = [
+        ("gecloud_data_no_warning_from_global_days_previous", test_gecloud_data_no_warning_from_global_days_previous, "days_previous alone must not trigger a GE Cloud Data warning"),
+        ("gecloud_data_warns_when_actually_misconfigured", test_gecloud_data_warns_when_actually_misconfigured, "GE Cloud Data still warns once genuinely (partially) configured"),
+    ]
+
+    failed = []
+    for name, test_func, description in tests:
+        print(f"\n*** Running: {name} - {description} ***")
+        try:
+            result = test_func(my_predbat)
+            if result:
+                failed.append(name)
+                print(f"FAILED: {name}")
+        except Exception as e:
+            failed.append(name)
+            print(f"ERROR in {name}: {e}")
+
+    if failed:
+        print(f"\n*** {len(failed)} test(s) failed: {', '.join(failed)} ***")
+        return True  # True = test failed
+    else:
+        print(f"\n*** All {len(tests)} components tests passed ***")
+        return False  # False = test passed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -245,6 +245,7 @@ from tests.test_download import test_download
 from tests.test_ohme import test_ohme
 from tests.test_myenergi import test_myenergi
 from tests.test_component_base import test_component_base_all
+from tests.test_components import test_components_all
 from tests.test_mock_base import test_mock_base_all
 from tests.test_solis import run_solis_tests
 from tests.test_load_ml import test_load_ml
@@ -611,6 +612,7 @@ def main():
         ("myenergi", test_myenergi, "myenergi Zappi and Eddi comprehensive tests (normalisation, transports, publishing, auto-config, controls)", False),
         # ComponentBase lifecycle tests
         ("component_base", test_component_base_all, "ComponentBase tests (all)", False),
+        ("components", test_components_all, "Components registry tests (all)", False),
         # Shared MockBase tests
         ("mock_base", test_mock_base_all, "Shared CLI-harness MockBase tests", False),
         # Solis Cloud API unit tests


### PR DESCRIPTION
## Summary
- `gecloud_data`'s arg list includes `days_previous`, a global load-forecasting setting that's set by default (`[7]`) in every installation's `apps.yaml`, regardless of inverter brand
- The "was this component configured" check treated presence of *any* of a component's args as intent to use it, so `days_previous` alone made it look like every user had tried to configure GE Cloud Data
- Result: `Warn: Skipping GivEnergy Cloud Data interface, missing required configuration: ge_cloud_data (must be true), ge_cloud_key` was logged for all users, including non-GivEnergy installations
- Fixes it by marking `days_previous` as `shared_config` and excluding shared/global args from that heuristic, so the warning only fires when a user actually starts configuring GE Cloud Data specifically

## Test plan
- [x] Added `apps/predbat/tests/test_components.py` covering both the false-positive case (only `days_previous` set) and the true-positive case (GE Cloud Data genuinely, partially configured)
- [x] Confirmed the new test reproduces the exact reported log line when reverted against the old code, and passes with the fix
- [x] `./run_all --quick` passes
- [x] `./run_pre_commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)