### PR TITLE
Accept Octopus free-session events with code: null

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -3267,12 +3267,14 @@ class Octopus:
                         start = event.get("start", None)
                         end = event.get("end", None)
                         code = event.get("code", None)
-                        if start and end and code:
+                        if start and end:
                             start_time = str2time(start)  # reformat the saving session start & end time for improved readability
                             end_time = str2time(end)
                             diff_time = start_time - self.now_utc
                             if abs(diff_time.days) <= 3:
-                                self.log("Octopus: free events code {} {}-{}".format(code, start_time.strftime("%a %d/%m %H:%M"), end_time.strftime("%H:%M")))
+                                # Auto-joined events (e.g. Weekend Happy Hours) publish code: null - only
+                                # "available to join" events carry a code, so fall back to the event id.
+                                self.log("Octopus: free events code {} {}-{}".format(code or event.get("id"), start_time.strftime("%a %d/%m %H:%M"), end_time.strftime("%H:%M")))
                             octopus_free_slot = {}
                             octopus_free_slot["start"] = start
                             octopus_free_slot["end"] = end

--- a/apps/predbat/tests/test_saving_session.py
+++ b/apps/predbat/tests/test_saving_session.py
@@ -229,6 +229,53 @@ friendly_name: Octopus Intelligent Saving Sessions
     return failed
 
 
+def test_octopus_free_session_null_code(my_predbat):
+    """
+    Test that octopus_free_session accepts booked/auto-joined events published with code: null
+    (e.g. Weekend Happy Hours) - issue #4835. Only "available to join" events carry a code, so
+    gating on it dropped genuine, already-booked free periods.
+    """
+    print("Test octopus_free_session with code: null (issue #4835)")
+    ha = my_predbat.ha_interface
+    failed = False
+
+    free_session_events = """
+events:
+    - id: 5798
+      code: null
+      start: '2026-08-30T12:00:00+01:00'
+      end: '2026-08-30T13:00:00+01:00'
+      duration_in_minutes: 60
+    - id: 5800
+      code: 'OCTOPLUS-99999'
+      start: '2026-08-30T14:00:00+01:00'
+      end: '2026-08-30T15:00:00+01:00'
+      duration_in_minutes: 60
+"""
+    ha.dummy_items["event.octopus_energy_a_12345678_octoplus_free_electricity_session_events"] = yaml.safe_load(free_session_events)
+    my_predbat.args["octopus_free_session"] = "event.octopus_energy_a_12345678_octoplus_free_electricity_session_events"
+    if "octopus_saving_session" in my_predbat.args:
+        del my_predbat.args["octopus_saving_session"]
+    if "octopus_free_url" in my_predbat.args:
+        del my_predbat.args["octopus_free_url"]
+    if "octopus_free_electricity" in my_predbat.args:
+        del my_predbat.args["octopus_free_electricity"]
+
+    octopus_free_slots, octopus_saving_slots = my_predbat.fetch_octopus_sessions()
+
+    expected_free = [
+        {"start": "2026-08-30T12:00:00+01:00", "end": "2026-08-30T13:00:00+01:00", "rate": 0},
+        {"start": "2026-08-30T14:00:00+01:00", "end": "2026-08-30T15:00:00+01:00", "rate": 0},
+    ]
+    if octopus_free_slots != expected_free:
+        print("ERROR: Expected free slots {} got {}".format(expected_free, octopus_free_slots))
+        failed = True
+
+    if not failed:
+        print("PASS: code: null free-session event is accepted, same as one with a real code")
+    return failed
+
+
 def test_saving_session_notify_config(my_predbat):
     """
     Test that set_event_notify configuration controls Octopus saving session notifications

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -78,6 +78,7 @@ from tests.test_single_debug import run_single_debug
 from tests.test_saving_session import (
     test_saving_session,
     test_saving_session_null_octopoints,
+    test_octopus_free_session_null_code,
     test_saving_session_notify_config,
     test_saving_session_default_rate,
     test_saving_session_axle_conflict,
@@ -529,6 +530,7 @@ def main():
         ("energydataservice", run_energydataservice_tests, "Energy data service tests", False),
         ("saving_session", test_saving_session, "Saving session tests", False),
         ("saving_session_null", test_saving_session_null_octopoints, "Saving session null octopoints test (issue #3079)", False),
+        ("octopus_free_session_null_code", test_octopus_free_session_null_code, "Octopus free-session code: null acceptance test (issue #4835)", False),
         ("saving_session_notify", test_saving_session_notify_config, "Saving session notification config tests", False),
         ("saving_session_default_rate", test_saving_session_default_rate, "Saving session default rate injection test", False),
         ("saving_session_axle_conflict", test_saving_session_axle_conflict, "Saving session Axle conflict avoidance test (issue #4120)", False),


### PR DESCRIPTION
## Summary
- `fetch_octopus_sessions()`'s `octopus_free_session` handling required a truthy `code` on every event, but auto-joined/booked events like Weekend Happy Hours are published with `code: null` - only "available to join" events carry a code. That silently dropped genuine free periods with no log trace, causing Predbat to price them at the normal rate and potentially schedule an export window across a free-import period.
- Two sibling code paths handling the same kind of event already gate on `start`/`end` alone (`octopus_free_electricity` at `octopus.py:3295`, and the Octopus Direct API publisher at `octopus.py:1275`) - this fixes the outlier to match.
- `code` was never used downstream (the resulting slot only carries `start`/`end`/`rate`), so dropping the requirement is safe. Kept it for the diagnostic log line only, falling back to the event `id` when it's null.

Fixes #4835

## Test plan
- [x] Added `test_octopus_free_session_null_code`, verified to actually fail against the pre-fix code (drops the null-code event) before trusting it
- [x] `saving_session`, `saving_session_null`, and the new test all pass
- [x] `./run_pre_commit` passes (black/ruff/cspell/markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)