### PR TITLE
ALPHAESS: Use charge to 10% @ 100w to implement hold.

### DIFF
--- a/apps/predbat/alphaess.py
+++ b/apps/predbat/alphaess.py
@@ -131,6 +131,12 @@ class AlphaESSAPI(ComponentBase):
         # allowance every time.
         self.write_burst_start = {}
         self.write_burst_writes = {}
+        # Target latched for the lifetime of one generic discharge hold. AlphaESS ignores
+        # an enabled discharge schedule with no periods, so a hold is expressed as a charge
+        # profile whose target is already below the battery SOC. Latching stops rising solar
+        # SOC from changing the target and consuming another cloud write for every 1% gained.
+        self.hold_target_soc = {}
+        self._hold_power_warned = set()
         # Serials Predbat has actually been asked to drive, i.e. ones whose write button has
         # been pressed at least once. The reconcile loop only re-applies for these, so a
         # startup cycle can never clobber an inverter before there is a plan to apply.
@@ -1020,6 +1026,102 @@ class AlphaESSAPI(ComponentBase):
         except (TypeError, ValueError):
             return low
 
+    def _window_active_now(self, window):
+        """Return whether a stored window covers Predbat's current minute.
+
+        The generic hold-charge path disables the charge-enable switch after deciding the
+        target has been reached, but deliberately leaves the start/end entities intact. The
+        times therefore retain the missing intent needed by this adapter. Hours above 24 are
+        accepted because Predbat represents a window crossing midnight as (for example)
+        23:00-25:00 before the AlphaESS boundary splits it.
+        """
+        start = hm_to_minutes(window.get("start"))
+        end = hm_to_minutes(window.get("end"))
+        if start == end:
+            return False
+        now = int(getattr(self.base, "minutes_now", 0)) % (24 * 60)
+        if end > 24 * 60 and now < start:
+            now += 24 * 60
+        if start < end:
+            return start <= now < end
+        return now >= start or now < end
+
+    def _hold_charge_window(self, sn, schedule):
+        """Translate Predbat's generic discharge hold into an AlphaESS charge profile.
+
+        Predbat represents every no-discharge hold (freeze charge, EV/iBoost hold and other
+        generic callers) by writing discharge power zero. AlphaESS ignores the previous
+        translation, discharge scheduling enabled with no periods. Live SMILE G3 testing in
+        GH#4725 established that an enabled CHARGE profile whose target is below current SOC
+        is the working device primitive instead.
+
+        A planned hold charge can arrive with normal discharge power: execute_plan has
+        already disabled its charge-enable switch and raised the reserve, while the original
+        target and times remain. A currently-active window at/below SOC recovers that intent.
+        A real charge target above SOC is kept verbatim even if another feature also asks for
+        a discharge hold; charging already prevents the battery feeding the load.
+
+        Returns a copied, enabled charge window while a hold is requested, otherwise None.
+        """
+        charge = schedule.get("charge", {}) or {}
+        export = schedule.get("export", {}) or {}
+        current_soc = self._as_float(self.device_values.get(sn, {}).get("soc"), 0.0)
+        charge_target = self._as_float(charge.get("soc"), 0.0)
+        charge_power = int(self._as_float(charge.get("power"), 0.0))
+        export_power = self._as_float(export.get("power"), 0.0)
+
+        discharge_hold = export_power <= 0
+        # A disabled window is only a generic hold while its computed charge rate is zero.
+        # Once execute_plan releases the hold it restores the rate before the old target/time
+        # entities are necessarily replaced; requiring zero prevents those stale fields from
+        # extending the hold. An explicitly enabled target-at/below-SOC profile is itself a
+        # hold regardless of the valid non-zero power it carries.
+        charge_window_hold = charge_target > 0 and charge_target <= current_soc and self._window_active_now(charge) and (bool(charge.get("enable")) or charge_power <= 0)
+        if not discharge_hold and not charge_window_hold:
+            self.hold_target_soc.pop(sn, None)
+            self._hold_power_warned.discard(sn)
+            return None
+
+        # Do not replace a genuine charge just because an EV/iBoost hold is present too.
+        # The active grid charge already prevents discharge and its requested target/rate
+        # must survive unchanged.
+        if bool(charge.get("enable")) and charge_target > current_soc and charge_power > 0:
+            self.hold_target_soc.pop(sn, None)
+            self._hold_power_warned.discard(sn)
+            return dict(charge)
+
+        power = charge_power if charge_power > 0 else int(self.battery_rate_max(sn))
+        if power <= 0:
+            if sn not in self._hold_power_warned:
+                self._hold_power_warned.add(sn)
+                self.log("Warn: AlphaESS {} cannot create its hold charge profile because neither the schedule nor the inverter rating supplies a positive power; keeping the legacy hold payload".format(sn))
+            return None
+        self._hold_power_warned.discard(sn)
+
+        if sn not in self.hold_target_soc:
+            below_current = self._clamp_percent(current_soc - 1, low=10, high=100)
+            # A genuine planned hold target is already below current SOC and should remain
+            # the target. Freeze charge and demand-mode holds carry an equal/empty target,
+            # so they use current SOC minus one instead.
+            if 10 <= charge_target < current_soc and charge_window_hold:
+                target = self._clamp_percent(charge_target, low=10, high=100)
+            else:
+                target = below_current
+            self.hold_target_soc[sn] = target
+
+        if charge_window_hold:
+            start = charge.get("start", "00:00:00")
+            end = charge.get("end", "23:45:00")
+        else:
+            # Generic demand-mode holds carry no end time. A stable daily profile avoids a
+            # rolling boundary that would change the payload and spend an AlphaESS cloud
+            # write every 15 minutes; reconciliation removes it as soon as the hold signal
+            # clears on the next Predbat cycle.
+            start = "00:00:00"
+            end = "23:45:00"
+
+        return {"enable": True, "soc": self.hold_target_soc[sn], "power": power, "start": start, "end": end}
+
     def split_window(self, start, end):
         """Split a window at midnight, returning ((start1, end1), (start2, end2)) in HH:mm.
 
@@ -1073,7 +1175,7 @@ class AlphaESSAPI(ComponentBase):
         A FULL REPLACEMENT, not a patch: all seven fields are always present, because the
         endpoint silently resets anything omitted.
         """
-        window = schedule.get("charge", {}) or {}
+        window = self._hold_charge_window(sn, schedule) or (schedule.get("charge", {}) or {})
         enabled = bool(window.get("enable"))
         # charge_rate zero is Predbat signalling freeze charge / no cross-charging. There
         # is no pause endpoint, so a zeroed rate is the only signal available and it
@@ -1113,15 +1215,23 @@ class AlphaESSAPI(ComponentBase):
         reserve = self._clamp_percent(schedule.get("reserve", 0))
         export_rate = self._as_float(window.get("power"), 0.0)
 
-        # discharge_rate zero means hold SOC (freeze export): discharge time control ON
-        # with no permitted period, so the battery cannot discharge at all. This does NOT
-        # depend on the charge rate - Predbat reaches discharge_rate == 0 together with
-        # charge_rate == 0 through ordinary, reachable combinations (set_freeze_export_during_demand
-        # zeroing the charge rate while a car-charging-from-battery hold or
-        # iboost_prevent_discharge zeroes the discharge rate in the same pass), and that
-        # combination is an explicit hold, not an absence of a plan. Treating it as "no plan"
-        # would let the battery discharge into the EV or iBoost load against the hold Predbat
-        # asked for.
+        # The working AlphaESS no-discharge primitive is the charge profile built by
+        # build_charge_payload, not an empty discharge programme. Leave discharge time
+        # control off so the ignored empty schedule cannot compete with that profile.
+        if self._hold_charge_window(sn, schedule):
+            return {
+                "sysSn": sn,
+                "ctrDis": 0,
+                "timeDisf1": ALPHAESS_TIME_DISABLED,
+                "timeDise1": ALPHAESS_TIME_DISABLED,
+                "timeDisf2": ALPHAESS_TIME_DISABLED,
+                "timeDise2": ALPHAESS_TIME_DISABLED,
+                "batUseCap": reserve,
+            }
+
+        # Fallback only: reached when a hold was requested but no positive charge-profile
+        # power could be derived. Hardware testing says AlphaESS ignores this empty schedule,
+        # but retaining it is safer than silently returning to demand when no rating is available.
         if export_rate <= 0:
             return {
                 "sysSn": sn,
@@ -1519,7 +1629,8 @@ class AlphaESSAPI(ComponentBase):
         holds schedule["reserve"] rather than an arbitrary constant - see
         build_discharge_payload for the same one-field-two-purposes rule on the legacy pair.
         """
-        charge = schedule.get("charge", {}) or {}
+        hold_charge = self._hold_charge_window(sn, schedule)
+        charge = hold_charge or (schedule.get("charge", {}) or {})
         export = schedule.get("export", {}) or {}
         reserve = schedule.get("reserve", 10)
         charge_rate = self._as_float(charge.get("power"), 0.0)
@@ -1531,14 +1642,10 @@ class AlphaESSAPI(ComponentBase):
             charge_on = False
         charge_list = [self._periodic_entry(charge_start, charge_end, charge.get("soc", 100), charge_rate)] if charge_on else [self._periodic_entry(ALPHAESS_TIME_DISABLED, ALPHAESS_TIME_DISABLED, 10, 0)]
 
-        # export_rate zero means hold SOC (freeze export), exactly as build_discharge_payload:
-        # discharge time control ON with no permitted period, so the battery cannot discharge
-        # at all. Decided before, and independently of, the window/enable check - Predbat
-        # reaches export_rate == 0 through ordinary, reachable combinations (see
-        # build_discharge_payload's comment), and that is an explicit hold, not the absence of
-        # a plan. Getting this wrong lets the battery discharge into the EV or iBoost load
-        # against the hold Predbat asked for; ctrDisCycle 0 here is DEMAND MODE, not a hold.
-        export_hold = export_rate <= 0
+        # While the hold charge profile is active it is the whole control action. Suppress
+        # any export schedule and leave discharge time control in demand mode; AlphaESS
+        # ignores the former ctrDisCycle=1 plus empty-period representation.
+        export_hold = hold_charge is not None
         if export_hold:
             export_on = False
         else:
@@ -1572,11 +1679,9 @@ class AlphaESSAPI(ComponentBase):
             "chargeTimeList": charge_list,
             "dischargeTimeList": discharge_list,
             "gridChargeCycle": 1 if charge_on else 0,
-            # export_hold sets this ON (1) with no permitted period - the hard hold.
-            # export_on sets it ON for a real scheduled window. Otherwise it is OFF (0),
-            # demand mode, where the battery covers the house down to the reserve floor
-            # carried by the idle discharge entry above.
-            "ctrDisCycle": 1 if (export_on or export_hold) else 0,
+            # A real export uses discharge time control. Hold charge deliberately leaves it
+            # off: the enabled charge profile is what prevents discharge on AlphaESS.
+            "ctrDisCycle": 1 if export_on else 0,
         }
 
     async def apply_settings(self, sn, schedule, force=False):

--- a/apps/predbat/alphaess.py
+++ b/apps/predbat/alphaess.py
@@ -131,12 +131,6 @@ class AlphaESSAPI(ComponentBase):
         # allowance every time.
         self.write_burst_start = {}
         self.write_burst_writes = {}
-        # Target latched for the lifetime of one generic discharge hold. AlphaESS ignores
-        # an enabled discharge schedule with no periods, so a hold is expressed as a charge
-        # profile whose target is already below the battery SOC. Latching stops rising solar
-        # SOC from changing the target and consuming another cloud write for every 1% gained.
-        self.hold_target_soc = {}
-        self._hold_power_warned = set()
         # Serials Predbat has actually been asked to drive, i.e. ones whose write button has
         # been pressed at least once. The reconcile loop only re-applies for these, so a
         # startup cycle can never clobber an inverter before there is a plan to apply.
@@ -1052,12 +1046,13 @@ class AlphaESSAPI(ComponentBase):
         Predbat represents every no-discharge hold (freeze charge, EV/iBoost hold and other
         generic callers) by writing discharge power zero. AlphaESS ignores the previous
         translation, discharge scheduling enabled with no periods. Live SMILE G3 testing in
-        GH#4725 established that an enabled CHARGE profile whose target is below current SOC
-        is the working device primitive instead.
+        GH#4725 established that an enabled CHARGE profile with a low target is the working
+        device primitive instead. Synthetic holds use a fixed 10% target and 100 W power.
 
         A planned hold charge can arrive with normal discharge power: execute_plan has
         already disabled its charge-enable switch and raised the reserve, while the original
-        target and times remain. A currently-active window at/below SOC recovers that intent.
+        target and times remain. A currently-active window at/below SOC recovers that intent
+        and converts it to the same fixed hold profile.
         A real charge target above SOC is kept verbatim even if another feature also asks for
         a discharge hold; charging already prevents the battery feeding the load.
 
@@ -1078,36 +1073,13 @@ class AlphaESSAPI(ComponentBase):
         # hold regardless of the valid non-zero power it carries.
         charge_window_hold = charge_target > 0 and charge_target <= current_soc and self._window_active_now(charge) and (bool(charge.get("enable")) or charge_power <= 0)
         if not discharge_hold and not charge_window_hold:
-            self.hold_target_soc.pop(sn, None)
-            self._hold_power_warned.discard(sn)
             return None
 
         # Do not replace a genuine charge just because an EV/iBoost hold is present too.
         # The active grid charge already prevents discharge and its requested target/rate
         # must survive unchanged.
         if bool(charge.get("enable")) and charge_target > current_soc and charge_power > 0:
-            self.hold_target_soc.pop(sn, None)
-            self._hold_power_warned.discard(sn)
             return dict(charge)
-
-        power = charge_power if charge_power > 0 else int(self.battery_rate_max(sn))
-        if power <= 0:
-            if sn not in self._hold_power_warned:
-                self._hold_power_warned.add(sn)
-                self.log("Warn: AlphaESS {} cannot create its hold charge profile because neither the schedule nor the inverter rating supplies a positive power; keeping the legacy hold payload".format(sn))
-            return None
-        self._hold_power_warned.discard(sn)
-
-        if sn not in self.hold_target_soc:
-            below_current = self._clamp_percent(current_soc - 1, low=10, high=100)
-            # A genuine planned hold target is already below current SOC and should remain
-            # the target. Freeze charge and demand-mode holds carry an equal/empty target,
-            # so they use current SOC minus one instead.
-            if 10 <= charge_target < current_soc and charge_window_hold:
-                target = self._clamp_percent(charge_target, low=10, high=100)
-            else:
-                target = below_current
-            self.hold_target_soc[sn] = target
 
         if charge_window_hold:
             start = charge.get("start", "00:00:00")
@@ -1120,7 +1092,11 @@ class AlphaESSAPI(ComponentBase):
             start = "00:00:00"
             end = "23:45:00"
 
-        return {"enable": True, "soc": self.hold_target_soc[sn], "power": power, "start": start, "end": end}
+        # Keep the synthetic profile deterministic. Zero power disables charging in
+        # Predbat and may cause AlphaESS to discard the profile, while 100 W is a small,
+        # positive setpoint on the periodic API. The legacy endpoint has no power field,
+        # but still receives the same enabled 10% target and time window.
+        return {"enable": True, "soc": 10, "power": 100, "start": start, "end": end}
 
     def split_window(self, start, end):
         """Split a window at midnight, returning ((start1, end1), (start2, end2)) in HH:mm.
@@ -1213,7 +1189,6 @@ class AlphaESSAPI(ComponentBase):
         window = schedule.get("export", {}) or {}
         enabled = bool(window.get("enable"))
         reserve = self._clamp_percent(schedule.get("reserve", 0))
-        export_rate = self._as_float(window.get("power"), 0.0)
 
         # The working AlphaESS no-discharge primitive is the charge profile built by
         # build_charge_payload, not an empty discharge programme. Leave discharge time
@@ -1222,20 +1197,6 @@ class AlphaESSAPI(ComponentBase):
             return {
                 "sysSn": sn,
                 "ctrDis": 0,
-                "timeDisf1": ALPHAESS_TIME_DISABLED,
-                "timeDise1": ALPHAESS_TIME_DISABLED,
-                "timeDisf2": ALPHAESS_TIME_DISABLED,
-                "timeDise2": ALPHAESS_TIME_DISABLED,
-                "batUseCap": reserve,
-            }
-
-        # Fallback only: reached when a hold was requested but no positive charge-profile
-        # power could be derived. Hardware testing says AlphaESS ignores this empty schedule,
-        # but retaining it is safer than silently returning to demand when no rating is available.
-        if export_rate <= 0:
-            return {
-                "sysSn": sn,
-                "ctrDis": 1,
                 "timeDisf1": ALPHAESS_TIME_DISABLED,
                 "timeDise1": ALPHAESS_TIME_DISABLED,
                 "timeDisf2": ALPHAESS_TIME_DISABLED,

--- a/apps/predbat/alphaess.py
+++ b/apps/predbat/alphaess.py
@@ -11,8 +11,13 @@
 Registers each discovered AlphaESS system as an ``AlphaESSCloud`` Predbat inverter,
 publishing monitoring sensors and schedule control entities. Predbat's controls map
 straight onto the AlphaESS schedule fields - gridCharge/timeChaf/batHighCap for charging
-and ctrDis/timeDisf/batUseCap for export - and the inverter does the timing, so there is
-no per-instant work mode to derive.
+and ctrDis/timeDisf/batUseCap for scheduled discharge permission - and the inverter does
+the timing, so there is no per-instant work mode to derive.
+
+Hardware testing confirms that the periodic discharge schedule only controls when the
+battery may serve local load; it does not force grid export. The legacy endpoint has no
+power field at all, so forced-export behaviour there remains unverified and cannot be
+requested at a particular wattage. The private VPP control used by providers is unavailable.
 
 Auth is stateless: every request carries appId, timeStamp and
 sign = sha512(appId + appSecret + timeStamp). There is no token and no refresh, so the
@@ -61,6 +66,8 @@ from alphaess_const import (
     window_is_empty,
     ALPHAESS_TIME_DISABLED,
     ALPHAESS_TIME_MAX,
+    ALPHAESS_HOLD_SOC,
+    ALPHAESS_HOLD_POWER,
     ALPHAESS_SETTLE_POLLS,
     ALPHAESS_WRITE_SETTLE_SECONDS,
     ALPHAESS_WRITE_BURST_MAX,
@@ -73,6 +80,9 @@ from alphaess_const import (
     ALPHAESS_TTL_CONFIG,
     ALPHAESS_TTL_ENERGY,
 )
+
+
+_HOLD_NOT_EVALUATED = object()
 
 
 class AlphaESSAPI(ComponentBase):
@@ -1026,14 +1036,14 @@ class AlphaESSAPI(ComponentBase):
         The generic hold-charge path disables the charge-enable switch after deciding the
         target has been reached, but deliberately leaves the start/end entities intact. The
         times therefore retain the missing intent needed by this adapter. Hours above 24 are
-        accepted because Predbat represents a window crossing midnight as (for example)
+        accepted because Predbat can represent a window crossing midnight as (for example)
         23:00-25:00 before the AlphaESS boundary splits it.
         """
         start = hm_to_minutes(window.get("start"))
         end = hm_to_minutes(window.get("end"))
         if start == end:
             return False
-        now = int(getattr(self.base, "minutes_now", 0)) % (24 * 60)
+        now = int(self.minutes_now) % (24 * 60)
         if end > 24 * 60 and now < start:
             now += 24 * 60
         if start < end:
@@ -1049,12 +1059,16 @@ class AlphaESSAPI(ComponentBase):
         GH#4725 established that an enabled CHARGE profile with a low target is the working
         device primitive instead. Synthetic holds use a fixed 10% target and 100 W power.
 
-        A planned hold charge can arrive with normal discharge power: execute_plan has
-        already disabled its charge-enable switch and raised the reserve, while the original
-        target and times remain. A currently-active window at/below SOC recovers that intent
-        and converts it to the same fixed hold profile.
-        A real charge target above SOC is kept verbatim even if another feature also asks for
-        a discharge hold; charging already prevents the battery feeding the load.
+        A planned hold charge arrives with normal (usually maximum) charge power:
+        execute_plan disables its charge-enable switch after the target is reached, raises
+        reserve and later restores the normal charge rate, while deliberately leaving target
+        and times intact. The active window plus target-at/below-SOC is therefore the usable
+        hold signature; requiring zero charge power would make this branch unreachable in
+        production.
+
+        A real charge target above SOC is kept verbatim only while its window is active.
+        Merely having a future charge schedule configured does not stop discharge now, so it
+        cannot satisfy a simultaneous EV/iBoost hold outside that period.
 
         Returns a copied, enabled charge window while a hold is requested, otherwise None.
         """
@@ -1062,41 +1076,42 @@ class AlphaESSAPI(ComponentBase):
         export = schedule.get("export", {}) or {}
         current_soc = self._as_float(self.device_values.get(sn, {}).get("soc"), 0.0)
         charge_target = self._as_float(charge.get("soc"), 0.0)
-        charge_power = int(self._as_float(charge.get("power"), 0.0))
+        charge_power = self._as_float(charge.get("power"), 0.0)
         export_power = self._as_float(export.get("power"), 0.0)
 
         discharge_hold = export_power <= 0
-        # A disabled window is only a generic hold while its computed charge rate is zero.
-        # Once execute_plan releases the hold it restores the rate before the old target/time
-        # entities are necessarily replaced; requiring zero prevents those stale fields from
-        # extending the hold. An explicitly enabled target-at/below-SOC profile is itself a
-        # hold regardless of the valid non-zero power it carries.
-        charge_window_hold = charge_target > 0 and charge_target <= current_soc and self._window_active_now(charge) and (bool(charge.get("enable")) or charge_power <= 0)
+        charge_window_active = self._window_active_now(charge)
+        # AlphaESS does not discharge down towards a reached grid-charge target while the
+        # charge period remains enabled: a target below current SOC holds the battery. Recover
+        # that hardware behaviour after generic execute.py has disabled the enable switch.
+        # The time test prevents stale target/time entities extending the hold beyond their
+        # original planned period.
+        charge_window_hold = charge_target > 0 and charge_target <= current_soc and charge_window_active
         if not discharge_hold and not charge_window_hold:
             return None
 
         # Do not replace a genuine charge just because an EV/iBoost hold is present too.
         # The active grid charge already prevents discharge and its requested target/rate
         # must survive unchanged.
-        if bool(charge.get("enable")) and charge_target > current_soc and charge_power > 0:
+        if bool(charge.get("enable")) and charge_target > current_soc and charge_power > 0 and charge_window_active:
             return dict(charge)
 
         if charge_window_hold:
-            start = charge.get("start", "00:00:00")
-            end = charge.get("end", "23:45:00")
+            start = charge.get("start", ALPHAESS_TIME_DISABLED)
+            end = charge.get("end", ALPHAESS_TIME_MAX)
         else:
             # Generic demand-mode holds carry no end time. A stable daily profile avoids a
             # rolling boundary that would change the payload and spend an AlphaESS cloud
             # write every 15 minutes; reconciliation removes it as soon as the hold signal
             # clears on the next Predbat cycle.
-            start = "00:00:00"
-            end = "23:45:00"
+            start = ALPHAESS_TIME_DISABLED
+            end = ALPHAESS_TIME_MAX
 
         # Keep the synthetic profile deterministic. Zero power disables charging in
         # Predbat and may cause AlphaESS to discard the profile, while 100 W is a small,
         # positive setpoint on the periodic API. The legacy endpoint has no power field,
         # but still receives the same enabled 10% target and time window.
-        return {"enable": True, "soc": 10, "power": 100, "start": start, "end": end}
+        return {"enable": True, "soc": ALPHAESS_HOLD_SOC, "power": ALPHAESS_HOLD_POWER, "start": start, "end": end}
 
     def split_window(self, start, end):
         """Split a window at midnight, returning ((start1, end1), (start2, end2)) in HH:mm.
@@ -1145,17 +1160,20 @@ class AlphaESSAPI(ComponentBase):
             periods.append((snapped_start, snapped_end))
         return periods[0], periods[1]
 
-    def build_charge_payload(self, sn, schedule):
+    def build_charge_payload(self, sn, schedule, hold_charge=_HOLD_NOT_EVALUATED):
         """Build the full updateChargeConfigInfo body for one inverter.
 
         A FULL REPLACEMENT, not a patch: all seven fields are always present, because the
         endpoint silently resets anything omitted.
         """
-        window = self._hold_charge_window(sn, schedule) or (schedule.get("charge", {}) or {})
+        if hold_charge is _HOLD_NOT_EVALUATED:
+            hold_charge = self._hold_charge_window(sn, schedule)
+        window = hold_charge or (schedule.get("charge", {}) or {})
         enabled = bool(window.get("enable"))
-        # charge_rate zero is Predbat signalling freeze charge / no cross-charging. There
-        # is no pause endpoint, so a zeroed rate is the only signal available and it
-        # overrides the window outright.
+        # Outside a derived AlphaESS hold profile, zero charge power still means disabled
+        # charging/no cross-charging to Predbat. A hold replaces it with the small positive
+        # ALPHAESS_HOLD_POWER because _periodic_entry omits non-positive power and AlphaESS's
+        # resulting default power is unknown.
         rate = self._as_float(window.get("power"), 0.0)
         if enabled and rate <= 0:
             enabled = False
@@ -1179,12 +1197,14 @@ class AlphaESSAPI(ComponentBase):
             "batHighCap": self._clamp_percent(window.get("soc", 100) if enabled else 100),
         }
 
-    def build_discharge_payload(self, sn, schedule):
+    def build_discharge_payload(self, sn, schedule, hold_charge=_HOLD_NOT_EVALUATED):
         """Build the full updateDisChargeConfigInfo body for one inverter.
 
-        batUseCap serves two Predbat concepts because the API has only one field for the
-        discharge floor: it is the export target while an export window is programmed and
-        the reserve otherwise.
+        Despite Predbat's generic ``export`` naming, this legacy endpoint has no discharge
+        power field. ctrDis configures a permitted discharge period and batUseCap its floor
+        (or the standing reserve otherwise); whether a legacy inverter ever sends surplus
+        to grid in that mode is not hardware-verified. The periodic path is confirmed to
+        serve load only, while known force-export/VPP control uses an unavailable private API.
         """
         window = schedule.get("export", {}) or {}
         enabled = bool(window.get("enable"))
@@ -1193,7 +1213,9 @@ class AlphaESSAPI(ComponentBase):
         # The working AlphaESS no-discharge primitive is the charge profile built by
         # build_charge_payload, not an empty discharge programme. Leave discharge time
         # control off so the ignored empty schedule cannot compete with that profile.
-        if self._hold_charge_window(sn, schedule):
+        if hold_charge is _HOLD_NOT_EVALUATED:
+            hold_charge = self._hold_charge_window(sn, schedule)
+        if hold_charge:
             return {
                 "sysSn": sn,
                 "ctrDis": 0,
@@ -1206,8 +1228,7 @@ class AlphaESSAPI(ComponentBase):
 
         (start1, end1), (start2, end2) = self._snapped_periods(sn, "export", window.get("start"), window.get("end"), enabled)
         # Same rule as build_charge_payload: only disable the payload when BOTH periods have
-        # collapsed, so a period-1 collapse never throws away a genuine period-2 remainder and
-        # costs a missed peak-rate export.
+        # collapsed, so a period-1 collapse never throws away a genuine period-2 remainder.
         period1_empty = start1 == ALPHAESS_TIME_DISABLED and end1 == ALPHAESS_TIME_DISABLED
         period2_empty = start2 == ALPHAESS_TIME_DISABLED and end2 == ALPHAESS_TIME_DISABLED
         if period1_empty and period2_empty:
@@ -1576,11 +1597,16 @@ class AlphaESSAPI(ComponentBase):
             entry["chargePower"] = int(power)
         return entry
 
-    def build_periodic_payload(self, sn, schedule):
+    def build_periodic_payload(self, sn, schedule, hold_charge=_HOLD_NOT_EVALUATED):
         """Build the setTimeChargeBySn body for one inverter.
 
         executeCycleType 0 (daily) only: Predbat replans continuously, so a weekday-aware
         schedule has nothing to express.
+
+        AlphaESS hardware testing confirms that a periodic ``dischargeTimeList`` permits
+        battery discharge to local load; it does not force export to grid even when the
+        power value is populated. Predbat keeps its generic export-facing entity names, but
+        this builder must not imply a force-export capability the public API does not have.
 
         Both lists must carry at least one element - an empty list is rejected with 6001
         "time list is null", and omitting the key gets 10001 - so a direction with no plan
@@ -1590,7 +1616,8 @@ class AlphaESSAPI(ComponentBase):
         holds schedule["reserve"] rather than an arbitrary constant - see
         build_discharge_payload for the same one-field-two-purposes rule on the legacy pair.
         """
-        hold_charge = self._hold_charge_window(sn, schedule)
+        if hold_charge is _HOLD_NOT_EVALUATED:
+            hold_charge = self._hold_charge_window(sn, schedule)
         charge = hold_charge or (schedule.get("charge", {}) or {})
         export = schedule.get("export", {}) or {}
         reserve = schedule.get("reserve", 10)
@@ -1606,8 +1633,8 @@ class AlphaESSAPI(ComponentBase):
         # While the hold charge profile is active it is the whole control action. Suppress
         # any export schedule and leave discharge time control in demand mode; AlphaESS
         # ignores the former ctrDisCycle=1 plus empty-period representation.
-        export_hold = hold_charge is not None
-        if export_hold:
+        hold_profile_active = hold_charge is not None
+        if hold_profile_active:
             export_on = False
         else:
             export_on = bool(export.get("enable"))
@@ -1640,8 +1667,9 @@ class AlphaESSAPI(ComponentBase):
             "chargeTimeList": charge_list,
             "dischargeTimeList": discharge_list,
             "gridChargeCycle": 1 if charge_on else 0,
-            # A real export uses discharge time control. Hold charge deliberately leaves it
-            # off: the enabled charge profile is what prevents discharge on AlphaESS.
+            # This enables scheduled discharge permission, not forced grid export. Hold
+            # charge deliberately leaves it off because the charge profile prevents local
+            # load discharge on AlphaESS.
             "ctrDisCycle": 1 if export_on else 0,
         }
 
@@ -1655,12 +1683,22 @@ class AlphaESSAPI(ComponentBase):
         """
         if not self.control_enable:
             return False
+        # Derive this once for the whole apply. Both legacy payloads must describe the same
+        # control decision, and the periodic payload uses the same path for parity.
+        hold_charge = self._hold_charge_window(sn, schedule)
         if self._periodic_ok.get(sn) is True:
-            payload = self.build_periodic_payload(sn, schedule)
+            payload = self.build_periodic_payload(sn, schedule, hold_charge=hold_charge)
             return await self._write_payload(sn, "periodic", "set_time_charge", payload, force=force)
-        charge_payload = self.build_charge_payload(sn, schedule)
-        discharge_payload = self.build_discharge_payload(sn, schedule)
+        charge_payload = self.build_charge_payload(sn, schedule, hold_charge=hold_charge)
+        discharge_payload = self.build_discharge_payload(sn, schedule, hold_charge=hold_charge)
         charge_ok = await self._write_payload(sn, "charge", "update_charge_config", charge_payload, force=force)
+        # Entering a hold is a two-endpoint transition on the legacy API: the enabled charge
+        # profile is the only working hold primitive, while ctrDis=0 is ordinary demand mode.
+        # Never switch discharge back to demand if the companion charge profile was rejected
+        # or held by pacing, otherwise the battery is left with no hold at all.
+        if hold_charge is not None and not charge_ok:
+            self.log("Info: AlphaESS {} discharge update deferred because its hold charge profile is not yet applied".format(sn))
+            return False
         if self.api_delay:
             await asyncio.sleep(self.api_delay)
         discharge_ok = await self._write_payload(sn, "discharge", "update_discharge_config", discharge_payload, force=force)

--- a/apps/predbat/alphaess_const.py
+++ b/apps/predbat/alphaess_const.py
@@ -175,6 +175,14 @@ ALPHAESS_TIME_STEP_MINUTES = 15
 ALPHAESS_TIME_MAX = "23:45"
 ALPHAESS_TIME_DISABLED = "00:00"
 
+# The Open API has no pause/hold operation. Live SMILE G3 testing established that an
+# enabled charge schedule whose target is already below SOC is the only available hold
+# primitive. Ten percent is the API's minimum accepted charge target. A zero power value is
+# not sent by our periodic builder and the inverter's omitted/default behaviour is unknown,
+# so 100 W is a deliberately small positive setpoint rather than an assumed zero-power mode.
+ALPHAESS_HOLD_SOC = 10
+ALPHAESS_HOLD_POWER = 100
+
 
 def hhmmss_to_hhmm(value):
     """Convert Predbat's HH:MM:SS control-entity value to the API's HH:mm.

--- a/apps/predbat/tests/test_alphaess_control.py
+++ b/apps/predbat/tests/test_alphaess_control.py
@@ -313,8 +313,8 @@ def test_alphaess_rate_zero_is_freeze():
     """Zero charge power disables charging; zero discharge power requests a hold.
 
     Live AlphaESS hardware ignores discharge scheduling enabled with no periods, so the
-    adapter must translate the generic zero-discharge signal into a charge profile below
-    current SOC instead.
+    adapter must translate the generic zero-discharge signal into a fixed 10% charge
+    profile instead.
     """
     failed = False
     client = _client()
@@ -351,7 +351,7 @@ def test_alphaess_both_rates_zero_still_holds_the_battery():
     charge rate (execute.py:532/538 - AlphaESSCloud has has_timed_pause False, so the "else"
     branch fires) together with a car-charging-from-battery-disable (execute.py:564) or
     iboost_prevent_discharge (execute.py:591) hold zeroing the discharge rate in the same
-    pass. The hold is realised as a charge profile below SOC, not the empty discharge
+    pass. The hold is realised as a fixed 10% charge profile, not the empty discharge
     schedule AlphaESS ignores. Stranding a genuinely unconfigured system is prevented
     elsewhere by the control_active gate in _reconcile_control, which only re-applies once
     a serial's write button has been pressed.
@@ -1381,7 +1381,7 @@ def test_alphaess_periodic_charge_limit_floor_is_clamped():
 
 
 def test_alphaess_periodic_rate_zero_is_freeze_not_demand_mode():
-    """Periodic zero discharge must use the same target-below-SOC charge profile."""
+    """Periodic zero discharge must use the same fixed 10% charge profile."""
     failed = False
     client = _client()
     client._periodic_ok["AL70"] = True

--- a/apps/predbat/tests/test_alphaess_control.py
+++ b/apps/predbat/tests/test_alphaess_control.py
@@ -327,13 +327,13 @@ def test_alphaess_rate_zero_is_freeze():
         print(f"ERROR: gridCharge {charge.get('gridCharge')} should be 0 when charge_rate is 0")
         failed = True
 
-    # discharge_rate == 0 -> a valid daily charge profile at current SOC minus one, with
+    # discharge_rate == 0 -> a valid daily charge profile at a fixed 10%, with
     # ordinary demand-mode discharge settings. The charge profile is the hardware hold.
     frozen_export = _schedule(reserve=10, export_power=0)
     hold_charge = client.build_charge_payload("AL70", frozen_export)
     discharge = client.build_discharge_payload("AL70", frozen_export)
-    if hold_charge.get("gridCharge") != 1 or hold_charge.get("batHighCap") != 49:
-        print(f"ERROR: zero-discharge hold did not create a 49% charge profile: {hold_charge}")
+    if hold_charge.get("gridCharge") != 1 or hold_charge.get("batHighCap") != 10:
+        print(f"ERROR: zero-discharge hold did not create a 10% charge profile: {hold_charge}")
         failed = True
     if hold_charge.get("timeChaf1") != "00:00" or hold_charge.get("timeChae1") != "23:45":
         print(f"ERROR: hold profile should cover the stable daily period, got {hold_charge}")
@@ -361,8 +361,8 @@ def test_alphaess_both_rates_zero_still_holds_the_battery():
     schedule = _schedule(reserve=15, charge_power=0, export_power=0)
     charge = client.build_charge_payload("AL70", schedule)
     discharge = client.build_discharge_payload("AL70", schedule)
-    if charge.get("gridCharge") != 1 or charge.get("batHighCap") != 49:
-        print(f"ERROR: both-zero hold did not create a target-below-SOC charge profile: {charge}")
+    if charge.get("gridCharge") != 1 or charge.get("batHighCap") != 10:
+        print(f"ERROR: both-zero hold did not create a 10% charge profile: {charge}")
         failed = True
     if discharge.get("ctrDis") != 0:
         print(f"ERROR: both-zero hold left discharge time control enabled: {discharge}")
@@ -373,8 +373,8 @@ def test_alphaess_both_rates_zero_still_holds_the_battery():
 def test_alphaess_disabled_planned_hold_recovers_the_charge_window():
     """Generic Hold charging disables the switch but leaves target and times intact.
 
-    Recover that active window and preserve its already-lower planned target instead of
-    turning a target-reached charge back into demand mode.
+    Recover that active window and use the fixed hold target instead of turning a
+    target-reached charge back into demand mode.
     """
     failed = False
     client = _client()
@@ -382,8 +382,8 @@ def test_alphaess_disabled_planned_hold_recovers_the_charge_window():
     schedule = _schedule(reserve=41, charge={"enable": False, "soc": 40, "power": 0, "start": "01:00:00", "end": "05:00:00"})
     charge = client.build_charge_payload("AL70", schedule)
     discharge = client.build_discharge_payload("AL70", schedule)
-    if charge.get("gridCharge") != 1 or charge.get("batHighCap") != 40:
-        print(f"ERROR: planned 40% hold was not recovered: {charge}")
+    if charge.get("gridCharge") != 1 or charge.get("batHighCap") != 10:
+        print(f"ERROR: planned hold was not converted to the fixed 10% profile: {charge}")
         failed = True
     if charge.get("timeChaf1") != "01:00" or charge.get("timeChae1") != "05:00":
         print(f"ERROR: recovered hold did not retain its planned times: {charge}")
@@ -409,29 +409,26 @@ def test_alphaess_restored_rate_releases_a_disabled_planned_hold():
     if second.get("gridCharge") != 0:
         print(f"ERROR: restored charge power did not release stale hold fields: {second}")
         failed = True
-    if "AL70" in client.hold_target_soc:
-        print(f"ERROR: released hold left its target latch behind: {client.hold_target_soc}")
-        failed = True
     assert not failed, "test_alphaess_restored_rate_releases_a_disabled_planned_hold"
 
 
-def test_alphaess_hold_target_is_latched_while_soc_rises():
-    """Solar gain during a hold must not consume one cloud write for every SOC percent."""
+def test_alphaess_hold_profile_is_constant_while_soc_changes():
+    """The fixed hold target must not follow live SOC or inverter rating."""
     failed = False
     client = _client()
     schedule = _schedule(reserve=15, export_power=0)
     first = client.build_charge_payload("AL70", schedule)
     client.device_values["AL70"]["soc"] = 55.0
     second = client.build_charge_payload("AL70", schedule)
-    if first.get("batHighCap") != 49 or second.get("batHighCap") != 49:
-        print(f"ERROR: hold target ratcheted with SOC: first={first} second={second}")
+    if first.get("batHighCap") != 10 or second.get("batHighCap") != 10:
+        print(f"ERROR: hold target changed with SOC: first={first} second={second}")
         failed = True
     client.build_charge_payload("AL70", _schedule(reserve=15))
     third = client.build_charge_payload("AL70", schedule)
-    if third.get("batHighCap") != 54:
-        print(f"ERROR: a new hold kept the old latched target: {third}")
+    if third.get("batHighCap") != 10:
+        print(f"ERROR: a new hold did not use the fixed target: {third}")
         failed = True
-    assert not failed, "test_alphaess_hold_target_is_latched_while_soc_rises"
+    assert not failed, "test_alphaess_hold_profile_is_constant_while_soc_changes"
 
 
 def test_alphaess_real_charge_survives_a_simultaneous_discharge_hold():
@@ -1394,11 +1391,11 @@ def test_alphaess_periodic_rate_zero_is_freeze_not_demand_mode():
         print(f"ERROR: hold cycle flags should be charge=1/discharge=0, got {payload}")
         failed = True
     entry = (payload.get("chargeTimeList") or [{}])[0]
-    if entry.get("beginTime") != "00:00" or entry.get("endTime") != "23:45" or entry.get("chargeLimit") != 49:
+    if entry.get("beginTime") != "00:00" or entry.get("endTime") != "23:45" or entry.get("chargeLimit") != 10:
         print(f"ERROR: periodic hold charge profile is wrong: {entry}")
         failed = True
-    if entry.get("chargePower") != 3000:
-        print(f"ERROR: periodic hold should retain the valid 3000W schedule power, got {entry}")
+    if entry.get("chargePower") != 100:
+        print(f"ERROR: periodic hold should use the fixed 100W power, got {entry}")
         failed = True
     assert not failed, "test_alphaess_periodic_rate_zero_is_freeze_not_demand_mode"
 
@@ -1413,7 +1410,7 @@ def test_alphaess_periodic_both_rates_zero_still_holds_the_battery():
     if payload.get("ctrDisCycle") != 0:
         print(f"ERROR: ctrDisCycle {payload.get('ctrDisCycle')} should be 0 while charge profile holds")
         failed = True
-    if payload.get("gridChargeCycle") != 1 or payload["chargeTimeList"][0].get("chargeLimit") != 49:
+    if payload.get("gridChargeCycle") != 1 or payload["chargeTimeList"][0].get("chargeLimit") != 10 or payload["chargeTimeList"][0].get("chargePower") != 100:
         print(f"ERROR: both-zero periodic intent did not create the hold profile: {payload}")
         failed = True
     assert not failed, "test_alphaess_periodic_both_rates_zero_still_holds_the_battery"
@@ -1811,7 +1808,7 @@ def run_alphaess_control_tests(my_predbat):
         ("both_rates_zero_still_holds", test_alphaess_both_rates_zero_still_holds_the_battery),
         ("disabled_planned_hold_recovers_window", test_alphaess_disabled_planned_hold_recovers_the_charge_window),
         ("restored_rate_releases_hold", test_alphaess_restored_rate_releases_a_disabled_planned_hold),
-        ("hold_target_latched", test_alphaess_hold_target_is_latched_while_soc_rises),
+        ("hold_profile_constant", test_alphaess_hold_profile_is_constant_while_soc_changes),
         ("real_charge_survives_hold", test_alphaess_real_charge_survives_a_simultaneous_discharge_hold),
         ("snap_inward", test_alphaess_times_snap_inward_to_the_15_minute_grid),
         ("collapsed_disabled", test_alphaess_window_collapsed_by_snapping_is_disabled_not_wrapped),

--- a/apps/predbat/tests/test_alphaess_control.py
+++ b/apps/predbat/tests/test_alphaess_control.py
@@ -310,8 +310,12 @@ def test_alphaess_batusecap_is_the_reserve_outside_an_export_window():
 
 
 def test_alphaess_rate_zero_is_freeze():
-    """AlphaESS has no pause endpoint, so Predbat expresses freeze by zeroing the rates
-    (execute.py:491-495). Zero is a distinct instruction, not just 'slow'."""
+    """Zero charge power disables charging; zero discharge power requests a hold.
+
+    Live AlphaESS hardware ignores discharge scheduling enabled with no periods, so the
+    adapter must translate the generic zero-discharge signal into a charge profile below
+    current SOC instead.
+    """
     failed = False
     client = _client()
 
@@ -323,16 +327,20 @@ def test_alphaess_rate_zero_is_freeze():
         print(f"ERROR: gridCharge {charge.get('gridCharge')} should be 0 when charge_rate is 0")
         failed = True
 
-    # discharge_rate == 0 -> ctrDis 1 with BOTH periods disabled, so the battery holds SOC.
+    # discharge_rate == 0 -> a valid daily charge profile at current SOC minus one, with
+    # ordinary demand-mode discharge settings. The charge profile is the hardware hold.
     frozen_export = _schedule(reserve=10, export_power=0)
+    hold_charge = client.build_charge_payload("AL70", frozen_export)
     discharge = client.build_discharge_payload("AL70", frozen_export)
-    if discharge.get("ctrDis") != 1:
-        print(f"ERROR: ctrDis {discharge.get('ctrDis')} should be 1 to hold SOC")
+    if hold_charge.get("gridCharge") != 1 or hold_charge.get("batHighCap") != 49:
+        print(f"ERROR: zero-discharge hold did not create a 49% charge profile: {hold_charge}")
         failed = True
-    for key in ("timeDisf1", "timeDise1", "timeDisf2", "timeDise2"):
-        if discharge.get(key) != "00:00":
-            print(f"ERROR: {key} = {discharge.get(key)} should be disabled to hold SOC")
-            failed = True
+    if hold_charge.get("timeChaf1") != "00:00" or hold_charge.get("timeChae1") != "23:45":
+        print(f"ERROR: hold profile should cover the stable daily period, got {hold_charge}")
+        failed = True
+    if discharge.get("ctrDis") != 0:
+        print(f"ERROR: discharge time control {discharge.get('ctrDis')} should be off while the charge profile holds")
+        failed = True
     assert not failed, "test_alphaess_rate_zero_is_freeze"
 
 
@@ -343,24 +351,103 @@ def test_alphaess_both_rates_zero_still_holds_the_battery():
     charge rate (execute.py:532/538 - AlphaESSCloud has has_timed_pause False, so the "else"
     branch fires) together with a car-charging-from-battery-disable (execute.py:564) or
     iboost_prevent_discharge (execute.py:591) hold zeroing the discharge rate in the same
-    pass. Treating that as "no plan" would let the battery discharge into the EV or iBoost
-    load, silently defeating the explicit hold Predbat asked for. Stranding a genuinely
-    unconfigured system is prevented elsewhere, by the control_active gate in
-    _reconcile_control (Task 10), which only re-applies once a serial's write button has
-    been pressed.
+    pass. The hold is realised as a charge profile below SOC, not the empty discharge
+    schedule AlphaESS ignores. Stranding a genuinely unconfigured system is prevented
+    elsewhere by the control_active gate in _reconcile_control, which only re-applies once
+    a serial's write button has been pressed.
     """
     failed = False
     client = _client()
     schedule = _schedule(reserve=15, charge_power=0, export_power=0)
+    charge = client.build_charge_payload("AL70", schedule)
     discharge = client.build_discharge_payload("AL70", schedule)
-    if discharge.get("ctrDis") != 1:
-        print(f"ERROR: ctrDis {discharge.get('ctrDis')} should be 1 - both rates zero still means hold")
+    if charge.get("gridCharge") != 1 or charge.get("batHighCap") != 49:
+        print(f"ERROR: both-zero hold did not create a target-below-SOC charge profile: {charge}")
         failed = True
-    for key in ("timeDisf1", "timeDise1", "timeDisf2", "timeDise2"):
-        if discharge.get(key) != "00:00":
-            print(f"ERROR: {key} = {discharge.get(key)} should be disabled to hold SOC")
-            failed = True
+    if discharge.get("ctrDis") != 0:
+        print(f"ERROR: both-zero hold left discharge time control enabled: {discharge}")
+        failed = True
     assert not failed, "test_alphaess_both_rates_zero_still_holds_the_battery"
+
+
+def test_alphaess_disabled_planned_hold_recovers_the_charge_window():
+    """Generic Hold charging disables the switch but leaves target and times intact.
+
+    Recover that active window and preserve its already-lower planned target instead of
+    turning a target-reached charge back into demand mode.
+    """
+    failed = False
+    client = _client()
+    client.base.minutes_now = 2 * 60
+    schedule = _schedule(reserve=41, charge={"enable": False, "soc": 40, "power": 0, "start": "01:00:00", "end": "05:00:00"})
+    charge = client.build_charge_payload("AL70", schedule)
+    discharge = client.build_discharge_payload("AL70", schedule)
+    if charge.get("gridCharge") != 1 or charge.get("batHighCap") != 40:
+        print(f"ERROR: planned 40% hold was not recovered: {charge}")
+        failed = True
+    if charge.get("timeChaf1") != "01:00" or charge.get("timeChae1") != "05:00":
+        print(f"ERROR: recovered hold did not retain its planned times: {charge}")
+        failed = True
+    if discharge.get("ctrDis") != 0:
+        print(f"ERROR: recovered hold should leave discharge time control off: {discharge}")
+        failed = True
+    assert not failed, "test_alphaess_disabled_planned_hold_recovers_the_charge_window"
+
+
+def test_alphaess_restored_rate_releases_a_disabled_planned_hold():
+    """Stale target/times must not extend a hold after execute restores charge power."""
+    failed = False
+    client = _client()
+    client.base.minutes_now = 2 * 60
+    held = _schedule(reserve=41, charge={"enable": False, "soc": 40, "power": 0, "start": "01:00:00", "end": "05:00:00"})
+    released = _schedule(reserve=10, charge={"enable": False, "soc": 40, "power": 3000, "start": "01:00:00", "end": "05:00:00"})
+    first = client.build_charge_payload("AL70", held)
+    second = client.build_charge_payload("AL70", released)
+    if first.get("gridCharge") != 1:
+        print(f"ERROR: test setup did not enter the recovered hold: {first}")
+        failed = True
+    if second.get("gridCharge") != 0:
+        print(f"ERROR: restored charge power did not release stale hold fields: {second}")
+        failed = True
+    if "AL70" in client.hold_target_soc:
+        print(f"ERROR: released hold left its target latch behind: {client.hold_target_soc}")
+        failed = True
+    assert not failed, "test_alphaess_restored_rate_releases_a_disabled_planned_hold"
+
+
+def test_alphaess_hold_target_is_latched_while_soc_rises():
+    """Solar gain during a hold must not consume one cloud write for every SOC percent."""
+    failed = False
+    client = _client()
+    schedule = _schedule(reserve=15, export_power=0)
+    first = client.build_charge_payload("AL70", schedule)
+    client.device_values["AL70"]["soc"] = 55.0
+    second = client.build_charge_payload("AL70", schedule)
+    if first.get("batHighCap") != 49 or second.get("batHighCap") != 49:
+        print(f"ERROR: hold target ratcheted with SOC: first={first} second={second}")
+        failed = True
+    client.build_charge_payload("AL70", _schedule(reserve=15))
+    third = client.build_charge_payload("AL70", schedule)
+    if third.get("batHighCap") != 54:
+        print(f"ERROR: a new hold kept the old latched target: {third}")
+        failed = True
+    assert not failed, "test_alphaess_hold_target_is_latched_while_soc_rises"
+
+
+def test_alphaess_real_charge_survives_a_simultaneous_discharge_hold():
+    """An EV/iBoost hold during real grid charging must not lower the charge target."""
+    failed = False
+    client = _client()
+    schedule = _schedule(reserve=10, charge={"enable": True, "soc": 90, "power": 3000, "start": "01:00:00", "end": "05:00:00"}, export_power=0)
+    charge = client.build_charge_payload("AL70", schedule)
+    discharge = client.build_discharge_payload("AL70", schedule)
+    if charge.get("gridCharge") != 1 or charge.get("batHighCap") != 90:
+        print(f"ERROR: real charge was replaced by a hold profile: {charge}")
+        failed = True
+    if discharge.get("ctrDis") != 0:
+        print(f"ERROR: real charge plus hold should leave discharge time control off: {discharge}")
+        failed = True
+    assert not failed, "test_alphaess_real_charge_survives_a_simultaneous_discharge_hold"
 
 
 def test_alphaess_times_snap_inward_to_the_15_minute_grid():
@@ -1297,48 +1384,37 @@ def test_alphaess_periodic_charge_limit_floor_is_clamped():
 
 
 def test_alphaess_periodic_rate_zero_is_freeze_not_demand_mode():
-    """discharge_rate == 0 must mean HOLD on the periodic path too, exactly as
-    build_discharge_payload's ctrDis=1-with-disabled-periods means on the legacy path.
-
-    Before the fix, build_periodic_payload computed export_on = enable and rate > 0, so a
-    zero rate fell straight into the "no export planned" branch and produced ctrDisCycle=0
-    - which this file's own legacy comment defines as demand mode, where the battery covers
-    the house normally. On a periodic-entitled system with iboost_prevent_discharge or a
-    car-charging hold active, that would let the battery discharge into the load against an
-    explicit hold.
-    """
+    """Periodic zero discharge must use the same target-below-SOC charge profile."""
     failed = False
     client = _client()
     client._periodic_ok["AL70"] = True
     schedule = _schedule(reserve=15, export_power=0)
     payload = client.build_periodic_payload("AL70", schedule)
-    if payload.get("ctrDisCycle") != 1:
-        print(f"ERROR: ctrDisCycle {payload.get('ctrDisCycle')} should be 1 (time control ON, hard hold), not demand mode")
+    if payload.get("gridChargeCycle") != 1 or payload.get("ctrDisCycle") != 0:
+        print(f"ERROR: hold cycle flags should be charge=1/discharge=0, got {payload}")
         failed = True
-    entry = (payload.get("dischargeTimeList") or [{}])[0]
-    if entry.get("beginTime") != "00:00" or entry.get("endTime") != "00:00":
-        print(f"ERROR: discharge period {entry} should be disabled to hold SOC")
+    entry = (payload.get("chargeTimeList") or [{}])[0]
+    if entry.get("beginTime") != "00:00" or entry.get("endTime") != "23:45" or entry.get("chargeLimit") != 49:
+        print(f"ERROR: periodic hold charge profile is wrong: {entry}")
         failed = True
-    if "chargePower" in entry:
-        print(f"ERROR: a frozen (rate 0) entry should carry no chargePower, got {entry}")
+    if entry.get("chargePower") != 3000:
+        print(f"ERROR: periodic hold should retain the valid 3000W schedule power, got {entry}")
         failed = True
     assert not failed, "test_alphaess_periodic_rate_zero_is_freeze_not_demand_mode"
 
 
 def test_alphaess_periodic_both_rates_zero_still_holds_the_battery():
-    """Both rates at zero is an ordinary, reachable hold on the periodic path too - see
-    test_alphaess_both_rates_zero_still_holds_the_battery for why this combination is
-    reachable and must not be read as "no plan"."""
+    """Both-zero periodic intent still creates the working charge-profile hold."""
     failed = False
     client = _client()
     client._periodic_ok["AL70"] = True
     schedule = _schedule(reserve=10, charge_power=0, export_power=0)
     payload = client.build_periodic_payload("AL70", schedule)
-    if payload.get("ctrDisCycle") != 1:
-        print(f"ERROR: ctrDisCycle {payload.get('ctrDisCycle')} should still be 1 - both rates zero still means hold")
+    if payload.get("ctrDisCycle") != 0:
+        print(f"ERROR: ctrDisCycle {payload.get('ctrDisCycle')} should be 0 while charge profile holds")
         failed = True
-    if payload.get("gridChargeCycle") != 0:
-        print(f"ERROR: gridChargeCycle {payload.get('gridChargeCycle')} should be 0 - charge_rate 0 disables charging")
+    if payload.get("gridChargeCycle") != 1 or payload["chargeTimeList"][0].get("chargeLimit") != 49:
+        print(f"ERROR: both-zero periodic intent did not create the hold profile: {payload}")
         failed = True
     assert not failed, "test_alphaess_periodic_both_rates_zero_still_holds_the_battery"
 
@@ -1733,6 +1809,10 @@ def run_alphaess_control_tests(my_predbat):
         ("batusecap_is_reserve", test_alphaess_batusecap_is_the_reserve_outside_an_export_window),
         ("rate_zero_is_freeze", test_alphaess_rate_zero_is_freeze),
         ("both_rates_zero_still_holds", test_alphaess_both_rates_zero_still_holds_the_battery),
+        ("disabled_planned_hold_recovers_window", test_alphaess_disabled_planned_hold_recovers_the_charge_window),
+        ("restored_rate_releases_hold", test_alphaess_restored_rate_releases_a_disabled_planned_hold),
+        ("hold_target_latched", test_alphaess_hold_target_is_latched_while_soc_rises),
+        ("real_charge_survives_hold", test_alphaess_real_charge_survives_a_simultaneous_discharge_hold),
         ("snap_inward", test_alphaess_times_snap_inward_to_the_15_minute_grid),
         ("collapsed_disabled", test_alphaess_window_collapsed_by_snapping_is_disabled_not_wrapped),
         ("midnight_end_snaps", test_alphaess_midnight_end_snaps_to_the_maximum),

--- a/apps/predbat/tests/test_alphaess_control.py
+++ b/apps/predbat/tests/test_alphaess_control.py
@@ -373,13 +373,14 @@ def test_alphaess_both_rates_zero_still_holds_the_battery():
 def test_alphaess_disabled_planned_hold_recovers_the_charge_window():
     """Generic Hold charging disables the switch but leaves target and times intact.
 
-    Recover that active window and use the fixed hold target instead of turning a
-    target-reached charge back into demand mode.
+    execute.py restores normal/max charge power after disabling the window, so zero power
+    is not a production-realistic hold signature. Recover the active target-reached window
+    with its normal power still present instead of returning AlphaESS to demand mode.
     """
     failed = False
     client = _client()
     client.base.minutes_now = 2 * 60
-    schedule = _schedule(reserve=41, charge={"enable": False, "soc": 40, "power": 0, "start": "01:00:00", "end": "05:00:00"})
+    schedule = _schedule(reserve=41, charge={"enable": False, "soc": 40, "power": 3000, "start": "01:00:00", "end": "05:00:00"})
     charge = client.build_charge_payload("AL70", schedule)
     discharge = client.build_discharge_payload("AL70", schedule)
     if charge.get("gridCharge") != 1 or charge.get("batHighCap") != 10:
@@ -394,22 +395,27 @@ def test_alphaess_disabled_planned_hold_recovers_the_charge_window():
     assert not failed, "test_alphaess_disabled_planned_hold_recovers_the_charge_window"
 
 
-def test_alphaess_restored_rate_releases_a_disabled_planned_hold():
-    """Stale target/times must not extend a hold after execute restores charge power."""
+def test_alphaess_planned_hold_releases_when_its_window_ends():
+    """Normal restored power must not release the hold early, but window end must.
+
+    AlphaESS does not discharge down towards a reached grid-charge target while that period
+    remains enabled. The retained target/time entities therefore recover the hold until the
+    planned window ends; the active-time check prevents stale fields latching it afterwards.
+    """
     failed = False
     client = _client()
     client.base.minutes_now = 2 * 60
-    held = _schedule(reserve=41, charge={"enable": False, "soc": 40, "power": 0, "start": "01:00:00", "end": "05:00:00"})
-    released = _schedule(reserve=10, charge={"enable": False, "soc": 40, "power": 3000, "start": "01:00:00", "end": "05:00:00"})
-    first = client.build_charge_payload("AL70", held)
-    second = client.build_charge_payload("AL70", released)
+    schedule = _schedule(reserve=41, charge={"enable": False, "soc": 40, "power": 3000, "start": "01:00:00", "end": "05:00:00"})
+    first = client.build_charge_payload("AL70", schedule)
+    client.base.minutes_now = 6 * 60
+    second = client.build_charge_payload("AL70", schedule)
     if first.get("gridCharge") != 1:
         print(f"ERROR: test setup did not enter the recovered hold: {first}")
         failed = True
     if second.get("gridCharge") != 0:
-        print(f"ERROR: restored charge power did not release stale hold fields: {second}")
+        print(f"ERROR: ended planned window did not release stale hold fields: {second}")
         failed = True
-    assert not failed, "test_alphaess_restored_rate_releases_a_disabled_planned_hold"
+    assert not failed, "test_alphaess_planned_hold_releases_when_its_window_ends"
 
 
 def test_alphaess_hold_profile_is_constant_while_soc_changes():
@@ -435,6 +441,7 @@ def test_alphaess_real_charge_survives_a_simultaneous_discharge_hold():
     """An EV/iBoost hold during real grid charging must not lower the charge target."""
     failed = False
     client = _client()
+    client.base.minutes_now = 2 * 60
     schedule = _schedule(reserve=10, charge={"enable": True, "soc": 90, "power": 3000, "start": "01:00:00", "end": "05:00:00"}, export_power=0)
     charge = client.build_charge_payload("AL70", schedule)
     discharge = client.build_discharge_payload("AL70", schedule)
@@ -445,6 +452,28 @@ def test_alphaess_real_charge_survives_a_simultaneous_discharge_hold():
         print(f"ERROR: real charge plus hold should leave discharge time control off: {discharge}")
         failed = True
     assert not failed, "test_alphaess_real_charge_survives_a_simultaneous_discharge_hold"
+
+
+def test_alphaess_future_charge_does_not_satisfy_a_current_discharge_hold():
+    """A configured charge window prevents discharge only while it is active.
+
+    Predbat can publish tonight's grid-charge schedule before it starts. Returning that
+    future profile for an EV/iBoost hold now would set ctrDis to ordinary demand mode while
+    no active charge schedule stops the battery feeding the load.
+    """
+    failed = False
+    client = _client()
+    client.base.minutes_now = 22 * 60
+    schedule = _schedule(reserve=10, charge={"enable": True, "soc": 90, "power": 3000, "start": "23:00:00", "end": "23:45:00"}, export_power=0)
+    charge = client.build_charge_payload("AL70", schedule)
+    discharge = client.build_discharge_payload("AL70", schedule)
+    if charge.get("batHighCap") != 10 or charge.get("timeChaf1") != "00:00" or charge.get("timeChae1") != "23:45":
+        print(f"ERROR: future real charge replaced the current full-day hold: {charge}")
+        failed = True
+    if discharge.get("ctrDis") != 0:
+        print(f"ERROR: current hold should leave discharge time control off: {discharge}")
+        failed = True
+    assert not failed, "test_alphaess_future_charge_does_not_satisfy_a_current_discharge_hold"
 
 
 def test_alphaess_times_snap_inward_to_the_15_minute_grid():
@@ -1044,6 +1073,35 @@ def test_alphaess_persistently_rejected_write_is_paced_not_retried_every_tick():
         print("ERROR: a rejected write was cached as applied")
         failed = True
     assert not failed, "test_alphaess_persistently_rejected_write_is_paced_not_retried_every_tick"
+
+
+def test_alphaess_rejected_hold_charge_defers_legacy_discharge_update():
+    """A rejected hold profile must not be followed by ctrDis=0 demand mode.
+
+    Legacy AlphaESS uses separate charge/discharge endpoints. The enabled charge profile is
+    the only working hold primitive, so sending the companion demand-mode payload after its
+    rejection would actively remove the old attempted hold while installing no replacement.
+    """
+    failed = False
+    client = _writable()
+    client.min_write_interval = 0
+    schedule = _schedule(reserve=10, export_power=0)
+    rejected = create_aiohttp_mock_response(status=200, json_data=_envelope(6008, None, msg="Set failed"))
+    with patch("alphaess.aiohttp.ClientSession", return_value=create_aiohttp_mock_session(rejected)) as session:
+        result = run_async_local(client.apply_settings("AL70", schedule))
+    if result:
+        print(f"ERROR: rejected hold transition returned {result!r}, should be falsy")
+        failed = True
+    if session.return_value.post.call_count != 1:
+        print(f"ERROR: rejected hold charge was followed by {session.return_value.post.call_count - 1} additional POST(s)")
+        failed = True
+    if client.applied_payload.get("AL70", {}).get("discharge") is not None:
+        print(f"ERROR: discharge payload was applied after hold charge rejection: {client.applied_payload}")
+        failed = True
+    if not any("discharge update deferred" in message.lower() for message in client.log_messages):
+        print(f"ERROR: deferred legacy discharge transition was not logged: {client.log_messages}")
+        failed = True
+    assert not failed, "test_alphaess_rejected_hold_charge_defers_legacy_discharge_update"
 
 
 def test_alphaess_held_write_is_not_reported_as_applied():
@@ -1807,9 +1865,10 @@ def run_alphaess_control_tests(my_predbat):
         ("rate_zero_is_freeze", test_alphaess_rate_zero_is_freeze),
         ("both_rates_zero_still_holds", test_alphaess_both_rates_zero_still_holds_the_battery),
         ("disabled_planned_hold_recovers_window", test_alphaess_disabled_planned_hold_recovers_the_charge_window),
-        ("restored_rate_releases_hold", test_alphaess_restored_rate_releases_a_disabled_planned_hold),
+        ("planned_hold_releases_at_window_end", test_alphaess_planned_hold_releases_when_its_window_ends),
         ("hold_profile_constant", test_alphaess_hold_profile_is_constant_while_soc_changes),
         ("real_charge_survives_hold", test_alphaess_real_charge_survives_a_simultaneous_discharge_hold),
+        ("future_charge_does_not_satisfy_hold", test_alphaess_future_charge_does_not_satisfy_a_current_discharge_hold),
         ("snap_inward", test_alphaess_times_snap_inward_to_the_15_minute_grid),
         ("collapsed_disabled", test_alphaess_window_collapsed_by_snapping_is_disabled_not_wrapped),
         ("midnight_end_snaps", test_alphaess_midnight_end_snaps_to_the_maximum),
@@ -1835,6 +1894,7 @@ def run_alphaess_control_tests(my_predbat):
         ("6053_backoff", test_alphaess_6053_backs_off_rather_than_counting_as_a_failure),
         ("6053_paces_the_retry", test_alphaess_6053_backs_off_the_retry_via_min_write_interval),
         ("persistent_rejection_paced", test_alphaess_persistently_rejected_write_is_paced_not_retried_every_tick),
+        ("rejected_hold_charge_defers_discharge", test_alphaess_rejected_hold_charge_defers_legacy_discharge_update),
         ("held_write_not_applied", test_alphaess_held_write_is_not_reported_as_applied),
         ("same_cycle_correction_not_held", test_alphaess_same_cycle_correction_is_not_held_by_the_write_pacer),
         ("correction_burst_capped", test_alphaess_correction_burst_is_capped_so_pacing_still_bounds_the_write_budget),


### PR DESCRIPTION
Since there's only 2 ways to stop the AlphaESS to discharge to load which is 

1) Set a discharge schedule OUTSIDE of the current time.

2) Set a charge schedule with a SOC below the current SOC, on my Smile G3 this will just hold the battery at the current charge.   

I went with option 2.

Note since 10% is the minimum the API accepts I set a 100w charge limit as well, if the battery is below 10% it will still charge from the grid and there's nothing we can really do about that.

https://github.com/springfall2008/batpred/issues/4725 was annoying me enough to take a stab at it.

Codex/ GPT 5.6 sol (medium) was used for this.

I'll need more time to do full H/W testing but it seems to be working with my Smile G3 stack.