### PR TITLE
Triage bot: disclose bot authorship on every comment it posts

### DIFF
--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -94,7 +94,7 @@ This is the last step on success — there is nothing further to report; the dae
 
 ## 7. On failure
 
-If step 4's quality gate failed, or an earlier step couldn't proceed (e.g. the fix genuinely needs information only a maintainer has), post exactly one comment on the issue via `gh issue comment <number> --body "..."` explaining plainly what you attempted and what failed — never word it so a skipped step reads as one you completed (same guardrail as the triage skill). Then stop. Do not commit, push, or open a PR — the daemon detects this outcome itself by finding no PR referencing the issue afterwards.
+If step 4's quality gate failed, or an earlier step couldn't proceed (e.g. the fix genuinely needs information only a maintainer has), post exactly one comment on the issue via `gh issue comment <number> --body "..."`, opening with a line disclosing this is an automated PR-creation attempt (a maintainer will review before any action is taken), followed by what you attempted and what failed — never word it so a skipped step reads as one you completed (same guardrail as the triage skill). Then stop. Do not commit, push, or open a PR — the daemon detects this outcome itself by finding no PR referencing the issue afterwards.
 
 ## Guardrails
 

--- a/.claude/skills/pr-cleanup/SKILL.md
+++ b/.claude/skills/pr-cleanup/SKILL.md
@@ -45,7 +45,7 @@ If the conflicts are extensive enough that a safe resolution would mean re-imple
 - CI status: `gh pr checks <pr-number>`. For any failing check, read its actual log (`gh run view <run-id> --job <job-id> --log`, or fetch the job log directly) to find the real failure, not just the pass/fail summary.
 - Skip anything already resolved: a review thread that already has a reply from you addressing it, or a check that's since gone green.
 
-If there is genuinely nothing new to address — step 2's merge was a no-op, every thread already has a reply, every check is green — post a brief comment saying so, opening with a line disclosing this is an automated cleanup check (nothing for a maintainer to act on), 
+If there is genuinely nothing new to address — step 2's merge was a no-op, every thread already has a reply, every check is green — post a brief comment saying so, opening with a line disclosing this is an automated cleanup check (nothing for a maintainer to act on),
 and stop; this is a normal, successful outcome, not a failure.
 
 ## 4. Evaluate before implementing
@@ -54,12 +54,12 @@ Per `receiving-code-review`: for each remaining item, verify it's technically co
 
 ## 5. Implement confirmed fixes
 
-Same conventions as `/issue-pr`: `CLAUDE.md` (already loaded automatically for this session), `lower_case_with_underscores` naming, 256-character line length, a one-line docstring on every new function or class, 
+Same conventions as `/issue-pr`: `CLAUDE.md` (already loaded automatically for this session), `lower_case_with_underscores` naming, 256-character line length, a one-line docstring on every new function or class,
 and a unit test for any new code.
 
 ## 6. Quality gate
 
-Both of these must pass before you push anything - this covers step 2's merge as much as any fix from step 5, so run it even if step 5 had nothing to do. `run_pre_commit` must run with `coverage/` as the working directory 
+Both of these must pass before you push anything - this covers step 2's merge as much as any fix from step 5, so run it even if step 5 had nothing to do. `run_pre_commit` must run with `coverage/` as the working directory
 (it sources `coverage/setup.csh` internally); `tools/triage_test.sh` must run from the repo root:
 
 ```bash
@@ -69,8 +69,8 @@ cd ..
 tools/triage_test.sh <name> <scratch>/test.log
 ```
 
-Use the test module the changed area maps to in `TEST_REGISTRY` (`apps/predbat/unit_test.py`), or `./run_all --quick` (from `coverage/`, same as above) if there's no clean single-module mapping. 
-If either still fails, go to step 7 and report what's still broken — do not push a change that doesn't pass its own quality gate, 
+Use the test module the changed area maps to in `TEST_REGISTRY` (`apps/predbat/unit_test.py`), or `./run_all --quick` (from `coverage/`, same as above) if there's no clean single-module mapping.
+If either still fails, go to step 7 and report what's still broken — do not push a change that doesn't pass its own quality gate,
 even if step 2's merge commit already exists locally: an unpushed local commit is discarded automatically the next time this runs.
 
 ## 7. Commit, push, and reply
@@ -90,7 +90,7 @@ gh api repos/springfall2008/batpred/pulls/<pr-number>/comments/<comment-id>/repl
 
 Or push back with your reasoning if you didn't implement the suggestion — never a bare "done" with no explanation. If anything is unclear, technically wrong, or you can't verify a suggestion, say so in the reply rather than guessing or implementing something you don't understand.
 
-If step 6's quality gate never passed, post one summary comment via `gh pr comment <pr-number> --body "..."` opening with the same automated-reply disclosure line, explaining what's still failing and why you didn't push, 
+If step 6's quality gate never passed, post one summary comment via `gh pr comment <pr-number> --body "..."` opening with the same automated-reply disclosure line, explaining what's still failing and why you didn't push,
 instead of doing the commit/push/reply steps above.
 
 ## Guardrails

--- a/.claude/skills/pr-cleanup/SKILL.md
+++ b/.claude/skills/pr-cleanup/SKILL.md
@@ -27,7 +27,7 @@ Work on the PR's own branch, not a new one — you're pushing back to it directl
 - CI status: `gh pr checks <pr-number>`. For any failing check, read its actual log (`gh run view <run-id> --job <job-id> --log`, or fetch the job log directly) to find the real failure, not just the pass/fail summary.
 - Skip anything already resolved: a review thread that already has a reply from you addressing it, or a check that's since gone green.
 
-If there is genuinely nothing new to address — every thread already has a reply, every check is green — say so in a brief comment and stop; this is a normal, successful outcome, not a failure.
+If there is genuinely nothing new to address — every thread already has a reply, every check is green — post a brief comment saying so, opening with a line disclosing this is an automated cleanup check (nothing for a maintainer to act on), and stop; this is a normal, successful outcome, not a failure.
 
 ## 3. Evaluate before implementing
 
@@ -58,15 +58,15 @@ git commit -m "<one-line summary of the fixes>"
 git push
 ```
 
-Reply to each review thread you addressed, in the thread itself, not as a new top-level comment:
+Reply to each review thread you addressed, in the thread itself, not as a new top-level comment. Open every reply with a short line disclosing it is an automated reply from the triage bot, then state what changed:
 
 ```bash
 gh api repos/springfall2008/batpred/pulls/<pr-number>/comments/<comment-id>/replies -f body="..."
 ```
 
-State what changed, or push back with your reasoning if you didn't implement the suggestion — never a bare "done" with no explanation. If anything is unclear, technically wrong, or you can't verify a suggestion, say so in the reply rather than guessing or implementing something you don't understand.
+Or push back with your reasoning if you didn't implement the suggestion — never a bare "done" with no explanation. If anything is unclear, technically wrong, or you can't verify a suggestion, say so in the reply rather than guessing or implementing something you don't understand.
 
-If step 5's quality gate never passed, post one summary comment via `gh pr comment <pr-number> --body "..."` explaining what's still failing and why you didn't push, instead of doing the commit/push/reply steps above.
+If step 5's quality gate never passed, post one summary comment via `gh pr comment <pr-number> --body "..."`, opening with the same automated-reply disclosure line, explaining what's still failing and why you didn't push, instead of doing the commit/push/reply steps above.
 
 ## Guardrails
 

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -641,6 +641,15 @@ class GhApiFormPromptTests(unittest.TestCase):
         completed review in the log. The prompt asks for a denial to be stated plainly."""
         self.assertIn("denied", triage_daemon.GH_API_ENDPOINT_FIRST_PROMPT)
 
+    def test_requires_disclosure_on_every_posted_comment_or_reply(self):
+        """/code-review's own instructions live in a skill we don't own, so this appended
+        prompt is the only lever available to make its inline comments disclose they're
+        automated - and it doubles as a belt-and-braces backup for /pr-cleanup's replies,
+        which already ask for disclosure directly in their own SKILL.md."""
+        prompt = triage_daemon.GH_API_ENDPOINT_FIRST_PROMPT
+        self.assertIn("disclosing", prompt)
+        self.assertIn("automated", prompt)
+
 
 class PrReviewActivityCountTests(unittest.TestCase):
     """Tests for pr_review_activity_count(), new - the evidence check behind verify-then-label."""
@@ -1261,6 +1270,44 @@ class ProcessBotCleanupPrTests(unittest.TestCase):
         printed = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
         self.assertIn("Add confirmed findings", printed)
         self.assertIn("https://github.com/springfall2008/batpred/pull/4742", printed)
+
+
+class CommentDisclosureTests(unittest.TestCase):
+    """Regression tests ensuring every comment triage_daemon.py posts directly (as
+    opposed to a comment an LLM invocation composes at runtime - those get their own
+    disclosure instructions in the relevant SKILL.md, or in GH_API_ENDPOINT_FIRST_PROMPT
+    for /code-review, which is covered by GhApiFormPromptTests instead) opens with a
+    plain "Automated ..." disclosure, so a maintainer never mistakes one for a human's."""
+
+    @staticmethod
+    def _body_of_first_comment_call(mock_run):
+        """Return the --body argument of the first `gh issue/pr comment` call made,
+        skipping any subsequent label-edit calls the same function also makes."""
+        for call in mock_run.call_args_list:
+            args = call.args[0]
+            if args[:2] in (["gh", "issue"], ["gh", "pr"]) and "comment" in args:
+                return args[args.index("--body") + 1]
+        raise AssertionError(f"no comment call found among {mock_run.call_args_list}")
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_not_actionable_discloses(self, mock_run):
+        triage_daemon.mark_pr_not_actionable(4720)
+        self.assertTrue(self._body_of_first_comment_call(mock_run).startswith("Automated"))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_review_failed_discloses(self, mock_run):
+        triage_daemon.mark_review_failed(3100)
+        self.assertTrue(self._body_of_first_comment_call(mock_run).startswith("Automated"))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_review_failed_discloses(self, mock_run):
+        triage_daemon.mark_pr_review_failed(4742)
+        self.assertTrue(self._body_of_first_comment_call(mock_run).startswith("Automated"))
+
+    @patch("triage_daemon.subprocess.run")
+    def test_mark_pr_cleanup_failed_discloses(self, mock_run):
+        triage_daemon.mark_pr_cleanup_failed(4742)
+        self.assertTrue(self._body_of_first_comment_call(mock_run).startswith("Automated"))
 
 
 if __name__ == "__main__":

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -647,8 +647,8 @@ class GhApiFormPromptTests(unittest.TestCase):
         automated - and it doubles as a belt-and-braces backup for /pr-cleanup's replies,
         which already ask for disclosure directly in their own SKILL.md."""
         prompt = triage_daemon.GH_API_ENDPOINT_FIRST_PROMPT
-        self.assertIn("disclosing", prompt)
-        self.assertIn("automated", prompt)
+        self.assertIn("must open with", prompt)
+        self.assertIn("Automated comment from the triage bot", prompt)
 
 
 class PrReviewActivityCountTests(unittest.TestCase):

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -257,7 +257,10 @@ DISALLOWED_TOOLS_CLEANUP = ",".join([item for item in _DISALLOWED_TOOLS_BASE if 
 # above: the allowlist covers the spellings we enumerated, this keeps the agent on the one
 # spelling that is certain to be covered, and asks it to say so loudly when a call is denied
 # anyway - #4758 quietly degraded to printing the comments it could not post, which reads like
-# a finished review in the log.
+# a finished review in the log. Also carries the bot-disclosure requirement for these two flows:
+# /code-review's own instructions live in a skill we don't own, so this prompt is the only
+# lever available for it; /pr-cleanup's SKILL.md already asks for disclosure directly, and
+# this is the belt-and-braces backup for it, same reasoning as the endpoint-first steer.
 GH_API_ENDPOINT_FIRST_PROMPT = (
     "Permission rules in this session match a literal command prefix, so `gh api` calls are only permitted when the current allowlist covers the exact spelling you use. "
     "Prefer the endpoint-first, unquoted form (endpoint immediately after `gh api`) and put flags after the endpoint - for example "
@@ -266,7 +269,10 @@ GH_API_ENDPOINT_FIRST_PROMPT = (
     "Keep each call to a single command: piping into head/tail/grep is fine, but redirecting output anywhere outside "
     f"{SCRATCH_DIR} or the repository clone - /tmp included - is denied as well. "
     "If a call is denied regardless, state that plainly in your final message and name the command; do not quietly fall back "
-    "to printing the comments you would have posted."
+    "to printing the comments you would have posted. "
+    "Every comment or reply you post in this session - an inline review comment, a review-thread reply - must open with a "
+    "short line disclosing it is automated, e.g. '_Automated comment from the triage bot._', so a maintainer can tell "
+    "bot-authored feedback from a human reviewer's without checking the author field."
 )
 
 
@@ -427,7 +433,7 @@ def mark_pr_not_actionable(issue_number):
             "--repo",
             REPO,
             "--body",
-            "`BOT_PR` was added but this issue isn't actionable for an automated implementation " "(closed, or not classified `bug`/`enhancement`) - not attempting a PR. Remove `BOT_PR_FAILED` " "and re-add `BOT_PR` once the classification changes.",
+            "Automated PR creation skipped: `BOT_PR` was added but this issue isn't actionable for an automated implementation " "(closed, or not classified `bug`/`enhancement`). Remove `BOT_PR_FAILED` and re-add `BOT_PR` once the classification changes.",
         ],
         check=True,
     )

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -272,7 +272,7 @@ GH_API_ENDPOINT_FIRST_PROMPT = (
     "to printing the comments you would have posted. "
     "Every comment or reply you post in this session - an inline review comment, a review-thread reply - must open with a "
     "short line disclosing it is automated, e.g. '_Automated comment from the triage bot._', so a maintainer can tell "
-    "bot-authored feedback from a human reviewer's without checking the author field."
+    "bot-authored feedback apart from a human reviewer's, without needing to check the author field."
 )
 
 


### PR DESCRIPTION
## Summary

- `BOT_CLEANUP` (`/pr-cleanup`) was replying to review threads and posting summary comments with no disclosure they came from the bot, unlike `/issue-triage`/`/issue-triage-followup`, which already open every comment with one.
- `.claude/skills/pr-cleanup/SKILL.md`: adds a disclosure requirement to thread replies, the "nothing to address" comment, and the quality-gate-failure summary comment.
- `.claude/skills/issue-pr/SKILL.md`: adds the same disclosure requirement to its step-7 failure comment (it had a plain description, unlike the triage skills' explicit "opening with a line disclosing..." instruction).
- `GH_API_ENDPOINT_FIRST_PROMPT` (`tools/triage_daemon.py`) — the appended system prompt used for `review_pr()`/`cleanup_pr()` — now also requires disclosure on every comment/reply posted through it. This is the only lever available for `/code-review`'s comments, since it's a built-in skill whose own instructions we don't own; it also acts as a belt-and-braces backup for `/pr-cleanup`'s replies.
- `mark_pr_not_actionable()`'s directly-posted comment didn't open with "Automated ..." the way the other three Python-composed comments (`mark_review_failed`, `mark_pr_review_failed`, `mark_pr_cleanup_failed`) already did — tightened for consistency.

## Test plan

- [x] `python3 tools/test_triage_daemon.py` — all passing, including new regression tests (`CommentDisclosureTests`) asserting every Python-composed comment body opens with "Automated", and a `GhApiFormPromptTests` test asserting the appended prompt requires disclosure
- [x] `./run_pre_commit` (coverage/) — clean, including the "triage daemon unit tests" hook and the full `./run_all --quick` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)