### PR TITLE
Report the context length Ollama will actually give, not the model's ceiling

### DIFF
--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -1395,7 +1395,13 @@ class ChatAgent(ComponentBase):
                     info = body.get("model_info") or {}
                     context = next((value for key, value in info.items() if key.endswith("context_length")), None)
                     context = context or model.get("context_length")
-                    # The server's own figure wins where it has one - see the docstring.
+                    # The server's own figure wins where it has one - see the docstring. Falsy is
+                    # deliberately "no answer" rather than an answer of zero throughout: no model
+                    # has a zero-token window, so a 0 from either endpoint is a placeholder or a
+                    # bug, and taking it would replace a usable figure with one that tells the user
+                    # nothing. The client agrees - contextLengthForModel() returns
+                    # `context_length || null` and renderContextUsage() shows the token count alone
+                    # when the limit is falsy.
                     effective = loaded_context.get(model["id"])
                     detailed.append(dict(model, context_length=effective or context))
         except (aiohttp.ClientError, asyncio.TimeoutError):
@@ -1421,6 +1427,8 @@ class ChatAgent(ComponentBase):
         for entry in (body or {}).get("models") or []:
             name = entry.get("model") or entry.get("name")
             context = entry.get("context_length")
+            # A zero is filtered out here rather than downstream, so it can never win over a
+            # model's own figure - see the note beside that comparison.
             if name and context:
                 loaded[name] = context
         return loaded

--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -1356,12 +1356,25 @@ class ChatAgent(ComponentBase):
         One request per model, measured at about 76ms each against a local server, and
         list_models() is cached for a day - but a single slow or missing model must not lose the
         whole catalogue, so a failed lookup keeps the model rather than dropping it.
+
+        /api/show reports the context length baked into the model, which is a ceiling rather than
+        what the model will actually be loaded with: the server caps every model at
+        OLLAMA_CONTEXT_LENGTH - on macOS an Ollama app setting, not an environment variable - and
+        Qwen3.8 27B's 262144 becomes 131072 behind a 128k cap. /api/ps carries the effective value
+        for each loaded model, so it is read once and used in preference. A model the server has
+        never loaded is not listed there and keeps its own ceiling, which is the only answer
+        available and still better than reporting it for everything.
+
+        This matters beyond a wrong number in the picker: the Chat tab's context counter measures
+        fullness against it, so a doubled limit reads half-full at the point the window is really
+        full - which is how a turn overflows with no warning.
         """
         base = ollama_native_url(base_url or self.base_url, "")
         detailed = []
         timeout = aiohttp.ClientTimeout(total=OLLAMA_DETAIL_TIMEOUT_SECONDS)
         try:
             async with aiohttp.ClientSession(timeout=timeout) as session:
+                loaded_context = await self._ollama_loaded_context(session, base)
                 for model in models:
                     try:
                         async with session.post("{}/api/show".format(base), json={"model": model["id"]}) as response:
@@ -1377,10 +1390,36 @@ class ChatAgent(ComponentBase):
                         continue
                     info = body.get("model_info") or {}
                     context = next((value for key, value in info.items() if key.endswith("context_length")), None)
-                    detailed.append(dict(model, context_length=context or model.get("context_length")))
+                    context = context or model.get("context_length")
+                    # The server's own figure wins where it has one - see the docstring.
+                    effective = loaded_context.get(model["id"])
+                    detailed.append(dict(model, context_length=effective or context))
         except (aiohttp.ClientError, asyncio.TimeoutError):
             return models
         return detailed
+
+    @staticmethod
+    async def _ollama_loaded_context(session, base):
+        """Return {model id: context length} for the models the Ollama server has loaded.
+
+        Empty when /api/ps cannot be read or nothing is loaded, which leaves every model on its
+        own ceiling - the same answer as before this existed, so a server too old to serve the
+        endpoint degrades to the previous behaviour rather than losing the catalogue.
+        """
+        try:
+            async with session.get("{}/api/ps".format(base)) as response:
+                if response.status != 200:
+                    return {}
+                body = await response.json()
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
+            return {}
+        loaded = {}
+        for entry in (body or {}).get("models") or []:
+            name = entry.get("model") or entry.get("name")
+            context = entry.get("context_length")
+            if name and context:
+                loaded[name] = context
+        return loaded
 
     async def _stream_chunks(self, payload):
         """Yield decoded chunk dicts from the chat-completions endpoint.

--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -1374,7 +1374,11 @@ class ChatAgent(ComponentBase):
         timeout = aiohttp.ClientTimeout(total=OLLAMA_DETAIL_TIMEOUT_SECONDS)
         try:
             async with aiohttp.ClientSession(timeout=timeout) as session:
-                loaded_context = await self._ollama_loaded_context(session, base)
+                # Only a locally loaded model can have been capped, so a catalogue with nothing
+                # local in it has nothing /api/ps could override. Ollama Cloud refuses that
+                # endpoint anyway - 401 with or without a key, because "loaded" is a local-server
+                # idea - so asking would spend a round trip to learn nothing.
+                loaded_context = {} if all(model.get("remote") for model in models) else await self._ollama_loaded_context(session, base)
                 for model in models:
                     try:
                         async with session.post("{}/api/show".format(base), json={"model": model["id"]}) as response:

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -3889,10 +3889,99 @@ def test_model_catalogue_is_cached_per_endpoint(my_predbat):
     return failed
 
 
+def test_ollama_context_length_is_what_the_server_will_actually_give(my_predbat):
+    """The picker must report the usable context, not the model's architectural ceiling.
+
+    /api/show returns the context length baked into the model - 262144 for Qwen3.8 27B. The
+    server caps every model at OLLAMA_CONTEXT_LENGTH (an Ollama app setting on macOS), so the
+    context the model will actually be loaded with can be half that. Reporting the ceiling makes
+    the Chat tab's context counter measure fullness against a limit that does not exist: it reads
+    50% at the point the window is genuinely full, which is precisely how a turn overflows without
+    warning.
+
+    /api/ps reports context_length for each loaded model, which is the effective value.
+    """
+    failed = False
+    print("**** Testing Ollama context length comes from the server, not the model ****")
+
+    agent = _make_agent(my_predbat, providers={"ollama": {"type": "ollama", "url": "http://127.0.0.1:11434/v1"}})
+    agent.select_provider("ollama")
+
+    shown = {"qwen3.8:27b": 262144, "gpt-oss:20b": 131072, "never-loaded:8b": 262144}
+    loaded = {"qwen3.8:27b": 131072, "gpt-oss:20b": 131072}
+
+    class _Response:
+        """Minimal aiohttp response stand-in for the stubbed session."""
+
+        def __init__(self, payload):
+            self.status = 200
+            self._payload = payload
+
+        async def json(self):
+            """Return the canned body."""
+            return self._payload
+
+        async def __aenter__(self):
+            """Enter the async context."""
+            return self
+
+        async def __aexit__(self, *args):
+            """Leave the async context."""
+            return False
+
+    class _Session:
+        """Stubbed session answering /api/show and /api/ps from the dicts above."""
+
+        def post(self, url, json=None):
+            """Answer an /api/show POST."""
+            model = (json or {}).get("model")
+            return _Response({"capabilities": ["tools"], "model_info": {"qwen35.context_length": shown[model]}})
+
+        def get(self, url):
+            """Answer an /api/ps GET."""
+            return _Response({"models": [{"model": name, "context_length": ctx} for name, ctx in loaded.items()]})
+
+        async def __aenter__(self):
+            """Enter the async context."""
+            return self
+
+        async def __aexit__(self, *args):
+            """Leave the async context."""
+            return False
+
+    original_session = chat.aiohttp.ClientSession
+    chat.aiohttp.ClientSession = lambda *args, **kwargs: _Session()
+    try:
+        models = asyncio.run(agent._add_ollama_details([{"id": name} for name in shown]))
+    finally:
+        chat.aiohttp.ClientSession = original_session
+
+    by_id = {entry["id"]: entry for entry in models}
+
+    if by_id["qwen3.8:27b"].get("context_length") != 131072:
+        print("ERROR: a loaded model should report the server's 131072, not its 262144 ceiling, got {}".format(by_id["qwen3.8:27b"].get("context_length")))
+        failed = True
+
+    if by_id["gpt-oss:20b"].get("context_length") != 131072:
+        print("ERROR: a model whose ceiling already matches the server should be unchanged, got {}".format(by_id["gpt-oss:20b"].get("context_length")))
+        failed = True
+
+    # Nothing is known about a model the server has never loaded, so its own ceiling is the only
+    # answer available - better than inventing one.
+    if by_id["never-loaded:8b"].get("context_length") != 262144:
+        print("ERROR: an unloaded model should fall back to its own ceiling, got {}".format(by_id["never-loaded:8b"].get("context_length")))
+        failed = True
+
+    if not failed:
+        print("✓ Test passed: Ollama context length reflects what the server will give")
+    return failed
+
+
 def run_chat_tests(my_predbat):
     """Run every chat agent test, returning True if any of them failed."""
     failed = False
     failed |= test_model_catalogue_is_cached_per_endpoint(my_predbat)
+    failed |= test_ollama_context_length_is_what_the_server_will_actually_give(my_predbat)
     failed |= test_a_working_catalogue_clears_the_previous_failure(my_predbat)
     failed |= test_local_models_are_free_however_little_pricing_they_publish(my_predbat)
     failed |= test_stop_reaches_a_turn_that_is_still_streaming(my_predbat)

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -4084,12 +4084,84 @@ def test_ollama_context_length_survives_a_server_that_cannot_answer(my_predbat):
     return failed
 
 
+def test_ollama_zero_context_length_is_treated_as_absent(my_predbat):
+    """A context length of zero means "unknown", not "a zero-token window".
+
+    Characterisation test, not a new behaviour: it pins a deliberate choice a reviewer read as an
+    accidental truthiness bug (#4859). No model has a zero-token context, so a 0 from either
+    endpoint is a placeholder or a bug, and letting it through would replace a perfectly good
+    figure with a useless one. The whole chain already agrees - _ollama_loaded_context() keeps only
+    truthy values, and on the client contextLengthForModel() returns `context_length || null` while
+    renderContextUsage() shows the token count alone when the limit is falsy.
+    """
+    failed = False
+    print("**** Testing a zero Ollama context length is treated as absent ****")
+
+    agent = _make_agent(my_predbat, providers={"ollama": {"type": "ollama", "url": "http://127.0.0.1:11434/v1"}})
+    agent.select_provider("ollama")
+
+    class _Response:
+        """Minimal aiohttp response stand-in."""
+
+        def __init__(self, payload):
+            self.status = 200
+            self._payload = payload
+
+        async def json(self):
+            """Return the canned body."""
+            return self._payload
+
+        async def __aenter__(self):
+            """Enter the async context."""
+            return self
+
+        async def __aexit__(self, *args):
+            """Leave the async context."""
+            return False
+
+    class _Session:
+        """A server reporting a zero context for a loaded model."""
+
+        def post(self, url, json=None):
+            """Answer /api/show with a real ceiling."""
+            return _Response({"capabilities": ["tools"], "model_info": {"qwen35.context_length": 262144}})
+
+        def get(self, url):
+            """Answer /api/ps with a zero, as a placeholder or a bug would."""
+            return _Response({"models": [{"model": "qwen3.8:27b", "context_length": 0}]})
+
+        async def __aenter__(self):
+            """Enter the async context."""
+            return self
+
+        async def __aexit__(self, *args):
+            """Leave the async context."""
+            return False
+
+    original_session = chat.aiohttp.ClientSession
+    chat.aiohttp.ClientSession = lambda *args, **kwargs: _Session()
+    try:
+        models = asyncio.run(agent._add_ollama_details([{"id": "qwen3.8:27b"}]))
+    finally:
+        chat.aiohttp.ClientSession = original_session
+
+    context = models[0].get("context_length") if models else None
+    if context != 262144:
+        print("ERROR: a zero from /api/ps should not replace the 262144 ceiling, got {}".format(context))
+        failed = True
+
+    if not failed:
+        print("✓ Test passed: a zero context length falls back rather than propagating")
+    return failed
+
+
 def run_chat_tests(my_predbat):
     """Run every chat agent test, returning True if any of them failed."""
     failed = False
     failed |= test_model_catalogue_is_cached_per_endpoint(my_predbat)
     failed |= test_ollama_context_length_is_what_the_server_will_actually_give(my_predbat)
     failed |= test_ollama_context_length_survives_a_server_that_cannot_answer(my_predbat)
+    failed |= test_ollama_zero_context_length_is_treated_as_absent(my_predbat)
     failed |= test_a_working_catalogue_clears_the_previous_failure(my_predbat)
     failed |= test_local_models_are_free_however_little_pricing_they_publish(my_predbat)
     failed |= test_stop_reaches_a_turn_that_is_still_streaming(my_predbat)

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -3977,11 +3977,119 @@ def test_ollama_context_length_is_what_the_server_will_actually_give(my_predbat)
     return failed
 
 
+def test_ollama_context_length_survives_a_server_that_cannot_answer(my_predbat):
+    """A server that will not serve /api/ps must leave every model on its own ceiling.
+
+    Ollama Cloud answers /api/ps with 401 while serving /api/show unauthenticated, and an older
+    local server may not have the endpoint at all. Neither may cost the catalogue its context
+    lengths - the fallback is exactly the behaviour from before /api/ps was consulted.
+    """
+    failed = False
+    print("**** Testing Ollama context length survives an unavailable /api/ps ****")
+
+    agent = _make_agent(my_predbat, providers={"ollama": {"type": "ollama", "url": "https://ollama.com/v1"}})
+    agent.select_provider("ollama")
+
+    class _ShowResponse:
+        """An /api/show answer carrying the model's own ceiling."""
+
+        status = 200
+
+        async def json(self):
+            """Return the canned body."""
+            return {"capabilities": ["tools"], "model_info": {"qwen35.context_length": 262144}}
+
+        async def __aenter__(self):
+            """Enter the async context."""
+            return self
+
+        async def __aexit__(self, *args):
+            """Leave the async context."""
+            return False
+
+    class _Unauthorized:
+        """What ollama.com returns for /api/ps without a key.
+
+        The body deliberately carries a models array as well as the error. A refusal is not always
+        an empty envelope - a proxy or captive portal can answer with a plausible-looking payload -
+        and without the status check the values in it would be trusted. A body with nothing usable
+        in it would let that check be deleted with every test still passing.
+        """
+
+        status = 401
+
+        async def json(self):
+            """Return an error body that would poison the result if the status were ignored."""
+            return {"error": "unauthorized", "models": [{"model": "qwen3.8:27b", "context_length": 4096}]}
+
+        async def __aenter__(self):
+            """Enter the async context."""
+            return self
+
+        async def __aexit__(self, *args):
+            """Leave the async context."""
+            return False
+
+    class _Session:
+        """Serves /api/show but refuses /api/ps, as Ollama Cloud does."""
+
+        def __init__(self, ps_raises=False):
+            self.ps_raises = ps_raises
+
+        def post(self, url, json=None):
+            """Answer the /api/show POST."""
+            return _ShowResponse()
+
+        def get(self, url):
+            """Refuse the /api/ps GET, by status or by raising."""
+            if self.ps_raises:
+                raise chat.aiohttp.ClientError("connection refused")
+            return _Unauthorized()
+
+        async def __aenter__(self):
+            """Enter the async context."""
+            return self
+
+        async def __aexit__(self, *args):
+            """Leave the async context."""
+            return False
+
+    original_session = chat.aiohttp.ClientSession
+    try:
+        for label, raises in (("401", False), ("a transport error", True)):
+            chat.aiohttp.ClientSession = lambda *args, **kwargs: _Session(ps_raises=raises)
+            models = asyncio.run(agent._add_ollama_details([{"id": "qwen3.8:27b"}]))
+            context = models[0].get("context_length") if models else None
+            if context != 262144:
+                print("ERROR: /api/ps answering {} should leave the model on its 262144 ceiling, got {}".format(label, context))
+                failed = True
+
+        # Ollama Cloud refuses /api/ps with or without a key - verified against ollama.com, where a
+        # key good enough for /v1/models and /api/tags still gets a 401 here, because "loaded" is a
+        # local-server idea. A catalogue with nothing local in it has nothing the endpoint could
+        # override, so it should not spend a round trip finding that out.
+        asked = _Session()
+        calls = []
+        asked.get = lambda url: calls.append(url) or _Unauthorized()
+        chat.aiohttp.ClientSession = lambda *args, **kwargs: asked
+        asyncio.run(agent._add_ollama_details([{"id": "gpt-oss:120b-cloud", "remote": True}]))
+        if calls:
+            print("ERROR: a cloud-only catalogue should not call /api/ps, but it called {}".format(calls))
+            failed = True
+    finally:
+        chat.aiohttp.ClientSession = original_session
+
+    if not failed:
+        print("✓ Test passed: an unavailable /api/ps leaves the ceiling in place")
+    return failed
+
+
 def run_chat_tests(my_predbat):
     """Run every chat agent test, returning True if any of them failed."""
     failed = False
     failed |= test_model_catalogue_is_cached_per_endpoint(my_predbat)
     failed |= test_ollama_context_length_is_what_the_server_will_actually_give(my_predbat)
+    failed |= test_ollama_context_length_survives_a_server_that_cannot_answer(my_predbat)
     failed |= test_a_working_catalogue_clears_the_previous_failure(my_predbat)
     failed |= test_local_models_are_free_however_little_pricing_they_publish(my_predbat)
     failed |= test_stop_reaches_a_turn_that_is_still_streaming(my_predbat)


### PR DESCRIPTION
## Summary

The model picker and the Chat tab's context counter reported a context window twice the real one for local Ollama models.

`/api/show` returns the context length baked into the model — 262144 for Qwen3.8 27B — and that is what the enrichment read. But the server caps every model at `OLLAMA_CONTEXT_LENGTH`, which **on macOS is an Ollama app setting rather than an environment variable** (it lives in the app's own `settings` table and is passed to the server it spawns, so `launchctl getenv` shows nothing while the server still reports it). Behind a 128k cap the same model is loaded with 131072.

Measured on a live server:

| Model | `/api/show` ceiling | Actually loaded | Predbat reported |
| --- | --- | --- | --- |
| `qwen3.8:27b` | 262144 | **131072** | 262144 |
| `qwen3.8:27b-mlx` | 262144 | **131072** | 262144 |
| `gpt-oss:20b` | 131072 | 131072 | 131072 |

## Why it matters beyond a wrong number

The Chat tab's context counter measures fullness against this figure. A doubled limit reads **half-full at the point the window is genuinely full**, so there is no warning before a turn overflows — the same failure #4840 hit from the other direction, where an oversized tool result pushed a conversation past the real limit and the provider answered `no user query found in messages`.

## Fix

`/api/ps` carries `context_length` per loaded model, which is the effective value. It is read once per enrichment pass and preferred over the ceiling.

- A model the server has **never loaded** is not listed there and keeps its own figure. That is the only answer available, and still better than reporting the ceiling for everything.
- Only the raw `/api/tags` response is cached — `_catalogue_to_models()` and this enrichment run on **every** `list_models()` call, so the reported figure tracks what is loaded rather than being frozen for a day.
- A server too old to serve `/api/ps`, or one with nothing loaded, returns an empty map and every model keeps its ceiling: exactly the behaviour before this change, so nothing degrades.

Deliberately Ollama-specific. The same `context_length` field on the OpenRouter path genuinely *is* the usable limit, because there is no local server capping it.

## Testing

Written test-first; the assertion was watched failing (`got 262144`) before the fix existed. The new test covers all three cases — a loaded model whose ceiling exceeds the cap, one whose ceiling already matches, and one the server has never loaded.

Verified against a live Ollama 0.33.2 as well as in the unit test:

```
live /api/ps via the new helper -> {'qwen3.8:27b': 131072}
model ceiling from /api/show    -> 262144
what the picker will now report -> 131072
```

`./run_pre_commit` — exit 0, all hooks passed, full `--quick` suite green.

## Note

Ollama 0.33 also auto-sizes a default context from available VRAM (`vram-based default context, total_vram="51.8 GiB", default_num_ctx=262144`), which the app setting then overrides. That is another reason the model's ceiling is a poor proxy for the usable window: neither number is under Predbat's control, and only the server knows the answer.