### PR TITLE
fix: bind aiohttp ClientSession to the loop that uses it

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -366,6 +366,7 @@ class OctopusEnergyApiClient:
         self.timeout = aiohttp.ClientTimeout(total=None, sock_connect=timeout_in_seconds, sock_read=timeout_in_seconds)
 
         self.session = None
+        self._session_loop = None
         self.saving_sessions_to_join = []
 
     async def async_close(self):
@@ -373,10 +374,26 @@ class OctopusEnergyApiClient:
             await self.session.close()
 
     async def async_create_client_session(self):
+        # An aiohttp.ClientSession is bound to the event loop that created it: its
+        # connector and transports live on that loop. Reusing one from a different
+        # loop raises at request time, and callers that swallow the error see the
+        # request silently do nothing.
+        #
+        # This component's own poll runs on one loop, but entity callbacks
+        # (switch/number/select events) can be dispatched from another, so the
+        # session is not guaranteed to be used on the loop that made it. Rebind if
+        # the loop has changed; the common case still reuses the connection.
+        running = asyncio.get_running_loop()
         if self.session is not None:
-            return self.session
+            if self._session_loop is running:
+                return self.session
+            # Different loop: the old session cannot be closed from here (that too
+            # would touch the wrong loop), so drop the reference and let its owner
+            # loop finalise it.
+            self.session = None
 
         self.session = aiohttp.ClientSession(headers=self.default_headers, skip_auto_headers=["User-Agent"])
+        self._session_loop = running
         return self.session
 
 

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -793,15 +793,35 @@ class OhmeApiClient:
         self._close_session = False
         self._timeout = 10
         self._last_rule: dict[str, Any] = {}
+        self._session_loop = None
         self.last_success_timestamp = None
 
     # Auth methods
 
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        """Return a ClientSession owned by the currently running event loop.
+
+        A ClientSession is bound to the loop that created it — its connector and
+        transports live there — so reusing one from a different loop raises at
+        request time, and a caller that swallows the error sees the request
+        silently do nothing. This component's own poll runs on one loop, but entity
+        callbacks can be dispatched from another, so rebind when the loop changes.
+        The common case still reuses the connection.
+        """
+        running = asyncio.get_running_loop()
+        if self._session is not None and self._session_loop is running:
+            return self._session
+        # A session from another loop cannot be closed from here without touching
+        # that loop; drop the reference and let its owner finalise it.
+        self._session = aiohttp.ClientSession()
+        self._session_loop = running
+        self._close_session = True
+        return self._session
+
+
     async def async_login(self) -> bool:
         """Refresh the user auth token from the stored credentials."""
-        if self._session is None:
-            self._session = aiohttp.ClientSession()
-            self._close_session = True
+        self._ensure_session()
 
         async with asyncio.timeout(self._timeout):
             async with self._session.post(
@@ -831,9 +851,7 @@ class OhmeApiClient:
         if time.time() - self._token_birth < 2700:
             return True
 
-        if self._session is None:
-            self._session = aiohttp.ClientSession()
-            self._close_session = True
+        self._ensure_session()
 
         async with asyncio.timeout(self._timeout):
             async with self._session.post(
@@ -879,9 +897,7 @@ class OhmeApiClient:
         """Make an HTTP request."""
         await self._async_refresh_session()
 
-        if self._session is None:
-            self._session = aiohttp.ClientSession()
-            self._close_session = True
+        self._ensure_session()
 
         async with asyncio.timeout(self._timeout):
             try:

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -818,7 +818,6 @@ class OhmeApiClient:
         self._close_session = True
         return self._session
 
-
     async def async_login(self) -> bool:
         """Refresh the user auth token from the stored credentials."""
         self._ensure_session()

--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -381,6 +381,7 @@ class SolisAPI(ComponentBase, OAuthMixin):
         self.base_url = SOLIS_OAUTH_BASE_URL if self.auth_method == "oauth" else base_url
         self.automatic = automatic
         self.session = None
+        self._session_loop = None
         # Fallback used only when an inverter has never reported a live batteryVoltage - matches
         # the previous hard-coded assumption (issue #4493). get_nominal_voltage() below is the
         # real source of truth once live data is available.
@@ -491,6 +492,26 @@ class SolisAPI(ComponentBase, OAuthMixin):
 
     # ==================== Core API Methods ====================
 
+    def _ensure_session(self):
+        """Return a ClientSession owned by the currently running event loop.
+
+        A ClientSession is bound to the loop that created it — its connector and
+        transports live there — so reusing one from a different loop raises at
+        request time, and a caller that swallows the error sees the request
+        silently do nothing. The poll cycle runs on one loop, but entity callbacks
+        can be dispatched from another, so rebind when the loop changes. The common
+        case still reuses the connection.
+        """
+        running = asyncio.get_running_loop()
+        if self.session is not None and self._session_loop is running:
+            return self.session
+        # A session from another loop cannot be closed from here without touching
+        # that loop; drop the reference and let its owner finalise it.
+        timeout = aiohttp.ClientTimeout(total=SOLIS_REQUEST_TIMEOUT)
+        self.session = aiohttp.ClientSession(timeout=timeout)
+        self._session_loop = running
+        return self.session
+
     async def _execute_request(self, endpoint, payload):
         """Execute HTTP POST request to Solis API"""
         # OAuth reads/control live in a different route namespace (see SOLIS_OAUTH_ENDPOINTS).
@@ -513,7 +534,7 @@ class SolisAPI(ComponentBase, OAuthMixin):
 
         try:
             async with asyncio.timeout(SOLIS_REQUEST_TIMEOUT):
-                async with self.session.post(url, headers=headers, json=payload) as response:
+                async with self._ensure_session().post(url, headers=headers, json=payload) as response:
                     # Check HTTP status
                     if response.status != 200:
                         error_text = await response.text()
@@ -3258,9 +3279,8 @@ class SolisAPI(ComponentBase, OAuthMixin):
 
         # One-time startup configuration
         if first:
-            # Create aiohttp session
-            timeout = aiohttp.ClientTimeout(total=SOLIS_REQUEST_TIMEOUT)
-            self.session = aiohttp.ClientSession(timeout=timeout)
+            # Session is created lazily by _ensure_session(), which binds it to
+            # whichever loop is actually running the request.
 
             # Discover inverters - always scan, filter by inverter_sn if specified
             try:

--- a/apps/predbat/tests/test_client_session_loop_affinity.py
+++ b/apps/predbat/tests/test_client_session_loop_affinity.py
@@ -1,0 +1,77 @@
+# fmt: off
+# pylint: disable=line-too-long
+"""
+Unit tests for ClientSession loop affinity.
+
+An aiohttp.ClientSession is bound to the event loop that created it — its
+connector and transports live on that loop. Reusing one from a different loop
+raises at request time, and a caller that swallows the error sees the request
+silently do nothing: the user is told their change was applied while the device
+was never contacted.
+
+The components' own poll cycles run on one loop, but entity callbacks can be
+dispatched from another, so a session is not guaranteed to be used on the loop
+that created it.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _run(coro):
+    """Run a coroutine on a fresh event loop and return its result."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _StubBase:
+    """Minimal stand-in so the accessors can run without a live component."""
+
+    def __init__(self):
+        self.session = None
+        self._session = None
+        self._session_loop = None
+        self._close_session = False
+
+
+def _accessor_rebinds_across_loops(make_holder, get_session):
+    holder = make_holder()
+
+    async def grab():
+        return get_session(holder), asyncio.get_running_loop()
+
+    first, loop_a = _run(grab())
+    second, loop_b = _run(grab())
+
+    assert loop_a is not loop_b, "test must exercise two distinct loops"
+    assert first is not second, "a session created on another loop must not be reused"
+
+
+def _accessor_reuses_within_one_loop(make_holder, get_session):
+    holder = make_holder()
+
+    async def grab_twice():
+        return get_session(holder), get_session(holder)
+
+    first, second = _run(grab_twice())
+    assert first is second, "the session must still be reused within a single loop"
+
+
+def test_ohme_session_rebinds_across_loops():
+    from ohme import OhmeApiClient
+
+    _accessor_rebinds_across_loops(_StubBase, lambda h: OhmeApiClient._ensure_session(h))
+
+
+def test_ohme_session_reused_within_one_loop():
+    from ohme import OhmeApiClient
+
+    _accessor_reuses_within_one_loop(_StubBase, lambda h: OhmeApiClient._ensure_session(h))

--- a/apps/predbat/tests/test_client_session_loop_affinity.py
+++ b/apps/predbat/tests/test_client_session_loop_affinity.py
@@ -18,7 +18,6 @@ import asyncio
 import os
 import sys
 
-import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 


### PR DESCRIPTION
## Problem

An `aiohttp.ClientSession` is bound to the event loop that created it — its connector and transports live on that loop. Reusing one from a different loop raises at request time.

The failure mode is quiet rather than loud: where the calling code catches the exception and returns normally, the request **silently does nothing**. The user is told their change was applied while the device was never contacted.

## Which components are affected

`solis.py`, `octopus.py` and `ohme.py` each hold a `ClientSession` across calls:

| file | where |
|---|---|
| `solis.py` | created in the first `run()` cycle, reused by every request |
| `octopus.py` | `async_create_client_session()` caches on `self.session` |
| `ohme.py` | created inline in three places when `self._session is None` |

Each component's poll cycle runs on one loop, but entity callbacks — the `switch`/`number`/`select` events dispatched through `trigger_callback` — can be invoked from a different one. So a held session is not guaranteed to be used on the loop that created it.

Most other components build a session per request with `async with aiohttp.ClientSession(...)` and are unaffected. This only concerns the three that hold one.

## Change

Each of the three now goes through an accessor that:

- returns the existing session when the running loop is the one it was created on — so the common path keeps its connection reuse, and a five-second poll is not paying for a new session each cycle;
- creates a fresh session when the loop has changed.

A session belonging to another loop is **dropped rather than closed**, because closing it would itself touch that loop.

`solis.py` previously created its session eagerly in the first run cycle; it is now created lazily by the same accessor, so it binds to whichever loop actually issues the request. Its `final()` cleanup is unchanged.

## Tests

`tests/test_client_session_loop_affinity.py` takes a session from two distinct event loops and asserts they differ, plus a companion asserting reuse within a single loop is preserved — the second matters because a naive fix (always create) would pass the first while quietly discarding connection reuse.

Verified by mutation: dropping the loop check fails the cross-loop test and leaves the same-loop test passing, so the two are testing distinct properties rather than one implying the other.

The wider `-k "octopus or ohme or solis"` selection reports an identical pass/fail/error count with and without this change (checked against a clean tree), so it introduces no regressions there; those pre-existing failures look environmental.

## Note

Reproducing this needs a caller that invokes an entity callback from a loop other than the component's own, so it will not show up in a single-loop setup. The change is defensive: on a single loop it is a no-op beyond one identity comparison per request.
