### PR TITLE
Clamp reserve target to device-published register bounds (GE Cloud)

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -1833,12 +1833,33 @@ class Inverter:
         # Clamp reserve at max setting
         reserve = min(reserve, self.reserve_max)
 
+        reserve_entity = None
+        if not self.rest_data:
+            reserve_entity = self.base.get_arg("reserve", indirect=False, index=self.id, required_unit="%")
+            if reserve_entity:
+                # Some components (e.g. GE Cloud) publish the inverter's own register bounds onto the entity's
+                # min/max attributes; respect them so we never ask for a value the device will silently clamp
+                # and confirm - otherwise write_and_poll_value's poll-back never matches the un-clamped target
+                # and the same failing write retries forever (GH#4826).
+                device_min = self.base.get_state_wrapper(reserve_entity, attribute="min", default=None)
+                device_max = self.base.get_state_wrapper(reserve_entity, attribute="max", default=None)
+                if device_min not in (None, ""):
+                    try:
+                        reserve = max(reserve, int(float(device_min) + 0.5))
+                    except (ValueError, TypeError):
+                        pass
+                if device_max not in (None, ""):
+                    try:
+                        reserve = min(reserve, int(float(device_max)))
+                    except (ValueError, TypeError):
+                        pass
+
         if current_reserve != reserve:
             self.base.log("Inverter {} Current Reserve is {}% and new target is {}%".format(self.id, dp0(current_reserve), dp0(reserve)))
             if self.rest_data:
                 self.rest_setReserve(reserve)
             else:
-                self.write_and_poll_value("reserve", self.base.get_arg("reserve", indirect=False, index=self.id, required_unit="%"), reserve)
+                self.write_and_poll_value("reserve", reserve_entity, reserve)
             if self.base.set_inverter_notify:
                 self.base.call_notify("Predbat: Inverter {} Target Reserve has been changed to {}% at {}".format(self.id, dp0(reserve), self.base.time_now_str()))
             self.mqtt_message(topic="set/reserve", payload=reserve)

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -322,6 +322,31 @@ def test_adjust_reserve(test_name, ha, inv, dummy_rest, prev_reserve, reserve, e
     return failed
 
 
+def test_adjust_reserve_device_bounds(test_name, ha, inv, prev_reserve, reserve, device_min, device_max, expect_reserve, reserve_min=4, reserve_max=100):
+    """
+    Test
+       inv.adjust_reserve(self, reserve) clamps its target against a component-published register
+       floor/ceiling (e.g. GE Cloud's "between:" validation rule surfaced onto the entity's min/max
+       attributes), rather than asking for a value the device will silently clamp-and-confirm to
+       something else forever (GH#4826)
+    """
+    failed = False
+    inv.reserve_percent = reserve_min
+    inv.reserve_min = reserve_min
+    inv.reserve_max = reserve_max
+
+    print("Test: {}".format(test_name))
+
+    inv.rest_data = None
+    ha.dummy_items["number.reserve"] = {"state": prev_reserve, "min": device_min, "max": device_max}
+    inv.adjust_reserve(reserve)
+    if ha.get_state("number.reserve") != expect_reserve:
+        print("ERROR: Reserve should be {} got {}".format(expect_reserve, ha.get_state("number.reserve")))
+        failed = True
+
+    return failed
+
+
 def test_adjust_force_export(test_name, ha, inv, dummy_rest, prev_start, prev_end, prev_force_export, prev_discharge_target, new_start, new_end, new_force_export, has_inv_time_button_press=False, expect_inv_time_button_press=False):
     """
     Test
@@ -3238,6 +3263,15 @@ def run_inverter_tests(my_predbat_dummy):
     failed |= test_adjust_reserve("adjust_reserve3", ha, inv, dummy_rest, 20, 100, reserve_max=100)
     failed |= test_adjust_reserve("adjust_reserve4", ha, inv, dummy_rest, 20, 100, 98, reserve_min=4, reserve_max=98)
     failed |= test_adjust_reserve("adjust_reserve5", ha, inv, dummy_rest, 50, 0, 0, reserve_min=0, reserve_max=100)
+    if failed:
+        return failed
+
+    # GH#4826: a device-published register floor above Predbat's requested target must be honoured
+    # so the write converges instead of retrying the unreachable target forever
+    failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_min1", ha, inv, 5, 4, device_min=5, device_max=100, expect_reserve=5)
+    failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_min2", ha, inv, 3, 4, device_min=5, device_max=100, expect_reserve=5)
+    failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_max1", ha, inv, 10, 80, device_min=4, device_max=50, expect_reserve=50)
+    failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_no_bounds", ha, inv, 4, 10, device_min=None, device_max=None, expect_reserve=10)
     if failed:
         return failed
 


### PR DESCRIPTION
This is an automated draft PR generated from issue #4826 — a maintainer should review it before merging.

Fixes #4826

## Summary

`adjust_reserve()` (`inverter.py`) previously only clamped its target against Predbat's own `reserve_percent`/`reserve_max` config, with no visibility into an inverter's own declared register bounds. On GE Cloud, if the configured reserve sits below the device's real minimum, `number_event()` silently clamps and confirms the write, but `write_and_poll_value()`'s poll-back kept comparing against the original, un-clamped target — reporting a permanent write failure (`had_errors=True`) every single cycle even though the device had already accepted the best achievable value.

The fix reads the write target entity's `min`/`max` attributes (already published onto it by `gecloud.py`'s `publish_registers()`) before writing, and clamps the target into that range in addition to the existing config-based clamps. This means `adjust_reserve()` never asks for a value the device has already told us it won't accept, so the poll-back matches and the spurious error stops. Inverters/components that don't publish these attributes are unaffected (the reads return `None`/empty and the extra clamp is a no-op), so this is scoped to the GE Cloud case described in the issue without touching `write_and_poll_value()` or `number_event()` shared by every other inverter integration.

## Testing

- `cd coverage && ./run_pre_commit` — all hooks and the full test suite passed.
- `tools/triage_test.sh inverter <log>` — targeted `inverter` test module passed, including 4 new scenarios added to `test_inverter.py` (`test_adjust_reserve_device_bounds`) covering: clamping up to a device-published minimum, clamping down to a device-published maximum, and no change in behaviour when a component publishes no bounds at all.

## Notes

Root-cause investigation and the choice between the issue's two proposed fixes are documented in the triage comment on #4826; this PR implements the second (smaller, targeted) option since the register bounds were already available on the entity without an extra API round-trip.