### PR TITLE
Drop dead 'all_rates' Octopus rates fallback

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -56,6 +56,7 @@ beforeunload
 bierner
 BLAS
 boostable
+Bottlecap
 brickatius
 byok
 cadata

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -3141,12 +3141,7 @@ class Octopus:
                 if data_import:
                     data_all += data_import
                 else:
-                    prev_rate_id = entity_id.replace("_current_rate", "_previous_rate")
-                    data_import = self.get_state_wrapper(entity_id=prev_rate_id, attribute="all_rates")
-                    if data_import:
-                        data_all += data_import
-                    else:
-                        self.log("Warn: Octopus: No Octopus data in sensor {} attribute 'all_rates'".format(prev_rate_id))
+                    self.log("Warn: Octopus: No Octopus data in event {} attribute 'rates'".format(prev_rate_id))
 
             # Current rates
             if "_current_rate" in entity_id:
@@ -3154,17 +3149,12 @@ class Octopus:
             else:
                 current_rate_id = entity_id
 
-            data_import = (
-                self.get_state_wrapper(entity_id=current_rate_id, attribute="rates")
-                or self.get_state_wrapper(entity_id=current_rate_id, attribute="all_rates")
-                or self.get_state_wrapper(entity_id=current_rate_id, attribute="raw_today")
-                or self.get_state_wrapper(entity_id=current_rate_id, attribute="prices")
-            )
+            data_import = self.get_state_wrapper(entity_id=current_rate_id, attribute="rates") or self.get_state_wrapper(entity_id=current_rate_id, attribute="raw_today") or self.get_state_wrapper(entity_id=current_rate_id, attribute="prices")
 
             if data_import:
                 data_all += data_import
             else:
-                self.log("Warn: Octopus: No Octopus data in sensor {} attribute 'all_rates' / 'rates' / 'raw_today' / 'prices'".format(current_rate_id))
+                self.log("Warn: Octopus: No Octopus data in sensor {} attribute 'rates' / 'raw_today' / 'prices'".format(current_rate_id))
 
             # Next rates
             if "_current_rate" in entity_id:
@@ -3172,11 +3162,6 @@ class Octopus:
                 data_import = self.get_state_wrapper(entity_id=next_rate_id, attribute="rates")
                 if data_import:
                     data_all += data_import
-                else:
-                    next_rate_id = entity_id.replace("_current_rate", "_next_rate")
-                    data_import = self.get_state_wrapper(entity_id=next_rate_id, attribute="all_rates")
-                    if data_import:
-                        data_all += data_import
             else:
                 # Nordpool tomorrow
                 data_import = self.get_state_wrapper(entity_id=current_rate_id, attribute="raw_tomorrow")

--- a/apps/predbat/tests/test_fetch_octopus_rates.py
+++ b/apps/predbat/tests/test_fetch_octopus_rates.py
@@ -16,8 +16,10 @@ def test_fetch_octopus_rates(my_predbat):
     Test the fetch_octopus_rates function
 
     Tests various sensor formats and attribute combinations:
-    - Legacy sensor with all_rates attribute
     - New event-based sensor with rates attribute
+    - A `_current_rate`-pattern entity whose day-rate events are missing (no legacy
+      'all_rates' fallback - see #1699, that attribute has not existed on any
+      BottlecapDave Octopus Energy integration sensor for a very long time)
     - Current rate sensor with previous/current/next day rates
     - Nordpool sensor with raw_today/raw_tomorrow
     - Different rate key formats (rate, value_inc_vat, value, price)
@@ -38,8 +40,8 @@ def test_fetch_octopus_rates(my_predbat):
     # Clear dummy_items from previous tests
     my_predbat.ha_interface.dummy_items.clear()
 
-    # Test 1: Legacy sensor with all_rates attribute
-    print("*** Test 1: Legacy sensor with all_rates attribute")
+    # Test 1: Current-day-rates event with a 'rates' attribute
+    print("*** Test 1: Current-day-rates event with a 'rates' attribute")
     entity_id = "sensor.octopus_energy_electricity_abc123_current_rate"
 
     # Mock the sensor data - standard Octopus format
@@ -75,7 +77,7 @@ def test_fetch_octopus_rates(my_predbat):
             print("ERROR: Expected rate 16.2 at minute 30, got {}".format(rate_data[30]))
             failed = True
 
-        print("Test 1 passed - legacy sensor format works")
+        print("Test 1 passed - current-day-rates event format works")
 
     # Test 2: New event-based sensor with previous, current, and next rates
     print("*** Test 2: Event-based sensor with previous/current/next rates")
@@ -201,6 +203,32 @@ def test_fetch_octopus_rates(my_predbat):
     else:
         print("ERROR: Expected minute 0 to be marked as intelligent adjusted")
         failed = True
+
+    # Test 5b: Missing day-rate events - no legacy 'all_rates' sensor fallback (#1699)
+    print("*** Test 5b: Missing previous/current day-rate events warn about 'rates', not 'all_rates'")
+
+    entity_id_no_events = "sensor.octopus_energy_electricity_missing_current_rate"
+    log_messages = []
+    orig_log = my_predbat.log
+    my_predbat.log = lambda msg, *args, **kwargs: log_messages.append(str(msg))
+    try:
+        rate_data = my_predbat.fetch_octopus_rates(entity_id_no_events)
+    finally:
+        my_predbat.log = orig_log
+
+    if rate_data != {}:
+        print("ERROR: Expected empty dict when day-rate events are missing, got {}".format(rate_data))
+        failed = True
+
+    if any("all_rates" in msg for msg in log_messages):
+        print("ERROR: A warning still references the dead 'all_rates' attribute: {}".format(log_messages))
+        failed = True
+
+    if not any("attribute 'rates'" in msg for msg in log_messages):
+        print("ERROR: Expected a warning about the missing 'rates' attribute, got {}".format(log_messages))
+        failed = True
+    else:
+        print("Test 5b passed - no 'all_rates' fallback attempted, warning references 'rates'")
 
     # Test 6: Empty entity_id
     print("*** Test 6: Empty entity_id returns empty dict")


### PR DESCRIPTION
## Summary
- `fetch_octopus_rates()` had a fallback probe for an `all_rates` attribute on the legacy Octopus rate sensors (`_previous_rate`, `_current_rate`/generic sensor, `_next_rate`). That attribute belonged to a much older BottlecapDave Octopus Energy integration entity shape from a while back and has not existed on any current sensor for a long time - confirmed by checking against the current integration source (v19.0.0): `previous_rate.py`/`current_rate.py` only ever populate `mpan`/`serial_number`/`is_export`/`is_smart_meter`/`start`/`end`, and `all_rates` only appears in a restore-compat list for reading old persisted state on upgrade, never as a live attribute.
- Since it can never succeed on any installation still receiving updates, it was just dead code that produced a spurious `Warn: Octopus: No Octopus data in sensor ... attribute 'all_rates'` on every fetch cycle whenever the primary event-based lookup came up empty - see #1699.
- Safe to delete: removed the probe from all three lookups (previous/current/next rates) and updated the warning text to reflect what's actually being checked (`rates` for previous/next, `rates`/`raw_today`/`prices` for current - the latter two are for other integrations like Nordpool/Energidataservice sharing this code path, left untouched).

## Test plan
- [x] Added a regression test asserting no `all_rates` fallback is attempted and the warning references `rates` instead
- [x] `tools/triage_test.sh fetch_octopus_rates` passes
- [x] `tools/triage_test.sh octopus_url` / `octopus_day_night_rates` / `octopus_tou_windows` / `basic_rates` pass
- [x] `./run_pre_commit` passes (black/ruff/cspell/markdownlint)

Fixes #1699

🤖 Generated with [Claude Code](https://claude.com/claude-code)