### PR TITLE
Default the 6-hour Octopus Intelligent slot cap for IOG-SMB tariffs

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -57,6 +57,7 @@ OCTOPUS_MAX_RETRIES = 5
 CATALOGUE_FRESH_MINUTES = 24 * 60
 CATALOGUE_STALE_MINUTES = 25 * 60
 OCTOPUS_SLOT_MAX_DEFAULT = 48  # 24 hours with 30-minute slots
+OCTOPUS_SLOT_MAX_CAPPED = 12  # 6 hours with 30-minute slots
 
 # Per-device settings read from the Octopus intelligent settings query. Kept as a list so a poll
 # whose settings query fails can carry the previous values forward rather than dropping the device.
@@ -1523,6 +1524,13 @@ class OctopusAPI(ComponentBase):
         else:
             return ("INTELLI-" in tariff_code) or ("IOG-" in tariff_code)
 
+    @staticmethod
+    def has_six_hour_cap(tariff_code):
+        """
+        Determine whether a tariff code enforces Octopus's 6-hour (12-slot) Intelligent cap.
+        """
+        return bool(tariff_code) and "IOG-SMB" in tariff_code
+
     async def async_get_tou_night_windows(self, days=7):
         """
         Read the meter's real off-peak windows from the measurements API's TOU bucket labels.
@@ -2876,6 +2884,24 @@ class Octopus:
 
         return start_minutes, end_minutes, kwh, source, location
 
+    def get_octopus_slot_max(self):
+        """
+        Resolve the Octopus Intelligent daily low-rate slot cap.
+
+        An explicit apps.yaml octopus_slot_max always wins. Otherwise IOG-SMB tariffs, which
+        Octopus enforces a 6-hour daily cap on, default to 12 slots; every other tariff
+        (including the older INTELLI-VAR) stays uncapped.
+        """
+        if "octopus_slot_max" in self.args:
+            return self.get_arg("octopus_slot_max", OCTOPUS_SLOT_MAX_DEFAULT)
+
+        components = getattr(self, "components", None)
+        octopus_api = components.get_component("octopus") if components else None
+        tariff_code = octopus_api.tariffs.get("import", {}).get("tariffCode") if octopus_api else None
+        if OctopusAPI.has_six_hour_cap(tariff_code):
+            return OCTOPUS_SLOT_MAX_CAPPED
+        return OCTOPUS_SLOT_MAX_DEFAULT
+
     def load_octopus_slots(self, car_n, octopus_slots, octopus_intelligent_consider_full):
         """
         Turn octopus slots into charging plan
@@ -2885,7 +2911,7 @@ class Octopus:
             # Car not configured, just return the slots as they are (for export or other non-car use)
             return new_slots
         octopus_slot_low_rate = self.get_arg("octopus_slot_low_rate", True)
-        octopus_slot_max = self.get_arg("octopus_slot_max", OCTOPUS_SLOT_MAX_DEFAULT)  # Default to 12 slots (6 hours) per midday-to-midday period
+        octopus_slot_max = self.get_octopus_slot_max()
         slots_per_day = {}  # Track 30-min blocks used per midday-to-midday period
         car_soc = self.car_charging_soc[car_n]
         limit = self.car_charging_limit[car_n]
@@ -3037,7 +3063,7 @@ class Octopus:
         # Octopus limits cheap slots to 6 hours (12 x 30-min slots) per 24-hour period
         """
         octopus_slot_low_rate = self.get_arg("octopus_slot_low_rate", True)
-        octopus_slot_max = self.get_arg("octopus_slot_max", OCTOPUS_SLOT_MAX_DEFAULT)
+        octopus_slot_max = self.get_octopus_slot_max()
 
         # Track slots per 24-hour period (keyed by day offset from midday)
         # Period 0 = noon today to 11:59 tomorrow, Period -1 = noon yesterday to 11:59 today, etc.
@@ -3052,6 +3078,14 @@ class Octopus:
             # Add in IO slots
             for slot in octopus_slots:
                 start_minutes, end_minutes, kwh, source, location = self.decode_octopus_slot(car_n, slot, raw=True)
+
+                # A dispatch that's already fully in the past and delivered zero kWh either never
+                # actually happened (a withdrawn planned slot Octopus hasn't dropped yet) or genuinely
+                # delivered nothing, so it shouldn't consume one of the day's capped low-rate slots.
+                # A future/still-active slot is left alone even at zero kWh - its kWh is usually
+                # synthesised rather than genuinely zero, and an in-progress dispatch is still real.
+                if end_minutes <= self.minutes_now and kwh <= 0:
+                    continue
 
                 # Ignore bump-charge slots as their cost won't change
                 if source != "bump-charge" and source != "BOOST" and (not location or location == "AT_HOME"):

--- a/apps/predbat/tests/test_octopus_day_night_rates.py
+++ b/apps/predbat/tests/test_octopus_day_night_rates.py
@@ -411,6 +411,30 @@ async def test_octopus_day_night_rates(my_predbat):
         print("PASS: async_update_intelligent_devices proceeds for IOG-only tariff code (no INTELLI substring)")
 
     # ------------------------------------------------------------------
+    # Test 11: has_six_hour_cap — detects the IOG-SMB tariff variant that
+    # Octopus enforces its 6-hour (12-slot) Intelligent cap on. Older
+    # INTELLI-VAR and non-SMB IOG tariffs are not capped by default.
+    # ------------------------------------------------------------------
+    print("\n*** Test 11: has_six_hour_cap detects IOG-SMB tariff codes ***")
+    six_hour_cap_cases = [
+        ("E-1R-IOG-SMB-TOU-25-12-12-H", True),
+        ("E-1R-INTELLI-VAR-25-01-01-H", False),
+        ("E-1R-IOG-FIX-12M-24-04-01-H", False),
+        ("E-1R-GO-VAR-22-10-14-H", False),
+        ("", False),
+        (None, False),
+    ]
+    case_failed = False
+    for tariff_code, expected in six_hour_cap_cases:
+        actual = OctopusAPI.has_six_hour_cap(tariff_code)
+        if actual != expected:
+            print(f"ERROR: has_six_hour_cap({tariff_code!r}) returned {actual}, expected {expected}")
+            failed = True
+            case_failed = True
+    if not case_failed:
+        print("PASS: has_six_hour_cap correctly classifies IOG-SMB and non-capped tariff codes")
+
+    # ------------------------------------------------------------------
     if failed:
         print("\n**** ❌ async_get_day_night_rates tests FAILED ****")
     else:

--- a/apps/predbat/tests/test_octopus_slots.py
+++ b/apps/predbat/tests/test_octopus_slots.py
@@ -14,6 +14,82 @@ from utils import dp2, in_car_slot
 import json
 
 
+class _MockOctopusComponent:
+    """Stand-in for the OctopusAPI component, reporting an import tariff code."""
+
+    def __init__(self, tariff_code=None):
+        """Initialize with the import tariff code to report."""
+        self.tariffs = {"import": {"tariffCode": tariff_code}} if tariff_code else {}
+
+
+class _MockComponents:
+    """Stand-in for the component registry."""
+
+    def __init__(self, octopus=None):
+        """Initialize with the given octopus component stand-in registered, if any."""
+        self._components = {"octopus": octopus} if octopus else {}
+
+    def get_component(self, name):
+        """Return the registered stand-in component, if any."""
+        return self._components.get(name)
+
+
+def run_octopus_slot_max_default_tests(my_predbat):
+    """
+    Test for get_octopus_slot_max — an explicit apps.yaml octopus_slot_max always wins;
+    otherwise IOG-SMB tariffs (which Octopus enforces a 6-hour daily cap on) default to
+    12 slots, and every other tariff (including the older INTELLI-VAR) stays uncapped at 48.
+    """
+    failed = False
+    print("**** Running Test: octopus_slot_max_default ****")
+
+    saved_args = my_predbat.args.pop("octopus_slot_max", "__unset__")
+    saved_components = getattr(my_predbat, "components", None)
+
+    try:
+        # Explicit apps.yaml value wins even for an IOG-SMB tariff
+        my_predbat.args["octopus_slot_max"] = 20
+        my_predbat.components = _MockComponents(_MockOctopusComponent("E-1R-IOG-SMB-TOU-25-12-12-H"))
+        result = my_predbat.get_octopus_slot_max()
+        if result != 20:
+            print("ERROR: Explicit octopus_slot_max should win over auto-detection, expected 20 got {}".format(result))
+            failed = True
+
+        # Unset + IOG-SMB tariff -> defaults to 12 (6 hours)
+        my_predbat.args.pop("octopus_slot_max", None)
+        my_predbat.components = _MockComponents(_MockOctopusComponent("E-1R-IOG-SMB-TOU-25-12-12-H"))
+        result = my_predbat.get_octopus_slot_max()
+        if result != 12:
+            print("ERROR: Unset octopus_slot_max on an IOG-SMB tariff should default to 12, got {}".format(result))
+            failed = True
+
+        # Unset + older INTELLI-VAR tariff -> stays uncapped at 48
+        my_predbat.components = _MockComponents(_MockOctopusComponent("E-1R-INTELLI-VAR-25-01-01-H"))
+        result = my_predbat.get_octopus_slot_max()
+        if result != 48:
+            print("ERROR: Unset octopus_slot_max on an INTELLI-VAR tariff should default to 48, got {}".format(result))
+            failed = True
+
+        # Unset + no octopus component registered -> stays uncapped at 48
+        my_predbat.components = None
+        result = my_predbat.get_octopus_slot_max()
+        if result != 48:
+            print("ERROR: Unset octopus_slot_max with no octopus component should default to 48, got {}".format(result))
+            failed = True
+    finally:
+        if saved_args == "__unset__":
+            my_predbat.args.pop("octopus_slot_max", None)
+        else:
+            my_predbat.args["octopus_slot_max"] = saved_args
+        my_predbat.components = saved_components
+
+    if failed:
+        print("**** ❌ octopus_slot_max_default tests FAILED ****")
+    else:
+        print("**** ✅ octopus_slot_max_default tests PASSED ****")
+    return failed
+
+
 def run_load_octopus_slot_test(testname, my_predbat, slots, expected_slots, consider_full, car_soc, car_limit, car_loss):
     """
     Run a test for load_octopus_slot

--- a/apps/predbat/tests/test_rate_add_io_slots.py
+++ b/apps/predbat/tests/test_rate_add_io_slots.py
@@ -345,6 +345,45 @@ def run_rate_add_io_slots_tests(my_predbat):
         expected_rates_17[minute] = 4.0
     failed |= run_rate_add_io_slots_test("test17_dup_does_not_waste_cap", my_predbat, slots_17, True, 2, expected_rates_17)
 
+    # Test 18: Zero kWh slot in the past does not consume cap budget or get the cheap rate.
+    # A dispatch that delivered (or was withdrawn / never actually happened and simply hasn't been
+    # metered as) zero kWh shouldn't eat into the day's slot cap the way a genuine dispatch does.
+    # 13 slots yesterday (all fully in the past), index 4 is zero kWh: without the fix, all 13
+    # compete for the 12-slot cap and the 13th (chronologically last) loses out; with the fix the
+    # zero-kWh slot is skipped entirely, leaving 12 real slots - all of which fit under the cap.
+    print("\n**** Test 18: Zero kWh slot in the past does not consume cap budget ****")
+    slots = []
+    expected_rates = {}
+    for i in range(13):
+        slot_start = midnight_utc - timedelta(days=1) + timedelta(minutes=i * 30)
+        slot_end = slot_start + timedelta(minutes=30)
+        kwh = 0 if i == 4 else 2.5
+        slots.append({"start": slot_start.strftime(TIME_FORMAT), "end": slot_end.strftime(TIME_FORMAT), "charge_in_kwh": kwh, "source": "smart-charge", "location": "AT_HOME"})
+        yesterday_minute = -1440 + i * 30
+        for minute in range(yesterday_minute, yesterday_minute + 30):
+            expected_rates[minute] = 10.0 if i == 4 else 4.0  # the zero-kWh slot itself is left at the default rate
+
+    failed |= run_rate_add_io_slots_test("test18_zero_kwh_past_excluded", my_predbat, slots, True, 12, expected_rates)
+
+    # Test 19: Zero kWh slot in the future still counts toward the cap and gets the cheap rate -
+    # the Test 18 exclusion is scoped to slots that have already happened, not ones still to come
+    # (a future planned dispatch's kWh is usually synthesised rather than genuinely zero, but the
+    # cap logic must not rely on that - it should treat a future zero-kWh slot the same as before).
+    print("\n**** Test 19: Zero kWh slot in the future is not excluded ****")
+    slots = []
+    expected_rates = {}
+    for i in range(13):  # 13 slots today, starting at 13:00 (after minutes_now=10:00, and after the
+        # midday cap boundary so all 13 land in the same midday-to-midday period), zero-kwh at index 4
+        slot_start = midnight_utc + timedelta(hours=13) + timedelta(minutes=i * 30)
+        slot_end = slot_start + timedelta(minutes=30)
+        kwh = 0 if i == 4 else 2.5
+        slots.append({"start": slot_start.strftime(TIME_FORMAT), "end": slot_end.strftime(TIME_FORMAT), "charge_in_kwh": kwh, "source": "smart-charge", "location": "AT_HOME"})
+        start_minute = 780 + i * 30  # 13:00 = minute 780
+        for minute in range(start_minute, start_minute + 30):
+            expected_rates[minute] = 4.0 if i < 12 else 10.0  # the zero-kWh slot at i=4 still consumes a cap slot
+
+    failed |= run_rate_add_io_slots_test("test19_zero_kwh_future_not_excluded", my_predbat, slots, True, 12, expected_rates)
+
     # Restore original forecast_minutes
     my_predbat.forecast_minutes = original_forecast_minutes
 

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -39,7 +39,7 @@ from tests.test_load_car_energy import test_load_car_energy_warns_when_configure
 from tests.test_predheat import test_predheat
 from tests.test_debug_enable_auto_scope import test_debug_enable_auto_scope
 from tests.test_charge_hold import run_charge_hold_tests
-from tests.test_octopus_slots import run_load_octopus_slots_tests
+from tests.test_octopus_slots import run_load_octopus_slots_tests, run_octopus_slot_max_default_tests
 from tests.test_multi_car_iog import run_multi_car_iog_tests
 from tests.test_fetch_config_options import test_fetch_config_options
 from tests.test_multi_inverter import run_inverter_multi_tests
@@ -491,6 +491,7 @@ def main():
         ("nordpool", run_nordpool_test, "Nordpool tests", False),
         ("futurerate_auto", test_futurerate_auto, "FutureRate auto Agile detection tests", False),
         ("octopus_slots", run_load_octopus_slots_tests, "Load Octopus slots tests", False),
+        ("octopus_slot_max_default", run_octopus_slot_max_default_tests, "Octopus slot max auto-detection from IOG-SMB tariff code", False),
         ("multi_car_iog", run_multi_car_iog_tests, "Multi-car IOG tests", False),
         ("rate_add_io_slots", run_rate_add_io_slots_tests, "Rate add IO slots tests", False),
         ("iog_charge_skew", run_iog_charge_skew_tests, "IOG earlier-charge skew characterisation tests", False),

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -119,9 +119,8 @@ If you are on the Octopus Intelligent Tariff set the following entries in `apps.
 
 - **octopus_slot_low_rate** - Default is `true`, meaning any Octopus Intelligent Slot reported will be at the lowest rate if at home. If `false` the existing rates only will be used which is only suitable for tariffs other than IOG.
 
-- **octopus_slot_max** - Default is 48 (disabled). Sets the maximum number of 30-minute cheap rate slots per 24-hour period.
-Octopus Intelligent users may be from March 2026 limited to 6 hours of cheap charging per day. Slots beyond this limit will use standard rates.
-It's recommended you set this to 12 (for 6 hours) once Octopus enforce this Octopus Intelligent limit.
+- **octopus_slot_max** - Sets the maximum number of 30-minute cheap rate slots per 24-hour period. Slots beyond this limit will use standard rates.
+If unset, Predbat defaults this to 12 (6 hours) automatically for tariffs that Octopus enforces the 6-hour Intelligent cap on (tariff codes containing `IOG-SMB`), and to 48 (disabled) for other tariffs such as the older `INTELLI-VAR`. Set this explicitly to override the automatic default in either direction.
 
 If you are using Octopus-led charging with the [Octopus Energy integration](energy-rates.md#octopus-energy-home-assistant-integration):
 


### PR DESCRIPTION
## Summary
- IOG-SMB tariffs enforce Octopus's 6-hour daily cap on cheap Intelligent slots, unlike older tariffs such as INTELLI-VAR. `octopus_slot_max` now auto-defaults to 12 (6 hours) for IOG-SMB tariffs and 48 (uncapped) for everything else, detected from the account's tariff code — an explicit `apps.yaml` value always overrides the auto-detected default.
- Fixed `rate_add_io_slots()` counting a zero-kWh dispatch that's already in the past toward the daily cap (it wasn't checking `kwh` at all), which could wrongly push a later genuine slot to the max rate. `load_octopus_slots()` already excluded these. Future/active zero-kWh slots are left alone since their `kWh` is usually synthesised rather than genuinely zero.

## Test plan
- [x] New unit tests: `has_six_hour_cap` tariff detection, `get_octopus_slot_max` tri-state resolution (explicit override / IOG-SMB / INTELLI-VAR / no component), and two `rate_add_io_slots` regression tests for the zero-kWh past/future boundary
- [x] `./run_all --test octopus_day_night_rates --test octopus_slot_max_default --test octopus_slots --test rate_add_io_slots --test multi_car_iog --test iog_charge_skew` all pass
- [x] `./run_pre_commit` passes (ruff, black, cspell, docstring coverage, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)