### PR TITLE
Show the dominant state in a mixed history slot, not the last one seen

### DIFF
--- a/apps/predbat/const.py
+++ b/apps/predbat/const.py
@@ -85,3 +85,10 @@ PREDBAT_MODE_MONITOR = 0
 PREDBAT_MODE_CONTROL_SOC = 1
 PREDBAT_MODE_CONTROL_CHARGE = 2
 PREDBAT_MODE_CONTROL_CHARGEDISCHARGE = 3
+
+# Predbat's core charge/export status strings, ordered most-active-first. Used two ways: execute.py
+# resolves one headline status across a multi-inverter fleet (#4446), and output.py breaks a tie when
+# a history slot's dominant state is ambiguous - e.g. an even split between two states (#4843). Both
+# need the same answer to "which of these two states is the more significant one to show".
+CHARGE_STATE_PRECEDENCE = ["Charging", "Freeze charging", "Hold charging"]
+EXPORT_STATE_PRECEDENCE = ["Exporting", "Freeze exporting", "Hold exporting"]

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -16,7 +16,7 @@ reserve level adjustments, and multi-inverter balancing.
 # pylint: disable=attribute-defined-outside-init
 
 from datetime import timedelta, datetime
-from const import MINUTE_WATT, EXPORT_LIMIT_FREEZE, EXPORT_LIMIT_IDLE
+from const import MINUTE_WATT, EXPORT_LIMIT_FREEZE, EXPORT_LIMIT_IDLE, CHARGE_STATE_PRECEDENCE, EXPORT_STATE_PRECEDENCE
 from utils import dp0, dp2, dp3, calc_percent_limit, find_charge_rate
 from predbat_metrics import metrics
 from inverter import Inverter
@@ -26,12 +26,8 @@ import time
 Execute Predbat plan
 """
 
-# Per-inverter core charge/export states, used to resolve one headline status across a multi-inverter
-# fleet instead of letting whichever inverter is processed last silently win. Precedence lists are
-# ordered most-active-first so the most informative sub-state is shown when inverters within the same
-# side disagree (e.g. one still actively Charging while another has already reached Hold charging).
-CHARGE_STATE_PRECEDENCE = ["Charging", "Freeze charging", "Hold charging"]
-EXPORT_STATE_PRECEDENCE = ["Exporting", "Freeze exporting", "Hold exporting"]
+# The precedence lists themselves live in const.py, as output.py's history reconstruction needs the
+# same most-active-first ordering to collapse a slot that changed state part way through (#4843).
 CHARGE_SIDE_STATES = set(CHARGE_STATE_PRECEDENCE)
 EXPORT_SIDE_STATES = set(EXPORT_STATE_PRECEDENCE)
 

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -21,7 +21,7 @@ import copy
 from html import escape as escape_html
 from datetime import timedelta
 from predbat import THIS_VERSION_DISPLAY
-from const import TIME_FORMAT, PREDICT_STEP, EXPORT_LIMIT_FREEZE, EXPORT_LIMIT_IDLE, MINUTE_WATT
+from const import TIME_FORMAT, PREDICT_STEP, EXPORT_LIMIT_FREEZE, EXPORT_LIMIT_IDLE, MINUTE_WATT, CHARGE_STATE_PRECEDENCE, EXPORT_STATE_PRECEDENCE
 from utils import dp0, dp1, dp2, dp3, calc_percent_limit, minute_data, minute_data_state, find_charge_rate
 from prediction import Prediction
 
@@ -50,6 +50,7 @@ REASON_TEMPLATES = {
     "manual_override_export": "You manually set this slot to export.",
     "manual_override_freeze_export": "You manually set this slot to freeze exporting.",
     "manual_override_demand": "You manually set this slot to demand mode.",
+    "mixed_slot_states": "This slot did not hold one state throughout - Predbat was in: {states}. The cell shows the most significant of them.",
 }
 
 
@@ -62,6 +63,58 @@ def yesterday_slot_is_exporting(slot_status):
     "exporting" alone would silently drop the export half of a real cross-charging slot.
     """
     return "exporting" in slot_status or "cross-charging" in slot_status
+
+
+def more_active_slot_status(current, candidate, precedence):
+    """Pick the more significant of two ``predbat.status`` strings, used to break a tie in
+    ``dominant_slot_status()`` below.
+
+    ``precedence`` is one of the most-active-first lists in const.py, matched case-insensitively and
+    exactly - "freeze exporting" contains "exporting", so a substring test would rank every export
+    sub-state as a full export. "Cross-charging" appears in neither list yet counts on both sides
+    (see ``yesterday_slot_is_exporting``); it ranks above everything, because a fleet charging and
+    discharging at once is the state a reader most needs to see. Anything else - Demand, Read-Only,
+    a Hold-for-car annotation - ranks last, and an incumbent is kept on a tie so the *first* of two
+    equal states wins rather than the last.
+    """
+    if not current:
+        return candidate
+
+    def rank(status):
+        if status == "cross-charging":
+            return -1
+        for index, entry in enumerate(precedence):
+            if status == entry.lower():
+                return index
+        return len(precedence)
+
+    return candidate if rank(candidate) < rank(current) else current
+
+
+def dominant_slot_status(minute_counts, precedence):
+    """Pick the ``predbat.status`` that held the most minutes of a history slot, from a
+    ``{status: minutes}`` tally.
+
+    ``calculate_yesterday()`` renders each 30-minute slot as a single charge or export state, but a
+    slot can legitimately contain more than one - a force export that hits its target part way
+    through drops to freeze export, and a manual override can change the state at any minute. The
+    reconstruction used to assign unconditionally as it scanned, so whichever state ran *last* won
+    and an earlier one that actually held the slot vanished: #4840's force export from 17:05-17:17
+    was erased by the freeze export that followed it at 17:18, and the History view showed no export
+    at all. The cell should instead show whichever state genuinely dominated the slot's minutes.
+
+    A tie - most often an exact even split - is broken with ``more_active_slot_status``, which also
+    carries the cross-charging special case.
+    """
+    if not minute_counts:
+        return ""
+
+    most_minutes = max(minute_counts.values())
+    dominant = ""
+    for status, minutes in minute_counts.items():
+        if minutes == most_minutes:
+            dominant = more_active_slot_status(dominant, status, precedence)
+    return dominant
 
 
 class Output:
@@ -1274,6 +1327,7 @@ class Output:
             soc_color = "#3AEE85"
             pv_symbol = ""
             split = False
+            raw_state_mixed = None
 
             if soc_percent < 20.0:
                 soc_color = "#F18261"
@@ -1443,6 +1497,22 @@ class Output:
                     state += " &#8526;"
                     raw_state_override = "Manual export freeze"
                     reason_parts.append({"code": "manual_override_freeze_export", "params": {}})
+
+            # A history slot can hold more than one state - Predbat re-runs every few minutes and a
+            # manual override can land on any minute - but a row shows exactly one. Mark a collapsed
+            # slot with an asterisk and list what actually happened in the row's reasons, which is a
+            # list and so copes with all six states a 30 minute slot can hold, unlike the two-way
+            # state/state2 split cell (#4843). Only calculate_yesterday()'s reconstruction sets
+            # "mixed" - forward plan windows never carry it, so the live plan is untouched.
+            mixed_states = []
+            if charge_window_n >= 0:
+                mixed_states += self.charge_window_best[charge_window_n].get("mixed", [])
+            if export_window_n >= 0:
+                mixed_states += self.export_window_best[export_window_n].get("mixed", [])
+            if mixed_states:
+                state += "*"
+                raw_state_mixed = [entry.capitalize() for entry in mixed_states]
+                reason_parts.append({"code": "mixed_slot_states", "params": {"states": ", ".join(raw_state_mixed)}})
 
             # Alert
             if in_alert:
@@ -1654,6 +1724,7 @@ class Output:
             json_row["state"] = raw_state
             json_row["state_target"] = raw_state_target
             json_row["state_override"] = raw_state_override
+            json_row["state_mixed"] = raw_state_mixed
             json_row["state_html"] = state
 
             json_row["reasons"] = reason_parts if reason_parts else demand_reason
@@ -3260,40 +3331,50 @@ class Output:
                 if "," in status:
                     # If there are multiple statuses take the first one
                     predbat_status[minute] = status.split(",")[0].strip()
+            # Ignore the first and last edge_minutes of each slot when they don't hold one state
+            # throughout - Predbat's reported status can lag a slot boundary by a minute or two while
+            # it catches up to a replan, and that leftover from the previous (or next) slot must not
+            # be mistaken for a real part of this one. A status occupying the *whole* edge window,
+            # though, is indistinguishable from a genuine replan landing right at the boundary, so it
+            # is trusted like any interior minute rather than discarded on principle.
+            edge_minutes = 5
             for minute in range(0, end_record + minutes_now, self.plan_interval_minutes):
                 minute_offset = minutes_now + end_record - minute
-                charge_during_slot = ""
-                export_during_slot = ""
+
+                # predbat_status is keyed by minutes AGO, so the status for plan-minute
+                # (minute + slot_offset) lives at (minute_offset - slot_offset).
+                slot_statuses = [predbat_status.get(minute_offset - slot_offset, "").lower() for slot_offset in range(self.plan_interval_minutes)]
+                tally_start = 0 if len(set(slot_statuses[:edge_minutes])) == 1 else edge_minutes
+                tally_end = self.plan_interval_minutes if len(set(slot_statuses[-edge_minutes:])) == 1 else self.plan_interval_minutes - edge_minutes
+
                 charge_start_minute = None
                 charge_end_minute = None
                 export_start_minute = None
                 export_end_minute = None
 
-                # Searching for charge or export in this slot, ignore the first and last 5 minutes to avoid edge effects
-                for slot_offset in range(5, self.plan_interval_minutes - 5):
-                    slot_minute = minute_offset - self.plan_interval_minutes + slot_offset
-                    slot_status = predbat_status.get(slot_minute, "").lower()
+                # A slot's rendered start/end always snaps to the slot grid unless charge and export
+                # genuinely hand off to each other mid-slot (both sides detected below), so this walk
+                # only needs the interior minutes it has always used - trusting a homogeneous edge
+                # cannot move a boundary that was already going to land on the slot edge.
+                for slot_offset in range(edge_minutes, self.plan_interval_minutes - edge_minutes):
+                    slot_status = slot_statuses[slot_offset]
                     real_minute = minute + slot_offset
 
                     # Cross-charging genuinely straddles both sides - track it as both an exporting
                     # and a charging slot (its name contains "charging" but not "exporting"), so
                     # these are independent "if"s rather than "if/elif".
-                    if yesterday_slot_is_exporting(slot_status):
-                        export_during_slot = slot_status
-                        if export_start_minute is None:
-                            export_start_minute = real_minute
-                            if slot_offset == 5:
-                                export_start_minute -= 5
-                            if charge_start_minute is not None:
-                                charge_end_minute = export_start_minute
-                    if "charging" in slot_status:
-                        charge_during_slot = slot_status
-                        if charge_start_minute is None:
-                            charge_start_minute = real_minute
-                            if slot_offset == 5:
-                                charge_start_minute -= 5
-                            if export_start_minute is not None:
-                                export_end_minute = charge_start_minute
+                    if yesterday_slot_is_exporting(slot_status) and export_start_minute is None:
+                        export_start_minute = real_minute
+                        if slot_offset == edge_minutes:
+                            export_start_minute -= edge_minutes
+                        if charge_start_minute is not None:
+                            charge_end_minute = export_start_minute
+                    if "charging" in slot_status and charge_start_minute is None:
+                        charge_start_minute = real_minute
+                        if slot_offset == edge_minutes:
+                            charge_start_minute -= edge_minutes
+                        if export_start_minute is not None:
+                            export_end_minute = charge_start_minute
 
                 # Assume slots end at end of period if not found
                 if export_end_minute is None and export_start_minute is not None:
@@ -3301,9 +3382,27 @@ class Output:
                 if charge_end_minute is None and charge_start_minute is not None:
                     charge_end_minute = minute + self.plan_interval_minutes
 
+                # Tally how many trusted minutes each status held, so the cell can show whichever one
+                # actually dominated the slot rather than whichever the scan above happened to detect
+                # first (#4843).
+                export_minute_counts = {}
+                charge_minute_counts = {}
+                for slot_offset in range(tally_start, tally_end):
+                    slot_status = slot_statuses[slot_offset]
+                    if yesterday_slot_is_exporting(slot_status):
+                        export_minute_counts[slot_status] = export_minute_counts.get(slot_status, 0) + 1
+                    if "charging" in slot_status:
+                        charge_minute_counts[slot_status] = charge_minute_counts.get(slot_status, 0) + 1
+
+                export_during_slot = dominant_slot_status(export_minute_counts, EXPORT_STATE_PRECEDENCE)
+                charge_during_slot = dominant_slot_status(charge_minute_counts, CHARGE_STATE_PRECEDENCE)
+
                 if yesterday_slot_is_exporting(export_during_slot):
                     # Assume exporting at this time
-                    self.export_window_best.append({"start": export_start_minute, "end": export_end_minute})
+                    export_window = {"start": export_start_minute, "end": export_end_minute}
+                    if len(export_minute_counts) > 1:
+                        export_window["mixed"] = list(export_minute_counts.keys())
+                    self.export_window_best.append(export_window)
                     if "freeze" in export_during_slot:
                         # Assume freeze export
                         self.export_limits_best.append(EXPORT_LIMIT_FREEZE)
@@ -3314,7 +3413,10 @@ class Output:
 
                 if "charging" in charge_during_slot:
                     # Assume charging at this time
-                    self.charge_window_best.append({"start": charge_start_minute, "end": charge_end_minute})
+                    charge_window = {"start": charge_start_minute, "end": charge_end_minute}
+                    if len(charge_minute_counts) > 1:
+                        charge_window["mixed"] = list(charge_minute_counts.keys())
+                    self.charge_window_best.append(charge_window)
                     if "freeze" in charge_during_slot:
                         # Assume freeze charge
                         self.charge_limit_best.append(self.reserve)

--- a/apps/predbat/tests/test_calculate_yesterday.py
+++ b/apps/predbat/tests/test_calculate_yesterday.py
@@ -27,8 +27,8 @@ from datetime import datetime, timedelta
 
 import pytz
 
-from const import PREDICT_STEP
-from output import yesterday_slot_is_exporting
+from const import PREDICT_STEP, EXPORT_LIMIT_FREEZE, CHARGE_STATE_PRECEDENCE, EXPORT_STATE_PRECEDENCE
+from output import yesterday_slot_is_exporting, more_active_slot_status
 from tests.test_infra import reset_rates, reset_inverter
 
 UTC = pytz.UTC
@@ -1191,6 +1191,406 @@ def _test_cross_charging_reconstructed_as_both_windows(my_predbat, failed):
     return failed
 
 
+def _test_slot_status_read_at_the_right_minute(my_predbat, failed):
+    """The status for a plan minute must be read from that minute, not its mirror image (#4843).
+
+    predbat_status is keyed by minutes AGO, so the status for plan-minute (minute + slot_offset)
+    lives at (minute_offset - slot_offset). The lookup used to ADD slot_offset instead, which agrees
+    only at slot_offset == 15 - the slot midpoint - and reflects about it everywhere else, walking
+    each slot from its latest minute to its earliest and attributing every status to the wrong
+    minute.
+
+    Exports for exactly five minutes at plan-minutes 1205-1210, deliberately off-centre in the
+    1200-1230 slot. Read correctly that is found at slot_offset 5-10 and the window starts at 1200
+    (offset 5 pulls the start back by 5). Read mirrored it is found at slot_offset 20-24 instead and
+    the window starts at 1220 - twenty minutes after the export actually happened.
+    """
+    print("calculate_yesterday: Test - a slot's status is read at the matching minute, not its mirror (#4843)")
+    now_utc = _setup_base(my_predbat)
+    prefix = my_predbat.prefix
+
+    # minutes_now=360 and end_record=1440, so the reconstruction covers 1800 minutes ending now and
+    # plan-minute m is (1800 - m) minutes ago.
+    export_from_plan_minute = 1205
+    export_to_plan_minute = 1210
+    start = now_utc - timedelta(minutes=1800)
+    status_points = []
+    for step in range(0, 1800, 5):
+        exporting = export_from_plan_minute <= step < export_to_plan_minute
+        stamp = start + timedelta(minutes=step)
+        status_points.append({"state": "Exporting" if exporting else "Demand", "last_updated": stamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"), "attributes": {"p/kWh": "0.0"}})
+    status_hist = [status_points]
+
+    def _history_with_one_export(entity_id, days=30, required=True, tracked=True):
+        if entity_id == prefix + ".cost_today":
+            return _make_constant_history(100.0, now_utc)
+        elif entity_id == prefix + ".soc_kw_h0":
+            return _make_constant_history(5.0, now_utc)
+        elif entity_id == prefix + ".status":
+            return status_hist
+        return None
+
+    captured = {}
+
+    def _capture_publish_html_plan(*args, **kwargs):
+        captured["export_window_best"] = copy.deepcopy(my_predbat.export_window_best)
+        return ("", "{}")
+
+    my_predbat.step_data_history = _make_mock_step_data(my_predbat.pv_today)
+    my_predbat.get_history_wrapper = _history_with_one_export
+    my_predbat.plan_write_debug = lambda *a, **kw: ("", "{}")
+    my_predbat.publish_html_plan = _capture_publish_html_plan
+    original_run_pred = my_predbat.run_prediction
+    my_predbat.run_prediction = lambda *a, **kw: _make_mock_run_prediction([])(my_predbat, *a, **kw)
+
+    my_predbat.calculate_yesterday()
+
+    windows = captured.get("export_window_best")
+    if not windows:
+        print("ERROR: a five minute Exporting history should rebuild one export window, got none")
+        failed = True
+    elif len(windows) != 1:
+        print("ERROR: expected exactly one rebuilt export window, got {}: {}".format(len(windows), windows))
+        failed = True
+    elif windows[0]["start"] != 1200:
+        print("ERROR: export at plan-minutes {}-{} rebuilt as starting at {} - the status was read from the mirror-image minute within the slot".format(export_from_plan_minute, export_to_plan_minute, windows[0]["start"]))
+        failed = True
+
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    return failed
+
+
+def _test_more_active_slot_status(my_predbat, failed):
+    """Unit tests for the slot-status collapse rule (#4843).
+
+    Statuses arrive lower-cased and must be matched exactly, not by substring - "freeze exporting"
+    contains "exporting", so a substring test would rank every export sub-state as a full export.
+    """
+    print("calculate_yesterday: Test - more_active_slot_status ranking (#4843)")
+
+    checks = [
+        # (current, candidate, precedence, expected, why)
+        ("", "freeze exporting", EXPORT_STATE_PRECEDENCE, "freeze exporting", "first status seen is always taken"),
+        ("freeze exporting", "exporting", EXPORT_STATE_PRECEDENCE, "exporting", "a real export beats a freeze seen earlier"),
+        ("exporting", "freeze exporting", EXPORT_STATE_PRECEDENCE, "exporting", "the #4840 case - a later freeze must not erase the export"),
+        ("hold exporting", "freeze exporting", EXPORT_STATE_PRECEDENCE, "freeze exporting", "freeze beats hold"),
+        ("freeze exporting", "hold exporting", EXPORT_STATE_PRECEDENCE, "freeze exporting", "hold does not beat freeze"),
+        ("exporting", "exporting", EXPORT_STATE_PRECEDENCE, "exporting", "equal states keep the incumbent"),
+        ("exporting", "demand", EXPORT_STATE_PRECEDENCE, "exporting", "an unranked status never wins"),
+        ("freeze exporting", "cross-charging", EXPORT_STATE_PRECEDENCE, "cross-charging", "cross-charging outranks every sub-state"),
+        ("cross-charging", "exporting", EXPORT_STATE_PRECEDENCE, "cross-charging", "cross-charging is not displaced by a plain export"),
+        ("freeze charging", "charging", CHARGE_STATE_PRECEDENCE, "charging", "same rule applies on the charge side"),
+        ("charging", "hold charging", CHARGE_STATE_PRECEDENCE, "charging", "charge side keeps the most active too"),
+    ]
+    for current, candidate, precedence, expected, why in checks:
+        result = more_active_slot_status(current, candidate, precedence)
+        if result != expected:
+            print("ERROR: more_active_slot_status({!r}, {!r}) should be {!r} got {!r} - {}".format(current, candidate, expected, result, why))
+            failed = True
+
+    return failed
+
+
+def _test_mixed_slot_keeps_most_active_state(my_predbat, failed):
+    """Regression for #4843, through the real calculate_yesterday() reconstruction path.
+
+    A 30-minute slot can hold more than one state - Predbat re-runs every few minutes and a manual
+    override can land on any minute - but the reconstruction emits a single window for it. It used
+    to assign unconditionally as it scanned, so whichever state the walk happened to visit LAST won
+    and a real force export could be collapsed to a freeze, regardless of how much of the slot each
+    state actually held. The cell must instead show whichever state dominated the slot's minutes.
+
+    The history here freezes for exactly the first half of every slot and force exports for exactly
+    the second - a dead-even split, so neither state dominates on minutes alone and the choice falls
+    to the most-active tie-break, which favours the real export over the freeze. Every rebuilt window
+    must come back as a real export target rather than EXPORT_LIMIT_FREEZE, and must be marked as
+    having held more than one state.
+    """
+    print("calculate_yesterday: Test - a slot holding two equally-sized states keeps the more active one (#4843)")
+    now_utc = _setup_base(my_predbat)
+    prefix = my_predbat.prefix
+
+    # Walk back 2 days at 5-minute resolution, freezing for the first half of each half-hour slot
+    # and force exporting for the second - a dead-even 15/15 split, so the tie-break decides.
+    start = now_utc - timedelta(days=2)
+    status_points = []
+    for step in range(0, 2 * 24 * 60, 5):
+        stamp = start + timedelta(minutes=step)
+        state = "Freeze exporting" if (stamp.hour * 60 + stamp.minute) % 30 < 15 else "Exporting"
+        status_points.append({"state": state, "last_updated": stamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"), "attributes": {"p/kWh": "0.0"}})
+    status_hist = [status_points]
+
+    def _history_with_split_slots(entity_id, days=30, required=True, tracked=True):
+        if entity_id == prefix + ".cost_today":
+            return _make_constant_history(100.0, now_utc)
+        elif entity_id == prefix + ".soc_kw_h0":
+            return _make_constant_history(5.0, now_utc)
+        elif entity_id == prefix + ".status":
+            return status_hist
+        return None
+
+    captured = {}
+
+    def _capture_publish_html_plan(*args, **kwargs):
+        captured["export_window_best"] = copy.deepcopy(my_predbat.export_window_best)
+        captured["export_limits_best"] = copy.deepcopy(my_predbat.export_limits_best)
+        return ("", "{}")
+
+    my_predbat.step_data_history = _make_mock_step_data(my_predbat.pv_today)
+    my_predbat.get_history_wrapper = _history_with_split_slots
+    my_predbat.plan_write_debug = lambda *a, **kw: ("", "{}")
+    my_predbat.publish_html_plan = _capture_publish_html_plan
+    original_run_pred = my_predbat.run_prediction
+    my_predbat.run_prediction = lambda *a, **kw: _make_mock_run_prediction([])(my_predbat, *a, **kw)
+
+    my_predbat.calculate_yesterday()
+
+    if "export_limits_best" not in captured:
+        print("ERROR: publish_html_plan was never called - could not observe the reconstructed windows")
+        failed = True
+    elif not captured["export_window_best"]:
+        print("ERROR: an Exporting history should rebuild export windows, got none")
+        failed = True
+    else:
+        frozen = [limit for limit in captured["export_limits_best"] if limit == EXPORT_LIMIT_FREEZE]
+        if frozen:
+            print("ERROR: {} of {} rebuilt export slots came back as freeze - on a dead-even split the tie-break should favour the real export".format(len(frozen), len(captured["export_limits_best"])))
+            failed = True
+        if len(captured["export_window_best"]) != len(captured["export_limits_best"]):
+            print("ERROR: rebuilt {} export windows but {} export limits - they must stay in step".format(len(captured["export_window_best"]), len(captured["export_limits_best"])))
+            failed = True
+        unmarked = [window for window in captured["export_window_best"] if len(window.get("mixed", [])) < 2]
+        if unmarked:
+            print("ERROR: {} of {} rebuilt export slots held two states but were not marked as mixed".format(len(unmarked), len(captured["export_window_best"])))
+            failed = True
+
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    return failed
+
+
+def _test_short_export_inside_a_freeze_slot(my_predbat, failed):
+    """The reporter's own slot from #4840: freeze, a short force export, then freeze again.
+
+    Predbat replanned five minutes into the 17:00-17:30 slot and started force exporting, and the
+    reporter manually overrode it back to freeze export twelve minutes later - so the export sat in
+    the middle of the slot with a freeze either side: 18 minutes of freeze against 12 of export.
+
+    The window boundaries cannot express it - export_start_minute latches on the first state that is
+    any kind of export, and "Freeze exporting" counts, so the window spans the whole slot rather than
+    the twelve minutes that actually exported. And a slot carries one headline state, so
+    freeze/export/freeze collapses to one. Freeze genuinely held the slot for longer, so it is the
+    dominant state and the correct headline; what must not happen is the twelve minutes of export
+    vanishing with no trace, so the window must still be marked as having held more than one state.
+
+    This is a deliberate change from the slot's old headline of "export": the old rule showed
+    whichever state ranked more *active*, which meant a brief force export could outrank a freeze
+    that held most of the slot. The reporter's actual complaint was that the export disappeared with
+    no record of it anywhere, not that freeze was shown - and that is what the "mixed" marker now
+    guarantees, regardless of which state ends up as the headline.
+    """
+    print("calculate_yesterday: Test - a short export between two freezes in one slot (#4840)")
+    now_utc = _setup_base(my_predbat)
+    prefix = my_predbat.prefix
+
+    # minutes_now=360 and end_record=1440, so plan-minute m is (1800 - m) minutes ago. Put the slot
+    # at plan-minutes 1200-1230 and force export for 1205-1217, freeze exporting either side.
+    slot_start = 1200
+    start = now_utc - timedelta(minutes=1800)
+    status_points = []
+    for step in range(0, 1800, 1):
+        if slot_start <= step < slot_start + 30:
+            state = "Exporting" if 5 <= (step - slot_start) < 17 else "Freeze exporting"
+        else:
+            state = "Demand"
+        stamp = start + timedelta(minutes=step)
+        status_points.append({"state": state, "last_updated": stamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"), "attributes": {"p/kWh": "0.0"}})
+    status_hist = [status_points]
+
+    def _history_with_short_export(entity_id, days=30, required=True, tracked=True):
+        if entity_id == prefix + ".cost_today":
+            return _make_constant_history(100.0, now_utc)
+        elif entity_id == prefix + ".soc_kw_h0":
+            return _make_constant_history(5.0, now_utc)
+        elif entity_id == prefix + ".status":
+            return status_hist
+        return None
+
+    captured = {}
+
+    def _capture_publish_html_plan(*args, **kwargs):
+        captured["export_window_best"] = copy.deepcopy(my_predbat.export_window_best)
+        captured["export_limits_best"] = copy.deepcopy(my_predbat.export_limits_best)
+        return ("", "{}")
+
+    my_predbat.step_data_history = _make_mock_step_data(my_predbat.pv_today)
+    my_predbat.get_history_wrapper = _history_with_short_export
+    my_predbat.plan_write_debug = lambda *a, **kw: ("", "{}")
+    my_predbat.publish_html_plan = _capture_publish_html_plan
+    original_run_pred = my_predbat.run_prediction
+    my_predbat.run_prediction = lambda *a, **kw: _make_mock_run_prediction([])(my_predbat, *a, **kw)
+
+    my_predbat.calculate_yesterday()
+
+    windows = captured.get("export_window_best")
+    limits = captured.get("export_limits_best")
+    if not windows:
+        print("ERROR: a freeze/export/freeze slot should rebuild an export window, got none")
+        failed = True
+    elif len(windows) != 1:
+        print("ERROR: expected exactly one rebuilt export window for the slot, got {}: {}".format(len(windows), windows))
+        failed = True
+    else:
+        if limits[0] != EXPORT_LIMIT_FREEZE:
+            print("ERROR: freeze held 18 of the slot's 30 minutes against 12 for export and should be the dominant headline state, got a real export target instead")
+            failed = True
+        if sorted(windows[0].get("mixed", [])) != ["exporting", "freeze exporting"]:
+            print("ERROR: a slot holding both a freeze and a force export should be marked with both so the export is not lost, got {!r}".format(windows[0].get("mixed")))
+            failed = True
+
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    return failed
+
+
+def _test_full_edge_state_counts_toward_the_dominant_tally(my_predbat, failed):
+    """A state occupying a full 5-minute slot edge is a real state, not edge noise (#4843 follow-up).
+
+    calculate_yesterday() ignores a slot's first/last 5 minutes when they don't hold one state
+    throughout - that guards against Predbat's reported status lagging a slot boundary by a minute or
+    two while it catches up to a replan. But a status occupying the *whole* edge window is
+    indistinguishable from a genuine replan landing right at the boundary, so it must still count: it
+    should show up in "mixed" even when it does not dominate the slot, rather than being silently
+    discarded just for sitting in the trimmed part of the scan.
+
+    The slot here force exports for its first 5 minutes exactly, then freeze exports for the
+    remaining 25 - freeze dominates on minutes, but the export must still be visible in "mixed".
+    """
+    print("calculate_yesterday: Test - a state holding a full slot edge counts, not just interior minutes (#4843)")
+    now_utc = _setup_base(my_predbat)
+    prefix = my_predbat.prefix
+
+    slot_start = 1200
+    start = now_utc - timedelta(minutes=1800)
+    status_points = []
+    for step in range(0, 1800, 1):
+        if slot_start <= step < slot_start + 30:
+            state = "Exporting" if (step - slot_start) < 5 else "Freeze exporting"
+        else:
+            state = "Demand"
+        stamp = start + timedelta(minutes=step)
+        status_points.append({"state": state, "last_updated": stamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"), "attributes": {"p/kWh": "0.0"}})
+    status_hist = [status_points]
+
+    def _history_with_edge_export(entity_id, days=30, required=True, tracked=True):
+        if entity_id == prefix + ".cost_today":
+            return _make_constant_history(100.0, now_utc)
+        elif entity_id == prefix + ".soc_kw_h0":
+            return _make_constant_history(5.0, now_utc)
+        elif entity_id == prefix + ".status":
+            return status_hist
+        return None
+
+    captured = {}
+
+    def _capture_publish_html_plan(*args, **kwargs):
+        captured["export_window_best"] = copy.deepcopy(my_predbat.export_window_best)
+        captured["export_limits_best"] = copy.deepcopy(my_predbat.export_limits_best)
+        return ("", "{}")
+
+    my_predbat.step_data_history = _make_mock_step_data(my_predbat.pv_today)
+    my_predbat.get_history_wrapper = _history_with_edge_export
+    my_predbat.plan_write_debug = lambda *a, **kw: ("", "{}")
+    my_predbat.publish_html_plan = _capture_publish_html_plan
+    original_run_pred = my_predbat.run_prediction
+    my_predbat.run_prediction = lambda *a, **kw: _make_mock_run_prediction([])(my_predbat, *a, **kw)
+
+    my_predbat.calculate_yesterday()
+
+    windows = captured.get("export_window_best")
+    limits = captured.get("export_limits_best")
+    if not windows:
+        print("ERROR: an export that fully occupies the slot's first 5 minutes should still rebuild an export window, got none")
+        failed = True
+    elif limits[0] != EXPORT_LIMIT_FREEZE:
+        print("ERROR: freeze held 25 of the slot's 30 minutes and should be the dominant headline state")
+        failed = True
+    elif sorted(windows[0].get("mixed", [])) != ["exporting", "freeze exporting"]:
+        print("ERROR: the 5 minutes of real export at the slot edge should still show up in mixed, got {!r}".format(windows[0].get("mixed")))
+        failed = True
+
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    return failed
+
+
+def _test_brief_edge_blip_is_not_counted(my_predbat, failed):
+    """A one-minute status blip at a slot's edge must not be treated as a real state (#4843 follow-up).
+
+    Only the slot's very first minute briefly reports "Exporting" - a leftover echo of the previous
+    slot's status before Predbat's real status for this slot, "Charging", takes over. That single
+    minute does not hold the whole first-5-minutes edge window, so it must be discarded as noise
+    rather than spawning a spurious export window or appearing in the charge window's "mixed" list.
+    """
+    print("calculate_yesterday: Test - a one-minute status blip at a slot edge is discarded, not counted (#4843)")
+    now_utc = _setup_base(my_predbat)
+    prefix = my_predbat.prefix
+
+    slot_start = 1200
+    start = now_utc - timedelta(minutes=1800)
+    status_points = []
+    for step in range(0, 1800, 1):
+        if slot_start <= step < slot_start + 30:
+            state = "Exporting" if step == slot_start else "Charging"
+        else:
+            state = "Demand"
+        stamp = start + timedelta(minutes=step)
+        status_points.append({"state": state, "last_updated": stamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"), "attributes": {"p/kWh": "0.0"}})
+    status_hist = [status_points]
+
+    def _history_with_edge_blip(entity_id, days=30, required=True, tracked=True):
+        if entity_id == prefix + ".cost_today":
+            return _make_constant_history(100.0, now_utc)
+        elif entity_id == prefix + ".soc_kw_h0":
+            return _make_constant_history(5.0, now_utc)
+        elif entity_id == prefix + ".status":
+            return status_hist
+        return None
+
+    captured = {}
+
+    def _capture_publish_html_plan(*args, **kwargs):
+        captured["export_window_best"] = copy.deepcopy(my_predbat.export_window_best)
+        captured["charge_window_best"] = copy.deepcopy(my_predbat.charge_window_best)
+        return ("", "{}")
+
+    my_predbat.step_data_history = _make_mock_step_data(my_predbat.pv_today)
+    my_predbat.get_history_wrapper = _history_with_edge_blip
+    my_predbat.plan_write_debug = lambda *a, **kw: ("", "{}")
+    my_predbat.publish_html_plan = _capture_publish_html_plan
+    original_run_pred = my_predbat.run_prediction
+    my_predbat.run_prediction = lambda *a, **kw: _make_mock_run_prediction([])(my_predbat, *a, **kw)
+
+    my_predbat.calculate_yesterday()
+
+    export_windows = captured.get("export_window_best") or []
+    charge_windows = captured.get("charge_window_best") or []
+    if export_windows:
+        print("ERROR: a one-minute Exporting blip at the slot edge should not rebuild an export window, got {}".format(export_windows))
+        failed = True
+    if not charge_windows:
+        print("ERROR: the slot should still rebuild a charge window from its 29 Charging minutes, got none")
+        failed = True
+    elif charge_windows[0].get("mixed"):
+        print("ERROR: the one-minute blip should not appear in the charge window's mixed list, got {!r}".format(charge_windows[0].get("mixed")))
+        failed = True
+
+    _restore_methods(my_predbat, original_run_pred)
+    my_predbat.savings_last_updated = None
+    return failed
+
+
 def _test_missing_cost_today_history(my_predbat, failed):
     """Test: no recorded history for predbat.cost_today (issue #4583).
 
@@ -1357,5 +1757,11 @@ def test_calculate_yesterday(my_predbat):
     failed = _test_carbon_yesterday(my_predbat, failed)
     failed = _test_yesterday_slot_is_exporting(my_predbat, failed)
     failed = _test_cross_charging_reconstructed_as_both_windows(my_predbat, failed)
+    failed = _test_slot_status_read_at_the_right_minute(my_predbat, failed)
+    failed = _test_mixed_slot_keeps_most_active_state(my_predbat, failed)
+    failed = _test_more_active_slot_status(my_predbat, failed)
+    failed = _test_short_export_inside_a_freeze_slot(my_predbat, failed)
+    failed = _test_full_edge_state_counts_toward_the_dominant_tally(my_predbat, failed)
+    failed = _test_brief_edge_blip_is_not_counted(my_predbat, failed)
 
     return failed

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -7131,8 +7131,10 @@ def get_plan_renderer_js():
         });
         // A split cell's first half is always a demand_before_export_* code paired with the export
         // reason as its second half - prefix "Then" (no comma) so the two read as one narrative
-        // instead of two disconnected sentences.
-        if (reasons.length === 2 && rendered[0] && rendered[1] && typeof reasons[0].code === 'string' && reasons[0].code.indexOf('demand_before_export_') === 0) {
+        // instead of two disconnected sentences. Length is >= 2 rather than == 2 because a history
+        // slot that held more than one state appends a mixed_slot_states note after the pair, and
+        // that must not cost the narrative its "Then".
+        if (reasons.length >= 2 && rendered[0] && rendered[1] && typeof reasons[0].code === 'string' && reasons[0].code.indexOf('demand_before_export_') === 0) {
             rendered[1] = 'Then ' + rendered[1].charAt(0).toLowerCase() + rendered[1].slice(1);
         }
         return rendered.filter(Boolean).join(' ');


### PR DESCRIPTION
## Summary
- `calculate_yesterday()`'s History-view slot reconstruction now shows whichever state actually held the most of a 30-minute slot's trusted minutes (the genuinely dominant one), rather than whichever state a scan happened to visit last or ranked highest by an abstract "most active" precedence.
- A slot that held more than one state is marked with an asterisk, and every state it passed through is listed in the cell's tooltip, in chronological order, so nothing is silently lost even when it isn't the headline state.
- A slot's first/last 5 minutes are only trusted when they hold one state throughout - this guards against Predbat's reported status lagging a slot boundary by a minute or two while it catches up to a replan, without discarding a state that genuinely occupies the full edge window.
- Also fixes a pre-existing bug where a slot's per-minute status was read from the wrong (mirrored) offset within the slot.

Addresses #4843.

## Test plan
- [x] `./run_all --test calculate_yesterday` - full suite including new edge-window regression tests
- [x] `./run_all --quick` - full quick suite
- [x] `./run_pre_commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)