### PR TITLE
feat(annual): warn when a solar kWp figure looks like Watts was entered

### DIFF
--- a/apps/predbat/annual.py
+++ b/apps/predbat/annual.py
@@ -122,8 +122,17 @@ def _require_number(value, field, minimum=None, maximum=None, integer=False, exc
         raise AnnualConfigError("{} must be a whole number, got {}".format(field, value))
     try:
         number = int(value) if integer else float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: a value over the float ceiling (a digit-only paste of hundreds
+        # of digits) fails only at conversion, and must surface as this config error
+        # like any other, not as a bare traceback in the caller's except clause.
         raise AnnualConfigError("{} must be a number, got {!r}".format(field, value))
+    # NaN passes every comparison (NaN <= 0 is False), and inf clears a lower bound, so
+    # neither is caught by the range checks below: a YAML "kwp: .nan" would otherwise
+    # validate, flow into the model and render every derived figure as nan/inf - the
+    # most implausible value of all surviving a validation pass that rejects 0 and -3.
+    if not math.isfinite(number):
+        raise AnnualConfigError("{} must be a finite number, got {}".format(field, number))
     if minimum is not None:
         if exclusive_minimum and number <= minimum:
             raise AnnualConfigError("{} must be greater than {}, got {}".format(field, minimum, number))
@@ -149,11 +158,8 @@ def _coerce_bool(value):
 
 def _validate_solar(raw):
     """Normalise the solar array list, applying defaults and rejecting arrays without kwp."""
+    raw = _solar_entries(raw)
     if raw is None:
-        return []
-    if isinstance(raw, dict):
-        raw = [raw]
-    if not isinstance(raw, list):
         raise AnnualConfigError("annual.solar must be a list of arrays")
 
     arrays = []
@@ -483,6 +489,41 @@ def validate_config(config, today=None):
     }
 
 
+def _solar_entries(raw):
+    """Return solar entries as a list, or None when the value is neither a mapping nor a list of them.
+
+    validate_config accepts a single array as a bare mapping (the wrapped YAML form
+    ``solar: {kwp: ...}``) as well as a list; every reader of this field wants the
+    same normalisation, so it lives here rather than being re-derived per caller.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, dict):
+        return [raw]
+    if isinstance(raw, list):
+        return raw
+    return None
+
+
+def _numeric_or_none(value):
+    """Return the value as a finite float, or None when it is not numeric.
+
+    Mirrors _require_number()'s coercion (numeric strings like the quoted figures a
+    hand-edited YAML or a stored form round-trip can carry are accepted) but instead
+    of raising, anything unusable returns None for the caller to skip: this is a
+    warning pass, and a value validation will reject has its own AnnualConfigError.
+    """
+    if isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: an absurd integer (a digit-only paste of hundreds of digits)
+        # is over the float ceiling before it converts, not a conversion failure.
+        return None
+    return number if math.isfinite(number) else None
+
+
 def config_warnings(config):
     """Return a list of non-fatal sanity warnings about a config, for surfacing in the web form.
 
@@ -503,19 +544,18 @@ def config_warnings(config):
         return []
 
     warnings = []
-    solar = raw.get("solar")
-    if isinstance(solar, dict):
-        solar = [solar]
-    if isinstance(solar, list):
-        for index, array in enumerate(solar):
-            if not isinstance(array, dict):
-                continue
-            kwp = array.get("kwp")
-            # bool is an int subclass, and True/False as a peak power is validation's problem.
-            if isinstance(kwp, bool) or not isinstance(kwp, (int, float)):
-                continue
-            if kwp > SOLAR_KWP_SOFT_LIMIT:
-                warnings.append("annual.solar[{}]: peak power {} kWp is far larger than a typical home array. If you entered Watts (Wp) rather than kWp, that is {:g} kWp.".format(index, round(kwp, 2), kwp / 1000.0))
+    solar = _solar_entries(raw.get("solar"))
+    if solar is None:
+        return []
+    for index, array in enumerate(solar):
+        if not isinstance(array, dict):
+            continue
+        kwp = _numeric_or_none(array.get("kwp"))
+        if kwp is None or kwp <= SOLAR_KWP_SOFT_LIMIT:
+            continue
+        # The form labels arrays from 1 while the config indexes them from 0: name
+        # both, so the note can be matched to the field it is talking about.
+        warnings.append("annual.solar[{}] (Array {} in the form): peak power {:g} kWp is far larger than a typical home array. If you entered Watts (Wp) rather than kWp, that is {:g} kWp.".format(index, index + 1, kwp, kwp / 1000.0))
     return warnings
 
 

--- a/apps/predbat/annual.py
+++ b/apps/predbat/annual.py
@@ -46,6 +46,13 @@ DEFAULT_EXPORT_LIMIT_KW = 10.0
 # A typical domestic panel in 2026. Only used to turn a panel count into kWp.
 DEFAULT_PANEL_WATTS = 400.0
 
+# A kWp figure above this in the solar config is far more likely Watts typed by
+# mistake - "6000" meaning 6,000 Wp - than a real array; even a large domestic
+# roof rarely reaches 30 kWp. Deliberately a warning, not a rejection: commercial
+# installations genuinely exceed it (see GH#4858), so the value is accepted and
+# modelled as typed, with config_warnings() flagging the likely mix-up.
+SOLAR_KWP_SOFT_LIMIT = 100.0
+
 # The Open-Meteo ERA5 archive, which the weather module draws on, starts in 1940.
 MINIMUM_YEAR = 1940
 
@@ -474,6 +481,42 @@ def validate_config(config, today=None):
         "pv10_derate_fallback": _require_number(raw.get("pv10_derate_fallback", DEFAULT_PV10_DERATE_FALLBACK), "annual.pv10_derate_fallback", minimum=0, exclusive_minimum=True, maximum=1),
         "raw": scrub_secrets(raw),
     }
+
+
+def config_warnings(config):
+    """Return a list of non-fatal sanity warnings about a config, for surfacing in the web form.
+
+    Unlike validate_config() these never block a run or a save. The case they exist
+    for is GH#4858: a peak power entered in Watts - "6000" meaning 6,000 Wp - in a
+    field that reads as kWp. Nothing downstream sees anything wrong, every derived
+    figure is merely very large rather than implausible, and only the total reads
+    as a 6 MWp roof. Accepts the same wrapped or bare mapping validate_config()
+    does, and is deliberately tolerant of input validate_config() will reject: a
+    malformed value gets its own AnnualConfigError, so warning about it here as
+    well would be noise. Warns only on the kWp field; the panels route (a count
+    times a per-panel wattage) cannot be mistaken for a single Wp figure.
+    """
+    if not isinstance(config, dict):
+        return []
+    raw = config.get("annual", config)
+    if not isinstance(raw, dict):
+        return []
+
+    warnings = []
+    solar = raw.get("solar")
+    if isinstance(solar, dict):
+        solar = [solar]
+    if isinstance(solar, list):
+        for index, array in enumerate(solar):
+            if not isinstance(array, dict):
+                continue
+            kwp = array.get("kwp")
+            # bool is an int subclass, and True/False as a peak power is validation's problem.
+            if isinstance(kwp, bool) or not isinstance(kwp, (int, float)):
+                continue
+            if kwp > SOLAR_KWP_SOFT_LIMIT:
+                warnings.append("annual.solar[{}]: peak power {} kWp is far larger than a typical home array. If you entered Watts (Wp) rather than kWp, that is {:g} kWp.".format(index, round(kwp, 2), kwp / 1000.0))
+    return warnings
 
 
 # Minimal apps.yaml for a headless run. PredBat's Hass base class reads this at

--- a/apps/predbat/annual_cli.py
+++ b/apps/predbat/annual_cli.py
@@ -24,7 +24,7 @@ import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from annual import INCLUDED_STATUSES, SCENARIO_KEYS, AnnualConfigError, AnnualPredictor  # noqa: E402
+from annual import INCLUDED_STATUSES, SCENARIO_KEYS, AnnualConfigError, AnnualPredictor, config_warnings  # noqa: E402
 from storage import StorageLocalFiles  # noqa: E402
 from tariff_catalogue import export_compare_tariffs  # noqa: E402
 
@@ -409,6 +409,14 @@ def main(argv=None, storage_factory=StorageLocalFiles):
     # stdout ahead of the final json.dump() would corrupt the one-JSON-object contract a parent
     # process depends on. The default (non-machine) path keeps log=print unchanged.
     log = _stderr_log if args.machine else print
+
+    # The same sanity warnings the web form surfaces (e.g. a kWp figure that looks like
+    # Watts were entered, GH#4858): a headless run must not be the one place a config
+    # mistake is invisible. Through log rather than a stdout write, so --machine's
+    # one-JSON-object stdout contract holds; machine mode already carries plain text on
+    # stderr alongside the JSON progress lines.
+    for warning in config_warnings(config):
+        log("Warn: Annual: {}".format(warning))
 
     storage = storage_factory(args.work_dir, log)
 

--- a/apps/predbat/tests/test_annual_config.py
+++ b/apps/predbat/tests/test_annual_config.py
@@ -364,6 +364,21 @@ def test_annual_config(my_predbat):
     config["annual"]["solar"] = [{"kwp": 0}]
     failed = expect_error("zero kwp", config, "kwp", failed)
 
+    print("Test: NaN and infinity are rejected as numbers, not silently swept past the bounds")
+    # NaN fails every comparison, so the exclusive-minimum check (NaN <= 0 is False)
+    # used to let it through to the model, which renders every derived figure as nan.
+    for bad in [float("nan"), float("inf"), float("-inf")]:
+        config = base_config()
+        config["annual"]["solar"] = [{"kwp": bad}]
+        try:
+            validate_config(config)
+            print("  ERROR: a {} kwp should be rejected".format(bad))
+            failed = True
+        except AnnualConfigError as error:
+            if "finite" not in str(error):
+                print("  ERROR: expected a 'finite number' message for kwp {}, got {}".format(bad, error))
+                failed = True
+
     print("Test: a kWp figure that looks like Watts warns without being rejected")
     config = base_config()
     config["annual"]["solar"] = [{"kwp": 6000}]
@@ -419,6 +434,61 @@ def test_annual_config(my_predbat):
         except Exception as error:
             print("  ERROR: config_warnings raised {} on junk config {!r}".format(error, junk))
             failed = True
+
+    print("Test: a quoted numeric kWp figure warns too (a hand-edited YAML round-trips as a string)")
+    # validate_config accepts "6000" as a string and models 6000.0 kWp; the warning
+    # pass must coerce the same way or the exact mistyped-Watts case stays silent.
+    warnings = config_warnings({"annual": {"solar": [{"kwp": "6000"}]}})
+    if len(warnings) != 1 or "6 kWp" not in warnings[0]:
+        print("  ERROR: a quoted '6000' kWp should warn with the kWp conversion, got {}".format(warnings))
+        failed = True
+
+    print("Test: the bare unwrapped config form warns (the web layer passes exactly that shape)")
+    warnings = config_warnings({"solar": [{"kwp": 6000}]})
+    if len(warnings) != 1 or "annual.solar[0]" not in warnings[0]:
+        print("  ERROR: an unwrapped config should warn against annual.solar[0], got {}".format(warnings))
+        failed = True
+
+    print("Test: dict-form solar (a single saved mapping) is normalised and warns")
+    warnings = config_warnings({"annual": {"solar": {"kwp": 6000}}})
+    if len(warnings) != 1 or "annual.solar[0]" not in warnings[0]:
+        print("  ERROR: a dict-form solar entry should warn like a list entry, got {}".format(warnings))
+        failed = True
+
+    print("Test: an absurd integer kWp overflows neither the warnings nor validation")
+    # A 400-digit paste clears the float ceiling at conversion: config_warnings skips
+    # it (unconvertible), and validate_config must reject it with an AnnualConfigError
+    # rather than letting a bare OverflowError escape into the CLI/web error handling.
+    try:
+        warnings = config_warnings({"annual": {"solar": [{"kwp": 10**400}]}})
+    except OverflowError:
+        print("  ERROR: a 400-digit kWp figure must not overflow the warning pass")
+        failed = True
+    else:
+        if warnings:
+            print("  ERROR: an unconvertible kWp figure should be left to validation, got {}".format(warnings))
+            failed = True
+    try:
+        config = base_config()
+        config["annual"]["solar"] = [{"kwp": 10**400}]
+        validate_config(config)
+        print("  ERROR: a 400-digit kWp figure should be rejected")
+        failed = True
+    except AnnualConfigError as error:
+        if "must be a number" not in str(error):
+            print("  ERROR: expected an actionable 'must be a number' message, got {}".format(error))
+            failed = True
+    except OverflowError:
+        print("  ERROR: a 400-digit kWp figure must not escape validation as a bare OverflowError")
+        failed = True
+
+    print("Test: the warning names the form's 1-based array label alongside the config index")
+    config = base_config()
+    config["annual"]["solar"] = [{"kwp": 5.6}, {"kwp": 5.6}, {"kwp": 6000}]
+    warnings = config_warnings(config)
+    if len(warnings) != 1 or "(Array 3 in the form)" not in warnings[0] or "annual.solar[2]" not in warnings[0]:
+        print("  ERROR: the third array's warning should name both solar[2] and 'Array 3 in the form', got {}".format(warnings))
+        failed = True
 
     print("Test: an efficiency above 1 is rejected")
     config = base_config()

--- a/apps/predbat/tests/test_annual_config.py
+++ b/apps/predbat/tests/test_annual_config.py
@@ -11,7 +11,7 @@
 
 from datetime import date
 
-from annual import DEFAULT_SAMPLES_PER_MONTH, AnnualConfigError, scrub_secrets, validate_config
+from annual import DEFAULT_SAMPLES_PER_MONTH, AnnualConfigError, config_warnings, scrub_secrets, validate_config
 
 
 def base_config():
@@ -363,6 +363,62 @@ def test_annual_config(my_predbat):
     config = base_config()
     config["annual"]["solar"] = [{"kwp": 0}]
     failed = expect_error("zero kwp", config, "kwp", failed)
+
+    print("Test: a kWp figure that looks like Watts warns without being rejected")
+    config = base_config()
+    config["annual"]["solar"] = [{"kwp": 6000}]
+    validated = validate_config(config, today=date(2026, 7, 25))
+    if abs(validated["solar"][0]["kwp"] - 6000) > 1e-9:
+        print("  ERROR: an oversized array must be accepted as typed, got {}".format(validated["solar"][0]["kwp"]))
+        failed = True
+    warnings = config_warnings(config)
+    if len(warnings) != 1:
+        print("  ERROR: expected one warning for a 6000 kWp array, got {}".format(warnings))
+        failed = True
+    elif "6 kWp" not in warnings[0] or "annual.solar[0]" not in warnings[0]:
+        print("  ERROR: the warning should name the array and suggest the kWp conversion, got {}".format(warnings[0]))
+        failed = True
+
+    print("Test: a normal kWp figure raises no warning")
+    if config_warnings(base_config()):
+        print("  ERROR: a 5.6 kWp array should not warn, got {}".format(config_warnings(base_config())))
+        failed = True
+
+    print("Test: the soft limit itself warns, anything below it does not")
+    config = base_config()
+    config["annual"]["solar"] = [{"kwp": 101}]
+    if len(config_warnings(config)) != 1:
+        print("  ERROR: 101 kWp is above the limit and should warn, got {}".format(config_warnings(config)))
+        failed = True
+    config["annual"]["solar"] = [{"kwp": 100}]
+    if config_warnings(config):
+        print("  ERROR: 100 kWp is at the limit, not above it, and should not warn")
+        failed = True
+
+    print("Test: multiple oversized arrays each get their own warning, indexed correctly")
+    config = base_config()
+    config["annual"]["solar"] = [{"kwp": 6000}, {"kwp": 5.6}, {"kwp": 200}]
+    warnings = config_warnings(config)
+    if len(warnings) != 2 or "annual.solar[0]" not in warnings[0] or "annual.solar[2]" not in warnings[1]:
+        print("  ERROR: expected warnings for arrays 0 and 2 only, got {}".format(warnings))
+        failed = True
+
+    print("Test: a panels-based array does not warn (a per-panel wattage cannot be a mistyped Wp figure)")
+    config = base_config()
+    config["annual"]["solar"] = [{"panels": 6000}]
+    if config_warnings(config):
+        print("  ERROR: a panel count should not trigger the kWp warning")
+        failed = True
+
+    print("Test: warnings tolerate junk validation would reject, without raising")
+    for junk in [None, [], "hello", {}, {"annual": {"solar": [5]}}, {"annual": {"solar": [{"kwp": "not-a-number"}]}}, {"annual": {"solar": [{"kwp": True}]}}]:
+        try:
+            if config_warnings(junk):
+                print("  ERROR: junk config {!r} should produce no warnings, got {}".format(junk, config_warnings(junk)))
+                failed = True
+        except Exception as error:
+            print("  ERROR: config_warnings raised {} on junk config {!r}".format(error, junk))
+            failed = True
 
     print("Test: an efficiency above 1 is rejected")
     config = base_config()

--- a/apps/predbat/tests/test_web_annual.py
+++ b/apps/predbat/tests/test_web_annual.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 from aiohttp import web as aiohttp_web
 
-from annual import AnnualConfigError, validate_config
+from annual import AnnualConfigError, config_warnings, validate_config
 from annual_store import list_runs, load_run, save_run
 from tariff_catalogue import BASELINE_DEFAULT_IMPORT_ID, CUSTOM_ID, EXPORT_TARIFFS, IMPORT_TARIFFS, NO_EXPORT_ID, PRICE_CAP_IMPORT_P
 from web import WebInterface
@@ -992,6 +992,26 @@ def test_web_annual_form(my_predbat):
             failed = True
         if 'value="3800"' not in html_with_error.replace("'", '"'):
             print("  ERROR: the form should stay populated when an error is shown")
+            failed = True
+
+        print("Test: an oversized kWp figure renders a warning; a sane figure renders none")
+        # The Wp-instead-of-kWp mix-up (GH#4858) is shown as a non-blocking note: the
+        # value stands as typed and the form stays runnable.
+        oversized = copy.deepcopy(config)
+        oversized["solar"] = [{"kwp": 6000}]
+        warning_html = page.render_form(oversized, errors=None, warnings=config_warnings(oversized))
+        if "annual-warning" not in warning_html or "6 kWp" not in warning_html:
+            print("  ERROR: an oversized kWp array should render a warning naming the kWp conversion")
+            failed = True
+        if "6000 kWp" not in warning_html:
+            print("  ERROR: the warning should echo the entered figure, got no 6000 kWp in the form")
+            failed = True
+        calm_html = page.render_form(config, warnings=config_warnings(config))
+        if "annual-warning" in calm_html:
+            print("  ERROR: a sane system size should not render a warning")
+            failed = True
+        if page.render_form(config) != page.render_form(config, warnings=None):
+            print("  ERROR: render_form with no warnings should render identically to the no-warnings default")
             failed = True
 
         print("Test: config_from_post rebuilds a config the engine accepts")

--- a/apps/predbat/tests/test_web_annual.py
+++ b/apps/predbat/tests/test_web_annual.py
@@ -1014,6 +1014,37 @@ def test_web_annual_form(my_predbat):
             print("  ERROR: render_form with no warnings should render identically to the no-warnings default")
             failed = True
 
+        print("Test: dict-form solar (a single saved mapping) renders instead of crashing the page")
+        # validate_config accepts a lone array as a bare mapping; the form used to walk
+        # its keys and raise AttributeError on the first string it met.
+        dict_form = copy.deepcopy(config)
+        dict_form["solar"] = {"kwp": 6000}
+        dict_html = page.render_form(dict_form, errors=None, warnings=config_warnings(dict_form))
+        if "annual-warning" not in dict_html or 'id="solar_kwp_0"' not in dict_html:
+            print("  ERROR: dict-form solar should render one array with its warning, not crash")
+            failed = True
+
+        print("Test: the script injects the server's soft limit and thresholds each kWp field")
+        # The live hint exists only through these lines: the injected constant and the
+        # per-array check. Asserting both pins them against a refactor that drops the
+        # concatenation (a missing constant would ReferenceError in every browser while
+        # every test stayed green).
+        script = page.render_script()
+        if "var ANNUAL_SOLAR_KWP_SOFT_LIMIT = 100" not in script:
+            print("  ERROR: render_script should inject the server's SOLAR_KWP_SOFT_LIMIT into the page")
+            failed = True
+        if "kwpValue > ANNUAL_SOLAR_KWP_SOFT_LIMIT" not in script or "Array ' + (index + 1)" not in script:
+            print("  ERROR: the live hint should threshold each kWp field and name its 1-based array")
+            failed = True
+
+        print("Test: html_annual passes config_warnings through to the rendered page")
+        # The only production call site for config_warnings: if this stops being wired
+        # up, the form silently loses the warning while every unit test above stays green.
+        response = asyncio.run(page.html_annual(FakeRequest(), config=copy.deepcopy(oversized)))
+        if "annual-warning" not in response.text:
+            print("  ERROR: the annual page should render the warning from the config it was handed")
+            failed = True
+
         print("Test: config_from_post rebuilds a config the engine accepts")
         postdata = {
             "postcode": "SW1A 1AA",

--- a/apps/predbat/web_annual.py
+++ b/apps/predbat/web_annual.py
@@ -423,10 +423,14 @@ class AnnualPage:
         # An ABSENT solar key means "not configured yet", so offer one blank array to fill
         # in. An explicitly EMPTY list means the user removed them all, which is a valid
         # battery-only run - collapsing the two with `or [{}]` made it impossible to get
-        # to zero arrays through the form.
+        # to zero arrays through the form. A single array may also be saved as a bare
+        # mapping (the wrapped YAML form validate_config accepts), which must be normalised
+        # to a one-element list here or the iteration below would walk the dict's keys.
         solar = config.get("solar")
         if solar is None:
             solar = [{}]
+        elif isinstance(solar, dict):
+            solar = [solar]
         battery = config.get("battery") or {}
         load = config.get("load") or {}
         tariff = config.get("tariff") or {}
@@ -1954,6 +1958,7 @@ function annualSolarModeChanged(index) {
 }
 function annualUpdateSolarTotal() {
   var totalKwp = 0, totalPanels = 0, allPanels = true, index = 0;
+  var hints = [];
   while (document.getElementById('solar_mode_' + index)) {
     var mode = document.getElementById('solar_mode_' + index).value;
     if (mode === 'panels') {
@@ -1963,7 +1968,17 @@ function annualUpdateSolarTotal() {
       totalKwp += count * watts / 1000;
     } else {
       allPanels = false;
-      totalKwp += parseFloat(document.getElementById('solar_kwp_' + index).value) || 0;
+      var kwpValue = parseFloat(document.getElementById('solar_kwp_' + index).value) || 0;
+      totalKwp += kwpValue;
+      // A peak power this large usually means Watts were typed into the kWp field
+      // (GH#4858). Per array, and kWp fields only, matching the server's
+      // config_warnings(): testing the sum instead would question systems the
+      // server deliberately accepts (two genuine 60 kWp arrays, or any panels-mode
+      // array), and dividing the total by 1000 would give every array the wrong
+      // suggested figure. Non-blocking: the value stands, the hint just questions it.
+      if (kwpValue > ANNUAL_SOLAR_KWP_SOFT_LIMIT) {
+        hints.push('Array ' + (index + 1) + ' is ' + kwpValue + ' kWp — if that is Watts (Wp) it would be ' + parseFloat((kwpValue / 1000).toFixed(2)) + ' kWp');
+      }
     }
     index += 1;
   }
@@ -1974,10 +1989,8 @@ function annualUpdateSolarTotal() {
   var label = allPanels && totalPanels > 0
     ? 'Total: ' + totalKwp.toFixed(2) + ' kWp across ' + totalPanels + ' panels'
     : 'Total: ' + totalKwp.toFixed(2) + ' kWp';
-  // A peak power this large usually means Watts were typed into the kWp field (GH#4858).
-  // Non-blocking: the value stands as entered, the hint just questions it.
-  if (totalKwp > ANNUAL_SOLAR_KWP_SOFT_LIMIT) {
-    label = label + ' — this looks like Watts (Wp) rather than kWp; if so it is ' + (totalKwp / 1000).toFixed(2) + ' kWp';
+  if (hints.length) {
+    label = label + ' — ' + hints.join('; ');
   }
   note.textContent = label;
 }

--- a/apps/predbat/web_annual.py
+++ b/apps/predbat/web_annual.py
@@ -25,7 +25,7 @@ import sys
 import yaml
 from aiohttp import web
 
-from annual import INCLUDED_STATUSES, AnnualConfigError, validate_config
+from annual import INCLUDED_STATUSES, SOLAR_KWP_SOFT_LIMIT, AnnualConfigError, config_warnings, validate_config
 from annual_costs import DEFAULT_COSTS, build_costs, resolve_costs
 from annual_job import AnnualJob
 from annual_store import backfill_summaries, delete_run, list_runs, load_plan, load_run, save_run
@@ -410,12 +410,15 @@ class AnnualPage:
         """Return the export catalogue id matching this tariff, or Custom, or None if unset."""
         return cls._selected_side_id(tariff, catalogue, "export_octopus_url", "rates_export")
 
-    def render_form(self, config, errors=None):
+    def render_form(self, config, errors=None, warnings=None):
         """Return the configuration form as HTML, populated from ``config``.
 
         ``errors`` is displayed above the form with every field left as the user
         entered it - losing their input on a validation failure would be worse
-        than the failure.
+        than the failure. ``warnings`` is a list of config_warnings() messages
+        shown the same way in a non-blocking style: sanity checks like kWp
+        entered in Watts are worth surfacing loudly, but the values are accepted
+        exactly as typed.
         """
         # An ABSENT solar key means "not configured yet", so offer one blank array to fill
         # in. An explicitly EMPTY list means the user removed them all, which is a valid
@@ -433,6 +436,8 @@ class AnnualPage:
 
         if errors:
             text += '<div class="annual-error"><strong>Could not run:</strong> {}</div>\n'.format(html.escape(str(errors), quote=True))
+        for warning in warnings or []:
+            text += '<div class="annual-warning"><strong>Note:</strong> {}</div>\n'.format(html.escape(str(warning), quote=True))
 
         if not self.is_configured():
             text += '<div class="annual-banner">Predbat isn\'t configured yet — these are <strong>example values</strong>, edit them to match your home.</div>\n'
@@ -933,7 +938,7 @@ class AnnualPage:
         text += "<body>\n"
         text += self.render_css()
         text += self.render_nav("config")
-        text += self.render_form(config, errors=error)
+        text += self.render_form(config, errors=error, warnings=config_warnings(config))
         text += self.render_script()
         text += "</body></html>\n"
         return web.Response(content_type="text/html", text=text)
@@ -1858,10 +1863,11 @@ annualLoadPlan();
    nowrap (which keeps its columns intact while it scrolls) is untouched.
    The max-width is for readability: prose set across an ultra-wide monitor is hard to
    track from the end of one line back to the start of the next. */
-.annual-form-wrap p, .annual-results p, .annual-compare-scroll p, .annual-banner, .annual-note, .annual-error, .annual-caveats li { white-space: normal; }
-.annual-banner, .annual-error, .annual-caveats li, .annual-form-wrap > p, .annual-results > p { max-width: 80ch; }
+.annual-form-wrap p, .annual-results p, .annual-compare-scroll p, .annual-banner, .annual-note, .annual-error, .annual-warning, .annual-caveats li { white-space: normal; }
+.annual-banner, .annual-error, .annual-warning, .annual-caveats li, .annual-form-wrap > p, .annual-results > p { max-width: 80ch; }
 .annual-banner { border-left: 4px solid #D55E00; padding: 0.5rem 0.75rem; margin-bottom: 1rem; }
 .annual-error { border-left: 4px solid #b00020; padding: 0.5rem 0.75rem; margin-bottom: 1rem; }
+.annual-warning { border-left: 4px solid #b8860b; padding: 0.5rem 0.75rem; margin-bottom: 1rem; }
 .annual-progress { margin: 1rem 0; }
 .annual-bar { height: 1.25rem; border: 1px solid var(--md-border, #cbd5e1); }
 .annual-bar-fill { height: 100%; background: #0072B2; width: 0%; }
@@ -1912,7 +1918,13 @@ table.annual-compare th, table.annual-compare td { padding: 4px 8px 4px 4px; }
 
     def render_script(self):
         """Return the polling and tariff-picker script."""
-        return """<script>
+        # The soft limit is injected from annual.py rather than hardcoded in the JavaScript,
+        # so this live hint and the server's config_warnings() warning cannot drift apart.
+        return (
+            """<script>
+var ANNUAL_SOLAR_KWP_SOFT_LIMIT = """
+            + str(SOLAR_KWP_SOFT_LIMIT)
+            + """;
 function annualTariffChanged(field) {
   // Import and export are independent, so each select drives only its own URL box.
   var sides = {
@@ -1959,9 +1971,15 @@ function annualUpdateSolarTotal() {
   if (!note) { return; }
   // The panel count is shown only when EVERY array was entered as panels. A partial
   // count would read as the whole system's, which is worse than not showing one.
-  note.textContent = allPanels && totalPanels > 0
+  var label = allPanels && totalPanels > 0
     ? 'Total: ' + totalKwp.toFixed(2) + ' kWp across ' + totalPanels + ' panels'
     : 'Total: ' + totalKwp.toFixed(2) + ' kWp';
+  // A peak power this large usually means Watts were typed into the kWp field (GH#4858).
+  // Non-blocking: the value stands as entered, the hint just questions it.
+  if (totalKwp > ANNUAL_SOLAR_KWP_SOFT_LIMIT) {
+    label = label + ' — this looks like Watts (Wp) rather than kWp; if so it is ' + (totalKwp / 1000).toFixed(2) + ' kWp';
+  }
+  note.textContent = label;
 }
 function annualSolarTotalKwp() {
   var total = 0, index = 0;
@@ -2084,3 +2102,4 @@ function annualPoll() {
 annualPoll();
 </script>
 """
+        )


### PR DESCRIPTION
This is an automated draft PR generated from issue #4858 — a maintainer should review it before merging.

Fixes #4858

## Summary

Adds a soft, non-blocking warning when a solar array's peak power exceeds 100 kWp (`SOLAR_KWP_SOFT_LIMIT` in `annual.py`), the size at which a figure entered in the kWp field is more likely Watts typed by mistake — "6000" meaning 6,000 Wp — than a real array. The value is still accepted and modelled exactly as typed, since genuine >100 kWp commercial installations exist; the warning just questions it.

Two surfaces, one threshold:

- **Server-side**: a new `config_warnings()` in `annual.py` (paired with, but separate from, `validate_config()`) renders an indexed warning above the form whenever the config is re-rendered after save, run, array add/remove or reset — e.g. `annual.solar[0]: peak power 6000 kWp is far larger than a typical home array. If you entered Watts (Wp) rather than kWp, that is 6 kWp.`
- **Client-side live hint**: the "Total: N kWp" note under the Solar fieldset appends the same explanation as the user types, with the threshold injected from the server constant so the two cannot drift.

## Testing

- `run_all --test annual_config` and `--test web_annual_form` (plus `tools/triage_test.sh` for both): all pass, including new cases covering the limit boundary (100 no / 101 yes), multi-array indexing, panels-mode exemption, junk-input tolerance, form rendering with/without the warning, and that an oversized figure still validates and runs.
- `./run_pre_commit`: all hooks pass.

## Notes

Approach follows the automated triage of #4858: soft warning rather than hard rejection, threshold chosen at the low end of the 100-200 range the reporter suggested.