### PR TITLE
fix(inverter): retry a service call the HA layer rejected instead of deduplicating it away

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -2949,13 +2949,11 @@ class Inverter:
         hash_index = domain
         last_service_hash = self.base.last_service_hash.get(hash_index, "")
         this_service_hash = hash(str(service) + "_" + str(data) + "_" + str(extra_data))
+        service_repeat = last_service_hash == this_service_hash
 
-        if last_service_hash == this_service_hash:
-            service_repeat = True
-        else:
-            # Record the last service called
-            self.base.last_service_hash[hash_index] = this_service_hash
-            service_repeat = False
+        # Whether every call this template actually made was accepted. The hash that suppresses a
+        # repeat is only recorded at the end, and only if this holds - see the note below.
+        service_calls_ok = True
 
         for service_template in service_list:
             service_data = {}
@@ -2989,10 +2987,27 @@ class Inverter:
             elif service_name:
                 service_name = service_name.replace(".", "/")
                 self.log("Inverter {} Calling service {} domain {} service_name {} with data {}".format(self.id, service, domain, service_name, service_data))
-                self.base.call_service_wrapper(service_name, **service_data)
+                if not self.base.call_service_wrapper(service_name, **service_data):
+                    self.log("Warn: Inverter {} service {} domain {} service_name {} was not accepted, it will be retried next cycle".format(self.id, service, domain, service_name))
+                    service_calls_ok = False
             else:
                 self.log("Warn: Inverter {} unable to find service name for {}".format(self.id, service))
 
+        # Only remember the call once it has actually been accepted. Recording it up front - as this
+        # used to, before the calls were even made - meant a service that silently failed was
+        # deduplicated away on every subsequent cycle ("Skipped service ... as it was previously
+        # called"), so Predbat believed it had set a control it had not. #4876 saw predbat.status
+        # read Charging while the inverter's own display still showed its idle program, until the
+        # identical call was re-sent by hand. Dropping the record instead lets the next cycle reissue
+        # it naturally, without needing "repeat: True" on the template in apps.yaml.
+        if service_calls_ok:
+            self.base.last_service_hash[hash_index] = this_service_hash
+        else:
+            self.base.last_service_hash.pop(hash_index, None)
+
+        # Deliberately not reporting the call result here: callers use this return value to choose a
+        # fallback service (e.g. "if not charge_freeze_service: charge_stop_service"), so reporting a
+        # transient failure would silently downgrade a freeze into a stop rather than retrying it.
         return True
 
     def adjust_charge_immediate(self, target_soc, freeze=False):

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -1469,6 +1469,71 @@ def test_call_service_template(test_name, my_predbat, inv, service_name="test", 
     return failed
 
 
+def test_call_service_template_retry(test_name, my_predbat, inv):
+    """A service call the HA layer rejects must be retried next cycle, not deduplicated away (#4876).
+
+    call_service_template() used to record the dedup hash before making the calls, and discard each
+    call's result. A service that silently failed was therefore treated as done, and every later
+    cycle with the same target logged "Skipped service ... as it was previously called" - so Predbat
+    believed it had set a control it had not. In #4876 that left a Deye sitting in its idle program
+    while predbat.status read Charging, until the identical call was re-sent by hand.
+
+    Note this is about the service call being *accepted*, not about the inverter's state: reading a
+    value back cannot settle it when the integration caches writes asynchronously.
+    """
+    failed = False
+    print("**** Running Test: {} ****".format(test_name))
+
+    ha = my_predbat.ha_interface
+    ha.service_store_enable = True
+    service_call = "retry_test_service"
+    my_predbat.args["retry_test"] = service_call
+    data = {"test": "data"}
+
+    try:
+        print("Test: a rejected call is retried on the next cycle")
+        my_predbat.last_service_hash = {}
+        ha.service_store_fail = {service_call}
+        inv.call_service_template("retry_test", data, domain="charge")
+        if not ha.get_service_store():
+            print("ERROR: the first call was never dispatched")
+            failed = True
+        if "charge" in my_predbat.last_service_hash:
+            print("ERROR: a rejected call was recorded as done - the next cycle will skip it")
+            failed = True
+        inv.call_service_template("retry_test", data, domain="charge")
+        if not ha.get_service_store():
+            print("ERROR: the call was not retried after being rejected - this is the #4876 hang")
+            failed = True
+
+        print("Test: once accepted, an identical call is deduplicated as before")
+        ha.service_store_fail = set()
+        my_predbat.last_service_hash = {}
+        inv.call_service_template("retry_test", data, domain="charge")
+        if not ha.get_service_store():
+            print("ERROR: the accepted call was never dispatched")
+            failed = True
+        inv.call_service_template("retry_test", data, domain="charge")
+        if ha.get_service_store():
+            print("ERROR: an accepted call was repeated - the dedup is meant to survive this fix")
+            failed = True
+
+        print("Test: a later rejection drops the earlier record rather than leaving it stale")
+        ha.service_store_fail = {service_call}
+        inv.call_service_template("retry_test", {"test": "other"}, domain="charge")
+        if "charge" in my_predbat.last_service_hash:
+            print("ERROR: the hash from the previous accepted call survived a rejection")
+            failed = True
+    finally:
+        ha.service_store_fail = set()
+        # Drain anything this test dispatched, or the next test in the module sees it as its own.
+        ha.get_service_store()
+        ha.service_store_enable = False
+        my_predbat.last_service_hash = {}
+
+    return failed
+
+
 def test_charge_window_none_illegal_time(test_name, my_predbat, dummy_items):
     """
     Test charge window handling when time is illegal (e.g., 'unknown')
@@ -3376,6 +3441,7 @@ def run_inverter_tests(my_predbat_dummy):
     if failed:
         return failed
 
+    failed |= test_call_service_template_retry("test_service_retry", my_predbat, inv)
     failed |= test_call_service_template("test_service_simple1", my_predbat, inv, service_name="test_service", domain="charge", data={"test": "data"}, extra_data={"extra": "data"})
     failed |= test_call_service_template("test_service_simple2", my_predbat, inv, service_name="test_service", domain="charge", data={"test": "data"}, extra_data={"extra": "data"}, clear=False, repeat=True)
     failed |= test_call_service_template("test_service_simple3", my_predbat, inv, service_name="test_service", domain="discharge", data={"test": "data"}, extra_data={"extra": "data"}, clear=False)


### PR DESCRIPTION
_Written by Claude, posted on behalf of @chalfontchubby._

Fixes #4876. Originally raised in discussion #4866.

`call_service_template()` recorded its deduplication hash *before* making any of the calls, and discarded each call's return value:

```python
else:
    # Record the last service called
    self.base.last_service_hash[hash_index] = this_service_hash   # recorded up front
    service_repeat = False
...
    self.base.call_service_wrapper(service_name, **service_data)  # result discarded
```

A rejected call was therefore remembered as done, and every later cycle carrying the same target logged `Skipped service ... as it was previously called`. Predbat believed it had set a control it had not, with nothing to correct it until the payload itself changed — which for a held charge target can be hours.

## Reported twice, on unrelated hardware

- **#2903** — a Libbi left un-charged for a 3.5 hour cheap-rate window after a failed `switch.myenergi_libbi_charge_from_grid` turn-on. Plan was correct throughout (`Charging target 7%-100%`); the switch call simply never landed and was never retried.
- **#4876** — a Deye SUN-12K via Solar Assistant left in its idle program, confirmed on the physical display, while `predbat.status` read `Charging`. The reporter re-sent the identical `select_option` by hand from Developer Tools and the battery moved from ~-30W to +850W within seconds.

## What this changes

Record the hash only once every call has been accepted, and drop any earlier record when one is rejected, so the next cycle reissues it naturally.

That is exactly what `repeat: True` on a service template already achieves manually (documented in `docs/inverter-setup.md`). Neither reporter had it set, and needing it is the thing being removed.

## What this deliberately does *not* do

**It is not read-back verification**, which is what #4866 originally asked for. As noted in that discussion, the integrations involved cache writes asynchronously, so re-reading an entity cannot settle whether a value actually reached the inverter — the same report's `charge_limit` path shows a readback trailing the write by a full cycle, which is a separate false-failure problem rather than this one.

This checks only that the service call itself was accepted. That is a fact the HA layer already returns and this code was throwing away.

**The return value is left at `True`.** Callers use it to choose a fallback service:

```python
if not self.call_service_template("charge_freeze_service", ...):
    self.call_service_template("charge_stop_service", ...)
```

Reporting a transient failure there would silently downgrade a freeze into a stop instead of retrying it, so the returned value keeps its existing "was a service configured and dispatched" meaning.

## Caveat worth a reviewer's eye

`call_service_wrapper` returns `None` on an explicit websocket failure *or* a two-minute timeout, and the standalone loopback branch returns `False` when the service is not in `EVENT_LISTEN_LIST`. `trigger_callback`'s docstring states that shared True/False contract is intentional, and Predbat.com does not drive inverters through HA services — but a vendor-specific service called in loopback mode would now look permanently rejected and be reissued each cycle rather than skipped.

## Relationship to #4845

Adjacent, not overlapping. #4845 covers the same act-on-an-unverified-write class at the ten `adjust_*` notify/MQTT sites, whose failure mode is announcing changes that did not happen. This path has no `write_and_poll_value()` at all and fails the opposite way — silently, with no retry. #4876's log shows both halves within one cycle of each other.

## Testing

New `test_call_service_template_retry` covering: a rejected call is retried next cycle; an accepted call is still deduplicated as before; and a later rejection drops the earlier record rather than leaving it stale. Confirmed it fails without the fix:

```
ERROR: a rejected call was recorded as done - the next cycle will skip it
ERROR: the call was not retried after being rejected - this is the #4876 hang
ERROR: the hash from the previous accepted call survived a rejection
```

`./run_all --quick` and `./run_all --test debug_cases` both pass.
