### PR TITLE
chore(lint): enable ruff E712 (comparison to True/False)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   hooks:
   # Run the linter.
   - id: ruff
-    args: [--select=F401,E713,F811,E722,F821,F841, --fix]
+    args: [--select=F401,E713,F811,E722,F821,F841,E712, --fix]
 - repo: https://github.com/psf/black
   rev: 23.11.0
   hooks:

--- a/apps/predbat/tests/test_carbon.py
+++ b/apps/predbat/tests/test_carbon.py
@@ -159,7 +159,7 @@ def _test_carbon_initialization(my_predbat=None):
         print("  ✗ ERROR: Postcode not set correctly")
         failed = 1
 
-    if api.automatic != True:
+    if api.automatic is not True:
         print("  ✗ ERROR: Automatic flag not set correctly")
         failed = 1
 
@@ -793,7 +793,7 @@ def _test_run_first_call(my_predbat=None):
         # Call run with first=True
         result = run_async(api.run(seconds=0, first=True))
 
-        if result != True:
+        if result is not True:
             print(f"ERROR: run() should return True")
             return 1
 

--- a/apps/predbat/tests/test_execute.py
+++ b/apps/predbat/tests/test_execute.py
@@ -415,7 +415,7 @@ def run_execute_test(
             if inverter.immediate_charge_soc_freeze != assert_immediate_charge_soc_freeze_array[inverter.id]:
                 print("ERROR: Inverter {} Immediate charge SOC freeze should be {} got {}".format(inverter.id, assert_immediate_charge_soc_freeze_array[inverter.id], inverter.immediate_charge_soc_freeze))
                 failed = True
-        elif assert_status in ["Freeze charging"] and inverter.immediate_charge_soc_freeze != True:
+        elif assert_status in ["Freeze charging"] and inverter.immediate_charge_soc_freeze is not True:
             print("ERROR: Inverter {} Immediate charge SOC freeze should be True got {}".format(inverter.id, inverter.immediate_charge_soc_freeze))
             failed = True
         if assert_immediate_discharge_soc_target_array:
@@ -427,7 +427,7 @@ def run_execute_test(
         if inverter.immediate_discharge_soc_target != assert_soc_target_force_dis:
             print("ERROR: Inverter {} Immediate export SOC target should be {} got {}".format(inverter.id, assert_soc_target_force_dis, inverter.immediate_discharge_soc_target))
             failed = True
-        if assert_status in ["Freeze exporting"] and inverter.immediate_discharge_soc_freeze != True:
+        if assert_status in ["Freeze exporting"] and inverter.immediate_discharge_soc_freeze is not True:
             print("ERROR: Inverter {} Immediate export SOC freeze should be True got {}".format(inverter.id, inverter.immediate_discharge_soc_freeze))
             failed = True
 

--- a/apps/predbat/tests/test_fetch_config_options.py
+++ b/apps/predbat/tests/test_fetch_config_options.py
@@ -100,8 +100,8 @@ def test_fetch_config_options(my_predbat):
     my_predbat.fetch_config_options()
 
     # Verify basic configuration was loaded
-    assert my_predbat.debug_enable == True, "debug_enable should be True"
-    assert my_predbat.plan_debug == False, "plan_debug should be False"
+    assert my_predbat.debug_enable is True, "debug_enable should be True"
+    assert my_predbat.plan_debug is False, "plan_debug should be False"
     assert my_predbat.forecast_days == 2, "forecast_days should be 2 (48 hours / 24)"
     assert my_predbat.forecast_minutes == 48 * 60, "forecast_minutes should be 2880"
     assert my_predbat.num_cars == 2, "num_cars should be 2"
@@ -123,7 +123,7 @@ def test_fetch_config_options(my_predbat):
     assert my_predbat.battery_loss == 0.95, "battery_loss should be 0.95 (1 - 0.05)"
     assert my_predbat.battery_loss_discharge == 0.95, "battery_loss_discharge should be 0.95"
     assert my_predbat.inverter_loss == 0.95, "inverter_loss should be 0.95"
-    assert my_predbat.inverter_hybrid == False, "inverter_hybrid should be False"
+    assert my_predbat.inverter_hybrid is False, "inverter_hybrid should be False"
     assert my_predbat.base_load == 0.1, "base_load should be 0.1 (100 / 1000)"
 
     # Verify SOC configuration
@@ -132,23 +132,23 @@ def test_fetch_config_options(my_predbat):
     assert my_predbat.best_soc_step == 0.25, "best_soc_step should be 0.25"
 
     # Verify car configuration
-    assert my_predbat.car_charging_from_battery == False, "car_charging_from_battery should be False"
-    assert my_predbat.car_charging_hold == True, "car_charging_hold should be True"
+    assert my_predbat.car_charging_from_battery is False, "car_charging_from_battery should be False"
+    assert my_predbat.car_charging_hold is True, "car_charging_hold should be True"
     assert my_predbat.car_charging_threshold == 1.0, "car_charging_threshold should be 1.0 (60 / 60)"
 
     # Verify read-only mode (should be False since axle_control is False)
-    assert my_predbat.set_read_only == False, "set_read_only should be False"
-    assert my_predbat.set_read_only_axle == False, "set_read_only_axle should be False"
+    assert my_predbat.set_read_only is False, "set_read_only should be False"
+    assert my_predbat.set_read_only_axle is False, "set_read_only_axle should be False"
 
     # Verify mode configuration (Control charge & discharge)
-    assert my_predbat.calculate_best_charge == True, "calculate_best_charge should be True"
-    assert my_predbat.calculate_best_export == True, "calculate_best_export should be True"
-    assert my_predbat.set_charge_window == True, "set_charge_window should be True"
-    assert my_predbat.set_export_window == True, "set_export_window should be True"
-    assert my_predbat.set_soc_enable == True, "set_soc_enable should be True"
+    assert my_predbat.calculate_best_charge is True, "calculate_best_charge should be True"
+    assert my_predbat.calculate_best_export is True, "calculate_best_export should be True"
+    assert my_predbat.set_charge_window is True, "set_charge_window should be True"
+    assert my_predbat.set_export_window is True, "set_export_window should be True"
+    assert my_predbat.set_soc_enable is True, "set_soc_enable should be True"
 
     # Verify iBoost configuration
-    assert my_predbat.iboost_enable == False, "iboost_enable should be False"
+    assert my_predbat.iboost_enable is False, "iboost_enable should be False"
     assert my_predbat.iboost_gas == 4.0, "iboost_gas should be 4.0"
     assert my_predbat.iboost_max_power == 0.05, "iboost_max_power should be 0.05 (3000 / 60000)"
     assert abs(my_predbat.iboost_min_power - 0.00833) < 0.001, "iboost_min_power should be ~0.00833 (500 / 60000)"
@@ -167,8 +167,8 @@ def test_fetch_config_options(my_predbat):
     my_predbat.fetch_config_options()
 
     # Verify read-only mode was enabled by Axle
-    assert my_predbat.set_read_only == True, "set_read_only should be True when Axle event is active"
-    assert my_predbat.set_read_only_axle == True, "set_read_only_axle should be True when Axle event is active"
+    assert my_predbat.set_read_only is True, "set_read_only should be True when Axle event is active"
+    assert my_predbat.set_read_only_axle is True, "set_read_only_axle should be True when Axle event is active"
 
     print("✓ Axle control with active event test passed")
 
@@ -181,8 +181,8 @@ def test_fetch_config_options(my_predbat):
     my_predbat.fetch_config_options()
 
     # Verify read-only mode was NOT enabled
-    assert my_predbat.set_read_only == False, "set_read_only should be False when no Axle event is active"
-    assert my_predbat.set_read_only_axle == False, "set_read_only_axle should be False when no Axle event is active"
+    assert my_predbat.set_read_only is False, "set_read_only should be False when no Axle event is active"
+    assert my_predbat.set_read_only_axle is False, "set_read_only_axle should be False when no Axle event is active"
 
     print("✓ Axle control with no active event test passed")
 
@@ -197,8 +197,8 @@ def test_fetch_config_options(my_predbat):
     my_predbat.fetch_config_options()
 
     # Verify manual read-only takes precedence (Axle logic skipped)
-    assert my_predbat.set_read_only == True, "set_read_only should be True from manual setting"
-    assert my_predbat.set_read_only_axle == False, "set_read_only_axle should be False when manual read-only is set"
+    assert my_predbat.set_read_only is True, "set_read_only should be True from manual setting"
+    assert my_predbat.set_read_only_axle is False, "set_read_only_axle should be False when manual read-only is set"
 
     print("✓ Manual read-only mode test passed")
 
@@ -214,11 +214,11 @@ def test_fetch_config_options(my_predbat):
 
     # Verify Monitor mode settings
     assert my_predbat.predbat_mode == "Monitor", "predbat_mode should be Monitor"
-    assert my_predbat.calculate_best_charge == False, "calculate_best_charge should be False in Monitor mode"
-    assert my_predbat.calculate_best_export == False, "calculate_best_export should be False in Monitor mode"
-    assert my_predbat.set_charge_window == False, "set_charge_window should be False in Monitor mode"
-    assert my_predbat.set_export_window == False, "set_export_window should be False in Monitor mode"
-    assert my_predbat.set_soc_enable == False, "set_soc_enable should be False in Monitor mode"
+    assert my_predbat.calculate_best_charge is False, "calculate_best_charge should be False in Monitor mode"
+    assert my_predbat.calculate_best_export is False, "calculate_best_export should be False in Monitor mode"
+    assert my_predbat.set_charge_window is False, "set_charge_window should be False in Monitor mode"
+    assert my_predbat.set_export_window is False, "set_export_window should be False in Monitor mode"
+    assert my_predbat.set_soc_enable is False, "set_soc_enable should be False in Monitor mode"
 
     print("✓ Monitor mode configuration test passed")
 
@@ -230,11 +230,11 @@ def test_fetch_config_options(my_predbat):
     my_predbat.fetch_config_options()
 
     assert my_predbat.predbat_mode == "Control SOC only", "predbat_mode should be Control SOC only"
-    assert my_predbat.calculate_best_charge == True, "calculate_best_charge should be True"
-    assert my_predbat.calculate_best_export == False, "calculate_best_export should be False"
-    assert my_predbat.set_charge_window == False, "set_charge_window should be False"
-    assert my_predbat.set_export_window == False, "set_export_window should be False"
-    assert my_predbat.set_soc_enable == True, "set_soc_enable should be True"
+    assert my_predbat.calculate_best_charge is True, "calculate_best_charge should be True"
+    assert my_predbat.calculate_best_export is False, "calculate_best_export should be False"
+    assert my_predbat.set_charge_window is False, "set_charge_window should be False"
+    assert my_predbat.set_export_window is False, "set_export_window should be False"
+    assert my_predbat.set_soc_enable is True, "set_soc_enable should be True"
 
     print("✓ Control SOC only mode test passed")
 
@@ -246,11 +246,11 @@ def test_fetch_config_options(my_predbat):
     my_predbat.fetch_config_options()
 
     assert my_predbat.predbat_mode == "Control charge", "predbat_mode should be Control charge"
-    assert my_predbat.calculate_best_charge == True, "calculate_best_charge should be True"
-    assert my_predbat.calculate_best_export == False, "calculate_best_export should be False"
-    assert my_predbat.set_charge_window == True, "set_charge_window should be True"
-    assert my_predbat.set_export_window == False, "set_export_window should be False"
-    assert my_predbat.set_soc_enable == True, "set_soc_enable should be True"
+    assert my_predbat.calculate_best_charge is True, "calculate_best_charge should be True"
+    assert my_predbat.calculate_best_export is False, "calculate_best_export should be False"
+    assert my_predbat.set_charge_window is True, "set_charge_window should be True"
+    assert my_predbat.set_export_window is False, "set_export_window should be False"
+    assert my_predbat.set_soc_enable is True, "set_soc_enable should be True"
 
     print("✓ Control charge mode test passed")
 
@@ -262,11 +262,11 @@ def test_fetch_config_options(my_predbat):
     my_predbat.fetch_config_options()
 
     assert my_predbat.predbat_mode == "Control charge & discharge", "predbat_mode should be Control charge & discharge"
-    assert my_predbat.calculate_best_charge == True, "calculate_best_charge should be True"
-    assert my_predbat.calculate_best_export == True, "calculate_best_export should be True"
-    assert my_predbat.set_charge_window == True, "set_charge_window should be True"
-    assert my_predbat.set_export_window == True, "set_export_window should be True"
-    assert my_predbat.set_soc_enable == True, "set_soc_enable should be True"
+    assert my_predbat.calculate_best_charge is True, "calculate_best_charge should be True"
+    assert my_predbat.calculate_best_export is True, "calculate_best_export should be True"
+    assert my_predbat.set_charge_window is True, "set_charge_window should be True"
+    assert my_predbat.set_export_window is True, "set_export_window should be True"
+    assert my_predbat.set_soc_enable is True, "set_soc_enable should be True"
 
     print("✓ Control charge & discharge mode test passed")
 
@@ -278,8 +278,8 @@ def test_fetch_config_options(my_predbat):
     my_predbat.fetch_config_options()
 
     assert my_predbat.predbat_mode == "Monitor", "Invalid mode should default to Monitor"
-    assert my_predbat.calculate_best_charge == False, "calculate_best_charge should be False for invalid mode"
-    assert my_predbat.set_soc_enable == False, "set_soc_enable should be False for invalid mode"
+    assert my_predbat.calculate_best_charge is False, "calculate_best_charge should be False for invalid mode"
+    assert my_predbat.set_soc_enable is False, "set_soc_enable should be False for invalid mode"
 
     print("✓ Invalid mode defaults to Monitor test passed")
 
@@ -342,8 +342,8 @@ def test_fetch_config_options(my_predbat):
 
     my_predbat.fetch_config_options()
 
-    assert my_predbat.car_charging_planned[0] == True, "car_charging_planned should be True when sensor state matches response list case-insensitively"
-    assert my_predbat.car_charging_now[0] == True, "car_charging_now should be True when sensor state matches response list case-insensitively"
+    assert my_predbat.car_charging_planned[0] is True, "car_charging_planned should be True when sensor state matches response list case-insensitively"
+    assert my_predbat.car_charging_now[0] is True, "car_charging_now should be True when sensor state matches response list case-insensitively"
 
     # A genuinely non-matching state should still be False
     mock_config.config["car_charging_planned"] = "EV Disconnected"
@@ -351,8 +351,8 @@ def test_fetch_config_options(my_predbat):
 
     my_predbat.fetch_config_options()
 
-    assert my_predbat.car_charging_planned[0] == False, "car_charging_planned should be False when sensor state does not match response list"
-    assert my_predbat.car_charging_now[0] == False, "car_charging_now should be False when sensor state does not match response list"
+    assert my_predbat.car_charging_planned[0] is False, "car_charging_planned should be False when sensor state does not match response list"
+    assert my_predbat.car_charging_now[0] is False, "car_charging_now should be False when sensor state does not match response list"
 
     print("✓ Case-insensitivity test passed")
 

--- a/apps/predbat/tests/test_fox_api.py
+++ b/apps/predbat/tests/test_fox_api.py
@@ -1092,7 +1092,7 @@ def test_schedules_are_equal_identical(my_predbat):
     ]
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == True, "Identical schedules should be equal"
+    assert result is True, "Identical schedules should be equal"
     return False
 
 
@@ -1146,7 +1146,7 @@ def test_schedules_are_equal_different_length(my_predbat):
     ]
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == False, "Different length schedules should not be equal"
+    assert result is False, "Different length schedules should not be equal"
     return False
 
 
@@ -1188,7 +1188,7 @@ def test_schedules_are_equal_different_values(my_predbat):
     ]
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == False, "Schedules with different values should not be equal"
+    assert result is False, "Schedules with different values should not be equal"
     return False
 
 
@@ -1230,7 +1230,7 @@ def test_schedules_are_equal_different_work_mode(my_predbat):
     ]
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == False, "Schedules with different work modes should not be equal"
+    assert result is False, "Schedules with different work modes should not be equal"
     return False
 
 
@@ -1272,7 +1272,7 @@ def test_schedules_are_equal_different_times(my_predbat):
     ]
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == False, "Schedules with different times should not be equal"
+    assert result is False, "Schedules with different times should not be equal"
     return False
 
 
@@ -1288,7 +1288,7 @@ def test_schedules_are_equal_both_empty(my_predbat):
     schedule2 = []
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == True, "Both empty schedules should be equal"
+    assert result is True, "Both empty schedules should be equal"
     return False
 
 
@@ -1317,7 +1317,7 @@ def test_schedules_are_equal_one_empty(my_predbat):
     schedule2 = []
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == False, "One empty schedule should not be equal to non-empty"
+    assert result is False, "One empty schedule should not be equal to non-empty"
     return False
 
 
@@ -1384,7 +1384,7 @@ def test_schedules_are_equal_same_but_different_order(my_predbat):
     ]
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == True, "Same entries in different order should be equal after sorting"
+    assert result is True, "Same entries in different order should be equal after sorting"
     return False
 
 
@@ -1426,7 +1426,7 @@ def test_schedules_are_equal_missing_key(my_predbat):
     ]
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == False, "Schedules with missing keys should not be equal"
+    assert result is False, "Schedules with missing keys should not be equal"
     return False
 
 
@@ -1482,7 +1482,7 @@ def test_schedules_are_equal_disabled_entries_stripped(my_predbat):
     ]
 
     result = schedules_are_equal(timenow, schedule1, schedule2)
-    assert result == True, "Disabled entries should be stripped before comparison"
+    assert result is True, "Disabled entries should be stripped before comparison"
     return False
 
 
@@ -1507,13 +1507,13 @@ def test_api_get_device_list(my_predbat):
     assert len(result) == 1
     assert result[0]["deviceSN"] == "TEST123456"
     assert result[0]["deviceType"] == "KH8"
-    assert result[0]["hasBattery"] == True
+    assert result[0]["hasBattery"] is True
     assert fox.device_list == result
 
     # Verify request was made correctly
     assert len(fox.request_log) == 1
     assert fox.request_log[0]["path"] == "/op/v0/device/list"
-    assert fox.request_log[0]["post"] == True
+    assert fox.request_log[0]["post"] is True
 
     return False
 
@@ -1552,8 +1552,8 @@ def test_api_get_device_detail(my_predbat):
     assert deviceSN in fox.device_detail
     assert fox.device_detail[deviceSN]["deviceType"] == "KH8"
     assert fox.device_detail[deviceSN]["capacity"] == 8
-    assert fox.device_detail[deviceSN]["hasBattery"] == True
-    assert fox.device_detail[deviceSN]["function"]["scheduler"] == True
+    assert fox.device_detail[deviceSN]["hasBattery"] is True
+    assert fox.device_detail[deviceSN]["function"]["scheduler"] is True
 
     return False
 
@@ -1654,7 +1654,7 @@ def test_api_get_device_history(my_predbat):
     # Verify the request was made correctly
     assert len(fox.request_log) == 1
     assert fox.request_log[0]["path"] == "/op/v0/device/history/query"
-    assert fox.request_log[0]["post"] == True
+    assert fox.request_log[0]["post"] is True
     assert fox.request_log[0]["datain"]["sn"] == deviceSN
 
     return False
@@ -1748,13 +1748,13 @@ def test_api_get_available_variables(my_predbat):
     assert "pvPower" in fox.available_variables
     assert fox.available_variables["pvPower"]["unit"] == "kW"
     assert fox.available_variables["pvPower"]["name"] == "PVPower"  # English name extracted
-    assert fox.available_variables["pvPower"]["Grid-tied inverter"] == True
-    assert fox.available_variables["pvPower"]["Energy-storage inverter"] == True
+    assert fox.available_variables["pvPower"]["Grid-tied inverter"] is True
+    assert fox.available_variables["pvPower"]["Energy-storage inverter"] is True
 
     assert "SoC" in fox.available_variables
     assert fox.available_variables["SoC"]["unit"] == "%"
     assert fox.available_variables["SoC"]["name"] == "SoC"
-    assert fox.available_variables["SoC"]["Grid-tied inverter"] == False
+    assert fox.available_variables["SoC"]["Grid-tied inverter"] is False
 
     assert "batTemperature" in fox.available_variables
     assert fox.available_variables["batTemperature"]["unit"] == "℃"
@@ -1902,12 +1902,12 @@ def test_api_set_device_setting(my_predbat):
 
     result = asyncio.run(fox.set_device_setting(deviceSN, "MinSoc", 20))
 
-    assert result == True
+    assert result is True
 
     # Verify request was made with correct data
     assert len(fox.request_log) == 1
     assert fox.request_log[0]["path"] == "/op/v0/device/setting/set"
-    assert fox.request_log[0]["post"] == True
+    assert fox.request_log[0]["post"] is True
     assert fox.request_log[0]["datain"]["sn"] == deviceSN
     assert fox.request_log[0]["datain"]["key"] == "MinSoc"
     assert fox.request_log[0]["datain"]["value"] == 20
@@ -1928,7 +1928,7 @@ def test_api_set_device_setting_unsupported_marks_unavailable(my_predbat):
 
     result = asyncio.run(fox.set_device_setting(deviceSN, "MaxSoc", 90))
 
-    assert result == True
+    assert result is True
     assert len(fox.request_log) == 1
     assert "maxsoc" in fox.device_settings_unavailable[deviceSN]
     assert fox.device_settings[deviceSN]["MaxSoc"]["value"] == 100
@@ -1936,7 +1936,7 @@ def test_api_set_device_setting_unsupported_marks_unavailable(my_predbat):
     # A later write attempt must be ignored entirely - no further API traffic
     fox.set_mock_response("/op/v0/device/setting/set", {})
     result2 = asyncio.run(fox.set_device_setting(deviceSN, "MaxSoc", 50))
-    assert result2 == True
+    assert result2 is True
     assert len(fox.request_log) == 1
     assert fox.device_settings[deviceSN]["MaxSoc"]["value"] == 100
 
@@ -1958,7 +1958,7 @@ def test_api_get_device_settings(my_predbat):
 
     # Verify initialize set up the expected attributes
     assert fox.key == "test_api_key"
-    assert fox.automatic == True
+    assert fox.automatic is True
     assert fox.failures_total == 0
     assert fox.device_list == []
     assert fox.device_detail == {}
@@ -2130,7 +2130,7 @@ def test_api_get_battery_charging_time(my_predbat):
 
     result = asyncio.run(fox.get_battery_charging_time(deviceSN))
 
-    assert result["enable1"] == True
+    assert result["enable1"] is True
     assert result["startTime1"]["hour"] == 2
     assert result["startTime1"]["minute"] == 30
     assert result["endTime1"]["hour"] == 5
@@ -2159,11 +2159,11 @@ def test_api_set_battery_charging_time(my_predbat):
 
     result = asyncio.run(fox.set_battery_charging_time(deviceSN, setting))
 
-    assert result == True
+    assert result is True
 
     # Verify request data
     assert fox.request_log[0]["datain"]["sn"] == deviceSN
-    assert fox.request_log[0]["datain"]["enable1"] == True
+    assert fox.request_log[0]["datain"]["enable1"] is True
 
     return False
 
@@ -2720,7 +2720,7 @@ def test_api_set_scheduler_v3_evo(my_predbat):
 
     result = asyncio.run(fox.set_scheduler(deviceSN, groups))
 
-    assert result == True
+    assert result is True
 
     # EVO detected by productType: v3 used directly, v1 never polled
     assert len(fox.request_log) == 1
@@ -2745,7 +2745,7 @@ def test_api_set_scheduler_v3_evo(my_predbat):
     assert "maxSoc" not in sent
 
     # Local state keeps the original flat groups
-    assert fox.device_scheduler[deviceSN]["enable"] == True
+    assert fox.device_scheduler[deviceSN]["enable"] is True
     assert fox.device_scheduler[deviceSN]["groups"] == groups
 
     return False
@@ -2792,7 +2792,7 @@ def test_api_set_scheduler_v3_evo_carries_stored_limits(my_predbat):
 
     result = asyncio.run(fox.set_scheduler(deviceSN, groups))
 
-    assert result == True
+    assert result is True
     sent_groups = fox.request_log[0]["datain"]["groups"]
     sent = sent_groups[0]
 
@@ -2832,7 +2832,7 @@ def test_api_set_scheduler_kh_stays_v1(my_predbat):
     result = asyncio.run(fox.set_scheduler(deviceSN, groups))
 
     # KH must only ever try v1 — never the v3 endpoint — and report failure
-    assert result == False
+    assert result is False
     paths = [request["path"] for request in fox.request_log]
     assert paths == ["/op/v1/device/scheduler/enable"]
 
@@ -3040,7 +3040,7 @@ def test_api_set_device_setting_failure(my_predbat):
 
     result = asyncio.run(fox.set_device_setting(deviceSN, "MinSoc", 20))
 
-    assert result == False
+    assert result is False
 
     return False
 
@@ -3624,7 +3624,7 @@ def test_request_get_func_auth_error_401(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False
+    assert allow_retry is False
     assert fox.failures_total == 1
 
     return False
@@ -3642,7 +3642,7 @@ def test_request_get_func_auth_error_403(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False
+    assert allow_retry is False
     assert fox.failures_total == 1
 
     return False
@@ -3660,7 +3660,7 @@ def test_request_get_func_rate_limit_429(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == True  # Should allow retry for rate limiting
+    assert allow_retry is True  # Should allow retry for rate limiting
     assert fox.failures_total == 1
 
     return False
@@ -3678,7 +3678,7 @@ def test_request_get_func_timeout(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == True  # Should allow retry for timeout
+    assert allow_retry is True  # Should allow retry for timeout
 
     return False
 
@@ -3695,7 +3695,7 @@ def test_request_get_func_connection_error(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == True  # Should allow retry for connection error
+    assert allow_retry is True  # Should allow retry for connection error
 
     return False
 
@@ -3712,7 +3712,7 @@ def test_request_get_func_json_decode_error(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # No retry for JSON decode error
+    assert allow_retry is False  # No retry for JSON decode error
 
     return False
 
@@ -3729,7 +3729,7 @@ def test_request_get_func_fox_error_rate_limit(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == True  # Should allow retry for Fox rate limit
+    assert allow_retry is True  # Should allow retry for Fox rate limit
     assert fox.failures_total == 1
 
     return False
@@ -3747,7 +3747,7 @@ def test_request_get_func_fox_error_api_limit(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # No retry for API limit exhausted
+    assert allow_retry is False  # No retry for API limit exhausted
     assert fox.failures_total == 1
 
     return False
@@ -3765,7 +3765,7 @@ def test_request_get_func_fox_error_unsupported(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # No retry for unsupported function
+    assert allow_retry is False  # No retry for unsupported function
     assert fox.failures_total == 1
 
     return False
@@ -3783,7 +3783,7 @@ def test_request_get_func_fox_error_invalid_param(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # No retry for invalid parameter
+    assert allow_retry is False  # No retry for invalid parameter
     assert fox.failures_total == 1
 
     return False
@@ -3801,7 +3801,7 @@ def test_request_get_func_fox_error_comms_issue(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == True  # Should allow retry for comms issue
+    assert allow_retry is True  # Should allow retry for comms issue
     assert fox.failures_total == 1
 
     return False
@@ -3820,7 +3820,7 @@ def test_request_get_func_success(my_predbat):
 
     assert result is not None
     assert result["data"][0]["deviceSN"] == "TEST123"
-    assert allow_retry == False
+    assert allow_retry is False
     assert fox.failures_total == 0
 
     return False
@@ -3838,7 +3838,7 @@ def test_request_get_func_unknown_error(my_predbat):
     result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # Unknown errors don't retry
+    assert allow_retry is False  # Unknown errors don't retry
     assert fox.failures_total == 1
 
     return False
@@ -3903,7 +3903,7 @@ def test_request_get_func_real_success_get(my_predbat):
 
     assert result is not None
     assert result["data"][0]["deviceSN"] == "TEST123"
-    assert allow_retry == False
+    assert allow_retry is False
     assert fox.failures_total == 0
 
     return False
@@ -3925,8 +3925,8 @@ def test_request_get_func_real_success_post(my_predbat):
         result, allow_retry = run_async(fox.request_get_func("/op/v0/device/setting", post=True, datain={"key": "value"}))
 
     assert result is not None
-    assert result["success"] == True
-    assert allow_retry == False
+    assert result["success"] is True
+    assert allow_retry is False
 
     return False
 
@@ -3947,7 +3947,7 @@ def test_request_get_func_real_auth_error_401(my_predbat):
         result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # Auth errors should not retry
+    assert allow_retry is False  # Auth errors should not retry
     assert fox.failures_total == 1
 
     return False
@@ -3970,7 +3970,7 @@ def test_request_get_func_real_rate_limit_429(my_predbat):
             result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == True  # Rate limit should allow retry
+    assert allow_retry is True  # Rate limit should allow retry
     assert fox.failures_total == 1
     mock_sleep.assert_called_once()  # Should have called sleep for rate limiting
 
@@ -3994,7 +3994,7 @@ def test_request_get_func_real_fox_errno_rate_limit(my_predbat):
             result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == True  # Rate limit errno should allow retry
+    assert allow_retry is True  # Rate limit errno should allow retry
     assert fox.failures_total == 1
     mock_sleep.assert_called_once()
 
@@ -4018,7 +4018,7 @@ def test_request_get_func_real_fox_errno_api_limit(my_predbat):
             result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # API limit should NOT retry
+    assert allow_retry is False  # API limit should NOT retry
     assert fox.failures_total == 1
     mock_sleep.assert_called_once()  # Should sleep for 5 minutes
 
@@ -4041,8 +4041,8 @@ def test_request_get_func_real_fox_errno_unsupported_42015(my_predbat):
         result, allow_retry = run_async(fox.request_get_func("/op/v0/device/setting/get"))
 
     assert result is None
-    assert allow_retry == False
-    assert fox.last_unsupported == True
+    assert allow_retry is False
+    assert fox.last_unsupported is True
 
     return False
 
@@ -4063,8 +4063,8 @@ def test_request_get_func_real_fox_errno_unsupported_44096(my_predbat):
         result, allow_retry = run_async(fox.request_get_func("/op/v0/device/setting/get"))
 
     assert result is None
-    assert allow_retry == False
-    assert fox.last_unsupported == True
+    assert allow_retry is False
+    assert fox.last_unsupported is True
 
     return False
 
@@ -4085,8 +4085,8 @@ def test_request_get_func_real_fox_errno_other_leaves_unsupported_false(my_predb
         result, allow_retry = run_async(fox.request_get_func("/op/v0/device/setting/get"))
 
     assert result is None
-    assert allow_retry == False
-    assert fox.last_unsupported == False
+    assert allow_retry is False
+    assert fox.last_unsupported is False
 
     return False
 
@@ -4106,7 +4106,7 @@ def test_request_get_func_real_connection_error(my_predbat):
         result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # Connection errors should not retry
+    assert allow_retry is False  # Connection errors should not retry
     assert fox.failures_total == 1
 
     return False
@@ -4127,7 +4127,7 @@ def test_request_get_func_real_timeout(my_predbat):
         result, allow_retry = run_async(fox.request_get_func("/op/v0/device/list"))
 
     assert result is None
-    assert allow_retry == False  # Timeout should not retry
+    assert allow_retry is False  # Timeout should not retry
     assert fox.failures_total == 1
 
     return False
@@ -4150,7 +4150,7 @@ def test_request_get_func_real_json_decode_error(my_predbat):
 
     # JSON decode error with status 200 returns empty dict (data=None -> data={})
     assert result == {}
-    assert allow_retry == False
+    assert allow_retry is False
 
     return False
 
@@ -4256,7 +4256,7 @@ def test_request_get_real_post_with_data(my_predbat):
         result = run_async(fox.request_get("/op/v0/device/setting", post=True, datain={"sn": "TEST123", "key": "MinSocOnGrid", "value": 10}))
 
     assert result is not None
-    assert result["success"] == True
+    assert result["success"] is True
 
     return False
 
@@ -4391,7 +4391,7 @@ def test_run_first_call_with_devices(my_predbat):
 
     result = run_async(fox.run(0, first=True))
 
-    assert result == True
+    assert result is True
     assert "get_device_list" in fox.method_calls
     assert "get_device_detail:TEST123" in fox.method_calls
     assert "get_device_detail:TEST456" in fox.method_calls
@@ -4416,7 +4416,7 @@ def test_run_first_call_no_devices(my_predbat):
 
     result = run_async(fox.run(0, first=True))
 
-    assert result == False
+    assert result is False
     assert "get_device_list" in fox.method_calls
 
     return False
@@ -4441,7 +4441,7 @@ def test_run_subsequent_call(my_predbat):
 
     result = run_async(fox.run(300, first=False))
 
-    assert result == True
+    assert result is True
     # Fresh data should NOT be re-fetched
     assert "get_device_list" not in fox.method_calls
     assert "get_device_detail:TEST123" not in fox.method_calls
@@ -4472,7 +4472,7 @@ def test_run_settings_refresh_on_age(my_predbat):
 
     result = run_async(fox.run(120, first=False))
 
-    assert result == True
+    assert result is True
     # Should refresh settings and scheduler
     assert "get_device_settings:TEST123" in fox.method_calls
     assert "get_schedule_settings_ha:TEST123" in fox.method_calls
@@ -4509,7 +4509,7 @@ def test_run_settings_refresh_forced_by_stale_cache_version(my_predbat):
 
     result = run_async(fox.run(0, first=False))
 
-    assert result == True
+    assert result is True
     # Forced despite a fresh device_settings cache age, because the version is stale
     assert "get_device_settings:TEST123" in fox.method_calls
     assert "get_scheduler:TEST123" in fox.method_calls
@@ -4521,7 +4521,7 @@ def test_run_settings_refresh_forced_by_stale_cache_version(my_predbat):
     fox.method_calls = []
     fox.data_age["device_settings"] = now
     result2 = run_async(fox.run(0, first=False))
-    assert result2 == True
+    assert result2 is True
     assert "get_device_settings:TEST123" not in fox.method_calls
 
     return False
@@ -4554,7 +4554,7 @@ def test_run_stale_cache_version_not_cleared_without_scheduler_success(my_predba
 
     result = run_async(fox.run(0, first=False))
 
-    assert result == True
+    assert result is True
     # Settings still succeeded and get attempted every cycle while the version stays stale
     assert "get_device_settings:TEST123" in fox.method_calls
     assert "get_scheduler:TEST123" in fox.method_calls
@@ -4566,7 +4566,7 @@ def test_run_stale_cache_version_not_cleared_without_scheduler_success(my_predba
     # than silently giving up because the version never cleared
     fox.method_calls = []
     result2 = run_async(fox.run(0, first=False))
-    assert result2 == True
+    assert result2 is True
     assert "get_device_settings:TEST123" in fox.method_calls
     assert "get_scheduler:TEST123" in fox.method_calls
 
@@ -4592,7 +4592,7 @@ def test_run_realtime_refresh_after_cache_expires(my_predbat):
 
     # First run while real-time data is fresh: it must NOT be re-fetched
     result = run_async(fox.run(60, first=False))
-    assert result == True
+    assert result is True
     assert "get_real_time_data:TEST123" not in fox.method_calls
 
     # Age the real-time cache past its threshold and run again: it must be re-fetched
@@ -4600,14 +4600,14 @@ def test_run_realtime_refresh_after_cache_expires(my_predbat):
     fox.data_age["device_values"] = now - timedelta(minutes=FOX_REFRESH_REALTIME + 1)
 
     result = run_async(fox.run(120, first=False))
-    assert result == True
+    assert result is True
     assert "get_real_time_data:TEST123" in fox.method_calls
     assert "publish_data" in fox.method_calls
 
     # And after refreshing, the cache age is reset so a subsequent run does not re-fetch
     fox.method_calls = []
     result = run_async(fox.run(180, first=False))
-    assert result == True
+    assert result is True
     assert "get_real_time_data:TEST123" not in fox.method_calls
 
     return False
@@ -4658,7 +4658,7 @@ def test_run_first_refreshes_device_list_despite_fresh_cache(my_predbat):
 
     result = run_async(fox.run(0, first=True))
 
-    assert result == True
+    assert result is True
     # Device list must always refresh on first start regardless of cache age
     assert "get_device_list" in fox.method_calls
     # Age-based categories with fresh data and a current settings cache version should NOT be
@@ -4696,7 +4696,7 @@ def test_run_new_device_invalidates_detail_cache(my_predbat):
 
     result = run_async(fox.run(0, first=True))
 
-    assert result == True
+    assert result is True
     assert "get_device_list" in fox.method_calls
     # All per-device caches must be re-fetched for both old and new devices
     assert "get_device_detail:TEST123" in fox.method_calls
@@ -4735,7 +4735,7 @@ def test_run_unchanged_device_list_preserves_cache(my_predbat):
 
     result = run_async(fox.run(0, first=True))
 
-    assert result == True
+    assert result is True
     assert "get_device_list" in fox.method_calls
     # Cache is still fresh and device set unchanged — no per-device fetches should happen
     assert "get_device_detail:TEST123" not in fox.method_calls
@@ -4757,8 +4757,8 @@ def test_run_with_automatic_config(my_predbat):
 
     result = run_async(fox.run(0, first=True))
 
-    assert result == True
-    assert fox.automatic_config_called == True
+    assert result is True
+    assert fox.automatic_config_called is True
     assert "automatic_config" in fox.method_calls
 
     return False
@@ -4776,8 +4776,8 @@ def test_run_without_automatic_config(my_predbat):
 
     result = run_async(fox.run(0, first=True))
 
-    assert result == True
-    assert fox.automatic_config_called == False
+    assert result is True
+    assert fox.automatic_config_called is False
     assert "automatic_config" not in fox.method_calls
 
     return False
@@ -4804,7 +4804,7 @@ def test_run_midnight_reset(my_predbat):
     fox.rate_limit_errors_today = 3
 
     result = run_async(fox.run(0, first=True))
-    assert result == True
+    assert result is True
 
     # Verify counters are initialised on first run
     initial_start_time = fox.start_time_today
@@ -4814,7 +4814,7 @@ def test_run_midnight_reset(my_predbat):
 
     # Second run - same day, counters should NOT be reset
     result = run_async(fox.run(0, first=False))
-    assert result == True
+    assert result is True
     assert fox.requests_today == 45  # Still unchanged
     assert fox.rate_limit_errors_today == 3  # Still unchanged
     assert fox.last_midnight_utc == day1_midnight
@@ -4825,7 +4825,7 @@ def test_run_midnight_reset(my_predbat):
     fox.base.midnight_utc = day2_midnight
 
     result = run_async(fox.run(0, first=False))
-    assert result == True
+    assert result is True
 
     # Verify counters are reset after midnight
     assert fox.requests_today == 0, f"Expected requests_today to be reset to 0, got {fox.requests_today}"
@@ -4850,10 +4850,10 @@ def test_apply_service_to_toggle_turn_on(my_predbat):
     fox = MockFoxAPIWithRequests()
 
     result = fox.apply_service_to_toggle(False, "turn_on")
-    assert result == True
+    assert result is True
 
     result = fox.apply_service_to_toggle(True, "turn_on")
-    assert result == True
+    assert result is True
 
     return False
 
@@ -4867,10 +4867,10 @@ def test_apply_service_to_toggle_turn_off(my_predbat):
     fox = MockFoxAPIWithRequests()
 
     result = fox.apply_service_to_toggle(True, "turn_off")
-    assert result == False
+    assert result is False
 
     result = fox.apply_service_to_toggle(False, "turn_off")
-    assert result == False
+    assert result is False
 
     return False
 
@@ -4884,10 +4884,10 @@ def test_apply_service_to_toggle_toggle(my_predbat):
     fox = MockFoxAPIWithRequests()
 
     result = fox.apply_service_to_toggle(False, "toggle")
-    assert result == True
+    assert result is True
 
     result = fox.apply_service_to_toggle(True, "toggle")
-    assert result == False
+    assert result is False
 
     return False
 
@@ -5590,8 +5590,8 @@ def test_publish_data_device_info(my_predbat):
     info_entity = f"sensor.predbat_fox_{deviceSN.lower()}_info"
     assert info_entity in fox.dashboard_items
     assert fox.dashboard_items[info_entity]["state"] == "Test Home"
-    assert fox.dashboard_items[info_entity]["attributes"]["hasBattery"] == True
-    assert fox.dashboard_items[info_entity]["attributes"]["hasScheduler"] == True
+    assert fox.dashboard_items[info_entity]["attributes"]["hasBattery"] is True
+    assert fox.dashboard_items[info_entity]["attributes"]["hasScheduler"] is True
 
     # Verify capacity entities
     inverter_capacity_entity = f"sensor.predbat_fox_{deviceSN.lower()}_inverter_capacity"

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -1863,7 +1863,7 @@ def _test_async_send_evc_command(my_predbat):
             if result != mock_success_response:
                 print("ERROR: Expected success response {}, got {}".format(mock_success_response, result))
                 return 1
-            if result["success"] != True:
+            if result["success"] is not True:
                 print("ERROR: Expected success=True in response")
                 return 1
 
@@ -2157,7 +2157,7 @@ def _test_async_get_evc_device(my_predbat):
             if result["serial_number"] != "EVC123456":
                 print(f"ERROR: Expected serial_number EVC123456, got {result['serial_number']}")
                 return 1
-            if result["online"] != True:
+            if result["online"] is not True:
                 print(f"ERROR: Expected online True, got {result['online']}")
                 return 1
             if result["status"] != "charging":
@@ -2186,7 +2186,7 @@ def _test_async_get_evc_device(my_predbat):
 
             result = await ge_cloud.async_get_evc_device(test_uuid, {})
 
-            if result["online"] != False:
+            if result["online"] is not False:
                 print(f"ERROR: Expected online False, got {result['online']}")
                 return 1
             if result["went_offline_at"] != "2025-12-24T10:30:00Z":
@@ -3446,7 +3446,7 @@ def _test_switch_event(my_predbat):
             if len(write_calls) != 1:
                 print("ERROR: Expected 1 write call, got {}".format(len(write_calls)))
                 return 1
-            if write_calls[0]["value"] != True:
+            if write_calls[0]["value"] is not True:
                 print("ERROR: Expected value=True for turn_on, got {}".format(write_calls[0]["value"]))
                 return 1
 
@@ -3456,7 +3456,7 @@ def _test_switch_event(my_predbat):
             if len(write_calls) != 2:
                 print("ERROR: Expected 2 write calls, got {}".format(len(write_calls)))
                 return 1
-            if write_calls[1]["value"] != False:
+            if write_calls[1]["value"] is not False:
                 print("ERROR: Expected value=False for turn_off, got {}".format(write_calls[1]["value"]))
                 return 1
 
@@ -4682,10 +4682,10 @@ def _test_enable_default_options(my_predbat):
         if not result:
             print("ERROR: enable_default_options should return True when enabling real-time control")
             return 1
-        if write_calls[0]["value"] != True:
+        if write_calls[0]["value"] is not True:
             print("ERROR: Expected value=True for real-time control, got {}".format(write_calls[0]["value"]))
             return 1
-        if registers[105]["value"] != True:
+        if registers[105]["value"] is not True:
             print("ERROR: Register value should be updated to True, got {}".format(registers[105]["value"]))
             return 1
 

--- a/apps/predbat/tests/test_hainterface_lifecycle.py
+++ b/apps/predbat/tests/test_hainterface_lifecycle.py
@@ -363,13 +363,13 @@ def test_hainterface_start_with_websocket(my_predbat=None):
     else:
         print("✓ socketLoop called")
 
-    if ha_interface.websocket_active != True:
+    if ha_interface.websocket_active is not True:
         print("ERROR: websocket_active should be True")
         failed += 1
     else:
         print("✓ websocket_active set to True")
 
-    if ha_interface.api_started != False:
+    if ha_interface.api_started is not False:
         print("ERROR: api_started should be False after exit")
         failed += 1
     else:
@@ -415,7 +415,7 @@ def test_hainterface_start_dummy_mode(my_predbat=None):
     else:
         print("✓ Dummy startup message logged")
 
-    if ha_interface.api_started != False:
+    if ha_interface.api_started is not False:
         print("ERROR: api_started should be False after exit")
         failed += 1
     else:

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -265,7 +265,7 @@ def test_adjust_charge_window(
         expect_data = [["dummy/setChargeSlot1", {"start": charge_start_time[0:5], "finish": charge_end_time[0:5]}]]
     else:
         expect_data = []
-    if prev_enable_charge != True:
+    if prev_enable_charge is not True:
         expect_data.append(["dummy/enableChargeSchedule", {"state": "enable"}])
 
     if json.dumps(expect_data) != json.dumps(rest_command):
@@ -1464,7 +1464,7 @@ def test_charge_window_none_illegal_time(test_name, my_predbat, dummy_items):
     inv.update_status(my_predbat.minutes_now)
 
     # Should set safe defaults
-    if inv.charge_enable_time != False:
+    if inv.charge_enable_time is not False:
         print(f"ERROR: {test_name} - charge_enable_time should be False, got {inv.charge_enable_time}")
         failed = True
     if inv.charge_start_time_minutes != my_predbat.forecast_minutes:
@@ -1504,7 +1504,7 @@ def test_charge_window_none_value(test_name, my_predbat, dummy_items):
     inv.update_status(my_predbat.minutes_now)
 
     # Should set safe defaults
-    if inv.charge_enable_time != False:
+    if inv.charge_enable_time is not False:
         print(f"ERROR: {test_name} - charge_enable_time should be False, got {inv.charge_enable_time}")
         failed = True
     if inv.charge_start_time_minutes != my_predbat.forecast_minutes:
@@ -1601,7 +1601,7 @@ def test_charge_window_rest_configured_but_no_data_yet(test_name, my_predbat, du
         return failed
 
     # Should set the same safe defaults as the "value is None" case
-    if inv.charge_enable_time != False:
+    if inv.charge_enable_time is not False:
         print(f"ERROR: {test_name} - charge_enable_time should be False, got {inv.charge_enable_time}")
         failed = True
     if inv.charge_start_time_minutes != my_predbat.forecast_minutes:
@@ -1671,7 +1671,7 @@ def test_charge_window_ge_cloud_configured_but_no_data_yet(test_name, my_predbat
         return True
 
     # Should set the same safe defaults as the REST case
-    if inv.charge_enable_time != False:
+    if inv.charge_enable_time is not False:
         print(f"ERROR: {test_name} - charge_enable_time should be False, got {inv.charge_enable_time}")
         failed = True
     if inv.charge_start_time_minutes != my_predbat.forecast_minutes:
@@ -1748,7 +1748,7 @@ def test_export_window_ge_cloud_configured_but_no_data_yet(test_name, my_predbat
         return True
 
     # Same safe defaults the discharge_start-is-None path already sets
-    if inv.discharge_enable_time != False:
+    if inv.discharge_enable_time is not False:
         print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
         failed = True
     # Inert, not merely disabled: 0 is midnight, which execute.py reads as "already started".
@@ -1843,7 +1843,7 @@ def test_discharge_window_none_illegal_time(test_name, my_predbat, dummy_items):
     inv.update_status(my_predbat.minutes_now)
 
     # Should set safe defaults
-    if inv.discharge_enable_time != False:
+    if inv.discharge_enable_time is not False:
         print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
         failed = True
     # Inert, not merely disabled: 0 is midnight, which execute.py reads as "already started".
@@ -1883,7 +1883,7 @@ def test_charge_window_invalid_format_time(test_name, my_predbat, dummy_items):
     inv.update_status(my_predbat.minutes_now)
 
     # Should set safe defaults
-    if inv.charge_enable_time != False:
+    if inv.charge_enable_time is not False:
         print(f"ERROR: {test_name} - charge_enable_time should be False, got {inv.charge_enable_time}")
         failed = True
     if inv.charge_start_time_minutes != my_predbat.forecast_minutes:
@@ -1923,7 +1923,7 @@ def test_discharge_window_invalid_format_time(test_name, my_predbat, dummy_items
     inv.update_status(my_predbat.minutes_now)
 
     # Should set safe defaults
-    if inv.discharge_enable_time != False:
+    if inv.discharge_enable_time is not False:
         print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
         failed = True
     # Inert, not merely disabled: 0 is midnight, which execute.py reads as "already started".
@@ -1965,7 +1965,7 @@ def test_discharge_window_none_value(test_name, my_predbat, dummy_items):
     inv.update_status(my_predbat.minutes_now)
 
     # Should set safe defaults
-    if inv.discharge_enable_time != False:
+    if inv.discharge_enable_time is not False:
         print(f"ERROR: {test_name} - discharge_enable_time should be False, got {inv.discharge_enable_time}")
         failed = True
     # Inert, not merely disabled: 0 is midnight, which execute.py reads as "already started".

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -271,7 +271,7 @@ async def test_octopus_set_intelligent_schedule(my_predbat):
     call_args = api6.async_graphql_query.call_args
     kwargs = call_args[1]
 
-    if "returns_data" not in kwargs or kwargs["returns_data"] != False:
+    if "returns_data" not in kwargs or kwargs["returns_data"] is not False:
         print(f"ERROR: Expected returns_data=False, got {kwargs}")
         failed = True
     else:
@@ -413,7 +413,7 @@ async def test_octopus_join_saving_session(my_predbat):
     call_args = api4.async_graphql_query.call_args
     kwargs = call_args[1]
 
-    if "returns_data" not in kwargs or kwargs["returns_data"] != False:
+    if "returns_data" not in kwargs or kwargs["returns_data"] is not False:
         print(f"ERROR: Expected returns_data=False, got {kwargs}")
         failed = True
     else:
@@ -536,7 +536,7 @@ async def test_octopus_get_saving_sessions(my_predbat):
         if context != "get-saving-sessions":
             print(f"ERROR: Expected context 'get-saving-sessions', got {context}")
             failed = True
-        elif "ignore_errors" not in kwargs or kwargs["ignore_errors"] != True:
+        elif "ignore_errors" not in kwargs or kwargs["ignore_errors"] is not True:
             print(f"ERROR: Expected ignore_errors=True, got {kwargs}")
             failed = True
         else:
@@ -643,7 +643,7 @@ async def test_octopus_get_saving_sessions(my_predbat):
     call_args = api6.async_graphql_query.call_args
     kwargs = call_args[1]
 
-    if "ignore_errors" not in kwargs or kwargs["ignore_errors"] != True:
+    if "ignore_errors" not in kwargs or kwargs["ignore_errors"] is not True:
         print(f"ERROR: Expected ignore_errors=True, got {kwargs}")
         failed = True
     else:

--- a/apps/predbat/tests/test_octopus_read_response_retry.py
+++ b/apps/predbat/tests/test_octopus_read_response_retry.py
@@ -200,7 +200,7 @@ async def test_octopus_read_response_retry(my_predbat):
         failed = True
     else:
         call_kwargs = api.async_read_response.call_args[1]
-        if "ignore_errors" not in call_kwargs or call_kwargs["ignore_errors"] != True:
+        if "ignore_errors" not in call_kwargs or call_kwargs["ignore_errors"] is not True:
             print(f"ERROR: ignore_errors=True not passed through correctly")
             failed = True
         else:

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -709,7 +709,7 @@ def _test_ohme_client_async_pause_charge(my_predbat=None):
 
     result = run_async(client.async_pause_charge())
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check request was logged
     assert len(client.request_log) > 0, "No requests logged"
@@ -730,7 +730,7 @@ def _test_ohme_client_async_resume_charge(my_predbat=None):
 
     result = run_async(client.async_resume_charge())
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check request was logged
     last_request = client.request_log[-1]
@@ -750,7 +750,7 @@ def _test_ohme_client_async_approve_charge(my_predbat=None):
 
     result = run_async(client.async_approve_charge())
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check request was logged
     last_request = client.request_log[-1]
@@ -770,7 +770,7 @@ def _test_ohme_client_async_max_charge_enable(my_predbat=None):
 
     result = run_async(client.async_max_charge(True))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check request was logged
     last_request = client.request_log[-1]
@@ -790,7 +790,7 @@ def _test_ohme_client_async_max_charge_disable(my_predbat=None):
 
     result = run_async(client.async_max_charge(False))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check request was logged
     last_request = client.request_log[-1]
@@ -815,7 +815,7 @@ def _test_ohme_client_async_set_target(my_predbat=None):
 
     result = run_async(client.async_set_target(target_percent=90, target_time=(8, 30)))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check request was logged - a PATCH against the rule id from _last_rule, with the changed
     # fields in the JSON body rather than the URL (#4719: the old PUT-with-query-params rule
@@ -864,7 +864,7 @@ def _test_ohme_client_async_update_device_info(my_predbat=None):
 
     result = run_async(client.async_update_device_info())
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check that serial was set
     assert client.serial == "TEST-SERIAL-123", f"Expected TEST-SERIAL-123, got {client.serial}"
@@ -902,7 +902,7 @@ def _test_ohme_client_async_login_success(my_predbat=None):
         with patch('aiohttp.ClientSession', return_value=mock_session):
             result = run_async(client.async_login())
 
-        assert result == True, f"Expected True, got {result}"
+        assert result is True, f"Expected True, got {result}"
         assert client._token is not None, "Token not set after login"
         assert client._refresh_token is not None, "Refresh token not set after login"
 
@@ -929,7 +929,7 @@ def _test_ohme_client_async_refresh_session_no_token(my_predbat=None):
 
     result = run_async(client._async_refresh_session())
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
     assert len(login_called) == 1, f"Expected async_login called once, got {len(login_called)}"
 
     print("PASS: _async_refresh_session calls async_login when no token")
@@ -955,7 +955,7 @@ def _test_ohme_client_async_refresh_session_recent_token(my_predbat=None):
 
     result = run_async(client._async_refresh_session())
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
     assert len(login_called) == 0, f"Expected async_login not called, got {len(login_called)}"
 
     print("PASS: _async_refresh_session skips refresh for recent token")
@@ -992,7 +992,7 @@ def _test_ohme_client_async_refresh_session_expired_token(my_predbat=None):
 
     result = run_async(client._async_refresh_session())
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
     assert client._token == "refreshed_token", f"Expected token 'refreshed_token', got {client._token}"
     assert client._refresh_token == "refreshed_refresh", f"Expected refresh token 'refreshed_refresh', got {client._refresh_token}"
 
@@ -1418,7 +1418,7 @@ def _test_ohme_client_async_set_vehicle_found(my_predbat=None):
     # Call async_set_vehicle with matching name
     result = run_async(client.async_set_vehicle("Tesla Model 3"))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check request was made to select vehicle
     last_request = client.request_log[-1]
@@ -1441,7 +1441,7 @@ def _test_ohme_client_async_set_vehicle_not_found(my_predbat=None):
     # Call async_set_vehicle with non-matching name
     result = run_async(client.async_set_vehicle("BMW i3"))
 
-    assert result == False, f"Expected False, got {result}"
+    assert result is False, f"Expected False, got {result}"
 
     # Check no request was made
     assert len(client.request_log) == 0, f"Expected no requests, got {len(client.request_log)}"
@@ -1471,12 +1471,12 @@ def _test_ohme_client_async_update_schedule_all_params(my_predbat=None):
         pre_condition_length=45
     ))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check rule was updated correctly
     assert client._next_session["targetPercent"] == 90, f"Expected 90%, got {client._next_session['targetPercent']}"
     assert client._next_session["targetTime"] == 30600, f"Expected 30600 seconds (8:30), got {client._next_session['targetTime']}"  # 8*3600 + 30*60
-    assert client._next_session["preconditioningEnabled"] == True, f"Expected True, got {client._next_session['preconditioningEnabled']}"
+    assert client._next_session["preconditioningEnabled"] is True, f"Expected True, got {client._next_session['preconditioningEnabled']}"
     assert client._next_session["preconditionLengthMins"] == 45, f"Expected 45 mins, got {client._next_session['preconditionLengthMins']}"
 
     # Check PUT request was made
@@ -1504,12 +1504,12 @@ def _test_ohme_client_async_update_schedule_partial_params(my_predbat=None):
     # Call async_update_schedule with only target_percent
     result = run_async(client.async_update_schedule(target_percent=85))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Check only target_percent was updated
     assert client._next_session["targetPercent"] == 85, f"Expected 85%, got {client._next_session['targetPercent']}"
     assert client._next_session["targetTime"] == 25200, f"Expected 25200 (unchanged), got {client._next_session['targetTime']}"
-    assert client._next_session["preconditioningEnabled"] == False, f"Expected False (unchanged), got {client._next_session['preconditioningEnabled']}"
+    assert client._next_session["preconditioningEnabled"] is False, f"Expected False (unchanged), got {client._next_session['preconditioningEnabled']}"
 
     print("PASS: async_update_schedule correctly updates only provided parameters")
     return 0
@@ -1525,7 +1525,7 @@ def _test_ohme_client_async_update_schedule_no_rule(my_predbat=None):
     # Call async_update_schedule
     result = run_async(client.async_update_schedule(target_percent=90))
 
-    assert result == False, f"Expected False, got {result}"
+    assert result is False, f"Expected False, got {result}"
 
     # Check no request was made
     assert len(client.request_log) == 0, f"Expected no requests, got {len(client.request_log)}"
@@ -2431,7 +2431,7 @@ def _test_ohme_publish_data(my_predbat=None):
         f"Expected preconditioning 30 mins, got {api.dashboard_items['number.predbat_ohme_preconditioning']['state']}"
 
     # Verify slot_active (should be True since we have an active slot)
-    assert api.dashboard_items["binary_sensor.predbat_ohme_slot_active"]["state"] == True, \
+    assert api.dashboard_items["binary_sensor.predbat_ohme_slot_active"]["state"] is True, \
         f"Expected slot_active True, got {api.dashboard_items['binary_sensor.predbat_ohme_slot_active']['state']}"
 
     # Verify planned_dispatches attribute exists
@@ -2485,7 +2485,7 @@ def _test_ohme_publish_data_disconnected(my_predbat=None):
         f"Expected status 'unplugged', got {api.dashboard_items['sensor.predbat_ohme_status']['state']}"
 
     # Verify slot_active is False (no slots)
-    assert api.dashboard_items["binary_sensor.predbat_ohme_slot_active"]["state"] == False, \
+    assert api.dashboard_items["binary_sensor.predbat_ohme_slot_active"]["state"] is False, \
         f"Expected slot_active False, got {api.dashboard_items['binary_sensor.predbat_ohme_slot_active']['state']}"
 
     # Verify available is "off"
@@ -2531,7 +2531,7 @@ def _test_ohme_run_first_call(my_predbat=None):
     # Call run with first=True
     result = run_async(api.run(seconds=0, first=True))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Verify first call log
     assert any("Ohme API: Started" in msg for msg in api.log_messages), "Expected 'Started' log message"
@@ -2577,7 +2577,7 @@ def _test_ohme_run_periodic_30min(my_predbat=None):
     # Call run with seconds=1800 (30 minutes)
     result = run_async(api.run(seconds=1800, first=False))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Verify async_update_device_info was called (30 min = 30*60 = 1800 seconds)
     assert len(update_device_called) == 1, f"Expected async_update_device_info called once, got {len(update_device_called)}"
@@ -2621,7 +2621,7 @@ def _test_ohme_run_periodic_120s(my_predbat=None):
     # Call run with seconds=120 (2 minutes)
     result = run_async(api.run(seconds=120, first=False))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Verify async_update_device_info was NOT called (120 doesn't divide 1800)
     assert len(update_device_called) == 0, f"Expected async_update_device_info not called, got {len(update_device_called)}"
@@ -2665,7 +2665,7 @@ def _test_ohme_run_no_periodic(my_predbat=None):
     # Call run with seconds=60 (doesn't trigger periodic updates)
     result = run_async(api.run(seconds=60, first=False))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Verify no periodic methods were called
     assert len(update_device_called) == 0, f"Expected async_update_device_info not called, got {len(update_device_called)}"
@@ -2714,7 +2714,7 @@ def _test_ohme_run_with_queued_events(my_predbat=None):
     # Call run with seconds=60 (normally wouldn't trigger updates)
     result = run_async(api.run(seconds=60, first=False))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Verify handler was called
     assert len(handler_called) == 1, f"Expected handler called once, got {len(handler_called)}"
@@ -2758,7 +2758,7 @@ def _test_ohme_run_event_handler_exception(my_predbat=None):
     # Call run - should not raise exception
     result = run_async(api.run(seconds=60, first=False))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Verify error was logged
     assert any("Event handler error" in msg for msg in api.log_messages), "Expected 'Event handler error' log message"
@@ -2799,7 +2799,7 @@ def _test_ohme_run_first_with_octopus_intelligent(my_predbat=None):
     # Call run with first=True
     result = run_async(api.run(seconds=0, first=True))
 
-    assert result == True, f"Expected True, got {result}"
+    assert result is True, f"Expected True, got {result}"
 
     # Verify automatic_config_octopus_intelligent was called
     assert len(auto_config_called) == 1, f"Expected automatic_config_octopus_intelligent called once, got {len(auto_config_called)}"

--- a/apps/predbat/tests/test_solax.py
+++ b/apps/predbat/tests/test_solax.py
@@ -1513,7 +1513,7 @@ async def test_write_setting_from_event(my_predbat):
     entity_id = f"switch.{solax_api.prefix}_solax_{test_plant_id}_battery_schedule_charge_enable"
     await solax_api.switch_event(entity_id, "turn_on")
 
-    if solax_api.controls[test_plant_id]["charge"]["enable"] != True:
+    if solax_api.controls[test_plant_id]["charge"]["enable"] is not True:
         print(f"**** ERROR: Charge enable not set to True ****")
         failed = True
     else:
@@ -1522,7 +1522,7 @@ async def test_write_setting_from_event(my_predbat):
     # Test 8: Update charge enable (switch - turn_off service)
     await solax_api.switch_event(entity_id, "turn_off")
 
-    if solax_api.controls[test_plant_id]["charge"]["enable"] != False:
+    if solax_api.controls[test_plant_id]["charge"]["enable"] is not False:
         print(f"**** ERROR: Charge enable not set to False ****")
         failed = True
     else:
@@ -1610,7 +1610,7 @@ async def test_write_setting_from_event(my_predbat):
     entity_id = f"switch.{solax_api.prefix}_solax_{test_plant_id}_battery_schedule_export_enable"
     await solax_api.switch_event(entity_id, "turn_on")
 
-    if solax_api.controls[test_plant_id]["export"]["enable"] != True:
+    if solax_api.controls[test_plant_id]["export"]["enable"] is not True:
         print(f"**** ERROR: Export enable not set to True ****")
         failed = True
     else:
@@ -1619,7 +1619,7 @@ async def test_write_setting_from_event(my_predbat):
     # Test 17: Update export enable (switch - toggle service)
     await solax_api.switch_event(entity_id, "toggle")
 
-    if solax_api.controls[test_plant_id]["export"]["enable"] != False:
+    if solax_api.controls[test_plant_id]["export"]["enable"] is not False:
         print(f"**** ERROR: Export enable not toggled to False ****")
         failed = True
     else:
@@ -1684,7 +1684,7 @@ async def test_fetch_controls(solax_api, test_plant_id):
     else:
         print("✓ Charge end_time fetched correctly (06:00:00)")
 
-    if charge_controls.get("enable") != True:
+    if charge_controls.get("enable") is not True:
         print(f"**** ERROR: Charge enable not fetched correctly. Expected True, got {charge_controls.get('enable')} ****")
         failed = True
     else:
@@ -1716,7 +1716,7 @@ async def test_fetch_controls(solax_api, test_plant_id):
     else:
         print("✓ Export end_time fetched correctly (19:00:00)")
 
-    if export_controls.get("enable") != False:
+    if export_controls.get("enable") is not False:
         print(f"**** ERROR: Export enable not fetched correctly. Expected False, got {export_controls.get('enable')} ****")
         failed = True
     else:
@@ -3280,7 +3280,7 @@ async def test_fetch_single_result(my_predbat):
     if result is None:
         print(f"**** ERROR: Expected result, got None ****")
         failed = True
-    elif result.get("success") != True:
+    elif result.get("success") is not True:
         print(f"**** ERROR: Result data mismatch ****")
         failed = True
     elif request_id != "req-789":
@@ -7841,7 +7841,7 @@ async def test_fetch_controls_value_conversion_main():
     if api3.controls[plant_id]["charge"]["start_time"] != "00:00":
         print(f"**** ERROR: Expected default start_time 00:00, got {api3.controls[plant_id]['charge']['start_time']} ****")
         failed = True
-    elif api3.controls[plant_id]["charge"]["enable"] != False:
+    elif api3.controls[plant_id]["charge"]["enable"] is not False:
         print(f"**** ERROR: Expected default enable False, got {api3.controls[plant_id]['charge']['enable']} ****")
         failed = True
     elif api3.controls[plant_id]["charge"]["target_soc"] != 100:

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -1749,7 +1749,7 @@ async def test_read_and_write_cid():
 
     # Test 1: Value changes - should read, write, then verify
     result = await api.read_and_write_cid(inverter_sn, 103, "80", field_description="battery SOC")
-    assert result == True, "Expected True for successful write"
+    assert result is True, "Expected True for successful write"
     assert len(read_calls) == 2, f"Expected 2 read calls (initial + verify), got {len(read_calls)}"
     assert read_calls[0]["cid"] == 103, f"Expected read CID 103, got {read_calls[0]['cid']}"
     assert len(write_calls) == 1, f"Expected 1 write call, got {len(write_calls)}"
@@ -1763,7 +1763,7 @@ async def test_read_and_write_cid():
     read_calls.clear()
     write_calls.clear()
     result = await api.read_and_write_cid(inverter_sn, 633, "33", field_description="storage mode")
-    assert result == True, "Expected True when value unchanged"
+    assert result is True, "Expected True when value unchanged"
     assert len(read_calls) == 2, f"Expected 2 read calls (initial + verify), got {len(read_calls)}"
     assert len(write_calls) == 1, f"Expected 1 write call, got {len(write_calls)}"
     print("PASSED: read_and_write_cid succeeds when value already matches")
@@ -1772,7 +1772,7 @@ async def test_read_and_write_cid():
     read_calls.clear()
     write_calls.clear()
     result = await api.read_and_write_cid(inverter_sn, 104, "100")
-    assert result == True, "Expected True for successful write"
+    assert result is True, "Expected True for successful write"
     assert len(read_calls) == 2, f"Expected 2 read calls, got {len(read_calls)}"
     assert len(write_calls) == 1, f"Expected 1 write call, got {len(write_calls)}"
     assert write_calls[0]["field_description"] is None, "Expected no field_description when not provided"
@@ -1790,7 +1790,7 @@ async def test_read_and_write_cid():
     api.read_cid = mock_read_cid_fail
 
     result = await api.read_and_write_cid(inverter_sn, 105, "50", field_description="test field")
-    assert result == False, "Expected False when read fails"
+    assert result is False, "Expected False when read fails"
     assert len(write_calls) == 0, f"Expected 0 write calls when read fails, got {len(write_calls)}"
     # Check that warning was logged
     assert any("Failed to read and set test field" in msg for msg in api.log_messages), "Expected warning log message"
@@ -1808,7 +1808,7 @@ async def test_read_and_write_cid():
     api.write_cid = mock_write_cid_fail
 
     result = await api.read_and_write_cid(inverter_sn, 106, "60")
-    assert result == False, "Expected False when write fails"
+    assert result is False, "Expected False when write fails"
     print("PASSED: read_and_write_cid returns False when write fails")
 
     # Test 6: Verify fails (write succeeds but read-back doesn't match) - should return False
@@ -1826,7 +1826,7 @@ async def test_read_and_write_cid():
     cid_state[107] = "10"  # Set initial value
 
     result = await api.read_and_write_cid(inverter_sn, 107, "99", field_description="verify test")
-    assert result == False, "Expected False when verify read doesn't match written value"
+    assert result is False, "Expected False when verify read doesn't match written value"
     assert len(write_calls) == 1, f"Expected 1 write call, got {len(write_calls)}"
     assert any("Failed to verify" in msg for msg in api.log_messages), "Expected verify failure log message"
     print("PASSED: read_and_write_cid returns False when verify read doesn't match")
@@ -1861,7 +1861,7 @@ async def test_write_cid():
 
     # Test 1: Write without old_value verification
     result = await api.write_cid(inverter_sn, 103, "80", field_description="battery SOC")
-    assert result == True, "Expected True for successful write"
+    assert result is True, "Expected True for successful write"
     assert len(execute_calls) == 1, f"Expected 1 API call, got {len(execute_calls)}"
     assert execute_calls[0]["payload"]["inverterSn"] == inverter_sn, "Expected correct inverter SN"
     assert execute_calls[0]["payload"]["cid"] == 103, "Expected correct CID"
@@ -1874,7 +1874,7 @@ async def test_write_cid():
     execute_calls.clear()
     api.log_messages.clear()
     result = await api.write_cid(inverter_sn, 633, "35", old_value="33", field_description="storage mode")
-    assert result == True, "Expected True for successful write"
+    assert result is True, "Expected True for successful write"
     assert len(execute_calls) == 1, f"Expected 1 API call, got {len(execute_calls)}"
     assert execute_calls[0]["payload"]["yuanzhi"] == "33", "Expected old_value in yuanzhi field"
     assert execute_calls[0]["payload"]["value"] == "35", "Expected new value"
@@ -1884,7 +1884,7 @@ async def test_write_cid():
     execute_calls.clear()
     api.log_messages.clear()
     result = await api.write_cid(inverter_sn, 104, "100")
-    assert result == True, "Expected True for successful write"
+    assert result is True, "Expected True for successful write"
     assert any(f"Set CID 104 to 100 on {inverter_sn}" in msg for msg in api.log_messages), "Expected success log without field description"
     print("PASSED: write_cid works without field_description")
 
@@ -1918,7 +1918,7 @@ async def test_write_cid():
     api._execute_request = mock_execute_request_error_code
 
     result = await api.write_cid(inverter_sn, 105, "50", field_description="test field")
-    assert result == False, "Expected False when API returns error code"
+    assert result is False, "Expected False when API returns error code"
     assert any("Failed to set test field" in msg for msg in api.log_messages), "Expected warning log on failure"
     print("PASSED: write_cid handles API error codes correctly")
 
@@ -1933,7 +1933,7 @@ async def test_write_cid():
     api._execute_request = mock_execute_request_no_data
 
     result = await api.write_cid(inverter_sn, 106, "60")
-    assert result == False, "Expected False when API returns None data"
+    assert result is False, "Expected False when API returns None data"
     print("PASSED: write_cid handles missing data field correctly")
 
     # Test 6: API returns non-array data
@@ -1947,7 +1947,7 @@ async def test_write_cid():
     api._execute_request = mock_execute_request_bad_format
 
     result = await api.write_cid(inverter_sn, 107, "70")
-    assert result == False, "Expected False when API returns non-array data"
+    assert result is False, "Expected False when API returns non-array data"
     print("PASSED: write_cid handles non-array data field correctly")
 
     # Test 7: Retry logic - fails twice then succeeds
@@ -1978,7 +1978,7 @@ async def test_write_cid():
     api._execute_request = mock_execute_request_retry
 
     result = await api.write_cid(inverter_sn, 108, "80", field_description="retry test")
-    assert result == True, f"Expected True after retries succeed, got {result}"
+    assert result is True, f"Expected True after retries succeed, got {result}"
     assert call_count[0] == 3, f"Expected 3 attempts, got {call_count[0]}"
     assert any("retry 1" in msg for msg in api.log_messages), "Expected retry warning for attempt 1"
     assert any("retry 2" in msg for msg in api.log_messages), "Expected retry warning for attempt 2"
@@ -1989,7 +1989,7 @@ async def test_write_cid():
     api._execute_request = mock_execute_request_success
 
     result = await api.write_cid(inverter_sn, 109, "90")
-    assert result == True, "Expected True for successful write"
+    assert result is True, "Expected True for successful write"
     assert inverter_sn in api.cached_values, "Expected inverter in cache"
     assert 109 in api.cached_values[inverter_sn], "Expected CID in cache"
     assert api.cached_values[inverter_sn][109] == "90", "Expected cached value to match written value"
@@ -2198,7 +2198,7 @@ async def test_write_time_windows_v2_mode():
     result = await api.write_time_windows_if_changed(inverter_sn)
 
     # Verify results
-    assert result == True, "write_time_windows_if_changed should return True"
+    assert result is True, "write_time_windows_if_changed should return True"
 
     # Check that read_and_write_cid was called with two-pass ordering:
     # Pass 1 (clear disabled slots):
@@ -2321,7 +2321,7 @@ async def test_write_time_windows_v2_stale_slot_clearing():
     }
 
     result = await api.write_time_windows_if_changed(inverter_sn)
-    assert result == True, "write_time_windows_if_changed should return True"
+    assert result is True, "write_time_windows_if_changed should return True"
 
     calls = api.read_and_write_cid_calls
 
@@ -2630,7 +2630,7 @@ async def test_write_time_windows_v2_no_active_slot():
     api.cached_values[inverter_sn] = {}
 
     result = await api.write_time_windows_if_changed(inverter_sn)
-    assert result == True, "write_time_windows_if_changed should return True"
+    assert result is True, "write_time_windows_if_changed should return True"
 
     # Storage mode must use the 'No Timed Charge/Discharge' variant since no slot is active
     storage_mode_calls = api.set_storage_mode_calls
@@ -2695,7 +2695,7 @@ async def test_write_time_windows_v1_mode():
     result = await api.write_time_windows_if_changed(inverter_sn)
 
     # Verify results
-    assert result == True, "write_time_windows_if_changed should return True"
+    assert result is True, "write_time_windows_if_changed should return True"
 
     # Check that read_and_write_cid was called for CID 103 only
     # V1 mode no longer writes global SOC values - it only encodes and writes CID 103
@@ -2758,7 +2758,7 @@ async def test_write_time_windows_v2_no_changes():
     result = await api.write_time_windows_if_changed(inverter_sn)
 
     # Verify results
-    assert result == True, "write_time_windows_if_changed should return True"
+    assert result is True, "write_time_windows_if_changed should return True"
 
     # Check that read_and_write_cid was NOT called (no changes)
     calls = api.read_and_write_cid_calls
@@ -2806,7 +2806,7 @@ async def test_write_time_windows_zero_charge_current():
     result = await api.write_time_windows_if_changed(inverter_sn)
 
     # Verify results
-    assert result == True, "write_time_windows_if_changed should return True"
+    assert result is True, "write_time_windows_if_changed should return True"
 
     # Verify storage mode was set to Feed-in priority (zero charge current)
     storage_mode_calls = api.set_storage_mode_calls
@@ -2869,7 +2869,7 @@ async def test_write_time_windows_v1_slot_detection():
     api._test_now_utc_exact = None
 
     # Verify results
-    assert result == True, "write_time_windows_if_changed should return True"
+    assert result is True, "write_time_windows_if_changed should return True"
 
     # Check that charge_soc_to_write was detected and logged
     charge_log = any("In charge slot" in msg and "95%" in msg for msg in api.log_messages)
@@ -2918,7 +2918,7 @@ async def test_write_time_windows_v1_discharge_slot_detection():
     result = await api.write_time_windows_if_changed(inverter_sn)
     api._test_now_utc_exact = None
 
-    assert result == True, "write_time_windows_if_changed should return True"
+    assert result is True, "write_time_windows_if_changed should return True"
 
     # Must detect we are inside the discharge slot and use 'Self-Use', NOT 'Self-Use - No Timed Charge/Discharge'
     discharge_log = any("In discharge slot" in msg for msg in api.log_messages)
@@ -2971,7 +2971,7 @@ async def test_write_time_windows_v1_local_time_not_utc():
     result_inside = await api.write_time_windows_if_changed(inverter_sn)
     api._test_now_utc_exact = None
 
-    assert result_inside == True
+    assert result_inside is True
     assert any("In discharge slot" in m for m in api.log_messages), "Should detect discharge slot at local 21:43"
     inside_mode = api.set_storage_mode_calls[-1]["mode"]
     assert inside_mode == "Self-Use", f"Expected 'Self-Use' at local 21:43, got '{inside_mode}'"
@@ -2986,7 +2986,7 @@ async def test_write_time_windows_v1_local_time_not_utc():
     result_outside = await api.write_time_windows_if_changed(inverter_sn)
     api._test_now_utc_exact = None
 
-    assert result_outside == True
+    assert result_outside is True
     outside_mode = api.set_storage_mode_calls[-1]["mode"]
     assert outside_mode == "Self-Use - No Timed Charge/Discharge", f"With UTC time 20:43 (outside window) expected 'Self-Use - No Timed Charge/Discharge', got '{outside_mode}'"
 


### PR DESCRIPTION
## Summary

Enables ruff's E712 (equality/inequality comparison to `True`/`False` instead of a truth check or `is`).

All 223 violations are in test files - none in production code. ruff's own `--fix` (checked, not assumed) consistently rewrites to `is`/`is not` identity comparisons rather than collapsing to a bare `if x:`/`if not x:` truthy check, so every fix is exact-semantics-preserving, including the handful of `.get(key)` sites where a missing key (`None`) and an explicit `False` need to stay distinguishable.

## Test plan

- [x] `ruff check --select=F401,E713,F811,E722,F821,F841,E712` - clean
- [x] `./run_all --quick` - passes
- [x] `./run_pre_commit` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)