### PR TITLE
fix: use headless matplotlib backend in tests unless --plot is passed

### DIFF
--- a/apps/predbat/tests/test_infra.py
+++ b/apps/predbat/tests/test_infra.py
@@ -14,9 +14,10 @@ from prediction import Prediction
 import sys
 import matplotlib
 
-# Force the non-interactive Agg backend unless --plot was passed, otherwise merely importing
+# Force the non-interactive Agg backend unless --plot was passed; otherwise merely importing
 # pyplot activates a GUI backend (bouncing the dock icon on macOS) even though plt.show() is
-# never called. Checked against sys.argv directly since this import runs before argparse.
+# normally gated behind PLOT_ENABLED and not called in typical runs. Checked against sys.argv
+# directly since this import runs before argparse.
 if "--plot" not in sys.argv:
     matplotlib.use("Agg")
 from matplotlib import pyplot as plt

--- a/apps/predbat/tests/test_infra.py
+++ b/apps/predbat/tests/test_infra.py
@@ -11,6 +11,14 @@
 from datetime import datetime, timedelta
 from const import PREDBAT_MAX_CARS, MINUTE_WATT
 from prediction import Prediction
+import sys
+import matplotlib
+
+# Force the non-interactive Agg backend unless --plot was passed, otherwise merely importing
+# pyplot activates a GUI backend (bouncing the dock icon on macOS) even though plt.show() is
+# never called. Checked against sys.argv directly since this import runs before argparse.
+if "--plot" not in sys.argv:
+    matplotlib.use("Agg")
 from matplotlib import pyplot as plt
 import asyncio
 import numpy as np


### PR DESCRIPTION
## Summary
- `tests/test_infra.py` imported `matplotlib.pyplot` at module load without setting a backend, so matplotlib picked its default interactive backend on macOS — bouncing the dock icon on every test run even though `plt.show()` is gated behind `PLOT_ENABLED`/`--plot` and normally never called.
- Now forces the non-interactive `Agg` backend before importing `pyplot`, unless `--plot` is present in `sys.argv` (checked directly since this import runs before argparse parses `unit_test.py`'s `--plot` flag).

## Test plan
- [x] `./run_all --quick` — all tests pass
- [x] `./run_all --test plot` — plot-specific tests pass (opt-in on-screen display still works)
- [x] Verified backend resolves to `Agg` without `--plot` and to `macosx` with `--plot`
- [x] `./run_pre_commit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)