### PR TITLE
fix: add yaml language tag to Hanchu iESS bridge script code block

### DIFF
--- a/docs/inverter-setup.md
+++ b/docs/inverter-setup.md
@@ -652,7 +652,8 @@ All four of Predbat's service hooks call the same script, `script.hanchu_set_sta
 
 Create a new script (Settings → Automations & Scenes → Scripts → Add Script → Edit in YAML) and paste the following, replacing `YOURSERIAL` with your device serial number as it appears in your HA entity IDs, and replacing `notify.notify` with your own mobile notification service:
 
-```alias: Hanchu Set State Queued
+```yaml
+alias: Hanchu Set State Queued
 mode: queued
 fields:
   mode_action:


### PR DESCRIPTION
## Summary

Adds the missing `yaml` language tag to the Hanchu iESS bridge script 
code block in `docs/inverter-setup.md`.

The opening fence was ```` ```alias: Hanchu Set State Queued ```` instead 
of ```` ```yaml ```` which caused the script to render as unformatted text 
on the live documentation page rather than as a syntax-highlighted code block.