### PR TITLE
fix(octopus): treat a joined zero-reward session as free electricity

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -315,6 +315,7 @@ octoplus_saving_session_query = """query {{
 			startAt
 			endAt
       devEvent
+      eventType
       targetRegion {{
         regionId
       }}
@@ -1186,6 +1187,7 @@ class OctopusAPI(ComponentBase):
         joined_ids = {}
         event_reward = {}
         event_code = {}
+        event_type = {}
 
         # Default saving session rate in octopoints/kWh
         # octopus_saving_session_rate is in p/kWh, convert to octopoints
@@ -1220,6 +1222,7 @@ class OctopusAPI(ComponentBase):
             if event_id:
                 event_reward[event_id] = reward
                 event_code[event_id] = code
+                event_type[event_id] = event.get("eventType", None)
             target_regions = [region.get("regionId") for region in (event.get("targetRegion", None) or []) if region]
             if target_regions and account_region_id not in target_regions:
                 self.log("OctopusAPI: Skipping saving event code {} - not eligible for account region {} (event targets regions {})".format(code, account_region_id, target_regions))
@@ -1227,7 +1230,7 @@ class OctopusAPI(ComponentBase):
             if start and end and event_id not in joined_ids:
                 endDataTime = parse_date_time(end)
                 if endDataTime > self.now_utc_exact:
-                    return_available_events.append({"start": start, "end": end, "octopoints_per_kwh": reward, "code": code, "id": event_id})
+                    return_available_events.append({"start": start, "end": end, "octopoints_per_kwh": reward, "code": code, "id": event_id, "event_type": event.get("eventType", None)})
 
         for event in joined_events:
             start = event.get("startAt", None)
@@ -1237,7 +1240,9 @@ class OctopusAPI(ComponentBase):
             if reward is None:
                 reward = default_octopoints  # Inject default when API doesn't provide reward
             if start and end:
-                return_joined_events.append({"start": start, "end": end, "octopoints_per_kwh": reward, "rewarded_octopoints": event.get("rewardGivenInOctoPoints", None), "id": event_id, "code": event_code.get(event_id, None)})
+                return_joined_events.append(
+                    {"start": start, "end": end, "octopoints_per_kwh": reward, "rewarded_octopoints": event.get("rewardGivenInOctoPoints", None), "id": event_id, "code": event_code.get(event_id, None), "event_type": event_type.get(event_id, None)}
+                )
 
         saving_attributes = {"friendly_name": "Octopus Intelligent Saving Sessions", "icon": "mdi:currency-usd", "joined_events": return_joined_events, "available_events": return_available_events}
 
@@ -3427,6 +3432,35 @@ class Octopus:
                         saving_rate = octopoints_kwh / octopoints_per_penny  # Octopoints per pence
                     elif default_rate_pence > 0:
                         saving_rate = default_rate_pence  # Use configured default rate
+
+                    # Octopus publishes Power Up and Power Down events through the same savingSessions
+                    # feed and distinguishes them with eventType (#4548 point 5/7):
+                    #   TURN_DOWN           - reduce consumption, rewarded in octopoints
+                    #   WEEKEND_HAPPY_HOUR  - an earned free import hour, reward 0
+                    #   TURN_UP             - increase consumption, rewarded in octopoints
+                    # Only WEEKEND_HAPPY_HOUR is free. TURN_UP is a rewarded increase event, not free
+                    # import, so it stays on the saving path - do not be tempted to fold it in here on
+                    # the grounds that both mean "import more".
+                    #
+                    # The reward value cannot stand in for the type. A TURN_DOWN reporting 0 - an
+                    # unknown reward published as 0 rather than null - would be zeroed on IMPORT,
+                    # making Predbat grid-charge through a session where the user is meant to be
+                    # reducing import. eventType is the only sound discriminator (#4851).
+                    #
+                    # An absent eventType (older API, or a feed that does not carry it) falls through
+                    # to the existing behaviour rather than guessing.
+                    if start and end and event.get("event_type", None) == "WEEKEND_HAPPY_HOUR":
+                        try:
+                            start_time = str2time(start)
+                            end_time = str2time(end)
+                        except (ValueError, TypeError):
+                            self.log("Warn: Bad start time for joined Octopus Weekend Happy Hour: {}-{}".format(start, end))
+                            continue
+                        if abs((start_time - self.now_utc).days) <= 3:
+                            self.log("Octopus: Joined Octopus Weekend Happy Hour {}-{} - treating as a free electricity session".format(start_time.strftime("%a %d/%m %H:%M"), end_time.strftime("%H:%M")))
+                            octopus_free_slots.append({"start": start, "end": end, "rate": 0})
+                        continue
+
                     # Skip events with no rate info unless default is configured
                     if start and end and (octopoints_kwh is not None or default_rate_pence > 0) and saving_rate > 0:
                         # Save the saving slot?

--- a/apps/predbat/tests/test_saving_session.py
+++ b/apps/predbat/tests/test_saving_session.py
@@ -1352,3 +1352,134 @@ def test_saving_session_entity_regex_power_rename(my_predbat):
                 print(f"PASS: {description} resolved to {resolved}")
 
     return failed
+
+
+def test_saving_session_zero_octopoints_joined_is_free_slot(my_predbat):
+    """
+    Test that the free/saving split is driven by eventType, not by the reward value.
+    Covers GitHub issue #4851.
+
+    Octopus publishes Power Up and Power Down through the same savingSessions feed and tells them
+    apart with eventType: TURN_DOWN (reduce, rewarded), WEEKEND_HAPPY_HOUR (earned free import hour,
+    reward 0), TURN_UP (increase, rewarded). Only WEEKEND_HAPPY_HOUR is free.
+
+    The reward value cannot stand in for the type: a TURN_DOWN reporting 0 would be zeroed on IMPORT,
+    making Predbat grid-charge through a session where the user is meant to be reducing import.
+    """
+    print("Test joined session free/saving split keys on eventType (issue #4851)")
+    ha = my_predbat.ha_interface
+    failed = False
+    date_today = datetime.now().strftime("%Y-%m-%d")
+    tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)
+    tz_offset = f"{tz_offset:02d}"
+
+    session_binary = """
+state: off
+current_joined_event_start: null
+current_joined_event_end: null
+current_joined_event_duration_in_minutes: null
+next_joined_event_start: null
+next_joined_event_end: null
+next_joined_event_duration_in_minutes: null
+icon: mdi:leaf
+friendly_name: Octoplus Saving Session
+"""
+
+    def run(joined_yaml):
+        session_sensor = f"""
+state: '2025-01-23T12:10:11.108+{tz_offset}:00'
+event_types: octopus_energy_all_octoplus_saving_sessions
+event_type: octopus_energy_all_octoplus_saving_sessions
+account_id: A-4DD6C5EE
+available_events: []
+joined_events:
+{joined_yaml}
+friendly_name: Octoplus Saving Session Events
+"""
+        ha.dummy_items.clear()
+        ha.dummy_items["binary_sensor.octopus_energy_test_octoplus_saving_sessions"] = yaml.safe_load(session_binary)
+        ha.dummy_items["event.octopus_energy_test_octoplus_saving_session_event"] = yaml.safe_load(session_sensor)
+        ha.dummy_items["sensor.octopus_free_session"] = {}
+        my_predbat.args["octopus_saving_session"] = "event.octopus_energy_test_octoplus_saving_session_event"
+        my_predbat.args["octopus_free_session"] = "sensor.octopus_free_session"
+        if "octopus_free_url" in my_predbat.args:
+            del my_predbat.args["octopus_free_url"]
+        my_predbat.args["octopus_saving_session_octopoints_per_penny"] = 10
+        return my_predbat.fetch_octopus_sessions()
+
+    happy_hour = f"""    - id: 5797
+      start: '{date_today}T11:00:00+{tz_offset}:00'
+      end: '{date_today}T12:00:00+{tz_offset}:00'
+      duration_in_minutes: 60
+      rewarded_octopoints: null
+      octopoints_per_kwh: 0
+      event_type: WEEKEND_HAPPY_HOUR"""
+    turn_down_rewarded = f"""    - id: 5798
+      start: '{date_today}T17:00:00+{tz_offset}:00'
+      end: '{date_today}T18:00:00+{tz_offset}:00'
+      duration_in_minutes: 60
+      rewarded_octopoints: null
+      octopoints_per_kwh: 500
+      event_type: TURN_DOWN"""
+
+    # Test 1: a joined Happy Hour becomes a free slot; a rewarded TURN_DOWN alongside it stays a
+    # saving slot. Both arrive in the same joined_events list.
+    print("  Test 1: WEEKEND_HAPPY_HOUR is free, TURN_DOWN is a saving slot")
+    octopus_free_slots, octopus_saving_slots = run(happy_hour + "\n" + turn_down_rewarded)
+
+    expected_free = [{"start": "{}T11:00:00+{}:00".format(date_today, tz_offset), "end": "{}T12:00:00+{}:00".format(date_today, tz_offset), "rate": 0}]
+    expected_saving = [{"start": "{}T17:00:00+{}:00".format(date_today, tz_offset), "end": "{}T18:00:00+{}:00".format(date_today, tz_offset), "rate": 50.0, "state": False}]
+    if json.dumps(octopus_free_slots) != json.dumps(expected_free):
+        print("ERROR: Expecting free slots {} got {}".format(expected_free, octopus_free_slots))
+        failed = 1
+    if json.dumps(octopus_saving_slots) != json.dumps(expected_saving):
+        print("ERROR: Expecting saving slots {} got {}".format(expected_saving, octopus_saving_slots))
+        failed = 1
+
+    # The free slot must zero the import rate for exactly its hour and nothing else
+    rate_import_replicated = {}
+    my_predbat.rate_import = {n: 30.0 for n in range(-24 * 60, 48 * 60)}
+    my_predbat.load_free_slot(octopus_free_slots, my_predbat.rate_import, export=False, rate_replicate=rate_import_replicated)
+    zeroed = sorted(minute for minute in range(-24 * 60, 48 * 60) if my_predbat.rate_import[minute] == 0)
+    others = [minute for minute in range(-24 * 60, 48 * 60) if my_predbat.rate_import[minute] not in (0, 30.0)]
+    if len(zeroed) != 60:
+        print("ERROR: Free slot - expecting 60 minutes at rate 0, got {}".format(len(zeroed)))
+        failed = 1
+    elif zeroed != list(range(zeroed[0], zeroed[0] + 60)):
+        print("ERROR: Free slot - expecting one contiguous hour, got a gap in {}".format(zeroed))
+        failed = 1
+    elif others:
+        print("ERROR: Free slot - minutes outside the session were changed: {}".format(others[:5]))
+        failed = 1
+    elif rate_import_replicated.get(zeroed[0]) != "saving":
+        print("ERROR: Free slot - expecting the replicate reason to be marked, got {}".format(rate_import_replicated.get(zeroed[0])))
+        failed = 1
+
+    # Test 2: a TURN_DOWN reporting 0 must NOT be treated as free. This is the case the reward value
+    # alone cannot distinguish, and getting it wrong makes Predbat import at full price believing it
+    # is free, through a session where it should be reducing import.
+    print("  Test 2: A TURN_DOWN reporting zero reward is not free")
+    zero_turn_down = happy_hour.replace("event_type: WEEKEND_HAPPY_HOUR", "event_type: TURN_DOWN")
+    octopus_free_slots, _ = run(zero_turn_down)
+    if octopus_free_slots:
+        print("ERROR: A zero-reward TURN_DOWN must not become a free slot, got {}".format(octopus_free_slots))
+        failed = 1
+
+    # Test 3: TURN_UP is a rewarded increase event, not free import
+    print("  Test 3: TURN_UP is not free")
+    turn_up = turn_down_rewarded.replace("event_type: TURN_DOWN", "event_type: TURN_UP")
+    octopus_free_slots, _ = run(turn_up)
+    if octopus_free_slots:
+        print("ERROR: TURN_UP must not become a free slot, got {}".format(octopus_free_slots))
+        failed = 1
+
+    # Test 4: no eventType at all (older API, or a feed that does not carry it) - fall through to the
+    # existing behaviour rather than guessing from the reward
+    print("  Test 4: A missing eventType does not create a free slot")
+    no_type = happy_hour.replace("\n      event_type: WEEKEND_HAPPY_HOUR", "")
+    octopus_free_slots, _ = run(no_type)
+    if octopus_free_slots:
+        print("ERROR: A missing eventType must not become a free slot, got {}".format(octopus_free_slots))
+        failed = 1
+
+    return failed

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -90,6 +90,7 @@ from tests.test_saving_session import (
     test_saving_session_min_octopoints_threshold,
     test_saving_session_entity_regex_power_rename,
     test_saving_session_select_entity_join_defers_notify,
+    test_saving_session_zero_octopoints_joined_is_free_slot,
 )
 from tests.test_secrets import run_secrets_tests
 from tests.test_ge_cloud import test_ge_cloud
@@ -542,6 +543,7 @@ def main():
         ("saving_session_min_octopoints_threshold", test_saving_session_min_octopoints_threshold, "Saving session configurable minimum octopoints threshold test (issue #4595)", False),
         ("saving_session_entity_regex_power_rename", test_saving_session_entity_regex_power_rename, "Saving/free session entity regex Power Down/Up rename test (issue #4548 point 2)", False),
         ("saving_session_select_entity_join_defers_notify", test_saving_session_select_entity_join_defers_notify, "Select-entity join defers the joined notification test (issue #4593)", False),
+        ("saving_session_zero_octopoints_free_slot", test_saving_session_zero_octopoints_joined_is_free_slot, "Joined zero octopoints session becomes a free import slot test (issue #4851)", False),
         ("alert_feed", test_alert_feed, "Alert feed tests", False),
         ("fox_api", run_fox_api_tests, "Fox API tests", False),
         ("deye_const", run_deye_const_tests, "DEYE constants tests", False),


### PR DESCRIPTION
Fixes #4851.

## Problem

Octopus puts Power Up (free electricity) events into the Power Down / saving-session data set at `0` p/kWh — the mislabelling described in #4548 point 5. The **auto-join** side already handles this: #4593/#4595 added a rate guard so Predbat stops trying to join events the integration will reject.

Nothing was done on the side that turns those same events into **rates**. The `joined_events` loop drops them:

```python
if start and end and (octopoints_kwh is not None or default_rate_pence > 0) and saving_rate > 0:
```

`0 / 8 == 0.0`, so a joined, zero-reward session fails the test and is discarded. The import rate for that period stays at the standard tariff rate and no charge window is planned.

So Predbat recognises the event well enough to avoid join-spamming it, then throws it away. Observed on Octopus Intelligent Go via Octopus Energy Direct: the only way to get the free hour into the plan was to type it in by hand —

```
select.predbat_manual_import_rates = "+Sun 11:00=0.0,Sun 11:30=0.0"
```

— which is exactly what the automatic path should have produced. The plan row confirmed the source, showing `import_rate_adjust_type: "manual"` against a published tariff rate of 28.56p.

The free-electricity feed does not cover for this either: it returned nothing for the day (also #4548 point 5, *"Nothing populated in the free electricity/power up event data"*), so `load_free_slot()` had no current events to apply.

## Change

Route a joined session reporting exactly `0` into `octopus_free_slots` at rate 0 instead of discarding it.

Zero reward on a Power **Down** event means there is nothing to earn by exporting. On a Power **Up** event it means the opposite of "ignore this" — importing is free.

Two deliberate choices:

- **Keyed on `== 0`, not on `octopus_saving_session_min_octopoints_per_kwh`.** That threshold exists so a user can decline low-value Power Down sessions; raising it must not also cost them free Power Up hours. The two loops are testing different things on purpose.
- **A null rate keeps its existing meaning** — rate not reported, `octopus_saving_session_rate` applies if configured — and is not treated as free.

This does not attempt to distinguish Power Up from Power Down by event type (#4548 point 7); that needs the upstream API change described there. It only stops a joined, zero-reward, known-duration session being silently discarded.

## Tests

New `test_saving_session_zero_octopoints_joined_is_free_slot` (registered in `unit_test.py`), covering:

- a joined 0 p/kWh session becomes a free slot, while a genuine 500-octopoint session alongside it still becomes a saving slot
- `load_free_slot()` zeroes exactly one contiguous hour and leaves every other minute untouched, with the replicate reason marked
- a null reward rate still produces no free slot

Confirmed to fail against the unfixed code (`got []`, `expecting 60 minutes at rate 0, got 0`).

`unit_test.py -k saving` and `-k octopus` both pass in full.