### PR TITLE
fix(overrides): decode manual overrides against an unfakeable clock (#4900)

### DIFF
--- a/apps/predbat/tests/test_manual_times.py
+++ b/apps/predbat/tests/test_manual_times.py
@@ -305,6 +305,101 @@ def run_test_manual_times(my_predbat):
     else:
         print("PASS: T10 Selecting same time with different rates correctly updates the rate")
 
+    # Test 11: A stored slot must survive calculate_yesterday()'s temporary clock shift (#4900)
+    # It sets minutes_now to 0 and winds midnight_utc back a day for the duration of the
+    # savings calculation, and a web request decoding the selection can land inside that window.
+    print("Test 11: Manual times survive the yesterday-savings clock shift")
+
+    my_predbat.midnight_utc = datetime(2025, 12, 19, 0, 0, 0, tzinfo=timezone.utc)
+    my_predbat.midnight = my_predbat.midnight_utc.astimezone(my_predbat.local_tz)
+    my_predbat.now_utc = my_predbat.midnight_utc + timedelta(minutes=120)
+    my_predbat.minutes_now = 120
+
+    my_predbat.manual_select("manual_export", "off")
+    my_predbat.manual_select("manual_export", "Fri 05:30")
+    stored_before = my_predbat.config_index["manual_export"].get("value")
+
+    save_minutes_now = my_predbat.minutes_now
+    save_midnight_utc = my_predbat.midnight_utc
+    my_predbat.minutes_now = 0
+    my_predbat.midnight_utc = my_predbat.midnight_utc - timedelta(days=1)
+    my_predbat.manual_times("manual_export", update=False)
+    my_predbat.manual_times("manual_export")
+    my_predbat.minutes_now = save_minutes_now
+    my_predbat.midnight_utc = save_midnight_utc
+
+    stored_after = my_predbat.config_index["manual_export"].get("value")
+    manual_export_times = my_predbat.manual_times("manual_export")
+
+    if stored_after != stored_before:
+        print("ERROR: T11 Stored selection moved from {} to {} across the clock shift".format(stored_before, stored_after))
+        failed = True
+    elif 330 not in manual_export_times:
+        print("ERROR: T11 Expected minute 330 (05:30 today) but got {}".format(manual_export_times))
+        failed = True
+    else:
+        print("PASS: T11 Manual export slot still resolves to {} after the clock shift".format(manual_export_times))
+
+    # Test 12: The same for manual rates, and a read-only decode must not touch the stored item
+    print("Test 12: Manual rates survive the shift and update=False does not write back")
+
+    my_predbat.manual_select("manual_soc", "off")
+    my_predbat.manual_select("manual_soc", "Fri 05:30=100.0")
+    stored_before = my_predbat.config_index["manual_soc"].get("value")
+    options_before = list(my_predbat.config_index["manual_soc"].get("options", []))
+
+    save_minutes_now = my_predbat.minutes_now
+    save_midnight_utc = my_predbat.midnight_utc
+    my_predbat.minutes_now = 0
+    my_predbat.midnight_utc = my_predbat.midnight_utc - timedelta(days=1)
+    my_predbat.manual_rates("manual_soc", update=False)
+    stored_readonly = my_predbat.config_index["manual_soc"].get("value")
+    options_readonly = list(my_predbat.config_index["manual_soc"].get("options", []))
+    my_predbat.manual_rates("manual_soc")
+    my_predbat.minutes_now = save_minutes_now
+    my_predbat.midnight_utc = save_midnight_utc
+
+    stored_after = my_predbat.config_index["manual_soc"].get("value")
+    manual_soc_keep = my_predbat.manual_rates("manual_soc")
+
+    if stored_readonly != stored_before or options_readonly != options_before:
+        print("ERROR: T12 update=False rewrote the stored item {} / options changed {}".format(stored_readonly, options_readonly != options_before))
+        failed = True
+    elif stored_after != stored_before:
+        print("ERROR: T12 Stored selection moved from {} to {} across the clock shift".format(stored_before, stored_after))
+        failed = True
+    elif manual_soc_keep.get(330, None) != 100.0:
+        print("ERROR: T12 Expected SoC override 100.0 at minute 330 but got {}".format(manual_soc_keep.get(330, None)))
+        failed = True
+    else:
+        print("PASS: T12 Manual SoC override survives the clock shift and read-only decode")
+
+    # Test 13: A click landing inside the shift must not silently drop a slot more than a day
+    # out - the 48 hour horizon is checked against the decoded minutes, so a clock a day behind
+    # pushed anything beyond 24 hours past the limit (#4900)
+    print("Test 13: A selection made during the clock shift keeps far-future slots")
+
+    my_predbat.manual_select("manual_export", "off")
+    my_predbat.manual_select("manual_export", "Fri 05:30")
+    my_predbat.manual_select("manual_export", "Sat 18:00")
+
+    save_minutes_now = my_predbat.minutes_now
+    save_midnight_utc = my_predbat.midnight_utc
+    my_predbat.minutes_now = 0
+    my_predbat.midnight_utc = my_predbat.midnight_utc - timedelta(days=1)
+    my_predbat.manual_select("manual_export", "Fri 06:00")
+    my_predbat.minutes_now = save_minutes_now
+    my_predbat.midnight_utc = save_midnight_utc
+
+    manual_export_times = my_predbat.manual_times("manual_export")
+    expected_minutes = {330, 360, 2520}
+
+    if not expected_minutes.issubset(set(manual_export_times)):
+        print("ERROR: T13 Expected minutes {} but got {}".format(expected_minutes, manual_export_times))
+        failed = True
+    else:
+        print("PASS: T13 Selecting during the clock shift kept every slot: {}".format(manual_export_times))
+
     # Restore time context to current time
     my_predbat.now_utc = datetime.now(my_predbat.local_tz)
     my_predbat.midnight_utc =  my_predbat.now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -314,4 +409,6 @@ def run_test_manual_times(my_predbat):
     # Clean up
     my_predbat.manual_select("manual_demand", "off")
     my_predbat.manual_select("manual_import_rates", "off")
+    my_predbat.manual_select("manual_export", "off")
+    my_predbat.manual_select("manual_soc", "off")
     return failed

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -1418,14 +1418,32 @@ class UserInterface:
         self.expose_config(config_item, values, force=True)
         return time_overrides
 
-    def manual_rates(self, config_item, exclude=[], new_value=None, default_rate=0):
+    def manual_time_origin(self):
+        """
+        Midnight and minutes-now for decoding manual override selections
+
+        Derived from now_utc rather than read from self.midnight_utc / self.minutes_now, which
+        calculate_yesterday() rewrites for the duration of the savings calculation. Those writes
+        land on the shared instance, so a caller on another thread - the web server rendering the
+        plan, or a user clicking a slot on the plan card - could otherwise decode the stored
+        selection against a clock a day behind, and persist the result (#4900).
+        """
+        midnight_utc = self.now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+        minutes_now = int((self.now_utc - midnight_utc).total_seconds() / 60)
+        return midnight_utc, minutes_now
+
+    def manual_rates(self, config_item, exclude=[], new_value=None, default_rate=0, update=True):
         """
         Update manual rates sensor
+
+        Set update=False to decode the stored selection without writing it back - read-only
+        callers should use this. See the note in manual_times() for the shared time origin.
         """
         rate_overrides_minutes = {}
         rate_overrides = []
         plan_interval = self.get_arg("plan_interval_minutes", 30)
-        minutes_now = int(self.minutes_now / plan_interval) * plan_interval
+        midnight_utc, minutes_now_real = self.manual_time_origin()
+        minutes_now = int(minutes_now_real / plan_interval) * plan_interval
         manual_rate_max = 48 * 60
 
         # Deconstruct the value into a list of minutes
@@ -1460,10 +1478,10 @@ class UserInterface:
 
             if override_time:
                 # Calculate minutes from midnight today
-                minutes = int((override_time - self.midnight_utc).total_seconds() / 60)
+                minutes = int((override_time - midnight_utc).total_seconds() / 60)
                 minutes_now_slot = int(minutes_now / plan_interval) * plan_interval
 
-                if (minutes - minutes_now_slot) >= 0 and (minutes - minutes_now) < manual_rate_max:
+                if (minutes - minutes_now_slot) >= 0 and (minutes - minutes_now_real) < manual_rate_max:
                     rate_overrides.append((minutes, rate_value))
                     for minute in range(minutes, minutes + plan_interval):
                         rate_overrides_minutes[minute] = rate_value
@@ -1471,7 +1489,7 @@ class UserInterface:
         # Reconstruct the list in order based on minutes
         values_list = []
         for minute, rate in rate_overrides:
-            minute_str = (self.midnight + timedelta(minutes=minute)).strftime("%a %H:%M")
+            minute_str = (midnight_utc + timedelta(minutes=minute)).strftime("%a %H:%M")
             minute_rate_str = minute_str + "=" + str(rate)
             if minute_rate_str not in exclude and minute_rate_str not in values_list:
                 values_list.append(minute_rate_str)
@@ -1480,32 +1498,43 @@ class UserInterface:
             values = "+" + values
 
         # Create the new dropdown
-        time_values = []
-        for minute in range(minutes_now, minutes_now + manual_rate_max, plan_interval):
-            minute_str = (self.midnight + timedelta(minutes=minute)).strftime("%a %H:%M")
-            if minute in rate_overrides_minutes:
-                rate_value = rate_overrides_minutes[minute]
-                minute_str = f"{minute_str}={rate_value}"
-                minute_str = "[" + minute_str + "]"
-            time_values.append(minute_str)
+        if update:
+            time_values = []
+            for minute in range(minutes_now, minutes_now + manual_rate_max, plan_interval):
+                minute_str = (midnight_utc + timedelta(minutes=minute)).strftime("%a %H:%M")
+                if minute in rate_overrides_minutes:
+                    rate_value = rate_overrides_minutes[minute]
+                    minute_str = f"{minute_str}={rate_value}"
+                    minute_str = "[" + minute_str + "]"
+                time_values.append(minute_str)
 
-        if values not in time_values:
-            time_values.append(values)
-        time_values.append("off")
-        item["options"] = time_values
-        if not values:
-            values = "off"
-        self.expose_config(config_item, values, force=True)
+            if values not in time_values:
+                time_values.append(values)
+            time_values.append("off")
+            item["options"] = time_values
+            if not values:
+                values = "off"
+            self.expose_config(config_item, values, force=True)
 
         return rate_overrides_minutes
 
-    def manual_times(self, config_item, exclude=[], new_value=None):
+    def manual_times(self, config_item, exclude=[], new_value=None, update=True):
         """
         Update manual times sensor
+
+        The stored selection is a list of "%a %H:%M" strings which this re-resolves to absolute
+        minutes and then writes back in its re-rendered form, so both halves of that round trip
+        share the single origin from manual_time_origin() - previously the parse used
+        self.midnight_utc and the render self.midnight, which moved every stored slot on by a day
+        whenever the two disagreed (#4900).
+
+        Set update=False to decode the stored selection without writing it back, which is what a
+        read-only caller wants.
         """
         time_overrides = []
         plan_interval = self.get_arg("plan_interval_minutes", 30)
-        minutes_now = int(self.minutes_now / plan_interval) * plan_interval
+        midnight_utc, minutes_now_real = self.manual_time_origin()
+        minutes_now = int(minutes_now_real / plan_interval) * plan_interval
         manual_time_max = 48 * 60
 
         # Deconstruct the value into a list of minutes
@@ -1530,7 +1559,7 @@ class UserInterface:
 
             if override_time:
                 # Calculate minutes from midnight today
-                minutes = int((override_time - self.midnight_utc).total_seconds() / 60)
+                minutes = int((override_time - midnight_utc).total_seconds() / 60)
                 minutes_now_slot = int(minutes_now / plan_interval) * plan_interval
 
                 if (minutes >= minutes_now_slot) and (minutes - minutes_now_slot) < manual_time_max:
@@ -1539,7 +1568,7 @@ class UserInterface:
         # Reconstruct the list in order based on minutes
         values_list = []
         for minute in time_overrides:
-            minute_str = (self.midnight + timedelta(minutes=minute)).strftime("%a %H:%M")
+            minute_str = (midnight_utc + timedelta(minutes=minute)).strftime("%a %H:%M")
             if minute_str not in exclude and minute_str not in values_list:
                 values_list.append(minute_str)
         values = ",".join(values_list)
@@ -1547,20 +1576,21 @@ class UserInterface:
             values = "+" + values
 
         # Create the new dropdown
-        time_values = []
-        for minute in range(minutes_now, minutes_now + manual_time_max, plan_interval):
-            minute_str = (self.midnight + timedelta(minutes=minute)).strftime("%a %H:%M")
-            if minute in time_overrides:
-                minute_str = "[" + minute_str + "]"
-            time_values.append(minute_str)
+        if update:
+            time_values = []
+            for minute in range(minutes_now, minutes_now + manual_time_max, plan_interval):
+                minute_str = (midnight_utc + timedelta(minutes=minute)).strftime("%a %H:%M")
+                if minute in time_overrides:
+                    minute_str = "[" + minute_str + "]"
+                time_values.append(minute_str)
 
-        if values not in time_values:
-            time_values.append(values)
-        time_values.append("off")
-        item["options"] = time_values
-        if not values:
-            values = "off"
-        self.expose_config(config_item, values, force=True)
+            if values not in time_values:
+                time_values.append(values)
+            time_values.append("off")
+            item["options"] = time_values
+            if not values:
+                values = "off"
+            self.expose_config(config_item, values, force=True)
 
         if time_overrides:
             time_txt = []

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -2486,15 +2486,17 @@ chart.render();
         baseline_timestamp = baseline_json.get("timestamp", None) if baseline_json else None
 
         # Get current manual overrides
-        manual_charge_times = self.base.manual_times("manual_charge")
-        manual_export_times = self.base.manual_times("manual_export")
-        manual_freeze_charge_times = self.base.manual_times("manual_freeze_charge")
-        manual_freeze_export_times = self.base.manual_times("manual_freeze_export")
-        manual_demand_times = self.base.manual_times("manual_demand")
-        manual_import_rates = self.base.manual_rates("manual_import_rates")
-        manual_export_rates = self.base.manual_rates("manual_export_rates")
-        manual_load_adjust = self.base.manual_rates("manual_load_adjust")
-        manual_soc_keep = self.base.manual_rates("manual_soc")
+        # Read-only: these run on the web server's own thread, so writing the decoded
+        # selection back could persist times captured mid-recompute (#4900)
+        manual_charge_times = self.base.manual_times("manual_charge", update=False)
+        manual_export_times = self.base.manual_times("manual_export", update=False)
+        manual_freeze_charge_times = self.base.manual_times("manual_freeze_charge", update=False)
+        manual_freeze_export_times = self.base.manual_times("manual_freeze_export", update=False)
+        manual_demand_times = self.base.manual_times("manual_demand", update=False)
+        manual_import_rates = self.base.manual_rates("manual_import_rates", update=False)
+        manual_export_rates = self.base.manual_rates("manual_export_rates", update=False)
+        manual_load_adjust = self.base.manual_rates("manual_load_adjust", update=False)
+        manual_soc_keep = self.base.manual_rates("manual_soc", update=False)
 
         # Convert manual rates dicts to list format for JavaScript
         manual_import_rates_list = [{"minutes": k, "rate": v} for k, v in manual_import_rates.items()]
@@ -2580,15 +2582,17 @@ chart.render();
         baseline_json = self.get_state_wrapper(entity_id=self.prefix + ".savings_yesterday_predbat", attribute="json", default=None)
 
         # Fetch override data
-        manual_charge_times = self.base.manual_times("manual_charge")
-        manual_export_times = self.base.manual_times("manual_export")
-        manual_freeze_charge_times = self.base.manual_times("manual_freeze_charge")
-        manual_freeze_export_times = self.base.manual_times("manual_freeze_export")
-        manual_demand_times = self.base.manual_times("manual_demand")
-        manual_import_rates = self.base.manual_rates("manual_import_rates")
-        manual_export_rates = self.base.manual_rates("manual_export_rates")
-        manual_load_adjust = self.base.manual_rates("manual_load_adjust")
-        manual_soc_keep = self.base.manual_rates("manual_soc")
+        # Read-only: these run on the web server's own thread, so writing the decoded
+        # selection back could persist times captured mid-recompute (#4900)
+        manual_charge_times = self.base.manual_times("manual_charge", update=False)
+        manual_export_times = self.base.manual_times("manual_export", update=False)
+        manual_freeze_charge_times = self.base.manual_times("manual_freeze_charge", update=False)
+        manual_freeze_export_times = self.base.manual_times("manual_freeze_export", update=False)
+        manual_demand_times = self.base.manual_times("manual_demand", update=False)
+        manual_import_rates = self.base.manual_rates("manual_import_rates", update=False)
+        manual_export_rates = self.base.manual_rates("manual_export_rates", update=False)
+        manual_load_adjust = self.base.manual_rates("manual_load_adjust", update=False)
+        manual_soc_keep = self.base.manual_rates("manual_soc", update=False)
 
         # Convert manual rates dicts to list format for JavaScript
         manual_import_rates_list = [{"minutes": k, "rate": v} for k, v in manual_import_rates.items()]
@@ -4620,7 +4624,7 @@ chart.render();
 
             # For clear operations, we need to use the actual stored rate value, not the passed rate
             if action == "Clear Import":
-                manual_import_rates = self.base.manual_rates("manual_import_rates")
+                manual_import_rates = self.base.manual_rates("manual_import_rates", update=False)
                 actual_rate = manual_import_rates.get(minutes_from_midnight, rate)
                 clear_option = "[{}={}]".format(override_time.strftime("%a %H:%M"), actual_rate)
                 await self.base.async_manual_select("manual_import_rates", clear_option)
@@ -4629,7 +4633,7 @@ chart.render();
                 await self.set_state_external(item.get("entity", None), rate)
                 await self.base.async_manual_select("manual_import_rates", selection_option)
             elif action == "Clear Export":
-                manual_export_rates = self.base.manual_rates("manual_export_rates")
+                manual_export_rates = self.base.manual_rates("manual_export_rates", update=False)
                 actual_rate = manual_export_rates.get(minutes_from_midnight, rate)
                 clear_option = "[{}={}]".format(override_time.strftime("%a %H:%M"), actual_rate)
                 await self.base.async_manual_select("manual_export_rates", clear_option)
@@ -4642,7 +4646,7 @@ chart.render();
                 await self.set_state_external(item.get("entity", None), rate)
                 await self.base.async_manual_select("manual_load_adjust", selection_option)
             elif action == "Clear Load":
-                manual_load_adjust = self.base.manual_rates("manual_load_adjust")
+                manual_load_adjust = self.base.manual_rates("manual_load_adjust", update=False)
                 actual_rate = manual_load_adjust.get(minutes_from_midnight, rate)
                 clear_option = "[{}={}]".format(override_time.strftime("%a %H:%M"), actual_rate)
                 await self.base.async_manual_select("manual_load_adjust", clear_option)
@@ -4651,7 +4655,7 @@ chart.render();
                 await self.set_state_external(item.get("entity", None), rate)
                 await self.base.async_manual_select("manual_soc", selection_option)
             elif action == "Clear SOC":
-                manual_soc = self.base.manual_rates("manual_soc")
+                manual_soc = self.base.manual_rates("manual_soc", update=False)
                 actual_rate = manual_soc.get(minutes_from_midnight, rate)
                 clear_option = "[{}={}]".format(override_time.strftime("%a %H:%M"), actual_rate)
                 await self.base.async_manual_select("manual_soc", clear_option)


### PR DESCRIPTION
*(Investigated and written by Claude Code on my behalf.)*

Fixes #4900.
Fixes #3078.

## The bug

A manual override set on the plan card is not dropped by the optimiser — it is **silently moved forward exactly 24 hours** and then honoured on the wrong day. In the reporter's log the seven slots pinned for 05:30–09:00 reappear five minutes later against tomorrow:

```
02:00:17  Export windows filtered [ 02-09 05:30-06:00 @ 15.72p 86.0%, 02-09 06:00-06:30 @ 76.0%, ... ]
02:05:17  Export windows filtered [ 02-09 07:55-08:00 @ 94.0%, ...,
                                    03-09 05:30-06:00 @ 15.72p 0.0%, 03-09 06:00-06:30 @ 0.0%, ... ]
```

Those `03-09` windows sit beyond `end_record`, where `optimise_charge_windows_reset()` parks everything at `EXPORT_LIMIT_IDLE`. The only thing that writes an unclipped `0.0` there is `optimise_charge_windows_manual()` — so the pins were still being applied, just to the wrong day.

## Why

The override is stored as a list of relative `"%a %H:%M"` labels on its select entity — there is no other copy. `manual_times()` and `manual_rates()` decode those labels to absolute minutes, re-render them, and write the result back with `expose_config(..., force=True)` on **every** call. The decode read `self.midnight_utc`; the render read `self.midnight`. Same instant normally, so the round trip is a no-op and the mismatch stayed latent.

`calculate_yesterday()` makes them differ. To re-simulate yesterday it winds `midnight_utc` back a day and zeroes `minutes_now` on the shared instance, restoring them at the end. Measured across 36 runs in the reporter's logs that window is **0.67–0.97s, mean 0.78s**, and it runs **once an hour** (gated on `savings_last_updated`), not per replan.

Four callers can reach these functions off the main thread and land in it:

| Trigger | Needs the web UI? |
|---|---|
| Plan page polling `/api/plan_data` every 5s | page open |
| Plan card click | yes |
| HA select changed from a dashboard, automation or script → `select_event` (websocket thread) | no |
| `agent_tools` / MCP | no |

For an open plan page that is a 0.78s window against a 5s poll — **~16% per hourly run**, so ~88% over a night. Not a rare race, which is why it was reported. `fetch_config_options()` can never hit it, being on the same thread as `calculate_yesterday()`.

The same borrowed clock also broke the **48-hour horizon check**: a selection made during the window measured every stored slot a day late, so anything beyond 24 hours fell past the limit and was deleted:

```
stored before : +Wed 05:30,Thu 18:00
(click "Wed 06:00" during the window)
stored during : +Wed 05:30,Wed 06:00     <- Thu 18:00 silently gone
```

## The fix

New `manual_time_origin()` derives midnight and minutes-now from `now_utc`, which nothing fakes. Both functions use it for the decode, the re-render **and** the horizon check, so interpreting a stored selection no longer depends on what the shared clock is doing or which thread is asking. That closes the read path, the click path and the horizon check together.

Both functions also gain `update=False`, used by every web read path, so rendering the plan can no longer write user config at all. That is belt-and-braces now rather than the thing making it correct — a GET simply should not be able to rewrite a user's overrides.

## Tests

Three regression tests in `tests/test_manual_times.py`, each verified to fail on `main`:

- **T11** — a stored slot survives the clock shift and still resolves to the right day
- **T12** — the same for manual rates, and `update=False` touches neither the value nor the options
- **T13** — a selection made mid-shift keeps a slot more than a day out

`./run_all --quick` passes; pre-commit clean.

## Not addressed

`calculate_yesterday()` fakes around twenty attributes plus `self.prediction` on the shared instance while other threads read it. `manual_times`/`manual_rates` were the only exposure that persisted anything — the rest of `web.py` reads published HA entities, not live base state — but a page rendered inside the window can still briefly hide the iBoost and carbon columns, since `iboost_enable` and `carbon_enable` are blanked too. That is cosmetic and self-heals. The wider shared-state faking is worth its own issue; it is the same function as the `forecast_minutes` bug in #4418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
