### PR TITLE
fix(octopus): review follow-ups for #4849, #4850 and #4852

### DIFF
--- a/apps/predbat/kraken_auth_mixin.py
+++ b/apps/predbat/kraken_auth_mixin.py
@@ -59,12 +59,12 @@ class KrakenAuthMixin:
         if self.token_mint_backoff_logged_at and (now - self.token_mint_backoff_logged_at).total_seconds() < TOKEN_MINT_BACKOFF_LOG_INTERVAL_SECONDS:
             return
         self.token_mint_backoff_logged_at = now
-        self.log(f"Warn: Kraken token mint still edge/WAF blocked (block {self.token_mint_block_count}) - suppressing mints until {self.token_mint_blocked_until}")
+        self.log(f"Warn: Kraken: Token mint still edge/WAF blocked (block {self.token_mint_block_count}) - suppressing mints until {self.token_mint_blocked_until}")
 
     def clear_token_mint_backoff(self):
         """Clear the mint backoff after a successful token mint"""
         if self.token_mint_block_count:
-            self.log(f"Kraken token mint recovered after {self.token_mint_block_count} edge/WAF block(s)")
+            self.log(f"Kraken: Token mint recovered after {self.token_mint_block_count} edge/WAF block(s)")
         self.token_mint_block_count = 0
         self.token_mint_blocked_until = None
         self.token_mint_backoff_logged_at = None
@@ -176,7 +176,7 @@ class KrakenAuthMixin:
                         if response.status == 403 and is_edge_block_body(body):
                             self.token_mint_edge_blocked = True
                         else:
-                            self.log(f"Warn: Kraken token request failed with HTTP {response.status}")
+                            self.log(f"Warn: Kraken: Token request failed with HTTP {response.status}")
                         return None
                     data = await response.json()
         except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -1208,6 +1208,15 @@ class OctopusAPI(ComponentBase):
                 event_reward[event_id] = reward
                 event_code[event_id] = code
                 event_type[event_id] = event.get("eventType", None)
+            # A Weekend Happy Hour cannot be joined through the API - Octopus either allocates one
+            # or the user books it on the website - so listing it as available only produces join
+            # attempts the API rejects (#4593/#4595) and clutters the join selector with options
+            # that cannot be selected. BottleCapDave's integration stopped passing these through in
+            # v19.0.1 for the same reason; match that. The reward/code/type maps are populated above
+            # first, because a joined Happy Hour takes its event type from this list.
+            if event.get("eventType", None) == "WEEKEND_HAPPY_HOUR":
+                self.log("OctopusAPI: Not offering Weekend Happy Hour event code {} as available - it cannot be joined through the API".format(code))
+                continue
             target_regions = [region.get("regionId") for region in (event.get("targetRegion", None) or []) if region]
             if target_regions and account_region_id not in target_regions:
                 self.log("OctopusAPI: Skipping saving event code {} - not eligible for account region {} (event targets regions {})".format(code, account_region_id, target_regions))

--- a/apps/predbat/tests/test_octopus_refresh_token.py
+++ b/apps/predbat/tests/test_octopus_refresh_token.py
@@ -27,6 +27,7 @@ async def test_octopus_refresh_token(my_predbat):
     - Test 5: Token refresh handles API failure gracefully
     - Test 6: Token refresh handles timeout gracefully
     - Test 7: Token expiry decoding from JWT
+    - Test 8: Invalid token formats handled gracefully
     - Test 9: A CDN/WAF 403 on the mint backs off instead of re-minting every poll
     - Test 10: No HTTP request is made at all while the mint backoff is active
     - Test 11: Backoff grows per block, is capped, and a success clears it

--- a/apps/predbat/tests/test_octopus_saving_event_type.py
+++ b/apps/predbat/tests/test_octopus_saving_event_type.py
@@ -1,0 +1,76 @@
+"""
+Tests for how OctopusAPI classifies savingSessions events by eventType
+"""
+
+from unittest.mock import MagicMock
+from octopus import OctopusAPI
+
+
+def test_octopus_saving_event_type(my_predbat):
+    """
+    Test get_saving_session_data() splits events by eventType.
+
+    Octopus publishes Power Up and Power Down through the same savingSessions feed and tells them
+    apart with eventType. A WEEKEND_HAPPY_HOUR cannot be joined through the API - Octopus either
+    allocates one or the user books it on the website - so it must not be offered as available,
+    matching BottleCapDave's integration from v19.0.1. It must still reach joined_events carrying
+    its type, because that is what the planner uses to price it as free (issue #4851).
+    """
+    print("**** Running Octopus saving session eventType tests ****")
+    failed = False
+
+    def make_api(events, joined):
+        api = OctopusAPI(my_predbat, key="test-key", account_id="A-TEST", automatic=False)
+        api.dashboard_item = MagicMock()
+        api.expose_config = MagicMock()
+        api.saving_sessions = {"events": events, "account": {"hasJoinedCampaign": True, "joinedEvents": joined, "signedUpMeterPoint": {"regionId": 6}}}
+        return api
+
+    # A national Happy Hour the account was allocated, three more it was not, and a real Power Down
+    happy_joined = {"id": 5797, "code": "EVENT_56", "rewardPerKwhInOctoPoints": 0, "startAt": "2030-01-05T10:00:00+00:00", "endAt": "2030-01-05T11:00:00+00:00", "eventType": "WEEKEND_HAPPY_HOUR", "targetRegion": []}
+    happy_offered = {"id": 5798, "code": "EVENT_57", "rewardPerKwhInOctoPoints": 0, "startAt": "2030-01-05T11:00:00+00:00", "endAt": "2030-01-05T12:00:00+00:00", "eventType": "WEEKEND_HAPPY_HOUR", "targetRegion": []}
+    power_down = {"id": 5799, "code": "EVENT_58", "rewardPerKwhInOctoPoints": 93, "startAt": "2030-01-06T17:00:00+00:00", "endAt": "2030-01-06T18:00:00+00:00", "eventType": "TURN_DOWN", "targetRegion": []}
+
+    api = make_api(
+        [happy_joined, happy_offered, power_down],
+        [{"eventId": 5797, "startAt": happy_joined["startAt"], "endAt": happy_joined["endAt"], "rewardGivenInOctoPoints": None}],
+    )
+    available, joined = api.get_saving_session_data()
+
+    available_codes = [event.get("code") for event in available]
+    if available_codes != ["EVENT_58"]:
+        print("ERROR: Expected only the TURN_DOWN to be offered as available, got {}".format(available_codes))
+        failed = True
+    elif len(joined) != 1 or joined[0].get("id") != 5797:
+        print("ERROR: Expected the allocated Happy Hour in joined_events, got {}".format(joined))
+        failed = True
+    elif joined[0].get("event_type") != "WEEKEND_HAPPY_HOUR":
+        # The type is looked up from the events list, which is also where the skip happens - if the
+        # skip were applied before the lookup map is filled, the planner would price this as a
+        # saving session instead of as free
+        print("ERROR: The joined Happy Hour lost its event_type, got {}".format(joined[0]))
+        failed = True
+    elif available[0].get("event_type") != "TURN_DOWN":
+        print("ERROR: Expected the available TURN_DOWN to carry its event_type, got {}".format(available[0]))
+        failed = True
+    else:
+        print("PASS: Happy Hours are withheld from available_events but keep their type when joined")
+
+    # An event with no eventType is unchanged - older API responses must keep working
+    untyped = {"id": 5900, "code": "EVENT_59", "rewardPerKwhInOctoPoints": 200, "startAt": "2030-01-07T17:00:00+00:00", "endAt": "2030-01-07T18:00:00+00:00", "targetRegion": []}
+    api = make_api([untyped], [])
+    available, _ = api.get_saving_session_data()
+    if [event.get("code") for event in available] != ["EVENT_59"]:
+        print("ERROR: An event with no eventType must still be offered, got {}".format(available))
+        failed = True
+    elif available[0].get("event_type") is not None:
+        print("ERROR: Expected event_type None for an untyped event, got {}".format(available[0]))
+        failed = True
+    else:
+        print("PASS: An event with no eventType is unaffected")
+
+    if failed:
+        print("\n**** Octopus saving session eventType tests FAILED ****")
+        return 1
+    print("\n**** All Octopus saving session eventType tests PASSED ****")
+    return 0

--- a/apps/predbat/tests/test_octopus_saving_event_type.py
+++ b/apps/predbat/tests/test_octopus_saving_event_type.py
@@ -27,9 +27,9 @@ def test_octopus_saving_event_type(my_predbat):
         return api
 
     # A national Happy Hour the account was allocated, three more it was not, and a real Power Down
-    happy_joined = {"id": 5797, "code": "EVENT_56", "rewardPerKwhInOctoPoints": 0, "startAt": "2030-01-05T10:00:00+00:00", "endAt": "2030-01-05T11:00:00+00:00", "eventType": "WEEKEND_HAPPY_HOUR", "targetRegion": []}
-    happy_offered = {"id": 5798, "code": "EVENT_57", "rewardPerKwhInOctoPoints": 0, "startAt": "2030-01-05T11:00:00+00:00", "endAt": "2030-01-05T12:00:00+00:00", "eventType": "WEEKEND_HAPPY_HOUR", "targetRegion": []}
-    power_down = {"id": 5799, "code": "EVENT_58", "rewardPerKwhInOctoPoints": 93, "startAt": "2030-01-06T17:00:00+00:00", "endAt": "2030-01-06T18:00:00+00:00", "eventType": "TURN_DOWN", "targetRegion": []}
+    happy_joined = {"id": 5797, "code": "EVENT_56", "rewardPerKwhInOctoPoints": 0, "startAt": "2099-01-05T10:00:00+00:00", "endAt": "2099-01-05T11:00:00+00:00", "eventType": "WEEKEND_HAPPY_HOUR", "targetRegion": []}
+    happy_offered = {"id": 5798, "code": "EVENT_57", "rewardPerKwhInOctoPoints": 0, "startAt": "2099-01-05T11:00:00+00:00", "endAt": "2099-01-05T12:00:00+00:00", "eventType": "WEEKEND_HAPPY_HOUR", "targetRegion": []}
+    power_down = {"id": 5799, "code": "EVENT_58", "rewardPerKwhInOctoPoints": 93, "startAt": "2099-01-06T17:00:00+00:00", "endAt": "2099-01-06T18:00:00+00:00", "eventType": "TURN_DOWN", "targetRegion": []}
 
     api = make_api(
         [happy_joined, happy_offered, power_down],

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -175,6 +175,7 @@ from tests.test_octopus_refresh_token import test_octopus_refresh_token_wrapper
 from tests.test_octopus_misc import test_octopus_misc_wrapper
 from tests.test_octopus_read_response import test_octopus_read_response_wrapper
 from tests.test_octopus_read_response_retry import test_octopus_read_response_retry_wrapper
+from tests.test_octopus_saving_event_type import test_octopus_saving_event_type
 from tests.test_octopus_waf_block import test_octopus_waf_block_wrapper
 from tests.test_octopus_catalogue_cache import test_octopus_catalogue_cache_wrapper
 from tests.test_octopus_rate_limit import test_octopus_rate_limit_wrapper
@@ -452,6 +453,7 @@ def main():
         ("octopus_misc", test_octopus_misc_wrapper, "Octopus misc API tests (set intelligent schedule, join saving sessions)", False),
         ("octopus_read_response", test_octopus_read_response_wrapper, "Octopus read response tests", False),
         ("octopus_read_response_retry", test_octopus_read_response_retry_wrapper, "Octopus read response retry with exponential backoff tests", False),
+        ("octopus_saving_event_type", test_octopus_saving_event_type, "Octopus savingSessions eventType classification tests (issue #4851)", False),
         ("octopus_waf_block", test_octopus_waf_block_wrapper, "Octopus CloudFront/WAF 403 handling tests", False),
         ("octopus_catalogue_cache", test_octopus_catalogue_cache_wrapper, "Octopus EV catalogue caching tests", False),
         ("octopus_rate_limit", test_octopus_rate_limit_wrapper, "Octopus API rate limit tests", False),

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -1741,7 +1741,7 @@ TOKEN_MINT_BACKOFF_LOG_INTERVAL_SECONDS = 600
 
 
 def token_mint_backoff_seconds(block_count):
-    """Backoff delay in seconds for the block_count'th consecutive CDN block on a token mint.
+    """Backoff delay in seconds after this many consecutive CDN blocks on a token mint.
 
     Doubles per consecutive block from TOKEN_MINT_BACKOFF_BASE_SECONDS, capped at
     TOKEN_MINT_BACKOFF_MAX_SECONDS so a block that lifts is still picked up within the hour.


### PR DESCRIPTION
Follow-ups to #4849, #4850 and #4852. All three merged quickly — thank you — but these landed on the branches just after the merges, so they need a fresh PR.

**1. `fix(octopus)`: stop offering Weekend Happy Hours as available to join** — @gcoan's request on #4851:

> The BottlecapDave integration has (in v19.0.1) decided to NOT pass through these zero valued events in the power down sensor since they cannot be joined by API. […] suggest we take the same approach of excluding them from available events.

Now that `eventType` is being requested (#4852) these are identifiable precisely, so Octopus Direct can match BCD. Listing them only produces the join attempts the API rejects (#4593/#4595) and fills the join selector with options that cannot be selected.

**Ordering trap worth a reviewer's eye, because it is invisible in the diff.** The reward/code/type lookup maps are built from the same `events` list, and a *joined* Happy Hour reads its type out of those maps. Skipping before they are populated leaves the joined event with `event_type: None` **and** the injected default reward — so a free hour is priced as an 80p/kWh saving session, which is worse than the bug #4852 fixed. The skip therefore sits after the maps are filled, and `test_octopus_saving_event_type` fails if it is moved above them.

**2. `style(kraken)`: use the `Kraken:` log prefix** — Copilot on #4850. The new backoff and token-request warnings read `Warn: Kraken token …` while the rest of the component uses `Warn: Kraken: …`; the odd one out breaks grep and log parsing on the usual prefix.

**3. `docs(octopus)`: test list numbering and docstring phrasing** — Copilot on #4849. The test docstring skipped Test 7 → Test 9 despite Test 8 existing, and "block_count'th" read awkwardly. Note the docstring moved to `utils.py` in #4850, so the fix is applied there.

Copilot's third point on #4849 was that the PR description undercounted the tests — that was a description issue on a now-merged PR, so there is nothing to change in the code.

## Tests

New `test_octopus_saving_event_type`, registered in `unit_test.py`:

- a Happy Hour the account was allocated is withheld from `available_events` but still reaches `joined_events` carrying `event_type: WEEKEND_HAPPY_HOUR`
- a `TURN_DOWN` alongside it is still offered, with its type
- an event with no `eventType` is unaffected

`unit_test.py -k octopus` (72), `-k saving` and `-k kraken` all pass.