### PR TITLE
fix(debug): keep the 5-minute step arrays in the debug yaml so dumps replay

### DIFF
--- a/apps/predbat/tests/test_debug_yaml_step_data.py
+++ b/apps/predbat/tests/test_debug_yaml_step_data.py
@@ -1,0 +1,95 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt: off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+
+"""Tests that a debug yaml always carries the 5-minute step arrays.
+
+update_pred() frees load_minutes_step, load_minutes_step10, pv_forecast_minute_step and
+pv_forecast_minute10_step at the end of every cycle unless switch.predbat_debug_enable is on, and
+only calculate_plan()'s recompute branch ever refills them. A debug yaml downloaded from the web
+interface with the switch off therefore shipped them as {}, and replaying such a dump raised
+KeyError on minute 0 inside run_prediction() - so the artefact most bug reports carry could not be
+replayed at all.
+"""
+
+STEP_KEYS = ["load_minutes_step", "load_minutes_step10", "pv_forecast_minute_step", "pv_forecast_minute10_step"]
+
+
+def test_debug_yaml_step_data(my_predbat):
+    """Verify create_debug_yaml() repopulates the step arrays when update_pred() has freed them."""
+    failed = False
+    print("**** Testing debug yaml step data ****")
+
+    saved = {key: getattr(my_predbat, key, {}) for key in STEP_KEYS}
+    # Set by fetch_config_options() on a running install; the test instance has not run a cycle.
+    for name, value in (("metric_load_divergence", None), ("load_scaling", 1.0), ("load_scaling10", 1.1)):
+        if not hasattr(my_predbat, name):
+            setattr(my_predbat, name, value)
+    try:
+        print("Test: step arrays freed by update_pred are rebuilt for the dump")
+        for key in STEP_KEYS:
+            setattr(my_predbat, key, {})
+
+        my_predbat.rebuild_debug_step_data()
+
+        for key in STEP_KEYS:
+            rebuilt = getattr(my_predbat, key)
+            if not rebuilt:
+                print("  ERROR: {} is still empty after the rebuild".format(key))
+                failed = True
+            elif 0 not in rebuilt:
+                print("  ERROR: {} was rebuilt without minute 0 - run_prediction indexes it directly and would raise KeyError".format(key))
+                failed = True
+
+        print("Test: the dump itself carries them, so it can be replayed")
+        for key in STEP_KEYS:
+            setattr(my_predbat, key, {})
+        debug_text = my_predbat.create_debug_yaml(write_file=False)
+        # Checked as text rather than parsed: the dump carries python object tags, so it needs
+        # yaml.unsafe_load, and "key: {}" is exactly the shape the broken dumps had.
+        for key in STEP_KEYS:
+            if "{}: {{}}".format(key) in debug_text:
+                print("  ERROR: debug yaml carries {} as an empty dict - a dump taken with debug disabled would not replay".format(key))
+                failed = True
+
+        print("Test: a rebuild that cannot run must not cost the user their dump")
+        for key in STEP_KEYS:
+            setattr(my_predbat, key, {})
+        saved_step_data_history = my_predbat.step_data_history
+
+        def _raise(*args, **kwargs):
+            raise AttributeError("simulated missing config")
+
+        my_predbat.step_data_history = _raise
+        try:
+            debug_text = my_predbat.create_debug_yaml(write_file=False)
+        except AttributeError:
+            print("  ERROR: a failing step-data rebuild aborted the whole debug yaml")
+            failed = True
+            debug_text = ""
+        finally:
+            my_predbat.step_data_history = saved_step_data_history
+        if debug_text and "soc_max" not in debug_text:
+            print("  ERROR: debug yaml came back without its normal content after a failed rebuild")
+            failed = True
+
+        print("Test: already-populated step arrays are left alone")
+        marker = {0: 1.0, 5: 2.0}
+        for key in STEP_KEYS:
+            setattr(my_predbat, key, dict(marker))
+        my_predbat.rebuild_debug_step_data()
+        for key in STEP_KEYS:
+            if getattr(my_predbat, key) != marker:
+                print("  ERROR: {} was rebuilt when it was already populated - the dump must reflect the plan that ran".format(key))
+                failed = True
+    finally:
+        for key, value in saved.items():
+            setattr(my_predbat, key, value)
+
+    return failed

--- a/apps/predbat/tests/test_single_debug.py
+++ b/apps/predbat/tests/test_single_debug.py
@@ -70,6 +70,16 @@ def run_single_debug(test_name, my_predbat, debug_file, expected_file=None, comp
     my_predbat.rate_max_base = 0
     my_predbat.rate_export_max_forward = {}
     my_predbat.read_debug_yaml(debug_file)
+    # A dump taken with switch.predbat_debug_enable off ships the 5-minute step arrays as {} -
+    # update_pred() frees them at the end of every cycle unless debug is on, and only
+    # calculate_plan()'s recompute branch refills them. Replaying one raised KeyError on minute 0
+    # from run_prediction(). Predbat now rebuilds them when the dump is created, but every dump
+    # already attached to a bug report predates that, so rebuild here too rather than crash. Only
+    # the load model is rebuilt - not rates or Octopus slots - so the replay stays faithful to what
+    # the reporter saw, unlike --redo.
+    if not redo and not my_predbat.pv_forecast_minute_step:
+        print("Step data missing from the debug file (taken with debug disabled) - rebuilding the load model")
+        reset_load_model = True
     my_predbat.config_root = "./"
     my_predbat.save_restore_dir = "./"
     my_predbat.load_user_config()

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -304,6 +304,7 @@ from tests.test_annual_export_sweep import (
 )
 from tests.test_debug_history import test_debug_history
 from tests.test_debug_history_capture import test_debug_history_capture, test_debug_history_capture_slot_alignment
+from tests.test_debug_yaml_step_data import test_debug_yaml_step_data
 
 # Mock the components and plugin system
 
@@ -724,6 +725,7 @@ def main():
         ("debug_history", test_debug_history, "Rolling debug-history snapshot buffer tests", False),
         ("debug_history_capture", test_debug_history_capture, "Debug history capture throttle/force-capture tests", False),
         ("debug_history_capture_alignment", test_debug_history_capture_slot_alignment, "Debug history capture timestamp is floored to the plan slot grid", False),
+        ("debug_yaml_step_data", test_debug_yaml_step_data, "Debug yaml carries the 5-minute step arrays even when update_pred freed them", False),
     ]
 
     # Parse command line arguments

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -751,6 +751,67 @@ class UserInterface:
                     current["value"] = item.get("value", None)
         self.log("Restored debug settings - minutes now {}".format(self.minutes_now))
 
+    def rebuild_debug_step_data(self):
+        """
+        Rebuild the 5-minute step arrays for the debug yaml if update_pred() has freed them
+
+        update_pred() drops load_minutes_step, load_minutes_step10, pv_forecast_minute_step and
+        pv_forecast_minute10_step at the end of every cycle to free memory, unless debug_enable is
+        on. They are only ever repopulated by calculate_plan()'s recompute branch, so a debug yaml
+        taken with the switch off ships them as {} - and a dump without them cannot be replayed at
+        all, since run_prediction() indexes pv_forecast_minute_step directly and raises KeyError on
+        minute 0. That is exactly the dump most bug reports carry, because the reporter downloads it
+        from the web interface without turning the switch on first.
+
+        Rebuilt from the same inputs calculate_plan() uses, so the dump is self-contained however it
+        was taken. Cheap enough to do unconditionally - it is a handful of step_data_history() calls
+        on an operation a user triggers by hand - and skipped when the arrays are already populated.
+
+        A failure here must never cost the user their dump, which is the whole point of the exercise
+        and is still useful without the step data, so anything going wrong is logged and swallowed.
+        The inputs come from fetch_config_options(), so they are all present on a running install but
+        not necessarily on one that has not completed a cycle yet.
+        """
+        if self.pv_forecast_minute_step and self.load_minutes_step:
+            return
+
+        try:
+            self.log("Rebuilding step data for the debug yaml as it was freed after the last plan")
+            self._rebuild_debug_step_data()
+        except (AttributeError, KeyError, TypeError, ValueError) as error:
+            self.log("Warn: Could not rebuild step data for the debug yaml ({}) - the dump will not replay without --redo".format(error))
+
+    def _rebuild_debug_step_data(self):
+        """Rebuild the step arrays, mirroring calculate_plan()'s own construction of them."""
+        self.load_minutes_step = self.step_data_history(
+            self.load_minutes,
+            self.minutes_now,
+            forward=False,
+            scale_today=self.load_inday_adjustment,
+            scale_fixed=self.load_scaling,
+            type_load=True,
+            load_forecast=self.load_forecast,
+            load_scaling_dynamic=self.load_scaling_dynamic,
+            cloud_factor=self.metric_load_divergence,
+            load_adjust=self.manual_load_adjust,
+            load_baseline=self.dynamic_load_baseline,
+        )
+        self.load_minutes_step10 = self.step_data_history(
+            self.load_minutes,
+            self.minutes_now,
+            forward=False,
+            scale_today=self.load_inday_adjustment,
+            scale_fixed=self.load_scaling10,
+            type_load=True,
+            load_forecast=self.load_forecast,
+            load_scaling_dynamic=self.load_scaling_dynamic,
+            cloud_factor=min(self.metric_load_divergence + 0.5, 1.0) if self.metric_load_divergence else None,
+            load_adjust=self.manual_load_adjust,
+            load_baseline=self.dynamic_load_baseline,
+        )
+        self.pv_forecast_minute_step = self.step_data_history(self.pv_forecast_minute, self.minutes_now, forward=True, cloud_factor=self.metric_cloud_coverage)
+        self.pv_forecast_minute10_step = self.step_data_history(self.pv_forecast_minute10, self.minutes_now, forward=True, cloud_factor=min(self.metric_cloud_coverage + 0.2, 1.0) if self.metric_cloud_coverage else None, flip=True)
+
     def create_debug_yaml(self, write_file=True):
         """
         Write out a debug info yaml
@@ -762,6 +823,7 @@ class UserInterface:
         filename_p = self.config_root_p + basename
 
         os.makedirs(os.path.dirname(filename), exist_ok=True)
+        self.rebuild_debug_step_data()
         debug = {}
 
         # Store all predbat member variables into debug


### PR DESCRIPTION
Fixes #4853

A debug yaml downloaded from the web interface while `switch.predbat_debug_enable` is off ships the 5-minute step arrays as `{}`, and cannot be replayed — `run_prediction()` indexes `pv_forecast_minute_step` directly and raises `KeyError: 0`.

`update_pred()` frees `load_minutes_step`, `load_minutes_step10`, `pv_forecast_minute_step` and `pv_forecast_minute10_step` at the end of every cycle unless debug is on, and only `calculate_plan()`'s recompute branch ever refills them. `create_debug_yaml()` serialises whatever is in memory, so with the switch off it always captures the freed state.

This matters more than it first looks because `DEBUG_ENABLE_MAX_HOURS = 2` auto-disables the switch. Even a reporter who follows the instruction to turn debug on ships a freed dump if they grab it more than two hours later, so the primary triage artefact is broken for most bug reports. `--redo` replays such a file but recomputes rates, load model and Octopus slots, so the inputs are no longer the reporter's and a plan bug may simply not reproduce.

## What this does

**`create_debug_yaml()` rebuilds the arrays if they have been freed**, from the same inputs `calculate_plan()` uses, so a dump is self-contained however it was taken. Already-populated arrays are left alone, so a dump taken with debug on still reflects the plan that actually ran rather than a fresh rebuild. A failure to rebuild is logged and swallowed — the dump is the whole point of the exercise and is still useful without step data, so it must never be lost to this.

**The replay harness rebuilds them too when a dump arrives without them**, since every dump already attached to a bug report predates this change. It resets only the load model, not rates or Octopus slots, so those replays stay faithful in a way `--redo` does not. Checked against a real dump from a live install: it now replays without `--redo` and reproduces `--redo`'s result exactly (orig `-111.7811`, final `18.9157`).

## Notes

The two `*90` step arrays are not in the free list and so were never affected — that asymmetry is what confirmed the diagnosis. They are left as they are here rather than widened, since freeing them would need the same rebuild treatment.

## Testing

New `debug_yaml_step_data` test module covering the rebuild, that the dump itself carries the arrays, that a failing rebuild does not cost the user their dump, and that populated arrays are left untouched. `./run_all --quick` and `./run_all --test debug_cases` both pass.
