### PR TITLE
Triage bot: --ollama/--ollama_review model selection, auto-review opened PRs

### DIFF
--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -230,6 +230,18 @@ class DuplicateGuardTests(unittest.TestCase):
         self.assertIn("--repo", args)
         self.assertEqual(args[args.index("--repo") + 1], "springfall2008/batpred")
 
+    @patch("triage_daemon.subprocess.run")
+    def test_find_pr_number_for_issue_returns_the_number(self, mock_run):
+        """A matching search result's PR number is returned, not just a bool."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 4742}]))
+        self.assertEqual(triage_daemon.find_pr_number_for_issue(4720), 4742)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_find_pr_number_for_issue_returns_none_when_no_match(self, mock_run):
+        """An empty search result means no PR exists yet for this issue."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([]))
+        self.assertIsNone(triage_daemon.find_pr_number_for_issue(4720))
+
 
 class IsActionableTests(unittest.TestCase):
     """Tests for is_actionable(), new - guards against implementing a closed,
@@ -288,10 +300,11 @@ class LabelSwapTests(unittest.TestCase):
     @patch("triage_daemon.subprocess.run")
     def test_mark_pr_opened_swaps_labels(self, mock_run):
         """Removes BOT_PR and adds BOT_PR_OPENED, scoped to the configured repo."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 4742}]))
         triage_daemon.mark_pr_opened(4720)
-        args = mock_run.call_args[0][0]
+        first_call_args = mock_run.call_args_list[0].args[0]
         self.assertEqual(
-            args,
+            first_call_args,
             [
                 "gh",
                 "issue",
@@ -305,6 +318,26 @@ class LabelSwapTests(unittest.TestCase):
                 "BOT_PR_OPENED",
             ],
         )
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_opened_flags_the_pr_for_review(self, mock_run):
+        """Once the issue's label is swapped, the PR itself is found and flagged
+        BOT_REVIEW - /issue-pr's own quality gate is pre-commit and a targeted test,
+        not an LLM review of the diff, so this is what actually triggers one."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([{"number": 4742}]))
+        triage_daemon.mark_pr_opened(4720)
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        self.assertIn(["gh", "pr", "edit", "4742", "--repo", "springfall2008/batpred", "--add-label", "BOT_REVIEW"], calls)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_opened_skips_flagging_when_no_pr_found(self, mock_run):
+        """Defensive path: an empty PR search (e.g. a race with the PR being closed
+        between the caller's has_existing_pr() check and this call) must not crash
+        trying to flag a PR number that doesn't exist."""
+        mock_run.return_value = MagicMock(stdout=json.dumps([]))
+        triage_daemon.mark_pr_opened(4720)  # must not raise
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        self.assertFalse(any(call[:3] == ["gh", "pr", "edit"] for call in calls))
 
     @patch("triage_daemon.subprocess.run")
     def test_mark_pr_failed_swaps_labels(self, mock_run):
@@ -326,6 +359,17 @@ class LabelSwapTests(unittest.TestCase):
                 "BOT_PR_FAILED",
             ],
         )
+
+
+class FlagPrForReviewTests(unittest.TestCase):
+    """Tests for flag_pr_for_review(), new - adds BOT_REVIEW to a PR directly."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_adds_bot_review_to_the_pr_scoped_to_repo(self, mock_run):
+        """Adds the label to the PR (not the issue), scoped to the configured repo."""
+        triage_daemon.flag_pr_for_review(4742)
+        args = mock_run.call_args[0][0]
+        self.assertEqual(args, ["gh", "pr", "edit", "4742", "--repo", "springfall2008/batpred", "--add-label", "BOT_REVIEW"])
 
 
 class PermissionModelTests(unittest.TestCase):
@@ -691,6 +735,210 @@ class SyncRepoTests(unittest.TestCase):
         self.assertLess(calls.index(checkout_call), calls.index(reset_call))
 
 
+class EffectiveOllamaModelTests(unittest.TestCase):
+    """Tests for effective_ollama_model(), new - the priority logic behind --ollama
+    (every claude invocation) vs --ollama_review (review-only invocations)."""
+
+    def setUp(self):
+        """Every test starts from the no-flag default, regardless of test order."""
+        for name in ("OLLAMA_MODEL", "OLLAMA_REVIEW_MODEL"):
+            patcher = patch.object(triage_daemon, name, None)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_none_by_default(self):
+        """With neither flag set, every invocation uses the default Claude model."""
+        self.assertIsNone(triage_daemon.effective_ollama_model())
+        self.assertIsNone(triage_daemon.effective_ollama_model(review_only=True))
+
+    def test_ollama_applies_regardless_of_review_only(self):
+        """--ollama (OLLAMA_MODEL) covers every invocation, including PR creation."""
+        with patch.object(triage_daemon, "OLLAMA_MODEL", "glm-5.3-flash:cloud"):
+            self.assertEqual(triage_daemon.effective_ollama_model(review_only=False), "glm-5.3-flash:cloud")
+            self.assertEqual(triage_daemon.effective_ollama_model(review_only=True), "glm-5.3-flash:cloud")
+
+    def test_ollama_review_only_applies_when_review_only_is_true(self):
+        """--ollama_review (OLLAMA_REVIEW_MODEL) is ignored unless the caller marks
+        this invocation review_only - this is what keeps PR creation (which never
+        passes review_only=True) on the default Claude model."""
+        with patch.object(triage_daemon, "OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud"):
+            self.assertIsNone(triage_daemon.effective_ollama_model(review_only=False))
+            self.assertEqual(triage_daemon.effective_ollama_model(review_only=True), "glm-5.3-flash:cloud")
+
+    def test_ollama_takes_precedence_over_ollama_review(self):
+        """If both somehow end up set, the blanket --ollama model wins."""
+        with patch.object(triage_daemon, "OLLAMA_MODEL", "full-model"), patch.object(triage_daemon, "OLLAMA_REVIEW_MODEL", "review-model"):
+            self.assertEqual(triage_daemon.effective_ollama_model(review_only=True), "full-model")
+
+
+class ClaudeModelArgsTests(unittest.TestCase):
+    """Tests for claude_model_args(), new - the --ollama/--ollama_review-to---model
+    plumbing shared by every 'claude' invocation (triage, triage_followup, create_pr,
+    review_pr, cleanup_pr)."""
+
+    def setUp(self):
+        """Every test starts from the no-flag default, regardless of test order."""
+        for name in ("OLLAMA_MODEL", "OLLAMA_REVIEW_MODEL"):
+            patcher = patch.object(triage_daemon, name, None)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_empty_by_default(self):
+        """With no --ollama, no --model flag is added to any claude invocation."""
+        self.assertEqual(triage_daemon.claude_model_args(), [])
+
+    def test_selects_the_configured_model(self):
+        """--ollama's model name is passed straight through as --model, :cloud suffix included."""
+        with patch.object(triage_daemon, "OLLAMA_MODEL", "glm-5.3-flash:cloud"):
+            self.assertEqual(triage_daemon.claude_model_args(), ["--model", "glm-5.3-flash:cloud"])
+
+    def test_review_only_model_used_when_review_only_true(self):
+        """claude_model_args(review_only=True) picks up --ollama_review when set -
+        the call form triage()/triage_followup()/review_pr()/cleanup_pr() use."""
+        with patch.object(triage_daemon, "OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud"):
+            self.assertEqual(triage_daemon.claude_model_args(review_only=True), ["--model", "glm-5.3-flash:cloud"])
+
+    def test_review_only_model_ignored_by_default(self):
+        """claude_model_args() with no argument - the form create_pr() uses - ignores
+        --ollama_review, so PR creation is unaffected by it."""
+        with patch.object(triage_daemon, "OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud"):
+            self.assertEqual(triage_daemon.claude_model_args(), [])
+
+
+class ClaudeEnvTests(unittest.TestCase):
+    """Tests for claude_env(), new - the Anthropic-compatible env overrides Ollama's
+    Claude Code integration documents (https://docs.ollama.com/integrations/claude-code)."""
+
+    def setUp(self):
+        """Every test starts from the no-flag default, regardless of test order."""
+        for name in ("OLLAMA_MODEL", "OLLAMA_REVIEW_MODEL"):
+            patcher = patch.object(triage_daemon, name, None)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_none_by_default(self):
+        """With no --ollama, env=None so subprocess.run() inherits the daemon's own
+        environment unchanged - no ANTHROPIC_* overrides pointing at Ollama."""
+        self.assertIsNone(triage_daemon.claude_env())
+
+    def test_adds_the_documented_overrides_when_configured(self):
+        """--ollama sets exactly the three env vars Ollama's integration guide documents."""
+        with patch.object(triage_daemon, "OLLAMA_MODEL", "glm-5.3-flash:cloud"):
+            env = triage_daemon.claude_env()
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+        self.assertEqual(env["ANTHROPIC_AUTH_TOKEN"], "ollama")
+        self.assertEqual(env["ANTHROPIC_API_KEY"], "")
+
+    def test_preserves_the_rest_of_the_process_environment(self):
+        """The overrides sit on top of the daemon's own environment, not a bare dict -
+        the gh/git subcommands inside the claude session still need PATH, HOME, etc."""
+        with patch.object(triage_daemon, "OLLAMA_MODEL", "glm-5.3-flash:cloud"), patch.dict("os.environ", {"SOME_OTHER_VAR": "keep-me"}):
+            env = triage_daemon.claude_env()
+        self.assertEqual(env.get("SOME_OTHER_VAR"), "keep-me")
+
+    def test_review_only_env_used_when_review_only_true(self):
+        """claude_env(review_only=True) picks up --ollama_review when set."""
+        with patch.object(triage_daemon, "OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud"):
+            env = triage_daemon.claude_env(review_only=True)
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+
+    def test_review_only_env_ignored_by_default(self):
+        """claude_env() with no argument - the form create_pr() uses - ignores --ollama_review."""
+        with patch.object(triage_daemon, "OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud"):
+            env = triage_daemon.claude_env()
+        self.assertIsNone(env)
+
+
+class ParseArgsTests(unittest.TestCase):
+    """Tests for parse_args(), new - the --ollama/--ollama_review CLI flags."""
+
+    def test_defaults_to_no_ollama_model(self):
+        """Without either flag, both args are None - every claude invocation uses the default model."""
+        with patch("sys.argv", ["triage_daemon.py"]):
+            args = triage_daemon.parse_args()
+        self.assertIsNone(args.ollama)
+        self.assertIsNone(args.ollama_review)
+
+    def test_parses_the_ollama_model_flag(self):
+        """--ollama <model> is captured verbatim, :cloud suffix included."""
+        with patch("sys.argv", ["triage_daemon.py", "--ollama", "glm-5.3-flash:cloud"]):
+            args = triage_daemon.parse_args()
+        self.assertEqual(args.ollama, "glm-5.3-flash:cloud")
+        self.assertIsNone(args.ollama_review)
+
+    def test_parses_the_ollama_review_model_flag(self):
+        """--ollama_review <model> is captured verbatim, separately from --ollama."""
+        with patch("sys.argv", ["triage_daemon.py", "--ollama_review", "glm-5.3-flash:cloud"]):
+            args = triage_daemon.parse_args()
+        self.assertEqual(args.ollama_review, "glm-5.3-flash:cloud")
+        self.assertIsNone(args.ollama)
+
+    def test_ollama_and_ollama_review_are_mutually_exclusive(self):
+        """Passing both is a usage error rather than a silently-resolved precedence -
+        --ollama already covers every flow --ollama_review does, so combining them
+        would just be ambiguous about which one the user actually meant."""
+        with patch("sys.argv", ["triage_daemon.py", "--ollama", "model-a", "--ollama_review", "model-b"]):
+            with self.assertRaises(SystemExit):
+                triage_daemon.parse_args()
+
+
+class TriageTests(DaemonPathsTestCase):
+    """Tests for triage(), exercised directly here for the first time - previously
+    only covered indirectly through the orchestrators, which mock it out."""
+
+    @patch("triage_daemon.subprocess.run")
+    def test_invokes_claude_with_the_triage_permission_set(self, mock_run):
+        """Runs the /issue-triage skill with the read-only allow/deny lists."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/issue-triage 4720", cmd[2])
+        self.assertIn(triage_daemon.ALLOWED_TOOLS, cmd)
+        self.assertIn(triage_daemon.DISALLOWED_TOOLS, cmd)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_no_model_flag_or_env_override_by_default(self, mock_run):
+        """Without --ollama, the invocation is unchanged: no --model flag, env=None
+        so the claude subprocess talks to Anthropic's API as normal."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertNotIn("--model", cmd)
+        self.assertIsNone(mock_run.call_args.kwargs["env"])
+
+    @patch("triage_daemon.subprocess.run")
+    def test_adds_the_ollama_model_flag_and_env_when_configured(self, mock_run):
+        """--ollama appends --model <name> to the cmd and routes the subprocess at
+        Ollama's Claude Code compatible endpoint via the env overrides."""
+        self._patch("OLLAMA_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_ollama_review_model_also_applies_to_triage(self, mock_run):
+        """--ollama_review covers first-pass triage too, not just the blanket --ollama."""
+        self._patch("OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_writes_a_log_file(self, mock_run):
+        """A per-issue log file is created under LOG_DIR."""
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage(4720)
+        self.assertTrue((self.log_dir / "issue-4720.log").exists())
+
+
 class CreatePrTests(DaemonPathsTestCase):
     """Tests for create_pr(), new in the bot PR flow."""
 
@@ -719,6 +967,29 @@ class CreatePrTests(DaemonPathsTestCase):
         mock_run.return_value = MagicMock(returncode=0)
         triage_daemon.create_pr(4720)
         self.assertTrue((self.log_dir / "issue-4720-pr.log").exists())
+
+    @patch("triage_daemon.subprocess.run")
+    def test_adds_the_ollama_model_flag_and_env_when_configured(self, mock_run):
+        """Same --ollama wiring as triage() - this flow also shells out to 'claude'."""
+        self._patch("OLLAMA_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.create_pr(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_ollama_review_model_does_not_apply_to_pr_creation(self, mock_run):
+        """--ollama_review is scoped to the review-only flows - PR creation must still
+        run on the default Claude model even when --ollama_review is set."""
+        self._patch("OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.create_pr(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertNotIn("--model", cmd)
+        self.assertIsNone(mock_run.call_args.kwargs["env"])
 
 
 class ProcessBotPrIssueTests(unittest.TestCase):
@@ -900,6 +1171,30 @@ class TriageFollowupTests(DaemonPathsTestCase):
         mock_run.return_value = MagicMock(returncode=0)
         triage_daemon.triage_followup(4720)
         self.assertTrue((self.log_dir / "issue-4720-followup.log").exists())
+
+    @patch("triage_daemon.subprocess.run")
+    def test_adds_the_ollama_model_flag_and_env_when_configured(self, mock_run):
+        """Same --ollama wiring as triage() - this flow also shells out to 'claude'."""
+        self._patch("OLLAMA_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage_followup(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_ollama_review_model_also_applies_to_followup(self, mock_run):
+        """--ollama_review covers the follow-up review too."""
+        self._patch("OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.triage_followup(4720)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
 
 
 class ProcessBotReviewIssueTests(unittest.TestCase):
@@ -1089,6 +1384,30 @@ class ReviewPrTests(DaemonPathsTestCase):
         triage_daemon.review_pr(4742)
         self.assertTrue((self.log_dir / "pr-4742-review.log").exists())
 
+    @patch("triage_daemon.subprocess.run")
+    def test_adds_the_ollama_model_flag_and_env_when_configured(self, mock_run):
+        """Same --ollama wiring as triage() - this flow also shells out to 'claude'."""
+        self._patch("OLLAMA_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.review_pr(4742)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_ollama_review_model_also_applies_to_pr_review(self, mock_run):
+        """--ollama_review covers PR review too - it's one of the review-only flows."""
+        self._patch("OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.review_pr(4742)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+
 
 class ProcessBotReviewPrTests(unittest.TestCase):
     """Tests for process_bot_review_pr(), new - the BOT_REVIEW-on-PR orchestrator."""
@@ -1225,6 +1544,30 @@ class CleanupPrTests(DaemonPathsTestCase):
         mock_run.return_value = MagicMock(returncode=0)
         triage_daemon.cleanup_pr(4742)
         self.assertTrue((self.log_dir / "pr-4742-cleanup.log").exists())
+
+    @patch("triage_daemon.subprocess.run")
+    def test_adds_the_ollama_model_flag_and_env_when_configured(self, mock_run):
+        """Same --ollama wiring as triage() - this flow also shells out to 'claude'."""
+        self._patch("OLLAMA_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.cleanup_pr(4742)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
+
+    @patch("triage_daemon.subprocess.run")
+    def test_ollama_review_model_also_applies_to_cleanup(self, mock_run):
+        """--ollama_review covers PR cleanup too - it's one of the review-only flows."""
+        self._patch("OLLAMA_REVIEW_MODEL", "glm-5.3-flash:cloud")
+        mock_run.return_value = MagicMock(returncode=0)
+        triage_daemon.cleanup_pr(4742)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertEqual(cmd[cmd.index("--model") + 1], "glm-5.3-flash:cloud")
+        env = mock_run.call_args.kwargs["env"]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], triage_daemon.OLLAMA_BASE_URL)
 
 
 class ProcessBotCleanupPrTests(unittest.TestCase):

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -408,7 +408,7 @@ def find_pr_number_for_issue(issue_number):
     """
     query = build_duplicate_search_query(issue_number)
     result = subprocess.run(
-        ["gh", "pr", "list", "--repo", REPO, "--search", query, "--state", "all", "--json", "number"],
+        ["gh", "pr", "list", "--repo", REPO, "--search", query, "--state", "all", "--json", "number", "--limit", "100"],
         capture_output=True,
         text=True,
         check=True,

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -37,6 +37,31 @@ Setup (one-time, on whichever always-on machine will run this):
 
        python3 tools/triage_daemon.py
 
+   Add --ollama <model> to run every 'claude' invocation against an Ollama
+   model instead of the default Claude model, e.g.:
+
+       python3 tools/triage_daemon.py --ollama glm-5.3-flash:cloud
+
+   Or add --ollama_review <model> to use Ollama only for the read-only/
+   review-ish flows - first-pass triage, follow-up review, PR review, PR
+   cleanup - while PR creation (/issue-pr, the flow that actually writes
+   the fix) still runs on the default Claude model:
+
+       python3 tools/triage_daemon.py --ollama_review glm-5.3-flash:cloud
+
+   --ollama and --ollama_review are mutually exclusive - --ollama already
+   covers every flow --ollama_review does, plus PR creation, so pass at
+   most one.
+
+   Both point the CLI at Ollama's Claude Code compatible endpoint
+   (https://docs.ollama.com/integrations/claude-code), served locally at
+   OLLAMA_BASE_URL (http://localhost:11434 by default) - so it needs a
+   local `ollama serve` running, and, for a :cloud-suffixed model, an
+   `ollama signin` on this machine. --max-budget-usd's cost estimate is
+   priced for Anthropic's API, so treat it as meaningless (not a real
+   cap) for whichever flows are running against Ollama; --max-turns is
+   the limit that still holds for them.
+
 What it does per new issue: syncs the dedicated clone to origin/main,
 empties the scratch directory used for issue attachments, then runs
 `claude -p "/issue-triage <number> scratch=<dir>"` (the skill at
@@ -66,7 +91,9 @@ you wouldn't hand to an issue reporter. DISALLOWED_TOOLS is a backstop
 against the obvious mistakes, not a sandbox boundary.
 """
 
+import argparse
 import json
+import os
 import shutil
 import subprocess
 import time
@@ -79,6 +106,14 @@ SCRATCH_DIR = BASE_DIR / "scratch"
 LOG_DIR = BASE_DIR / "logs"
 STATE_FILE = BASE_DIR / "state.json"
 POLL_SECONDS = 300
+# Set from --ollama/--ollama_review by main() - see effective_ollama_model() for how the
+# two interact. OLLAMA_BASE_URL is Ollama's own Claude Code compatible endpoint
+# (https://docs.ollama.com/integrations/claude-code); a :cloud-suffixed model is still
+# routed through it, forwarded using the machine's `ollama signin` credentials rather
+# than a separate API key.
+OLLAMA_MODEL = None
+OLLAMA_REVIEW_MODEL = None
+OLLAMA_BASE_URL = "http://localhost:11434"
 
 EDIT_SCOPE = f"//{CLONE_DIR.relative_to('/')}/**"
 SCRATCH_SCOPE = f"//{SCRATCH_DIR.relative_to('/')}/**"
@@ -367,8 +402,10 @@ def build_duplicate_search_query(issue_number):
     return f'"Fixes #{issue_number}" in:body'
 
 
-def has_existing_pr(issue_number):
-    """Return True if a PR already references this issue, in any state."""
+def find_pr_number_for_issue(issue_number):
+    """Return the number of the PR referencing this issue (matching the exact
+    "Fixes #N" phrase /issue-pr always includes), or None if none exists yet.
+    """
     query = build_duplicate_search_query(issue_number)
     result = subprocess.run(
         ["gh", "pr", "list", "--repo", REPO, "--search", query, "--state", "all", "--json", "number"],
@@ -376,7 +413,13 @@ def has_existing_pr(issue_number):
         text=True,
         check=True,
     )
-    return len(json.loads(result.stdout)) > 0
+    prs = json.loads(result.stdout)
+    return prs[0]["number"] if prs else None
+
+
+def has_existing_pr(issue_number):
+    """Return True if a PR already references this issue, in any state."""
+    return find_pr_number_for_issue(issue_number) is not None
 
 
 def is_actionable(issue_number):
@@ -398,12 +441,26 @@ def is_actionable(issue_number):
     return bool(label_names & {"bug", "enhancement"})
 
 
+def flag_pr_for_review(pr_number):
+    """Add BOT_REVIEW to a PR, so the next poll cycle runs /code-review against it.
+    Idempotent - adding a label the PR already carries is a no-op, not an error.
+    """
+    subprocess.run(["gh", "pr", "edit", str(pr_number), "--repo", REPO, "--add-label", "BOT_REVIEW"], check=True)
+
+
 def mark_pr_opened(issue_number):
-    """Swap BOT_PR for BOT_PR_OPENED once the draft PR has been confirmed open."""
+    """Swap BOT_PR for BOT_PR_OPENED once the draft PR has been confirmed open, and
+    flag the PR itself with BOT_REVIEW so a code review runs against it automatically -
+    /issue-pr's own quality gate (step 4 of its SKILL.md) is pre-commit and a targeted
+    test, not an LLM review of the diff.
+    """
     subprocess.run(
         ["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--remove-label", "BOT_PR", "--add-label", "BOT_PR_OPENED"],
         check=True,
     )
+    pr_number = find_pr_number_for_issue(issue_number)
+    if pr_number is not None:
+        flag_pr_for_review(pr_number)
 
 
 def mark_pr_failed(issue_number):
@@ -454,6 +511,47 @@ def reset_scratch():
     SCRATCH_DIR.mkdir(parents=True, exist_ok=True)
 
 
+def effective_ollama_model(review_only=False):
+    """Return the Ollama model this claude invocation should use, or None to use the
+    default Claude model. --ollama (OLLAMA_MODEL) always wins and applies to every
+    invocation, including PR creation. --ollama_review (OLLAMA_REVIEW_MODEL) applies
+    only when the caller passes review_only=True - triage(), triage_followup(),
+    review_pr() and cleanup_pr() do; create_pr() never does, so PR creation still runs
+    on the full Claude model even when --ollama_review is set.
+    """
+    if OLLAMA_MODEL:
+        return OLLAMA_MODEL
+    if review_only and OLLAMA_REVIEW_MODEL:
+        return OLLAMA_REVIEW_MODEL
+    return None
+
+
+def claude_model_args(review_only=False):
+    """Return the extra 'claude' CLI args selecting the Ollama model for this
+    invocation, or [] to use the default Claude model. Appended to every claude
+    invocation's cmd list below.
+    """
+    model = effective_ollama_model(review_only)
+    return ["--model", model] if model else []
+
+
+def claude_env(review_only=False):
+    """Return the subprocess environment for a 'claude' invocation: None (inherit
+    the daemon's own environment unchanged) unless this invocation is using an
+    Ollama model, in which case add the Anthropic-compatible overrides Ollama's
+    Claude Code integration documents, so the CLI talks to the local Ollama server
+    instead of Anthropic's API.
+    """
+    model = effective_ollama_model(review_only)
+    if not model:
+        return None
+    env = os.environ.copy()
+    env["ANTHROPIC_BASE_URL"] = OLLAMA_BASE_URL
+    env["ANTHROPIC_AUTH_TOKEN"] = "ollama"
+    env["ANTHROPIC_API_KEY"] = ""
+    return env
+
+
 def triage(issue_number):
     cmd = [
         "claude",
@@ -480,7 +578,7 @@ def triage(issue_number):
         # file reads plus a test run.
         "--max-budget-usd",
         "10.00",
-    ]
+    ] + claude_model_args(review_only=True)
     log_path = LOG_DIR / f"issue-{issue_number}.log"
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     print(f"[triage] issue #{issue_number}: starting, logging to {log_path}", flush=True)
@@ -489,7 +587,7 @@ def triage(issue_number):
     with log_path.open("a") as log_handle:
         log_handle.write(f"\n==== issue #{issue_number} started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
         log_handle.flush()
-        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT, env=claude_env(review_only=True))
         log_handle.write(f"==== issue #{issue_number} exited {result.returncode} ====\n")
     if result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd)
@@ -518,14 +616,14 @@ def triage_followup(issue_number):
         "60",
         "--max-budget-usd",
         "10.00",
-    ]
+    ] + claude_model_args(review_only=True)
     log_path = LOG_DIR / f"issue-{issue_number}-followup.log"
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     print(f"[review] issue #{issue_number}: starting follow-up, logging to {log_path}", flush=True)
     with log_path.open("a") as log_handle:
         log_handle.write(f"\n==== issue #{issue_number} follow-up started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
         log_handle.flush()
-        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT, env=claude_env(review_only=True))
         log_handle.write(f"==== issue #{issue_number} follow-up exited {result.returncode} ====\n")
     if result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd)
@@ -557,14 +655,14 @@ def create_pr(issue_number):
         "150",
         "--max-budget-usd",
         "25.00",
-    ]
+    ] + claude_model_args()
     log_path = LOG_DIR / f"issue-{issue_number}-pr.log"
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     print(f"[pr] issue #{issue_number}: starting, logging to {log_path}", flush=True)
     with log_path.open("a") as log_handle:
         log_handle.write(f"\n==== issue #{issue_number} PR flow started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
         log_handle.flush()
-        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT, env=claude_env())
         log_handle.write(f"==== issue #{issue_number} PR flow exited {result.returncode} ====\n")
     print(f"[pr] issue #{issue_number}: exited {result.returncode}", flush=True)
 
@@ -778,14 +876,14 @@ def review_pr(pr_number):
         "100",
         "--max-budget-usd",
         "20.00",
-    ]
+    ] + claude_model_args(review_only=True)
     log_path = LOG_DIR / f"pr-{pr_number}-review.log"
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     print(f"[review-pr] PR #{pr_number}: starting, logging to {log_path}", flush=True)
     with log_path.open("a") as log_handle:
         log_handle.write(f"\n==== PR #{pr_number} review started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
         log_handle.flush()
-        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT, env=claude_env(review_only=True))
         log_handle.write(f"==== PR #{pr_number} review exited {result.returncode} ====\n")
     if result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd)
@@ -871,14 +969,14 @@ def cleanup_pr(pr_number):
         "150",
         "--max-budget-usd",
         "25.00",
-    ]
+    ] + claude_model_args(review_only=True)
     log_path = LOG_DIR / f"pr-{pr_number}-cleanup.log"
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     print(f"[cleanup-pr] PR #{pr_number}: starting, logging to {log_path}", flush=True)
     with log_path.open("a") as log_handle:
         log_handle.write(f"\n==== PR #{pr_number} cleanup started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
         log_handle.flush()
-        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT)
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT, env=claude_env(review_only=True))
         log_handle.write(f"==== PR #{pr_number} cleanup exited {result.returncode} ====\n")
     if result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd)
@@ -903,9 +1001,41 @@ def process_bot_cleanup_pr(pr):
     remove_pr_cleanup_label(pr_number)
 
 
+def parse_args():
+    """Parse the daemon's CLI arguments - --ollama and --ollama_review, to run
+    'claude' invocations against an Ollama model instead of the default Claude model.
+    """
+    parser = argparse.ArgumentParser(description="Poll batpred issues/PRs and triage them with Claude Code.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--ollama",
+        metavar="MODEL",
+        help="Run every 'claude' invocation against an Ollama model served at "
+        f"{OLLAMA_BASE_URL} instead of the default Claude model - e.g. --ollama glm-5.3-flash:cloud. "
+        "Uses Ollama's Claude Code compatible endpoint (https://docs.ollama.com/integrations/claude-code); "
+        "a :cloud-suffixed model is still routed through the local Ollama server, forwarded using this "
+        "machine's `ollama signin` credentials rather than a separate API key.",
+    )
+    group.add_argument(
+        "--ollama_review",
+        metavar="MODEL",
+        help="Like --ollama, but only for the read-only/review-ish flows - first-pass " "triage, follow-up review, PR review, PR cleanup. PR creation (/issue-pr, the " "flow that writes the actual fix) still runs on the default Claude model.",
+    )
+    return parser.parse_args()
+
+
 def main():
+    global OLLAMA_MODEL, OLLAMA_REVIEW_MODEL
+    args = parse_args()
+    OLLAMA_MODEL = args.ollama
+    OLLAMA_REVIEW_MODEL = args.ollama_review
+
     if not CLONE_DIR.exists():
         raise SystemExit(f"Expected a git clone at {CLONE_DIR} - see setup steps before running this daemon.")
+    if OLLAMA_MODEL:
+        print(f"[triage] using Ollama model {OLLAMA_MODEL!r} via {OLLAMA_BASE_URL} for every claude invocation", flush=True)
+    elif OLLAMA_REVIEW_MODEL:
+        print(f"[triage] using Ollama model {OLLAMA_REVIEW_MODEL!r} via {OLLAMA_BASE_URL} for review flows only (PR creation still uses Claude)", flush=True)
 
     state = load_state()
     while True:


### PR DESCRIPTION
## Summary

- Adds `--ollama <model>` to `tools/triage_daemon.py`, so it can run every `claude` invocation (triage, follow-up review, PR creation, PR review, PR cleanup) against an Ollama model (local or `:cloud`) instead of the default Claude model, using the env vars [Ollama's Claude Code integration](https://docs.ollama.com/integrations/claude-code) documents.
- Adds `--ollama_review <model>`, mutually exclusive with `--ollama`: uses Ollama only for the read-only/review-ish flows (first-pass triage, follow-up review, PR review, PR cleanup) while PR creation (`/issue-pr`, the flow that writes the actual fix) still runs on the default Claude model.
- `mark_pr_opened()` now also flags the newly-opened PR with `BOT_REVIEW`, so `/code-review` runs against it automatically on the next poll cycle. `/issue-pr`'s own "quality gate" is `run_pre_commit` + a targeted test — not an LLM review of the diff — so previously a PR only got reviewed if a maintainer manually added the label.

## Test plan

- [x] `python3 tools/test_triage_daemon.py` - 145/145 passing (30 new tests covering the Ollama wiring, the mutually-exclusive CLI flags, and the auto-`BOT_REVIEW` flagging including its defensive no-PR-found path)
- [x] `./run_pre_commit` (coverage/) - clean, including the "triage daemon unit tests" hook and the full `./run_all --quick` suite
- [x] Manually exercised `--ollama_review` end-to-end against `effective_ollama_model()`/`claude_model_args()`/`claude_env()` to confirm PR creation is unaffected while review flows pick up the model and env overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)