### PR TITLE
fix: mask the Octopus API key on the What If tab as a password field

### DIFF
--- a/apps/predbat/tests/test_web_annual.py
+++ b/apps/predbat/tests/test_web_annual.py
@@ -488,12 +488,12 @@ def test_web_annual_form(my_predbat):
         # It is a secret credential, so it should not be readable as plain text
         # over someone's shoulder or in a screen share, unlike the account id.
         key_row = re.search(r'<label for="load_octopus_api_key".*?</div>', wide_form, re.S)
-        if not key_row or 'type="password"' not in key_row.group(0):
-            print('  ERROR: load_octopus_api_key should render as type="password"')
+        if not key_row or 'type="password"' not in key_row.group(0) or 'autocomplete="off"' not in key_row.group(0):
+            print('  ERROR: load_octopus_api_key should render as type="password" with autocomplete="off"')
             failed = True
         account_row = re.search(r'<label for="load_octopus_account_id".*?</div>', wide_form, re.S)
-        if not account_row or 'type="text"' not in account_row.group(0):
-            print('  ERROR: load_octopus_account_id should still render as type="text"')
+        if not account_row or 'type="text"' not in account_row.group(0) or "autocomplete" in account_row.group(0):
+            print('  ERROR: load_octopus_account_id should still render as a plain type="text" field, unaffected by the API key masking')
             failed = True
 
         print("Test: selecting a basic-rates tariff uses THAT tariff, not the price-cap default")

--- a/apps/predbat/tests/test_web_annual.py
+++ b/apps/predbat/tests/test_web_annual.py
@@ -484,6 +484,18 @@ def test_web_annual_form(my_predbat):
                 print("  ERROR: {} should be rendered as a wide field".format(field))
                 failed = True
 
+        print("Test: the Octopus API key is masked like a password field")
+        # It is a secret credential, so it should not be readable as plain text
+        # over someone's shoulder or in a screen share, unlike the account id.
+        key_row = re.search(r'<label for="load_octopus_api_key".*?</div>', wide_form, re.S)
+        if not key_row or 'type="password"' not in key_row.group(0):
+            print('  ERROR: load_octopus_api_key should render as type="password"')
+            failed = True
+        account_row = re.search(r'<label for="load_octopus_account_id".*?</div>', wide_form, re.S)
+        if not account_row or 'type="text"' not in account_row.group(0):
+            print('  ERROR: load_octopus_account_id should still render as type="text"')
+            failed = True
+
         print("Test: selecting a basic-rates tariff uses THAT tariff, not the price-cap default")
         # The bug this pins: the dropdown only ever populated the URL boxes, and
         # config_from_post read the boxes. A basic-rates entry has no URL, so both boxes

--- a/apps/predbat/web_annual.py
+++ b/apps/predbat/web_annual.py
@@ -340,7 +340,7 @@ class AnnualPage:
             name=name, label=label, step=step, value=html.escape(str(value), quote=True) if value is not None else "", suffix=" {}".format(suffix) if suffix else ""
         )
 
-    def _text_field(self, name, label, value, wide=False):
+    def _text_field(self, name, label, value, wide=False, secret=False):
         """Return one labelled text input row.
 
         ``value`` is HTML-escaped before interpolation - it is user-controlled
@@ -349,9 +349,13 @@ class AnnualPage:
         ``wide`` puts the input on its own full-width line beneath the label, for the
         long values - rates URLs and API keys - that are otherwise shown through a
         keyhole and cannot be read or checked without scrolling within the box.
+
+        ``secret`` renders the input as type="password" so the value is masked on
+        screen (a shoulder-surfing / screen-share concern for an API key), while
+        it can still be pasted, selected and submitted like any other text input.
         """
-        return '<div class="annual-field{wide}"><label for="{name}">{label}</label><input type="text" id="{name}" name="{name}" value="{value}"></div>\n'.format(
-            name=name, label=label, wide=" annual-field-wide" if wide else "", value=html.escape(str(value), quote=True) if value is not None else ""
+        return '<div class="annual-field{wide}"><label for="{name}">{label}</label><input type="{type}" id="{name}" name="{name}" value="{value}" autocomplete="off"></div>\n'.format(
+            name=name, label=label, wide=" annual-field-wide" if wide else "", type="password" if secret else "text", value=html.escape(str(value), quote=True) if value is not None else ""
         )
 
     @staticmethod
@@ -520,7 +524,7 @@ class AnnualPage:
         # _validate_load treats the two as mutually exclusive.
         saved_octopus = load.get("octopus") or {}
         args_key, args_account = self._octopus_from_args()
-        text += self._text_field("load_octopus_api_key", "Octopus API key", saved_octopus.get("api_key") or (args_key if args_key and args_account else "") or "", wide=True)
+        text += self._text_field("load_octopus_api_key", "Octopus API key", saved_octopus.get("api_key") or (args_key if args_key and args_account else "") or "", wide=True, secret=True)
         text += self._text_field("load_octopus_account_id", "Account ID", saved_octopus.get("account_id") or (args_account if args_key and args_account else "") or "", wide=True)
         text += '<p class="annual-note">Your meter readings already include any car charging, so the figures above are not used with this option.</p>\n'
         # An import meter records what was BOUGHT, not what the house used. On a home that
@@ -1828,7 +1832,7 @@ annualLoadPlan();
    rather than beside it, so they can use the full width without pushing the form wide;
    max-width keeps them inside the column on a narrow screen. */
 .annual-field.annual-field-wide label { display: block; min-width: 0; margin-bottom: 0.15rem; }
-.annual-field-wide input[type="text"] { width: 100%; max-width: 60rem; box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9rem; }
+.annual-field-wide input[type="text"], .annual-field-wide input[type="password"] { width: 100%; max-width: 60rem; box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9rem; }
 .annual-subgroup { margin-left: 1.5rem; }
 /* Each array is its own block. Without this the Remove button of one array sat directly
    against the "Array N" heading of the next, reading as though it belonged to the array

--- a/apps/predbat/web_annual.py
+++ b/apps/predbat/web_annual.py
@@ -353,9 +353,17 @@ class AnnualPage:
         ``secret`` renders the input as type="password" so the value is masked on
         screen (a shoulder-surfing / screen-share concern for an API key), while
         it can still be pasted, selected and submitted like any other text input.
+        It also sets autocomplete="off", since a password-type input is otherwise
+        a candidate for the browser's saved-password manager, which is the wrong
+        prompt for a site API key; other fields are unaffected.
         """
-        return '<div class="annual-field{wide}"><label for="{name}">{label}</label><input type="{type}" id="{name}" name="{name}" value="{value}" autocomplete="off"></div>\n'.format(
-            name=name, label=label, wide=" annual-field-wide" if wide else "", type="password" if secret else "text", value=html.escape(str(value), quote=True) if value is not None else ""
+        return '<div class="annual-field{wide}"><label for="{name}">{label}</label><input type="{type}" id="{name}" name="{name}" value="{value}"{autocomplete}></div>\n'.format(
+            name=name,
+            label=label,
+            wide=" annual-field-wide" if wide else "",
+            type="password" if secret else "text",
+            autocomplete=' autocomplete="off"' if secret else "",
+            value=html.escape(str(value), quote=True) if value is not None else "",
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- The What If tab's Octopus API key field rendered as a plain `type="text"` input, showing the key in the clear on screen.
- It now renders as `type="password"`, masking the value while still allowing paste, select, and normal form submission — the account id field is untouched.

## Test plan
- [x] `./run_all --test web_annual_form` — includes a new assertion that `load_octopus_api_key` renders `type="password"` and `load_octopus_account_id` stays `type="text"`
- [x] `./run_pre_commit` — full pre-commit suite (black, ruff, cspell, unit tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)