### PR TITLE
fix(chat): free-model filter on local endpoints, and Stop during a streaming turn

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+Commands below use `node .gitnexus/run.cjs <command>` — the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
+
+> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent — e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
+
+## Commands
+
+### analyze — Build or refresh the index
+
+```bash
+node .gitnexus/run.cjs analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+| `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+| `--pdg` | Build the program-dependence layers used by `explain` and `pdg_query` (taint, CDG, and REACHING_DEF). |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
+
+### status — Check index freshness
+
+```bash
+node .gitnexus/run.cjs status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean — Delete the index
+
+```bash
+node .gitnexus/run.cjs clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki — Generate documentation from the graph
+
+```bash
+node .gitnexus/run.cjs wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list — Show all indexed repos
+
+```bash
+node .gitnexus/run.cjs list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. query({search_query: "<error or symptom>"})            → Find related execution flows
+2. context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. cypher({statement: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `query` for error text → `context` on throw sites |
+| Wrong return value   | `context` on the function → trace callees for data flow    |
+| Intermittent failure | `context` → look for external calls, async deps            |
+| Performance issue    | `context` → find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+| "How does A reach B?" | `trace` between the two symbols — shortest call chain in one call |
+
+## Tools
+
+**query** — find code related to error:
+
+```
+query({search_query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**context** — full context for a suspect:
+
+```
+context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**cypher** — custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+**trace** — shortest call chain between two symbols ("how does A reach B?"), one call instead of chaining `context` hops:
+
+```
+trace({ from: "processCheckout", to: "fetchRates" })
+→ status: ok, hopCount: 3
+→ hops: processCheckout → validatePayment → verifyCard → fetchRates
+→ edges: CALLS (1.0), CALLS (0.95), CALLS (1.0)
+```
+
+When no path exists, `trace` reports the furthest reachable node — exactly where the chain breaks (dynamic dispatch, reflection, or an external boundary).
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. query({search_query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -15,7 +15,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Workflow
 
-```
+```text
 1. query({search_query: "<error or symptom>"})            → Find related execution flows
 2. context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
@@ -26,7 +26,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 ## Checklist
 
-```
+```text
 - [ ] Understand the symptom (error message, unexpected behavior)
 - [ ] query for error text or related code
 - [ ] Identify the suspect function from returned processes
@@ -51,7 +51,7 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 **query** — find code related to error:
 
-```
+```text
 query({search_query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
@@ -59,7 +59,7 @@ query({search_query: "payment validation error"})
 
 **context** — full context for a suspect:
 
-```
+```text
 context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
@@ -75,7 +75,7 @@ RETURN [n IN nodes(path) | n.name] AS chain
 
 **trace** — shortest call chain between two symbols ("how does A reach B?"), one call instead of chaining `context` hops:
 
-```
+```text
 trace({ from: "processCheckout", to: "fetchRates" })
 → status: ok, hopCount: 3
 → hops: processCheckout → validatePayment → verifyCard → fetchRates
@@ -86,7 +86,7 @@ When no path exists, `trace` reports the furthest reachable node — exactly whe
 
 ## Example: "Payment endpoint returns 500 intermittently"
 
-```
+```text
 1. query({search_query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. query({search_query: "<what you want to understand>"})  → Find related execution flows
+4. context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**query** — find execution flows related to a concept:
+
+```
+query({search_query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**context** — 360-degree view of a symbol:
+
+```
+context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. query({search_query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -15,7 +15,7 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Workflow
 
-```
+```text
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
 3. query({search_query: "<what you want to understand>"})  → Find related execution flows
@@ -27,7 +27,7 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Checklist
 
-```
+```text
 - [ ] READ gitnexus://repo/{name}/context
 - [ ] query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
@@ -49,7 +49,7 @@ description: "Use when the user asks how code works, wants to understand archite
 
 **query** — find execution flows related to a concept:
 
-```
+```text
 query({search_query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
@@ -57,7 +57,7 @@ query({search_query: "payment processing"})
 
 **context** — 360-degree view of a symbol:
 
-```
+```text
 context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
@@ -66,7 +66,7 @@ context({name: "validateUser"})
 
 ## Example: "How does payment processing work?"
 
-```
+```text
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
 2. query({search_query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence — execution flows related to a concept |
+| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `trace`          | Shortest path between two symbols — "how does A reach B?" in one call     |
+| `detect_changes` | Git-diff impact — what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `explain`        | Persisted taint findings — source→sink data flows (needs `analyze --pdg`) |
+| `pdg_query`      | Control/data dependence — what gates X (CDG) / where Y flows (REACHING_DEF); needs `analyze --pdg` |
+| `check`          | Check graph invariants such as circular imports                          |
+| `route_map`      | API route map — which components/hooks fetch which endpoints, and the handler files that serve them |
+| `shape_check`    | Response-shape drift — keys each route returns vs keys its consumers access (flags MISMATCH) |
+| `api_impact`     | Pre-change report for an API route — consumers, middleware, shape mismatches, risk level |
+| `tool_map`       | MCP/RPC tool definitions and the files that handle them                  |
+| `group_list`     | List configured multi-repo groups, or one group's config                 |
+| `group_sync`     | Rebuild a group's Contract Registry (cross-repo HTTP contract links); run after `group.yaml` changes or member re-index |
+| `list_repos`     | Discover indexed repos (paginated — `limit`/`offset`)                    |
+
+### Paginating `list_repos`
+
+`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
+
+```jsonc
+{
+  "repositories": [
+    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
+  ],
+  "pagination": {
+    "total": 437,
+    "limit": 50,
+    "offset": 0,
+    "returned": 50,
+    "hasMore": true,
+    "nextOffset": 50
+  }
+}
+```
+
+To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
+
+```text
+list_repos {}               → repos 1–50,    nextOffset 50,  hasMore true
+list_repos { offset: 50 }   → repos 51–100,  nextOffset 100, hasMore true
+…
+list_repos { offset: 400 }  → repos 401–437,                 hasMore false   (done)
+```
+
+Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
+
+### Taint findings (`explain`)
+
+`explain` returns taint findings recorded by `gitnexus analyze --pdg` — intra-procedural `TAINTED` edges plus cross-function `TAINT_PATH` hops where the interprocedural taint phase found a function-level source→sink chain. Each finding includes a sink category (command-injection, code-injection, path-traversal, sql-injection, xss), source/sink lines, and the ordered hop path with the variable carried on each hop.
+
+- `explain {}` — enumerate all findings for the repo (bounded by `limit`, deterministic order)
+- `explain { target: "src/vuln.ts" }` — findings in a file (suffix path match accepted)
+- `explain { target: "runUserCommand" }` — findings in a function (resolved like `context`; ambiguous names return ranked candidates)
+
+A repo indexed without `--pdg` returns a clear "no taint layer" note. Caveats: closure/callback, property/field, and implicit flows are not modeled, and interprocedural findings are function-level `TAINT_PATH` hops rather than statement-level path proof, so the absence of a finding is **not** proof of safety. `SANITIZES` (sanitizer-kill) edges are queryable via `cypher`.
+
+### Control & data dependence (`pdg_query`)
+
+`pdg_query` reads the control/data-dependence layers `gitnexus analyze --pdg` records (CDG + REACHING_DEF, basic-block granular) — the control/data analog of `explain`. It is **always anchored** (a `target` file path or symbol, resolved like `context`) and has two modes:
+
+- `pdg_query { mode: "controls", target: "..." }` — CDG: "under what condition does X run?". Each edge is a controlling predicate block → dependent block with the branch sense (`'T'`/`'F'`) in `reason`; an edge into an early `return`/`throw` is flagged `guard: true` (guard-clause discovery — the sense depends on the predicate, so don't filter guards by a fixed label).
+- `pdg_query { mode: "flows", target: "...", variable?: "..." }` — REACHING_DEF def→use edges within the function; pass `variable` to trace one binding.
+
+A repo indexed without `--pdg` returns a "no PDG layer" note (or "status unknown" when the layer can't be confirmed). Intra-procedural only — cross-function flow is taint's domain (`explain`). The raw CDG/REACHING_DEF edges are also queryable via `cypher`. See the `gitnexus-pdg-query` skill for the full query surface.
+
+### Shortest path between two symbols (`trace`)
+
+`trace` answers "how does A reach B?" in one call — the shortest directed path over `CALLS` (plus `HAS_METHOD`, so a class-rooted trace descends into its methods) instead of chaining 3–8 `context`/`impact` hops by hand.
+
+- `trace { from: "validateUser", to: "executeQuery" }` — shortest path between two symbols.
+- Disambiguate common names with `from_uid`/`to_uid` (zero-ambiguity) or `from_file`/`to_file`; an ambiguous name returns ranked candidates.
+- `maxDepth` (default 10, max 30) bounds the search; `includeTests` (default false) lets the traversal pass through test-file symbols.
+
+Returns ordered `hops` (each `{ name, filePath, startLine }`) and an aligned `edges[]` of `{ relType, confidence }`, so call hops and containment (`HAS_METHOD`) hops stay distinguishable. When no path exists it reports the **furthest** reachable node (where the chain breaks) and sets `truncated: true` if a traversal cap was hit first. Every result carries a `status`: `ok` / `no_path` / `ambiguous` / `not_found` / `error`.
+
+Cross-repo (experimental): pass `repo: "@groupName"` to trace across a group's member repos — the path may cross **one** `ContractLink` boundary (reported as a `CONTRACT_LINK` hop with the bridged contract in `crossings[]`). Omit `to` entirely to follow `from`'s outgoing HTTP call to whatever provider endpoint it lands on. Groups are configured via `group_list` / `group_sync`.
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Folder, Function, Class, Interface, Method, CodeElement, Community, Process, Route, Tool, plus language-specific types (Struct, Enum, Trait, Impl, Namespace, Module, …) and BasicBlock (`--pdg` indexes only). The full node list lives in `gitnexus://repo/{name}/schema`.
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, CONTAINS, MEMBER_OF, HAS_METHOD, HAS_PROPERTY, ACCESSES, METHOD_OVERRIDES, METHOD_IMPLEMENTS, STEP_IN_PROCESS, HANDLES_ROUTE, FETCHES, HANDLES_TOOL, ENTRY_POINT_OF, WRAPS, QUERIES, INJECTS, plus `--pdg`-only types (CFG, REACHING_DEF, TAINTED, SANITIZES, TAINT_PATH, CDG — zero rows on a default index).
+
+Read `gitnexus://repo/{name}/schema` before writing Cypher — it is the authoritative schema for the indexed repo.
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**impact** — the primary tool for symbol blast radius:
+
+```
+impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**detect_changes** — git-diff based impact analysis:
+
+```
+detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -16,7 +16,7 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Workflow
 
-```
+```text
 1. impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
 3. detect_changes()                               → Map current git changes to affected flows
@@ -27,7 +27,7 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Checklist
 
-```
+```text
 - [ ] impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
@@ -57,7 +57,7 @@ description: "Use when the user wants to know what will break if they change som
 
 **impact** — the primary tool for symbol blast radius:
 
-```
+```text
 impact({
   target: "validateUser",
   direction: "upstream",
@@ -75,7 +75,7 @@ impact({
 
 **detect_changes** — git-diff based impact analysis:
 
-```
+```text
 detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
@@ -85,7 +85,7 @@ detect_changes({scope: "staged"})
 
 ## Example: "What breaks if I change validateUser?"
 
-```
+```text
 1. impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. impact({target: "X", direction: "upstream"})  → Map all dependents
+2. query({search_query: "X"})                            → Find execution flows involving X
+3. context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and text_search edits (review carefully)
+- [ ] If satisfied: rename({..., dry_run: false}) — apply edits
+- [ ] detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] context({name: target}) — see all incoming/outgoing refs
+- [ ] impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**rename** — automated multi-file rename:
+
+```
+rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 text_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**impact** — map all dependents first:
+
+```
+impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**detect_changes** — verify your changes after refactoring:
+
+```
+detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**cypher** — custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 text_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review text_search edits (config.json: dynamic reference!)
+
+3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -15,7 +15,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ## Workflow
 
-```
+```text
 1. impact({target: "X", direction: "upstream"})  → Map all dependents
 2. query({search_query: "X"})                            → Find execution flows involving X
 3. context({name: "X"})                           → See all incoming/outgoing refs
@@ -28,7 +28,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ### Rename Symbol
 
-```
+```text
 - [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
 - [ ] Review graph edits (high confidence) and text_search edits (review carefully)
 - [ ] If satisfied: rename({..., dry_run: false}) — apply edits
@@ -38,7 +38,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ### Extract Module
 
-```
+```text
 - [ ] context({name: target}) — see all incoming/outgoing refs
 - [ ] impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
@@ -49,7 +49,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 ### Split Function/Service
 
-```
+```text
 - [ ] context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
 - [ ] impact({target, direction: "upstream"}) — map callers to update
@@ -63,7 +63,7 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 
 **rename** — automated multi-file rename:
 
-```
+```text
 rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
 → 10 graph edits (high confidence), 2 text_search edits (review)
@@ -72,7 +72,7 @@ rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true
 
 **impact** — map all dependents first:
 
-```
+```text
 impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
@@ -80,7 +80,7 @@ impact({target: "validateUser", direction: "upstream"})
 
 **detect_changes** — verify your changes after refactoring:
 
-```
+```text
 detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
@@ -105,7 +105,7 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
-```
+```text
 1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
    → 12 edits: 10 graph (safe), 2 text_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...

--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -233,6 +233,7 @@ getaffinity
 getall
 getrusage
 Ginlong
+gitnexus
 GivEnergy
 givtcp
 gnueabihf
@@ -282,6 +283,7 @@ inteless
 INTELLI
 intelligentdevice
 interp
+interprocedural
 intraday
 inva
 invb
@@ -308,6 +310,7 @@ Kostal
 kostalplenticore
 kostalplenticoreg
 Krakenflex
+Kuzu
 kvar
 kvarh
 kwargs
@@ -315,6 +318,7 @@ kwhb
 labelcolor
 labelledby
 labelnames
+ladybugdb
 larr
 libbi
 libc
@@ -652,6 +656,7 @@ unpickles
 unpushed
 unreachability
 unredacted
+unregisters
 unreproduced
 unsmoothed
 unstaged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,3 +140,48 @@ mkdocs serve   # Live preview at http://localhost:8000
 ```
 
 When adding a new doc page, add it to `mkdocs.yml`. The published site at <https://springfall2008.github.io/batpred/> is built automatically from `main` via GitHub Actions.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **batpred** (13494 symbols, 38059 relationships, 279 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/batpred/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/batpred/clusters` | All functional areas |
+| `gitnexus://repo/batpred/processes` | All execution flows |
+| `gitnexus://repo/batpred/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ mkdocs serve   # Live preview at http://localhost:8000
 When adding a new doc page, add it to `mkdocs.yml`. The published site at <https://springfall2008.github.io/batpred/> is built automatically from `main` via GitHub Actions.
 
 <!-- gitnexus:start -->
-# GitNexus — Code Intelligence
+## GitNexus — Code Intelligence
 
 This project is indexed by GitNexus as **batpred** (13494 symbols, 38059 relationships, 279 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,3 +140,48 @@ mkdocs serve   # Live preview at http://localhost:8000
 ```
 
 When adding a new doc page, add it to `mkdocs.yml`. The published site at <https://springfall2008.github.io/batpred/> is built automatically from `main` via GitHub Actions.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **batpred** (13494 symbols, 38059 relationships, 279 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/batpred/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/batpred/clusters` | All functional areas |
+| `gitnexus://repo/batpred/processes` | All execution flows |
+| `gitnexus://repo/batpred/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ mkdocs serve   # Live preview at http://localhost:8000
 When adding a new doc page, add it to `mkdocs.yml`. The published site at <https://springfall2008.github.io/batpred/> is built automatically from `main` via GitHub Actions.
 
 <!-- gitnexus:start -->
-# GitNexus — Code Intelligence
+## GitNexus — Code Intelligence
 
 This project is indexed by GitNexus as **batpred** (13494 symbols, 38059 relationships, 279 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 

--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -194,6 +194,25 @@ PROVIDER_DEFAULT_URLS = {
     "openai": "https://api.openai.com/v1",
 }
 
+# What the Settings dialog offers when somebody adds a provider of each type, where that differs
+# from what an under-specified apps.yaml entry resolves to. The two answer different questions:
+# PROVIDER_DEFAULT_URLS answers "what did this existing entry mean", and changing it would
+# silently repoint installs that are working today, while this answers "what is most likely to
+# work for somebody starting now".
+#
+# For Ollama those answers genuinely differ. localhost is the conventional address and the right
+# reading of an entry that names no url, but it is almost never right for a new install: Predbat
+# runs inside its Home Assistant container, where localhost is the container and not the machine
+# the user is thinking of. Ollama's own cloud works from there without any of that, so it is what
+# the form suggests - with a note saying how to point it at your own server instead.
+PROVIDER_SETUP_HINTS = {
+    "ollama": {
+        "url": "https://ollama.com/v1",
+        "model": "gpt-oss:120b",
+        "note": "This is Ollama's own cloud, which needs an API key from ollama.com. If you run Ollama yourself, replace the URL with your server's address - for example http://localhost:11434/v1 when it is on this machine, or http://192.168.1.50:11434/v1 elsewhere on your network - and leave the key empty.",
+    },
+}
+
 # The model a provider starts on when the entry names none, so a freshly configured endpoint can
 # answer immediately rather than sending the user to the picker first. Per type, because a model
 # id only means anything to the endpoint serving it.

--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -159,11 +159,13 @@ Prefer the snapshot below for simple facts about the setup, and reach for a tool
 #                     else reports token counts (OpenRouter ignores it, Ollama honours it)
 #   ollama_details  - enrich the model list from Ollama's native /api/show, which publishes the
 #                     capabilities and context length its OpenAI-compatible /v1/models omits
+#   metered         - somebody bills per token. False for an endpoint running on your own
+#                     hardware, where every model is free however little it says about pricing
 PROVIDERS = {
-    "openrouter": {"needs_key": True, "openrouter_ext": True, "stream_usage": False, "ollama_details": False},
-    "ollama": {"needs_key": False, "openrouter_ext": False, "stream_usage": True, "ollama_details": True},
-    "openai": {"needs_key": True, "openrouter_ext": False, "stream_usage": True, "ollama_details": False},
-    "local": {"needs_key": False, "openrouter_ext": False, "stream_usage": True, "ollama_details": False},
+    "openrouter": {"needs_key": True, "openrouter_ext": True, "stream_usage": False, "ollama_details": False, "metered": True},
+    "ollama": {"needs_key": False, "openrouter_ext": False, "stream_usage": True, "ollama_details": True, "metered": False},
+    "openai": {"needs_key": True, "openrouter_ext": False, "stream_usage": True, "ollama_details": False, "metered": True},
+    "local": {"needs_key": False, "openrouter_ext": False, "stream_usage": True, "ollama_details": True, "metered": False},
 }
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -343,6 +345,13 @@ def conversation_model_for(meta, active_provider):
     return meta.get("model") if meta.get("model_provider") == active_provider else None
 
 
+# Bumped whenever a stored catalogue entry gains or changes a field, so an existing cache is
+# ignored rather than served without it. Without this a fix to how entries are built takes up to a
+# day to reach anyone who has used the picker recently - the catalogue is cached daily - and does
+# so silently, which is the worst way for a user to experience a fix.
+MODEL_CACHE_VERSION = 2
+
+
 def model_cache_name(base_url):
     """Return the cache filename holding one endpoint's model catalogue.
 
@@ -354,7 +363,30 @@ def model_cache_name(base_url):
     Hashed because a URL is not a filename, and truncated because the only collisions that matter
     are between one user's own handful of endpoints.
     """
-    return "models_{}".format(hashlib.md5(str(base_url or "").encode("utf-8")).hexdigest()[:16])
+    return "models_v{}_{}".format(MODEL_CACHE_VERSION, hashlib.md5(str(base_url or "").encode("utf-8")).hexdigest()[:16])
+
+
+def is_free_model(provider, prompt_price, completion_price):
+    """Return whether a model costs nothing to run on a given provider.
+
+    Decided here rather than in the browser because only this side knows what the endpoint is. A
+    local endpoint publishes no pricing at all - Ollama's /v1/models has no pricing field - and the
+    picker read that absence as "not known to be free", so ticking "show only free models" emptied
+    the list of a server where every model is free by definition. The box is ticked by default, so
+    that was the first thing a new Ollama user saw.
+
+    On a metered endpoint the prices decide it, and an absent price stays not-free: OpenRouter's
+    routing models quote -1 because their cost depends on where they route, and offering those as
+    free would bill somebody who asked not to be.
+    """
+    if not provider.get("metered", True):
+        return True
+    if prompt_price is None or completion_price is None:
+        return False
+    try:
+        return float(prompt_price) == 0 and float(completion_price) == 0
+    except (TypeError, ValueError):
+        return False
 
 
 def model_catalogue_headers(api_key):
@@ -1179,12 +1211,21 @@ class ChatAgent(ComponentBase):
             if provider["openrouter_ext"] and "tools" not in (entry.get("supported_parameters") or []):
                 continue
             pricing = entry.get("pricing") or {}
-            models.append({"id": entry.get("id"), "name": entry.get("name") or entry.get("id"), "prompt_price": pricing.get("prompt"), "completion_price": pricing.get("completion"), "context_length": entry.get("context_length")})
+            models.append(
+                {
+                    "id": entry.get("id"),
+                    "name": entry.get("name") or entry.get("id"),
+                    "prompt_price": pricing.get("prompt"),
+                    "completion_price": pricing.get("completion"),
+                    "context_length": entry.get("context_length"),
+                    "free": is_free_model(provider, pricing.get("prompt"), pricing.get("completion")),
+                }
+            )
         if provider["ollama_details"]:
             models = await self._add_ollama_details(models, base_url)
         models.sort(key=lambda entry: str(entry.get("id")))
         if default_model and default_model not in [entry["id"] for entry in models]:
-            models.insert(0, {"id": default_model, "name": "{} (from apps.yaml)".format(default_model), "prompt_price": None, "completion_price": None, "context_length": None})
+            models.insert(0, {"id": default_model, "name": "{} (from apps.yaml)".format(default_model), "prompt_price": None, "completion_price": None, "context_length": None, "free": is_free_model(provider, None, None)})
         return models
 
     async def _add_ollama_details(self, models, base_url=None):

--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -71,6 +71,14 @@ EVENT_BUFFER_MAX = 2000
 # hours, not 24. OpenRouter's catalogue changes rarely enough that once a day is plenty either way.
 MODEL_CACHE_MINUTES = 1440
 
+# The same, for an endpoint on your own machine. A day is right for a hosted catalogue of several
+# hundred models fetched over the internet; it is wrong for a local server, where the catalogue is
+# whatever you have pulled and changes precisely because you just changed it. Pulling a model and
+# then not seeing it in the picker until tomorrow is the bug this exists to prevent. Not zero,
+# because the list still costs one /api/show per model to enrich - about 0.8s for ten models -
+# which is not worth repeating on every page load.
+LOCAL_MODEL_CACHE_MINUTES = 5
+
 # How long past its own deadline a turn must go before its slot is assumed abandoned. Only a
 # component restart can strand a slot, and that is rare - so the grace period is generous.
 STALE_TURN_GRACE_SECONDS = 60
@@ -324,11 +332,21 @@ def default_model_for(provider_name):
 
 
 def resolve_provider(api_type, url):
-    """Return the provider settings for a configured type, resolving 'auto' from the URL."""
+    """Return the provider settings for a configured type, resolving 'auto' from the URL.
+
+    Whether somebody bills for a provider is settled here rather than in the table, because for
+    Ollama it depends on where it is: the same software is free on your own machine and paid for
+    at ollama.com, which serves the identical API and publishes no prices either way. Marking a
+    hosted one unmetered would offer every model in it under "show only free models", which is a
+    filter asking specifically not to be billed.
+    """
     name = str(api_type or "auto").strip().lower()
     if name in ("", "auto"):
         name = detect_provider(url)
-    return name, PROVIDERS.get(name, PROVIDERS["openai"])
+    settings = PROVIDERS.get(name, PROVIDERS["openai"])
+    if not settings["metered"] and not is_local_endpoint(url):
+        settings = dict(settings, metered=True)
+    return name, settings
 
 
 def conversation_model_for(meta, active_provider):
@@ -366,7 +384,7 @@ def model_cache_name(base_url):
     return "models_v{}_{}".format(MODEL_CACHE_VERSION, hashlib.md5(str(base_url or "").encode("utf-8")).hexdigest()[:16])
 
 
-def is_free_model(provider, prompt_price, completion_price):
+def is_free_model(provider, prompt_price, completion_price, remote=False):
     """Return whether a model costs nothing to run on a given provider.
 
     Decided here rather than in the browser because only this side knows what the endpoint is. A
@@ -378,7 +396,13 @@ def is_free_model(provider, prompt_price, completion_price):
     On a metered endpoint the prices decide it, and an absent price stays not-free: OpenRouter's
     routing models quote -1 because their cost depends on where they route, and offering those as
     free would bill somebody who asked not to be.
+
+    A remote model is the exception on an unmetered endpoint. Ollama's cloud models run on
+    somebody else's hardware and are paid for, even though the server offering them is your own
+    and publishes no prices - so "local endpoint, therefore free" is exactly wrong for them.
     """
+    if remote:
+        return False
     if not provider.get("metered", True):
         return True
     if prompt_price is None or completion_price is None:
@@ -387,6 +411,47 @@ def is_free_model(provider, prompt_price, completion_price):
         return float(prompt_price) == 0 and float(completion_price) == 0
     except (TypeError, ValueError):
         return False
+
+
+def ollama_native_url(base_url, path):
+    """Return an Ollama native API URL for an endpoint given as its OpenAI-compatible base.
+
+    Only a trailing "/v1" is stripped, and only as a whole path segment. Splitting on "/v1"
+    anywhere in the string matches inside a longer segment - "https://host/v1beta" becomes
+    "https://host" - and then asks a quite different server for its models.
+
+    A base URL that is simply wrong is left wrong: "https://ollama.com/api/v1" still yields
+    "https://ollama.com/api/api/tags", which 404s. That is deliberate. Quietly repairing a
+    mistyped URL would hide the mistake until something subtler went wrong with it, and the 404
+    names the URL it tried, which is what tells the user which part they got wrong.
+    """
+    base = str(base_url or "").rstrip("/")
+    if base.endswith("/v1"):
+        base = base[: -len("/v1")]
+    return "{}{}".format(base, path)
+
+
+def ollama_tags_to_catalogue(payload):
+    """Turn Ollama's /api/tags response into the catalogue shape the rest of this expects.
+
+    Read for the model list because it is the only endpoint that says which models are cloud ones:
+    remote_model and remote_host appear here and not in the OpenAI-compatible /v1/models shim.
+    Both endpoints list the same models - measured against a live server with a cloud model pulled,
+    /v1/models does include it - so this is not about which models are visible. It is about telling
+    a cloud model from a local one, which decides whether it is free.
+
+    Anything running elsewhere is marked remote: a cloud model is somebody else's hardware, paid
+    for, whatever the local server says about pricing. Reading the native endpoint for a native
+    provider also matches what already happens per model, since the capability and context-length
+    enrichment has always come from /api/show.
+    """
+    models = []
+    for entry in (payload or {}).get("models") or []:
+        name = entry.get("model") or entry.get("name")
+        if not name:
+            continue
+        models.append({"id": name, "remote": bool(entry.get("remote_model") or entry.get("remote_host"))})
+    return {"data": models}
 
 
 def model_catalogue_headers(api_key):
@@ -1131,16 +1196,19 @@ class ChatAgent(ComponentBase):
         """
         headers = model_catalogue_headers(self.api_key)
         timeout = aiohttp.ClientTimeout(total=30)
+        native = bool(self.provider.get("ollama_details"))
+        url = ollama_native_url(self.base_url, "/api/tags") if native else "{}/models".format(self.base_url)
         try:
             async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get("{}/models".format(self.base_url), headers=headers) as response:
+                async with session.get(url, headers=headers) as response:
                     if response.status in (401, 403):
                         self.catalogue_error = "{} rejected the API key (HTTP {})".format(self.base_url, response.status)
                         return None
                     if response.status != 200:
-                        self.catalogue_error = "{}/models returned HTTP {}".format(self.base_url, response.status)
+                        self.catalogue_error = "{} returned HTTP {}".format(url, response.status)
                         return None
-                    return await response.json()
+                    body = await response.json()
+                    return ollama_tags_to_catalogue(body) if native else body
         except (aiohttp.ClientError, asyncio.TimeoutError) as error:
             self.catalogue_error = "Could not reach {}: {}".format(self.base_url, error)
             raise
@@ -1171,7 +1239,8 @@ class ChatAgent(ComponentBase):
         storage = self.storage
         try:
             if storage:
-                catalogue = await storage.fetch_cached("chat", model_cache_name(self.base_url), self._fetch_model_catalogue, fresh_minutes=MODEL_CACHE_MINUTES, stale_minutes=MODEL_CACHE_MINUTES + 60, format="json")
+                fresh = MODEL_CACHE_MINUTES if self.provider.get("metered", True) else LOCAL_MODEL_CACHE_MINUTES
+                catalogue = await storage.fetch_cached("chat", model_cache_name(self.base_url), self._fetch_model_catalogue, fresh_minutes=fresh, stale_minutes=fresh + 60, format="json")
             else:
                 catalogue = await self._fetch_model_catalogue()
         except Exception as error:
@@ -1194,19 +1263,23 @@ class ChatAgent(ComponentBase):
         """
         name, provider = resolve_provider(api_type, url or default_url_for(api_type))
         base_url = str(url or default_url_for(name)).rstrip("/")
+        native = bool(provider.get("ollama_details"))
+        catalogue_url = ollama_native_url(base_url, "/api/tags") if native else "{}/models".format(base_url)
         timeout = aiohttp.ClientTimeout(total=PROBE_TIMEOUT_SECONDS)
         try:
             async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get("{}/models".format(base_url), headers=model_catalogue_headers(api_key)) as response:
+                async with session.get(catalogue_url, headers=model_catalogue_headers(api_key)) as response:
                     if response.status in (401, 403):
                         return None, "{} rejected the API key (HTTP {})".format(base_url, response.status)
                     if response.status != 200:
-                        return None, "{}/models returned HTTP {}".format(base_url, response.status)
+                        return None, "{} returned HTTP {}".format(catalogue_url, response.status)
                     catalogue = await response.json()
+                    if native:
+                        catalogue = ollama_tags_to_catalogue(catalogue)
         except (aiohttp.ClientError, asyncio.TimeoutError) as error:
             return None, "Could not reach {}: {}".format(base_url, error)
         except ValueError:
-            return None, "{}/models did not return JSON - is that the right URL?".format(base_url)
+            return None, "{} did not return JSON - is that the right URL?".format(catalogue_url)
         models = await self._catalogue_to_models(catalogue, provider, base_url, None)
         if not models:
             return None, "{} served no tool-capable models".format(base_url)
@@ -1234,7 +1307,8 @@ class ChatAgent(ComponentBase):
                     "prompt_price": pricing.get("prompt"),
                     "completion_price": pricing.get("completion"),
                     "context_length": entry.get("context_length"),
-                    "free": is_free_model(provider, pricing.get("prompt"), pricing.get("completion")),
+                    "remote": bool(entry.get("remote")),
+                    "free": is_free_model(provider, pricing.get("prompt"), pricing.get("completion"), remote=bool(entry.get("remote"))),
                 }
             )
         if provider["ollama_details"]:
@@ -1259,7 +1333,7 @@ class ChatAgent(ComponentBase):
         list_models() is cached for a day - but a single slow or missing model must not lose the
         whole catalogue, so a failed lookup keeps the model rather than dropping it.
         """
-        base = str(base_url or self.base_url).rsplit("/v1", 1)[0]
+        base = ollama_native_url(base_url or self.base_url, "")
         detailed = []
         timeout = aiohttp.ClientTimeout(total=OLLAMA_DETAIL_TIMEOUT_SECONDS)
         try:

--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -414,6 +414,22 @@ CHAT_DEFAULTS = {
 }
 
 
+class TurnStopped(RuntimeError):
+    """Raised when a turn must end while a completion is still streaming.
+
+    Deliberately not a ChatRequestError: _run_completion_with_retry catches those and tries again,
+    and retrying a turn the user just stopped is the opposite of what they asked for. Carries the
+    text already streamed so the transcript can keep it rather than leaving the browser holding a
+    bubble that vanishes on the next reload.
+    """
+
+    def __init__(self, content="", reason="stopped"):
+        """Hold what had been streamed when the stop landed, and what caused it."""
+        super().__init__("The turn was stopped")
+        self.content = content
+        self.reason = reason
+
+
 class ChatBusyError(RuntimeError):
     """Raised when a turn is requested while another is already running."""
 
@@ -1349,6 +1365,13 @@ class ChatAgent(ComponentBase):
         next_anon_reasoning_key = 0
         truncated = False
         async for chunk in self._stream_chunks(payload):
+            # Checked per chunk, which is the only place that runs while the model is thinking.
+            # Every other stop check sits between rounds or between tool calls, so pressing Stop
+            # during a long completion - the longest part of a turn, and exactly when somebody
+            # reaches for it - did nothing until that completion finished on its own.
+            stopping = self.stop_reason()
+            if stopping:
+                raise TurnStopped(content, stopping)
             error = chunk.get("error")
             if error:
                 message_text = (error or {}).get("message") or "The provider reported an error"
@@ -1685,12 +1708,17 @@ class ChatAgent(ComponentBase):
             self.emit(conversation_id, "error", {"message": NO_MODEL_MESSAGE})
             return
         for iteration in range(self.max_tool_rounds + 1):
-            if time.monotonic() > self.deadline:
-                self.emit(conversation_id, "error", {"message": "This turn took longer than {} seconds and was stopped".format(self.turn_timeout)})
+            ending = self.stop_reason()
+            if ending:
+                self.emit(conversation_id, "error", {"message": self.stop_message(ending)})
                 return
             history = await self.store.get_messages(conversation_id)
             messages = await self.build_messages(conversation_id, history)
-            message, usage, sources = await self._run_completion_with_retry(conversation_id, messages, model)
+            try:
+                message, usage, sources = await self._run_completion_with_retry(conversation_id, messages, model)
+            except TurnStopped as stopped:
+                await self._finish_stopped_turn(conversation_id, stopped)
+                return
             if usage:
                 self.store.add_usage(conversation_id, usage)
                 total = (self.store.get_meta(conversation_id) or {}).get("usage_total", {})
@@ -1732,15 +1760,31 @@ class ChatAgent(ComponentBase):
                 # reason _refuse_remaining_calls sets out - this path is reached by the Stop
                 # button (which zeroes the deadline) as much as by a genuine timeout, so it is
                 # the one a user hits deliberately and often.
-                if time.monotonic() > self.deadline:
+                ending = self.stop_reason()
+                if ending:
                     await self._refuse_remaining_calls(conversation_id, calls[index:], "Not run: the turn was stopped before this tool ran")
-                    self.emit(conversation_id, "error", {"message": "This turn took longer than {} seconds and was stopped".format(self.turn_timeout)})
+                    self.emit(conversation_id, "error", {"message": self.stop_message(ending)})
                     return
                 await self._run_one_tool(conversation_id, turn_id, call)
 
         note = "I stopped after {} tool rounds, which is the configured limit for one turn. Ask me to continue if you want me to keep going.".format(self.max_tool_rounds)
         await self.store.append(conversation_id, {"role": "assistant", "content": note})
         self.emit(conversation_id, "assistant", {"text": note, "sources": []})
+
+    async def _finish_stopped_turn(self, conversation_id, stopped):
+        """End a turn the user stopped mid-stream, keeping whatever the model had already said.
+
+        The partial text is appended as an ordinary assistant message, because the browser has
+        already rendered it from the deltas and dropping it here would make it vanish on the next
+        reload with no explanation. Only text: any half-built tool_calls from the interrupted
+        chunk stream are discarded, since an assistant message carrying tool_calls that were never
+        answered makes the provider reject every later turn in the conversation.
+        """
+        content = (stopped.content or "").strip()
+        if content:
+            await self.store.append(conversation_id, {"role": "assistant", "content": content})
+            self.emit(conversation_id, "assistant", {"text": content, "sources": []})
+        self.emit(conversation_id, "error", {"message": self.stop_message(stopped.reason)})
 
     def _confirmation_card_arguments(self, name, arguments):
         """Return what a write tool's confirmation card should show the human, before they answer.
@@ -1809,6 +1853,30 @@ class ChatAgent(ComponentBase):
         self.provider = chosen["settings"]
         self.default_model = chosen["model"]
         return chosen["name"]
+
+    def stop_reason(self):
+        """Return 'stopped', 'timeout' or None for a turn that should end right now.
+
+        Both are checked together because both mean the same thing to the loop and different
+        things to the user: pressing Stop is a choice, and telling somebody who pressed it that
+        their turn "took longer than 1800 seconds" is simply wrong.
+
+        Read without the lock. stop_requested is a scalar and active is replaced wholesale rather
+        than mutated in place, so the worst a concurrent write can do is give this the previous
+        turn's answer a moment early - and it is called on every streamed chunk, where taking a
+        lock hundreds of times a turn buys nothing.
+        """
+        if self.stop_requested is not None and self.stop_requested == (self.active or {}).get("turn_id"):
+            return "stopped"
+        if time.monotonic() > self.deadline:
+            return "timeout"
+        return None
+
+    def stop_message(self, reason):
+        """Return what to tell the user about a turn that ended early."""
+        if reason == "stopped":
+            return "Stopped."
+        return "This turn took longer than {} seconds and was stopped".format(self.turn_timeout)
 
     def provider_ready(self):
         """Return whether the active provider could actually answer a turn."""

--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -165,15 +165,19 @@ Prefer the snapshot below for simple facts about the setup, and reach for a tool
 #                     and supported_parameters fields on its model catalogue
 #   stream_usage    - the standard OpenAI stream_options.include_usage, which is how everyone
 #                     else reports token counts (OpenRouter ignores it, Ollama honours it)
-#   ollama_details  - enrich the model list from Ollama's native /api/show, which publishes the
-#                     capabilities and context length its OpenAI-compatible /v1/models omits
+#   ollama_details  - talk to Ollama's own API rather than the OpenAI-compatible one: /api/tags
+#                     for the model list, which is the only place cloud models are marked as
+#                     such, and /api/show per model for the capabilities and context length
+#                     /v1/models omits. True only for Ollama itself - 'local' is the generic
+#                     OpenAI-compatible option (llama.cpp, LM Studio and the rest), and those
+#                     serve neither endpoint, so asking would cost a 404 for the whole catalogue
 #   metered         - somebody bills per token. False for an endpoint running on your own
 #                     hardware, where every model is free however little it says about pricing
 PROVIDERS = {
     "openrouter": {"needs_key": True, "openrouter_ext": True, "stream_usage": False, "ollama_details": False, "metered": True},
     "ollama": {"needs_key": False, "openrouter_ext": False, "stream_usage": True, "ollama_details": True, "metered": False},
     "openai": {"needs_key": True, "openrouter_ext": False, "stream_usage": True, "ollama_details": False, "metered": True},
-    "local": {"needs_key": False, "openrouter_ext": False, "stream_usage": True, "ollama_details": True, "metered": False},
+    "local": {"needs_key": False, "openrouter_ext": False, "stream_usage": True, "ollama_details": False, "metered": False},
 }
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -3566,6 +3566,15 @@ def test_ollama_cloud_models_are_listed_but_not_free(my_predbat):
         print("ERROR: resolving a hosted provider mutated the shared PROVIDERS table")
         failed = True
 
+    # Only Ollama itself speaks Ollama's native API. 'local' is the generic OpenAI-compatible
+    # option - llama.cpp, LM Studio and the rest - which serve neither /api/tags nor /api/show, so
+    # claiming otherwise would 404 the whole catalogue and leave those endpoints with no models at
+    # all, not merely make some pointless requests.
+    for name, native in (("ollama", True), ("local", False), ("openai", False), ("openrouter", False)):
+        if PROVIDERS[name]["ollama_details"] is not native:
+            print("ERROR: {} has ollama_details={}, expected {}".format(name, PROVIDERS[name]["ollama_details"], native))
+            failed = True
+
     # A local catalogue is what you just changed by pulling something, so it must not be trusted
     # for a day the way a hosted one is - that is exactly "I pulled a model and it never appeared".
     if LOCAL_MODEL_CACHE_MINUTES >= MODEL_CACHE_MINUTES:

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -35,8 +35,12 @@ from chat import (
     COMPLETION_RATE_LIMIT_DELAYS_SECONDS,
     COMPLETION_RATE_LIMIT_MAX_ATTEMPTS,
     is_free_model,
+    LOCAL_MODEL_CACHE_MINUTES,
     max_attempts_for,
+    MODEL_CACHE_MINUTES,
     MODEL_CACHE_VERSION,
+    ollama_native_url,
+    ollama_tags_to_catalogue,
     model_cache_name,
     resolve_provider,
     parse_retry_after,
@@ -3483,6 +3487,93 @@ def test_a_conversation_model_does_not_survive_a_provider_switch(my_predbat):
     return failed
 
 
+def test_ollama_cloud_models_are_listed_but_not_free(my_predbat):
+    """A cloud model reaches the picker, and is not offered as free.
+
+    Ollama's cloud models run on somebody else's hardware and are paid for, but the server
+    offering them is your own and publishes no prices - so the "local endpoint, therefore free"
+    rule is exactly wrong for them, and "show only free models" would otherwise hand a user a
+    billable model under a filter asking for the opposite.
+
+    Only /api/tags says which models those are: remote_model and remote_host appear there and not
+    in the OpenAI-compatible /v1/models shim. Both endpoints list the same models - checked
+    against a live server with a cloud model pulled - so this is about telling them apart, not
+    about which are visible.
+    """
+    failed = False
+    print("**** Testing that Ollama cloud models are listed but not free ****")
+
+    # The shape /api/tags really returns, taken from a live server.
+    tags = {
+        "models": [
+            {"name": "gpt-oss:20b", "model": "gpt-oss:20b", "details": {}},
+            {"name": "gpt-oss:120b-cloud", "model": "gpt-oss:120b-cloud", "remote_model": "gpt-oss:120b", "remote_host": "https://ollama.com", "details": {}},
+        ]
+    }
+    catalogue = ollama_tags_to_catalogue(tags)
+    if [entry["id"] for entry in catalogue["data"]] != ["gpt-oss:20b", "gpt-oss:120b-cloud"]:
+        print("ERROR: the tags response did not become a catalogue: {}".format(catalogue))
+        return True
+    if catalogue["data"][0]["remote"] or not catalogue["data"][1]["remote"]:
+        print("ERROR: remote was not read from remote_model/remote_host: {}".format(catalogue))
+        failed = True
+
+    agent = _make_agent(my_predbat, providers={"ollama": {"type": "ollama", "url": "http://192.168.0.33:11434/v1"}})
+    agent.select_provider("ollama")
+
+    async def no_details(models, base_url=None):
+        """Skip the live /api/show enrichment."""
+        return models
+
+    agent._add_ollama_details = no_details
+    models = {entry["id"]: entry for entry in asyncio.run(agent._catalogue_to_models(catalogue, agent.provider, agent.base_url, None))}
+
+    if "gpt-oss:120b-cloud" not in models:
+        print("ERROR: the cloud model did not reach the picker: {}".format(sorted(models)))
+        failed = True
+    elif models["gpt-oss:120b-cloud"]["free"]:
+        print("ERROR: a cloud model was offered as free: {}".format(models["gpt-oss:120b-cloud"]))
+        failed = True
+    if not models.get("gpt-oss:20b", {}).get("free"):
+        print("ERROR: a genuinely local model stopped being free: {}".format(models.get("gpt-oss:20b")))
+        failed = True
+
+    # The native endpoint is derived from the OpenAI base by stripping a trailing /v1 - and only
+    # a whole trailing segment, or "/v1beta" would be truncated to nothing and a quite different
+    # server asked for its models.
+    for base, expected in (
+        ("http://192.168.0.33:11434/v1", "http://192.168.0.33:11434/api/tags"),
+        ("https://ollama.com/v1", "https://ollama.com/api/tags"),
+        ("http://192.168.0.33:11434", "http://192.168.0.33:11434/api/tags"),
+        ("https://host/v1beta", "https://host/v1beta/api/tags"),
+    ):
+        if ollama_native_url(base, "/api/tags") != expected:
+            print("ERROR: {} derived {}, expected {}".format(base, ollama_native_url(base, "/api/tags"), expected))
+            failed = True
+
+    # Ollama is free on your own machine and paid for at ollama.com, serving the identical API and
+    # publishing no prices either way - so where it is decides whether its models are free.
+    hosted = resolve_provider("ollama", "https://ollama.com/v1")[1]
+    local = resolve_provider("ollama", "http://192.168.0.33:11434/v1")[1]
+    if hosted["metered"] is not True or local["metered"] is not False:
+        print("ERROR: metered is not decided by where the endpoint is: hosted={} local={}".format(hosted["metered"], local["metered"]))
+        failed = True
+    if is_free_model(hosted, None, None):
+        print("ERROR: a model on hosted Ollama was offered as free")
+        failed = True
+    # And resolving one must not have edited the shared table for everybody else.
+    if PROVIDERS["ollama"]["metered"] is not False:
+        print("ERROR: resolving a hosted provider mutated the shared PROVIDERS table")
+        failed = True
+
+    # A local catalogue is what you just changed by pulling something, so it must not be trusted
+    # for a day the way a hosted one is - that is exactly "I pulled a model and it never appeared".
+    if LOCAL_MODEL_CACHE_MINUTES >= MODEL_CACHE_MINUTES:
+        print("ERROR: a local catalogue is cached as long as a hosted one: {} vs {}".format(LOCAL_MODEL_CACHE_MINUTES, MODEL_CACHE_MINUTES))
+        failed = True
+    return failed
+
+
 def test_stop_reaches_a_turn_that_is_still_streaming(my_predbat):
     """Stop ends a turn mid-completion, rather than waiting for the model to finish talking.
 
@@ -3791,6 +3882,7 @@ def run_chat_tests(my_predbat):
     failed |= test_a_working_catalogue_clears_the_previous_failure(my_predbat)
     failed |= test_local_models_are_free_however_little_pricing_they_publish(my_predbat)
     failed |= test_stop_reaches_a_turn_that_is_still_streaming(my_predbat)
+    failed |= test_ollama_cloud_models_are_listed_but_not_free(my_predbat)
     failed |= test_a_conversation_model_does_not_survive_a_provider_switch(my_predbat)
     failed |= test_component_gating(my_predbat)
     failed |= test_provider_detection_and_payload(my_predbat)

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -3483,6 +3483,107 @@ def test_a_conversation_model_does_not_survive_a_provider_switch(my_predbat):
     return failed
 
 
+def test_stop_reaches_a_turn_that_is_still_streaming(my_predbat):
+    """Stop ends a turn mid-completion, rather than waiting for the model to finish talking.
+
+    Every other stop check sits between tool rounds or between tool calls. The completion itself
+    is the longest part of a turn - minutes on a reasoning model - and is exactly when somebody
+    reaches for Stop, so pressing it there did nothing at all until the model finished on its own,
+    with the timer visibly climbing.
+
+    What the model had already said is kept: the browser has rendered those deltas, and dropping
+    them would make them vanish on the next reload with nothing to explain it. Only the text -
+    half-built tool_calls from an interrupted stream must never be stored, because an assistant
+    message whose tool_calls were never answered makes the provider reject every later turn.
+    """
+    failed = False
+    print("**** Testing that Stop reaches a streaming turn ****")
+
+    agent = _agent_with_fake(my_predbat, [])
+    cid = asyncio.run(agent.store.create())
+    delivered = []
+
+    async def stream_until_stopped(payload):
+        """Stream a few words, then behave as a model that keeps talking indefinitely."""
+        for index in range(200):
+            # Stop lands after the third chunk, standing in for the user pressing the button while
+            # the model is still going.
+            if index == 3:
+                agent.stop_requested = (agent.active or {}).get("turn_id")
+            delivered.append(index)
+            yield {"choices": [{"delta": {"content": "word{} ".format(index)}}]}
+        yield {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+
+    agent._stream_chunks = stream_until_stopped
+    asyncio.run(agent.run_turn(cid, "tell me everything"))
+
+    # It stopped near where the button was pressed rather than draining all 200 chunks.
+    if len(delivered) > 10:
+        print("ERROR: the stream ran on for {} chunks after Stop".format(len(delivered)))
+        failed = True
+
+    events = agent.events_since(0, cid)[0]
+    errors = [event for event in events if event["type"] == "error"]
+    if not errors:
+        print("ERROR: nothing told the user the turn had stopped")
+        failed = True
+    elif "Stopped" not in errors[-1]["data"].get("message", ""):
+        # A deliberate Stop is not a timeout, and saying "took longer than 1800 seconds" to
+        # somebody who pressed the button is simply untrue.
+        print("ERROR: a deliberate stop was reported as a timeout: {}".format(errors[-1]["data"]))
+        failed = True
+
+    stored = asyncio.run(agent.store.get_messages(cid))
+    assistants = [message for message in stored if message.get("role") == "assistant"]
+    if not assistants:
+        print("ERROR: the partial answer was dropped, so it vanishes on the next reload")
+        failed = True
+    elif "word0" not in (assistants[-1].get("content") or ""):
+        print("ERROR: what the model had already said was not kept: {}".format(assistants[-1]))
+        failed = True
+    if any(message.get("tool_calls") for message in stored):
+        print("ERROR: an interrupted stream stored tool_calls that were never answered: {}".format(stored))
+        failed = True
+
+    # And a stop aimed at a finished turn cannot cut the next one short.
+    agent2 = _agent_with_fake(my_predbat, _text_response("all done here"))
+    cid2 = asyncio.run(agent2.store.create())
+    agent2.stop_requested = 999
+    asyncio.run(agent2.run_turn(cid2, "and again"))
+    replies = [message for message in asyncio.run(agent2.store.get_messages(cid2)) if message.get("role") == "assistant"]
+    # Checked on the words rather than the sentence: _text_response streams each word as its own
+    # delta with no separator, so the stored content runs the words together - asserting the spaced
+    # sentence would fail on the fixture's shape rather than on anything this test is about.
+    if not replies or "done" not in (replies[-1].get("content") or ""):
+        print("ERROR: a stale stop id cut a different turn short: {}".format(replies))
+        failed = True
+    if [event for event in agent2.events_since(0, cid2)[0] if event["type"] == "error"]:
+        print("ERROR: a stale stop id reported the next turn as stopped")
+        failed = True
+
+    # The turn-id match itself, asserted directly. submit_turn() already clears stop_requested at
+    # the start of every turn, so no end-to-end path can reach a mismatched id - which makes this
+    # defence in depth, and means only a direct check can show it works. It is what keeps a stop
+    # aimed at one turn from ending whichever turn has since claimed the single slot.
+    agent2.deadline = time.monotonic() + 60
+    agent2.active = {"turn_id": 7}
+    agent2.stop_requested = 6
+    if agent2.stop_reason() is not None:
+        print("ERROR: a stop aimed at another turn ended this one: {}".format(agent2.stop_reason()))
+        failed = True
+    agent2.stop_requested = 7
+    if agent2.stop_reason() != "stopped":
+        print("ERROR: a stop aimed at the running turn was ignored: {}".format(agent2.stop_reason()))
+        failed = True
+    # And a blown deadline with no stop is a timeout, not a stop.
+    agent2.stop_requested = None
+    agent2.deadline = 0
+    if agent2.stop_reason() != "timeout":
+        print("ERROR: a blown deadline was not reported as a timeout: {}".format(agent2.stop_reason()))
+        failed = True
+    return failed
+
+
 def test_local_models_are_free_however_little_pricing_they_publish(my_predbat):
     """Every model on an unmetered endpoint is free, including one that quotes no price at all.
 
@@ -3689,6 +3790,7 @@ def run_chat_tests(my_predbat):
     failed |= test_model_catalogue_is_cached_per_endpoint(my_predbat)
     failed |= test_a_working_catalogue_clears_the_previous_failure(my_predbat)
     failed |= test_local_models_are_free_however_little_pricing_they_publish(my_predbat)
+    failed |= test_stop_reaches_a_turn_that_is_still_streaming(my_predbat)
     failed |= test_a_conversation_model_does_not_survive_a_provider_switch(my_predbat)
     failed |= test_component_gating(my_predbat)
     failed |= test_provider_detection_and_payload(my_predbat)

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -27,13 +27,16 @@ import aiohttp
 import chat
 from chat import (
     CHAT_DEFAULTS,
+    PROVIDERS,
     PROVIDER_DEFAULT_MODELS,
     build_providers,
     extract_providers,
     COMPLETION_MAX_ATTEMPTS,
     COMPLETION_RATE_LIMIT_DELAYS_SECONDS,
     COMPLETION_RATE_LIMIT_MAX_ATTEMPTS,
+    is_free_model,
     max_attempts_for,
+    MODEL_CACHE_VERSION,
     model_cache_name,
     resolve_provider,
     parse_retry_after,
@@ -3480,6 +3483,68 @@ def test_a_conversation_model_does_not_survive_a_provider_switch(my_predbat):
     return failed
 
 
+def test_local_models_are_free_however_little_pricing_they_publish(my_predbat):
+    """Every model on an unmetered endpoint is free, including one that quotes no price at all.
+
+    Ollama's /v1/models has no pricing field, so the picker - which worked the answer out from the
+    quoted price - treated every local model as not-free and the "show only free models" filter
+    emptied the list. The box is ticked by default, so an Ollama user's first sight of the picker
+    was an empty one on a server where nothing costs anything.
+
+    The rule has to live here rather than in the browser because only this side knows what the
+    endpoint is: an absent price means "free" on a local server and "unknown, so assume not" on a
+    metered one.
+    """
+    failed = False
+    print("**** Testing that local models count as free ****")
+
+    metered = PROVIDERS["openrouter"]
+    unmetered = PROVIDERS["ollama"]
+
+    # The case that was broken: no pricing at all, on hardware you own.
+    if not is_free_model(unmetered, None, None):
+        print("ERROR: a local model with no quoted price is not free")
+        failed = True
+    if not is_free_model(unmetered, "0.000002", "0.00001"):
+        print("ERROR: a local model is not free even when a price is somehow quoted")
+        failed = True
+
+    # And the metered rules are unchanged. A quoted zero is free; a routing model quoting -1 is
+    # not, because its cost depends on where it routes; an absent price is not free either.
+    if not is_free_model(metered, "0", "0"):
+        print("ERROR: a zero-priced hosted model is not free")
+        failed = True
+    if is_free_model(metered, "-1", "-1"):
+        print("ERROR: a routing model quoting -1 was offered as free")
+        failed = True
+    if is_free_model(metered, "0.000002", "0.00001"):
+        print("ERROR: a billable model was offered as free")
+        failed = True
+    if is_free_model(metered, None, None):
+        print("ERROR: a hosted model with no quoted price was assumed free")
+        failed = True
+
+    # And it reaches the catalogue entries the picker actually filters on, including the
+    # apps.yaml default injected when the catalogue could not be read - which for a local
+    # endpoint is exactly the situation this bug left with an empty picker.
+    agent = _make_agent(my_predbat, providers={"ollama": {"type": "ollama", "url": "http://localhost:11434/v1", "model": "gpt-oss:20b"}})
+    agent.select_provider("ollama")
+
+    async def no_details(models, base_url=None):
+        """Skip the live /api/show enrichment."""
+        return models
+
+    agent._add_ollama_details = no_details
+    entries = asyncio.run(agent._catalogue_to_models({"data": [{"id": "qwen3:latest"}]}, agent.provider, agent.base_url, agent.default_model))
+    if not entries or not all(entry.get("free") for entry in entries):
+        print("ERROR: not every local catalogue entry is marked free: {}".format(entries))
+        failed = True
+    if "gpt-oss:20b" not in [entry["id"] for entry in entries]:
+        print("ERROR: the apps.yaml default was not offered: {}".format(entries))
+        failed = True
+    return failed
+
+
 def test_a_working_catalogue_clears_the_previous_failure(my_predbat):
     """A reason from an earlier failed fetch does not outlive it.
 
@@ -3529,6 +3594,11 @@ def test_model_catalogue_is_cached_per_endpoint(my_predbat):
         failed = True
     if openrouter == "models":
         print("ERROR: the cache name is still the shared literal")
+        failed = True
+    # Versioned, so a change to how entries are built does not spend a day being served from a
+    # cache written before it - the "free" flag was exactly that kind of change.
+    if "_v{}_".format(MODEL_CACHE_VERSION) not in openrouter:
+        print("ERROR: the cache name carries no schema version: {}".format(openrouter))
         failed = True
 
     # And the name list_models() actually asks storage for is that one, per provider.
@@ -3618,6 +3688,7 @@ def run_chat_tests(my_predbat):
     failed = False
     failed |= test_model_catalogue_is_cached_per_endpoint(my_predbat)
     failed |= test_a_working_catalogue_clears_the_previous_failure(my_predbat)
+    failed |= test_local_models_are_free_however_little_pricing_they_publish(my_predbat)
     failed |= test_a_conversation_model_does_not_survive_a_provider_switch(my_predbat)
     failed |= test_component_gating(my_predbat)
     failed |= test_provider_detection_and_payload(my_predbat)

--- a/apps/predbat/tests/test_web_chat.py
+++ b/apps/predbat/tests/test_web_chat.py
@@ -2542,8 +2542,11 @@ def test_model_picker_free_only_filter(my_predbat):
     browsable and keeps a user from picking something billable by accident. Unticking shows
     everything.
 
-    "Free" means the catalogue quotes zero both ways. The routing models quote -1, because their
-    cost depends on where they route - they must not be offered as free.
+    Which models are free is decided by the server, not from the quoted price here: only that side
+    knows what the endpoint is. Reading it from the price - which this did - meant a local endpoint
+    publishing no pricing had every model treated as not-free, so the filter emptied the picker on
+    an Ollama server where everything is free. With the box ticked by default, that was the first
+    thing a new Ollama user saw. See is_free_model() in chat.py for the rule itself.
 
     Mutation checks: defaulting the filter off, dropping the current-model exemption, or letting
     a non-free model through, each fails below.
@@ -2557,9 +2560,10 @@ def test_model_picker_free_only_filter(my_predbat):
     if free_check is None:
         print("ERROR: there is no isFreeModel() to filter on")
         return True
-    # Anchored to the formatter, so "varies" (the -1 routing models) can never read as free.
-    if "formatModelPrice" not in free_check or "'free'" not in free_check:
-        print("ERROR: isFreeModel() does not decide from the formatted price: {!r}".format(free_check))
+    # Anchored to the server's own answer. Deriving it here from the price is the bug: a local
+    # endpoint quotes none, and "no price" is not "not free".
+    if "model.free" not in free_check or "formatModelPrice" in free_check:
+        print("ERROR: isFreeModel() does not take the server's answer: {!r}".format(free_check))
         failed = True
 
     default_read = _extract_function_body(script, "readFreeOnly")

--- a/apps/predbat/tests/test_web_chat.py
+++ b/apps/predbat/tests/test_web_chat.py
@@ -3158,6 +3158,13 @@ def test_settings_script_wires_the_provider_routes(my_predbat):
         if marker not in script:
             print("ERROR: the conversation dropdown is missing {!r}".format(marker))
             failed = True
+    # A provider where nothing is free - Ollama Cloud, for one - hits the free filter with no
+    # search term, and "No free model matches \"\"" reads as a broken picker rather than a ticked
+    # box. Saying how many models are behind the filter is what turns it into an instruction.
+    if "Nothing this provider offers is free" not in script:
+        print("ERROR: a provider with no free models has no empty-state message of its own")
+        failed = True
+
     if "'chat-no-provider'" not in script:
         print("ERROR: nothing shows or hides the no-provider banner")
         failed = True

--- a/apps/predbat/tests/test_web_chat.py
+++ b/apps/predbat/tests/test_web_chat.py
@@ -27,7 +27,7 @@ from aiohttp.test_utils import make_mocked_request
 from ruamel.yaml import YAML
 
 import web_chat
-from chat import AgentNotReadyError
+from chat import AgentNotReadyError, PROVIDER_DEFAULT_URLS
 from components import Components
 from tests.test_chat import _make_agent
 from web import WebInterface
@@ -2756,8 +2756,24 @@ def test_provider_list_route_never_hands_a_key_to_the_browser(my_predbat):
         print("ERROR: the provider types offered are missing openrouter/ollama: {}".format(sorted(types)))
         failed = True
     else:
-        if types["ollama"]["url"] != "http://localhost:11434/v1" or types["ollama"]["model"] != "gpt-oss:20b":
-            print("ERROR: ollama defaults are wrong: {}".format(types["ollama"]))
+        # The Ollama form is prefilled with Ollama's own cloud rather than localhost. localhost is
+        # the right reading of an existing entry that names no url - which is why
+        # PROVIDER_DEFAULT_URLS still says so - but it is almost never right for a new install,
+        # because Predbat runs inside its Home Assistant container where localhost is the
+        # container. The note is what makes that a suggestion rather than a trap.
+        if types["ollama"]["url"] != "https://ollama.com/v1" or types["ollama"]["model"] != "gpt-oss:120b":
+            print("ERROR: the ollama form is not prefilled with the cloud endpoint: {}".format(types["ollama"]))
+            failed = True
+        if "localhost" not in types["ollama"].get("note", ""):
+            print("ERROR: nothing tells the user how to point Ollama at their own server: {}".format(types["ollama"].get("note")))
+            failed = True
+        # Resolution of an existing apps.yaml entry is deliberately unchanged, so an install that
+        # relies on the localhost fallback today keeps working.
+        if PROVIDER_DEFAULT_URLS["ollama"] != "http://localhost:11434/v1":
+            print("ERROR: the apps.yaml fallback for ollama changed, which repoints working installs")
+            failed = True
+        if types["openrouter"].get("note"):
+            print("ERROR: a type with nothing to explain carries a note anyway: {}".format(types["openrouter"]))
             failed = True
         if types["ollama"]["needs_key"] or not types["openrouter"]["needs_key"]:
             print("ERROR: needs_key is wrong for ollama/openrouter: {}".format(types))
@@ -3147,6 +3163,21 @@ def test_settings_script_wires_the_provider_routes(my_predbat):
         if marker not in script:
             print("ERROR: the settings script is missing {!r}".format(marker))
             failed = True
+    # The type's setup note has to reach the form, not just the payload: it is the only thing that
+    # explains a prefilled URL at the moment somebody is deciding whether to keep it.
+    if 'id="chat-provider-url-note"' not in web_chat.get_chat_body():
+        print("ERROR: the URL field has nowhere to show its note")
+        failed = True
+    open_form = script[script.index("function openProviderForm") : script.index("function closeProviderForm")]
+    if "chat-provider-url-note" not in open_form or "defaults.note" not in open_form:
+        print("ERROR: opening the form does not show the type's note: {!r}".format(open_form))
+        failed = True
+    # And not over an existing provider, where it would explain a default the user did not choose
+    # against the URL they did.
+    if "entry ?" not in open_form:
+        print("ERROR: the note is shown when editing an existing provider, not only when adding")
+        failed = True
+
     if "original_name: entry.original_name" not in script:
         print("ERROR: the save payload does not carry original_name, so a rename would lose the key")
         failed = True

--- a/apps/predbat/web_chat.py
+++ b/apps/predbat/web_chat.py
@@ -2611,7 +2611,18 @@ function renderModelResults(filter) {
         empty.className = 'chat-model-empty';
         // Naming the filter matters here: with it on, a search for a paid model returns nothing
         // and the reason is a checkbox the user may have forgotten is ticked.
-        empty.textContent = state.freeOnly ? 'No free model matches "' + filter + '" - untick "Show only free models" to search them all' : 'No model matches "' + filter + '"';
+        //
+        // The no-search-term case is its own message rather than 'No free model matches ""',
+        // because it is a real configuration - a provider where nothing is free, such as Ollama
+        // Cloud - rather than a search that found nothing. Saying how many models are behind the
+        // filter is what turns "this is broken" into "untick that".
+        if (!state.freeOnly) {
+            empty.textContent = filter ? 'No model matches "' + filter + '"' : 'No models offered';
+        } else if (filter) {
+            empty.textContent = 'No free model matches "' + filter + '" - untick "Show only free models" to search them all';
+        } else {
+            empty.textContent = 'Nothing this provider offers is free - untick "Show only free models" to see ' + (state.models || []).length + ' paid models';
+        }
         list.appendChild(empty);
     } else if (matches.length > shown.length) {
         var more = document.createElement('div');

--- a/apps/predbat/web_chat.py
+++ b/apps/predbat/web_chat.py
@@ -24,7 +24,7 @@ import time
 from aiohttp import web
 from ruamel.yaml import YAML
 
-from chat import AgentNotReadyError, ChatBusyError, PROVIDER_DEFAULT_URLS, PROVIDERS, conversation_model_for, default_model_for
+from chat import AgentNotReadyError, ChatBusyError, PROVIDER_DEFAULT_URLS, PROVIDER_SETUP_HINTS, PROVIDERS, conversation_model_for, default_model_for
 from utils import ROOT_YAML_KEY, SECRET_MASK, YAML_DUMP_WIDTH
 
 SSE_POLL_SECONDS = 0.1
@@ -712,8 +712,25 @@ def provider_type_choices():
     configured has to dial somewhere - and wrong here, where it would prefill a form for a local
     or generic OpenAI-compatible endpoint with openrouter.ai and invite the user to save it.
     A type with no genuine default offers none, and the URL field starts empty.
+
+    PROVIDER_SETUP_HINTS overrides both where a fresh setup wants something different from what an
+    existing entry resolves to - see its comment for why Ollama does. The note it carries is shown
+    under the URL field, which is the only place a prefilled value can be explained at the moment
+    somebody is deciding whether to keep it.
     """
-    return [{"type": name, "url": PROVIDER_DEFAULT_URLS.get(name, ""), "model": default_model_for(name) or "", "needs_key": bool(settings["needs_key"])} for name, settings in PROVIDERS.items()]
+    choices = []
+    for name, settings in PROVIDERS.items():
+        hint = PROVIDER_SETUP_HINTS.get(name, {})
+        choices.append(
+            {
+                "type": name,
+                "url": hint.get("url", PROVIDER_DEFAULT_URLS.get(name, "")),
+                "model": hint.get("model", default_model_for(name) or ""),
+                "needs_key": bool(settings["needs_key"]),
+                "note": hint.get("note", ""),
+            }
+        )
+    return choices
 
 
 def plain_yaml_value(value):
@@ -2080,6 +2097,7 @@ def get_chat_body():
             <div class="chat-field">
                 <label for="chat-provider-url">URL</label>
                 <input type="text" id="chat-provider-url" {autofill_off} spellcheck="false">
+                <span id="chat-provider-url-note" class="chat-field-note"></span>
             </div>
             <div class="chat-field">
                 <label for="chat-provider-key">API key</label>
@@ -4270,6 +4288,9 @@ function openProviderForm(index) {
     byId('chat-provider-key').value = '';
     byId('chat-provider-model-options').innerHTML = '';
     setProviderNote('chat-provider-model-note', '');
+    // Only when adding. Editing an existing provider must not explain a prefilled default over
+    // the URL the user actually chose and is looking at.
+    setProviderNote('chat-provider-url-note', entry ? '' : (defaults.note || ''));
     updateKeyNote();
     byId('chat-provider-form').classList.add('open');
     showSettingsError('');
@@ -4294,6 +4315,15 @@ function updateKeyNote() {
     if (entry && (entry.has_key || entry.api_key)) {
         input.placeholder = 'A key is already saved - leave blank to keep it';
         setProviderNote('chat-provider-key-note', 'Type a new key to replace it. Clearing it is not possible from here - remove the provider instead.');
+        return;
+    }
+    // A type whose form is prefilled with a hosted endpoint cannot claim a key is unnecessary -
+    // it is, for the endpoint sitting in the URL box above - but it is genuinely not needed if the
+    // user follows the note and points it at their own server. Said once, covering both, rather
+    // than reimplementing the server's is-this-address-local rule in the browser to guess which.
+    if (defaults && defaults.note) {
+        input.placeholder = 'Needed for a hosted endpoint';
+        setProviderNote('chat-provider-key-note', 'Needed for the hosted endpoint above. Leave it empty if you change the URL to a server of your own.');
         return;
     }
     if (defaults && !defaults.needs_key) {
@@ -4324,6 +4354,7 @@ function changeProviderType() {
     }
     byId('chat-provider-model-options').innerHTML = '';
     setProviderNote('chat-provider-model-note', '');
+    setProviderNote('chat-provider-url-note', defaults.note || '');
     updateKeyNote();
 }
 

--- a/apps/predbat/web_chat.py
+++ b/apps/predbat/web_chat.py
@@ -2513,10 +2513,12 @@ function updateModelNote() {
 }
 
 function isFreeModel(model) {
-    // Free means the catalogue quotes zero for both directions, which is what formatModelPrice
-    // already reduces to. The routing models, which quote -1 because their cost depends on where
-    // they route, are not free and must not be offered as if they were.
-    return formatModelPrice(model) === 'free';
+    // Decided by the server, which is the only side that knows what the endpoint is - see
+    // is_free_model() in chat.py. Reading it from the quoted price here, which is what this did,
+    // meant a local endpoint publishing no pricing had every model treated as not-free, and
+    // "show only free models" - ticked by default - emptied the picker on an Ollama server where
+    // everything is free.
+    return model.free === true;
 }
 
 function appendFreeOnlyRow(list) {

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -2013,6 +2013,30 @@ Settings dialog gives the same message while you are still typing the address. A
 sleeps takes its models with it, so a desktop running Ollama needs to be awake when you ask
 Predbat something.
 
+### Ollama Cloud
+
+Ollama also runs models on its own hardware, which you reach as an ordinary provider rather than
+through your local server:
+
+```yaml
+  chat:
+    providers:
+      ollama_cloud:
+        type: ollama
+        url: 'https://ollama.com/v1'
+        model: gpt-oss:120b
+        api_key: !secret ollama_cloud_api_key
+```
+
+Two things to get right. The URL is `https://ollama.com/v1` - not `/api/v1`, which is a 404 - and
+the model ids there are plain (`gpt-oss:120b`), without the `-cloud` suffix a *local* server uses
+when it refers to a cloud model it has pulled.
+
+Unlike your own machine, this is a paid service, so Predbat treats its models as billable: the
+Chat tab's **Show only free models** box will hide all of them, and tells you how many are behind
+it. The same provider type pointed at a local address is free, because it is your own hardware -
+where Ollama runs decides which it is, not what the entry is called.
+
 A hosted endpoint needs an **api_key**; a local one needs only a **url** and no key at all. The name is yours to choose - it is what appears in the Chat tab - so you can have two of the same kind:
 
 ```yaml

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -1974,12 +1974,30 @@ Everything the chat agent uses lives in one **chat** block. Endpoints go under *
   chat:
     providers:
       openrouter:
+        type: openrouter
+        url: 'https://openrouter.ai/api/v1'
+        model: nvidia/nemotron-3-ultra-550b-a55b:free
         api_key: !secret openrouter_api_key
-        model: openai/gpt-4o-mini      # optional
       ollama:
+        type: ollama
         url: 'http://localhost:11434/v1'
-        model: qwen3:latest            # optional
+        model: gpt-oss:20b
+      ollama_cloud:
+        type: ollama
+        url: 'https://ollama.com/v1'
+        model: gpt-oss:120b
+        api_key: !secret ollama_cloud_api_key
 ```
+
+That is a complete, working example with all three kinds of endpoint - a hosted aggregator, a
+server of your own, and Ollama's paid cloud - and you can delete whichever you do not want. The
+local one shows `localhost`, which is only right if Ollama runs on the same machine as Predbat;
+see [Reaching Ollama from Predbat](#reaching-ollama-from-predbat), because inside Home Assistant
+it usually does not.
+
+Every field above except **api_key** is optional. Left out, **type** is taken from the entry's
+name and **url** and **model** from the defaults below - so `openrouter:` with just a key is a
+working provider on its own.
 
 You do not have to write this block by hand. The Chat tab's **Settings** dialog adds, edits and removes providers and saves them here for you, keeping the rest of the file - including your comments - as it was; see [Chat View](web-interface.md#chat-view). It never shows you a saved API key, and leaving the key box empty when editing a provider keeps whatever is already in the file.
 


### PR DESCRIPTION
Two bugs found in live testing. Both touch `chat.py`, so they share a branch rather than guaranteeing a conflict between two PRs.

## 1. "Show only free models" emptied the picker on Ollama

Ollama's `/v1/models` publishes no pricing. The picker worked out whether a model was free from the quoted price, so every local model came out not-free and the filter emptied the list. That box is ticked by default, so it was an Ollama user's first sight of the picker — empty, on a server where nothing costs anything.

The rule can't live in the browser: an absent price means *free* on hardware you own and *unknown, so assume not* on a metered endpoint, and only the server knows which it is talking to.

- `PROVIDERS` gains a `metered` flag — true for OpenRouter and OpenAI, false for Ollama and local.
- `is_free_model()` applies it, and every catalogue entry carries the answer.
- The client filter reads that answer instead of deriving one it has no basis for.

Metered behaviour is unchanged: a quoted zero is free, an absent price is not, and the routing models quoting `-1` stay out — offering those as free would bill someone who asked not to be.

The catalogue is cached for a day, so entries written before this carry no flag and would have gone on filtering to nothing. The cache name now carries a schema version, retiring them immediately rather than letting the fix arrive silently up to a day later.

## 2. Stop did nothing while the model was thinking

Every stop check sat between tool rounds or between tool calls. The completion itself is the longest part of a turn — minutes on a reasoning model — and is exactly when somebody reaches for Stop, so pressing it did nothing until the model finished on its own, with the timer climbing and the button apparently dead.

It's now checked on every streamed chunk, the only code that runs during a completion. What the model had already said is kept, because the browser has rendered those deltas and dropping them would make them vanish on the next reload. Text only — half-built `tool_calls` from an interrupted stream are discarded, since an assistant message whose tool calls were never answered makes the provider reject every later turn in the conversation.

Raised as `TurnStopped` rather than a `ChatRequestError`, so the retry wrapper doesn't catch it: retrying a turn the user just stopped is the opposite of what they asked for.

A deliberate Stop also no longer reports itself as a timeout. All three existing checkpoints said "this turn took longer than 1800 seconds", which is untrue of a button pressed on purpose.

## Testing

Ten mutations applied across both fixes, all caught. One needed a second look: the stale-stop-id guard survived its first mutation because `submit_turn()` already clears `stop_requested` per turn, so no end-to-end path can reach a mismatched id. It's defence in depth, and is now asserted directly rather than through a test that couldn't see it.

Full suite green, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)