### PR TITLE
docs: update Hanchu iESS bridge script to use Predbat planned charge/discharge times

### DIFF
--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -652,8 +652,7 @@ All four of Predbat's service hooks call the same script, `script.hanchu_set_sta
 
 Create a new script (Settings → Automations & Scenes → Scripts → Add Script → Edit in YAML) and paste the following, replacing `YOURSERIAL` with your device serial number as it appears in your HA entity IDs, and replacing `notify.notify` with your own mobile notification service:
 
-```yaml
-alias: Hanchu Set State Queued
+```alias: Hanchu Set State Queued
 mode: queued
 fields:
   mode_action:
@@ -681,11 +680,24 @@ sequence:
     then:
       - stop: "No change — same action already applied, skipping API call"
   - variables:
-      start_seconds: "{{ (now() - now().replace(hour=0, minute=0, second=0, microsecond=0)).seconds }}"
-      tct_start: "{{ start_seconds if act == 'charge_start' else 0 }}"
-      tct_end: "{{ 39600 if act == 'charge_start' else 0 }}"      # 11:00:00
-      tdt_start: "{{ start_seconds if act == 'discharge_start' else 0 }}"
-      tdt_end: "{{ 86340 if act == 'discharge_start' else 0 }}"   # 23:59:00
+      # Convert HH:MM:SS time strings from Predbat sensors to seconds since midnight
+      charge_start_seconds: >-
+        {% set t = states('sensor.predbat_HC_0_charge_start_time').split(':') %}
+        {{ (t[0]|int * 3600) + (t[1]|int * 60) + (t[2]|int) }}
+      charge_end_seconds: >-
+        {% set t = states('sensor.predbat_HC_0_charge_end_time').split(':') %}
+        {{ (t[0]|int * 3600) + (t[1]|int * 60) + (t[2]|int) }}
+      discharge_start_seconds: >-
+        {% set t = states('sensor.predbat_HC_0_discharge_start_time').split(':') %}
+        {{ (t[0]|int * 3600) + (t[1]|int * 60) + (t[2]|int) }}
+      discharge_end_seconds: >-
+        {% set t = states('sensor.predbat_HC_0_discharge_end_time').split(':') %}
+        {{ (t[0]|int * 3600) + (t[1]|int * 60) + (t[2]|int) }}
+      # Set slot values based on action — zeroise inactive slots
+      tct_start: "{{ charge_start_seconds if act == 'charge_start' else 0 }}"
+      tct_end: "{{ charge_end_seconds if act == 'charge_start' else 0 }}"
+      tdt_start: "{{ discharge_start_seconds if act == 'discharge_start' else 0 }}"
+      tdt_end: "{{ discharge_end_seconds if act == 'discharge_start' else 0 }}"
   - action: hanchuess.device_control
     data:
       sn: YOURSERIAL


### PR DESCRIPTION
## Summary

Updates the Hanchu iESS bridge script in `docs/inverter-setup.md` to use 
Predbat's planned charge/discharge window times (`sensor.predbat_HC_0_charge_start_time`, 
`sensor.predbat_HC_0_charge_end_time`, `sensor.predbat_HC_0_discharge_start_time`, 
`sensor.predbat_HC_0_discharge_end_time`) rather than hardcoded sentinel values 
(11:00:00 for charge end, 23:59:00 for discharge end).

The Hanchu inverter now receives accurate window end times from Predbat's plan, 
so if Predbat's stop signal is slightly delayed the inverter will stop at the 
correct time regardless. Tested in production over several days.