### PR TITLE
fix(security): stop apps.yaml downloads and debug dumps leaking credentials

### DIFF
--- a/apps/predbat/agent_tools.py
+++ b/apps/predbat/agent_tools.py
@@ -1128,7 +1128,7 @@ class PredbatTools:
                     continue
                 if callable(value):
                     continue
-                if key == "args":
+                if key in ("args", "args_from_apps_yaml"):
                     value = mask_secret_args(value)
 
                 fits, safe, size = measure_state_value(value, max_bytes)

--- a/apps/predbat/components.py
+++ b/apps/predbat/components.py
@@ -15,6 +15,13 @@ Defines COMPONENT_LIST mapping all available components to their classes
 and configuration requirements, and provides the Components class for
 initialising, starting, stopping, and restarting components in the correct
 phase order. Routes HA events to components based on entity prefix filtering.
+
+Each entry in a component's "args" maps a constructor keyword to the apps.yaml key that
+supplies it ("config"), plus how it is resolved ("required", "required_true", "default",
+"indirect", "config_late_resolve", "shared_config"). Mark an arg "secret": True when its
+value is a credential, so it is redacted from debug dumps, downloads and anything served
+to an AI assistant - see secret_config_names() below for what that covers and, importantly,
+what it deliberately does not.
 """
 
 from storage import StorageComponent
@@ -73,7 +80,7 @@ COMPONENT_LIST = {
         "name": "Home Assistant Interface",
         "args": {
             "ha_url": {"required": False, "config": "ha_url", "default": "http://supervisor/core"},
-            "ha_key": {"required": False, "config": "ha_key", "default": os.environ.get("SUPERVISOR_TOKEN", None)},
+            "ha_key": {"required": False, "secret": True, "config": "ha_key", "default": os.environ.get("SUPERVISOR_TOKEN", None)},
             "db_enable": {"required": False, "config": "db_enable", "default": False},
             "db_mirror_ha": {"required": False, "config": "db_mirror_ha", "default": False},
             "db_primary": {"required": False, "config": "db_primary", "default": False},
@@ -95,7 +102,7 @@ COMPONENT_LIST = {
         "name": "MCP Server",
         "args": {
             "mcp_enable": {"required": True, "config": "mcp_enable", "default": False},
-            "mcp_secret": {"required": False, "config": "mcp_secret", "default": "predbat_mcp_secret"},
+            "mcp_secret": {"required": False, "secret": True, "config": "mcp_secret", "default": "predbat_mcp_secret"},
             "mcp_port": {"required": False, "config": "mcp_port", "default": 8199},
         },
         "phase": 1,
@@ -122,7 +129,7 @@ COMPONENT_LIST = {
         "name": "Solar API",
         "args": {
             "solcast_host": {"required": False, "config": "solcast_host", "default": "https://api.solcast.com.au/"},
-            "solcast_api_key": {"required": False, "config": "solcast_api_key"},
+            "solcast_api_key": {"required": False, "secret": True, "config": "solcast_api_key"},
             "solcast_sites": {"required": False, "config": "solcast_sites"},
             "solcast_poll_hours": {"required": False, "config": "solcast_poll_hours", "default": 8},
             "forecast_solar": {"required": False, "config": "forecast_solar", "default": False},
@@ -151,6 +158,7 @@ COMPONENT_LIST = {
             },
             "api_key": {
                 "required": True,
+                "secret": True,
                 "config": "ge_cloud_key",
             },
             "automatic": {
@@ -181,6 +189,7 @@ COMPONENT_LIST = {
             },
             "ge_cloud_key": {
                 "required": True,
+                "secret": True,
                 "config": "ge_cloud_key",
             },
             "ge_cloud_serial": {
@@ -207,10 +216,12 @@ COMPONENT_LIST = {
         "args": {
             "key": {
                 "required": True,
+                "secret": True,
                 "config": "octopus_api_key",
             },
             "account_id": {
                 "required": True,
+                "secret": True,
                 "config": "octopus_api_account",
             },
             "automatic": {
@@ -228,10 +239,12 @@ COMPONENT_LIST = {
         "args": {
             "email": {
                 "required": True,
+                "secret": True,
                 "config": "ohme_login",
             },
             "password": {
                 "required": True,
+                "secret": True,
                 "config": "ohme_password",
             },
             "ohme_automatic": {
@@ -259,11 +272,11 @@ COMPONENT_LIST = {
         "event_filter": "predbat_myenergi_",
         "args": {
             "auth_method": {"required": False, "config": "myenergi_auth_method", "default": "direct"},
-            "hub_serial": {"required": False, "config": "myenergi_hub_serial"},
-            "api_key": {"required": False, "config": "myenergi_api_key"},
-            "key": {"required": False, "config": "myenergi_key"},
+            "hub_serial": {"required": False, "secret": True, "config": "myenergi_hub_serial"},
+            "api_key": {"required": False, "secret": True, "config": "myenergi_api_key"},
+            "key": {"required": False, "secret": True, "config": "myenergi_key"},
             "token_expires_at": {"required": False, "config": "myenergi_token_expires_at"},
-            "token_hash": {"required": False, "config": "myenergi_token_hash"},
+            "token_hash": {"required": False, "secret": True, "config": "myenergi_token_hash"},
             "automatic": {"required": False, "config": "myenergi_automatic", "default": True},
             "enable_controls": {"required": False, "config": "myenergi_enable_controls", "default": True},
             "poll_seconds": {"required": False, "config": "myenergi_poll_seconds", "default": 60},
@@ -288,6 +301,7 @@ COMPONENT_LIST = {
         "args": {
             "key": {
                 "required": True,
+                "secret": True,
                 "config": "fox_key",
             },
             "automatic": {
@@ -315,6 +329,7 @@ COMPONENT_LIST = {
             },
             "token_hash": {
                 "required": False,
+                "secret": True,
                 "config": "fox_token_hash",
             },
         },
@@ -325,20 +340,20 @@ COMPONENT_LIST = {
         "name": "DEYE Cloud",
         "event_filter": "predbat_deye_",
         "args": {
-            "app_id": {"required": False, "config": "deye_app_id"},
-            "app_secret": {"required": False, "config": "deye_app_secret"},
+            "app_id": {"required": False, "secret": True, "config": "deye_app_id"},
+            "app_secret": {"required": False, "secret": True, "config": "deye_app_secret"},
             # In oauth mode OAuthMixin assigns 'key' straight to access_token (see
             # oauth_mixin._init_oauth). Predbat.com injects the access token as deye_key;
             # without this entry it is dropped and DEYE rejects every call as
             # "auth invalid token".
-            "key": {"required": False, "config": "deye_key"},
-            "username": {"required": False, "config": "deye_username"},
-            "password": {"required": False, "config": "deye_password"},
+            "key": {"required": False, "secret": True, "config": "deye_key"},
+            "username": {"required": False, "secret": True, "config": "deye_username"},
+            "password": {"required": False, "secret": True, "config": "deye_password"},
             "data_center": {"required": False, "default": "eu", "config": "deye_data_center"},
-            "company_id": {"required": False, "config": "deye_company_id"},
+            "company_id": {"required": False, "secret": True, "config": "deye_company_id"},
             "auth_method": {"required": False, "default": "app_credentials", "config": "deye_auth_method"},
             "token_expires_at": {"required": False, "config": "deye_token_expires_at"},
-            "token_hash": {"required": False, "config": "deye_token_hash"},
+            "token_hash": {"required": False, "secret": True, "config": "deye_token_hash"},
             "inverter_sn": {"required": False, "config": "deye_inverter_sn"},
             "automatic": {"required": False, "default": False, "config": "deye_automatic"},
             "automatic_ignore_pv": {"required": False, "default": False, "config": "deye_automatic_ignore_pv"},
@@ -361,16 +376,16 @@ COMPONENT_LIST = {
         "name": "Sunsynk Cloud",
         "event_filter": "predbat_sunsynk_",
         "args": {
-            "username": {"required": False, "config": "sunsynk_username"},
-            "password": {"required": False, "config": "sunsynk_password"},
+            "username": {"required": False, "secret": True, "config": "sunsynk_username"},
+            "password": {"required": False, "secret": True, "config": "sunsynk_password"},
             # In oauth mode OAuthMixin assigns 'key' straight to access_token (see
             # oauth_mixin._init_oauth). Predbat.com injects the access token as
             # sunsynk_key; without this entry it is dropped and every call is rejected.
-            "key": {"required": False, "config": "sunsynk_key"},
+            "key": {"required": False, "secret": True, "config": "sunsynk_key"},
             "region": {"required": False, "default": "sunsynk", "config": "sunsynk_region"},
             "auth_method": {"required": False, "default": "password", "config": "sunsynk_auth_method"},
             "token_expires_at": {"required": False, "config": "sunsynk_token_expires_at"},
-            "token_hash": {"required": False, "config": "sunsynk_token_hash"},
+            "token_hash": {"required": False, "secret": True, "config": "sunsynk_token_hash"},
             "inverter_sn": {"required": False, "config": "sunsynk_inverter_sn"},
             "automatic": {"required": False, "default": False, "config": "sunsynk_automatic"},
             "automatic_ignore_pv": {"required": False, "default": False, "config": "sunsynk_automatic_ignore_pv"},
@@ -395,8 +410,8 @@ COMPONENT_LIST = {
         "name": "AlphaESS Cloud API",
         "event_filter": "predbat_alphaess_",
         "args": {
-            "app_id": {"required": False, "config": "alphaess_app_id"},
-            "app_secret": {"required": False, "config": "alphaess_app_secret"},
+            "app_id": {"required": False, "secret": True, "config": "alphaess_app_id"},
+            "app_secret": {"required": False, "secret": True, "config": "alphaess_app_secret"},
             "inverter_sn": {"required": False, "config": "alphaess_inverter_sn"},
             "automatic": {"required": False, "default": False, "config": "alphaess_automatic"},
             "automatic_ignore_pv": {"required": False, "default": False, "config": "alphaess_automatic_ignore_pv"},
@@ -424,14 +439,17 @@ COMPONENT_LIST = {
         "args": {
             "username": {
                 "required": True,
+                "secret": True,
                 "config": "enphase_username",
             },
             "password": {
                 "required": True,
+                "secret": True,
                 "config": "enphase_password",
             },
             "site_id": {
                 "required": False,
+                "secret": True,
                 "config": "enphase_site_id",
             },
             "automatic": {
@@ -458,18 +476,22 @@ COMPONENT_LIST = {
             },
             "account_id": {
                 "required": True,
+                "secret": True,
                 "config": "kraken_account_id",
             },
             "key": {
                 "required": False,
+                "secret": True,
                 "config": "kraken_key",
             },
             "email": {
                 "required": False,
+                "secret": True,
                 "config": "kraken_email",
             },
             "password": {
                 "required": False,
+                "secret": True,
                 "config": "kraken_password",
             },
             "auth_method": {
@@ -483,18 +505,22 @@ COMPONENT_LIST = {
             },
             "token_hash": {
                 "required": False,
+                "secret": True,
                 "config": "kraken_token_hash",
             },
             "mpan": {
                 "required": False,
+                "secret": True,
                 "config": "kraken_mpan",
             },
             "export_account_id": {
                 "required": False,
+                "secret": True,
                 "config": "kraken_export_account_id",
             },
             "export_mpan": {
                 "required": False,
+                "secret": True,
                 "config": "kraken_export_mpan",
             },
             "base_url": {
@@ -542,13 +568,13 @@ COMPONENT_LIST = {
         "name": "Axle Energy",
         "event_filter": "predbat_axle_",
         "args": {
-            "api_key": {"required": False, "config": "axle_api_key"},
+            "api_key": {"required": False, "secret": True, "config": "axle_api_key"},
             "pence_per_kwh": {"required": False, "config": "axle_pence_per_kwh", "default": 100},
             "automatic": {"required": False, "config": "axle_automatic", "default": True},
             "managed_mode": {"required": False, "config": "axle_managed_mode", "default": False},
-            "site_id": {"required": False, "config": "axle_site_id"},
-            "partner_username": {"required": False, "config": "axle_partner_username"},
-            "partner_password": {"required": False, "config": "axle_partner_password"},
+            "site_id": {"required": False, "secret": True, "config": "axle_site_id"},
+            "partner_username": {"required": False, "secret": True, "config": "axle_partner_username"},
+            "partner_password": {"required": False, "secret": True, "config": "axle_partner_password"},
             "api_base_url": {"required": False, "config": "axle_api_base_url", "default": "https://api.axle.energy"},
         },
         "required_or": ["api_key", "managed_mode"],
@@ -559,14 +585,14 @@ COMPONENT_LIST = {
         "name": "Sigenergy Cloud API",
         "event_filter": "predbat_sigenergy_",
         "args": {
-            "system_id": {"required": True, "config": "sigenergy_system_id"},
-            "app_key": {"required": True, "config": "sigenergy_app_key"},
-            "app_secret": {"required": True, "config": "sigenergy_app_secret"},
+            "system_id": {"required": True, "secret": True, "config": "sigenergy_system_id"},
+            "app_key": {"required": True, "secret": True, "config": "sigenergy_app_key"},
+            "app_secret": {"required": True, "secret": True, "config": "sigenergy_app_secret"},
             "base_url": {"required": False, "config": "sigenergy_base_url", "default": "https://openapi-eu.sigencloud.com"},
             "mqtt_host": {"required": False, "config": "sigenergy_mqtt_host"},
             "ca_cert": {"required": False, "config": "sigenergy_ca_pem"},
-            "client_cert": {"required": False, "config": "sigenergy_client_pem"},
-            "client_key": {"required": False, "config": "sigenergy_client_key"},
+            "client_cert": {"required": False, "secret": True, "config": "sigenergy_client_pem"},
+            "client_key": {"required": False, "secret": True, "config": "sigenergy_client_key"},
             "automatic": {"required": False, "config": "sigenergy_automatic", "default": False},
             "enable_controls": {"required": False, "config": "sigenergy_enable_controls", "default": True},
         },
@@ -578,13 +604,13 @@ COMPONENT_LIST = {
         "name": "Tesla Powerwall (Teslemetry)",
         "event_filter": "predbat_teslemetry_",
         "args": {
-            "key": {"required": True, "config": "teslemetry_key"},
-            "site_id": {"required": False, "config": "teslemetry_site_id"},
+            "key": {"required": True, "secret": True, "config": "teslemetry_key"},
+            "site_id": {"required": False, "secret": True, "config": "teslemetry_site_id"},
             "base_url": {"required": False, "config": "teslemetry_base_url", "default": "https://api.teslemetry.com"},
             "automatic": {"required": False, "default": False, "config": "teslemetry_automatic"},
             "auth_method": {"required": False, "config": "teslemetry_auth_method", "default": "api_key"},
             "token_expires_at": {"required": False, "config": "teslemetry_token_expires_at"},
-            "token_hash": {"required": False, "config": "teslemetry_token_hash"},
+            "token_hash": {"required": False, "secret": True, "config": "teslemetry_token_hash"},
         },
         "phase": 1,
         "can_restart": True,
@@ -594,9 +620,9 @@ COMPONENT_LIST = {
         "name": "SolaX Cloud API",
         "event_filter": "predbat_solax_",
         "args": {
-            "client_id": {"required": True, "config": "solax_client_id"},
-            "client_secret": {"required": True, "config": "solax_client_secret"},
-            "plant_id": {"required": False, "config": "solax_plant_id"},
+            "client_id": {"required": True, "secret": True, "config": "solax_client_id"},
+            "client_secret": {"required": True, "secret": True, "config": "solax_client_secret"},
+            "plant_id": {"required": False, "secret": True, "config": "solax_plant_id"},
             "region": {"required": False, "config": "solax_region", "default": "eu"},
             "automatic": {"required": False, "config": "solax_automatic", "default": False},
             "enable_controls": {"required": False, "config": "solax_enable_controls", "default": True},
@@ -614,12 +640,12 @@ COMPONENT_LIST = {
         "event_filter": "predbat_solis_",
         "args": {
             # api_key/api_secret (HMAC) OR auth_method=oauth+access_token must be supplied.
-            "api_key": {"required": False, "config": "solis_api_key"},
-            "api_secret": {"required": False, "config": "solis_api_secret"},
+            "api_key": {"required": False, "secret": True, "config": "solis_api_key"},
+            "api_secret": {"required": False, "secret": True, "config": "solis_api_secret"},
             "auth_method": {"required": False, "config": "solis_auth_method", "default": "api_key"},
-            "access_token": {"required": False, "config": "solis_access_token"},
+            "access_token": {"required": False, "secret": True, "config": "solis_access_token"},
             "token_expires_at": {"required": False, "config": "solis_token_expires_at"},
-            "token_hash": {"required": False, "config": "solis_token_hash"},
+            "token_hash": {"required": False, "secret": True, "config": "solis_token_hash"},
             "inverter_sn": {"required": False, "config": "solis_inverter_sn"},
             "automatic": {"required": False, "config": "solis_automatic", "default": False},
             "base_url": {"required": False, "config": "solis_base_url", "default": "https://www.soliscloud.com:13333"},
@@ -654,10 +680,10 @@ if HAS_GATEWAY:
         "name": "PredBat Gateway",
         "event_filter": "predbat_gateway_",
         "args": {
-            "gateway_device_id": {"required": True, "config": "gateway_device_id"},
+            "gateway_device_id": {"required": True, "secret": True, "config": "gateway_device_id"},
             "mqtt_host": {"required": True, "config": "gateway_mqtt_host"},
             "mqtt_port": {"required": False, "config": "gateway_mqtt_port", "default": 8883},
-            "mqtt_token": {"required": True, "config": "gateway_mqtt_token"},
+            "mqtt_token": {"required": True, "secret": True, "config": "gateway_mqtt_token"},
             "gateway_inverter_serial": {"required": False, "config": "gateway_inverter_serial", "default": None},
             "gateway_evc_automatic": {"required": False, "config": "gateway_evc_automatic", "default": False},
             "gateway_evc_control": {"required": False, "config": "gateway_evc_control", "default": False},
@@ -665,6 +691,30 @@ if HAS_GATEWAY:
         "phase": 1,
         "can_restart": True,
     }
+
+
+def secret_config_names():
+    """Return every apps.yaml config name the registry flags with "secret": True.
+
+    Feeds utils.is_secret_key(), so redaction covers the credentials its key-name substrings
+    cannot infer: account numbers (octopus_api_account, kraken_account_id), meter point numbers
+    (kraken_mpan), site/system/plant ids, login identifiers (deye_username, kraken_email,
+    ohme_login, myenergi_hub_serial - the digest auth username) and the id half of an
+    id/secret pair (deye_app_id, solax_client_id). Read from the live dict rather than
+    precomputed, so the conditionally-registered gateway component is included.
+
+    Device serial numbers are deliberately not flagged: they address hardware rather than
+    authenticate it, and they are what makes an integration bug report diagnosable - the same
+    trade-off SECRET_KEY_EXEMPT_SUFFIXES makes for token expiry times.
+    """
+    names = set()
+    for component_info in COMPONENT_LIST.values():
+        for arg_info in component_info.get("args", {}).values():
+            if isinstance(arg_info, dict) and arg_info.get("secret", False):
+                config = arg_info.get("config", None)
+                if config:
+                    names.add(str(config).lower())
+    return frozenset(names)
 
 
 class Components:

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -76,7 +76,7 @@ from const import (
 )
 from config import APPS_SCHEMA, CONFIG_ITEMS
 import debug_history
-from utils import minutes_since_yesterday, dp1, dp2, dp3, find_unmasked_secret_paths
+from utils import minutes_since_yesterday, dp1, dp2, dp3, find_unmasked_secret_paths, mask_secret_args
 from predheat import PredHeat
 from octopus import Octopus
 from energydataservice import Energidataservice
@@ -1856,7 +1856,10 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         # (auto_config/load_user_config) or any component's automatic_config() touches self.args -
         # lets ComponentBase.set_arg_auto() tell "user explicitly configured this" apart from
         # "Predbat defaulted it" or "another component already overwrote it" (issue #4494 follow-up).
-        self.args_from_apps_yaml = copy.deepcopy(self.args)
+        # Masked at the source (set_arg_auto() is only ever called with auto-discovery targets
+        # like battery_scaling or sensor entity ids, never credential-shaped keys) so this second
+        # copy of apps.yaml can never carry a real secret regardless of how it's later dumped.
+        self.args_from_apps_yaml = mask_secret_args(self.args)
         self.apps_yaml_override_warned = set()  # {arg} already warned about via set_arg_auto()
         self.log("Predbat: Startup {}".format(__name__))
         self.update_time(print=False)

--- a/apps/predbat/tests/test_agent_tools.py
+++ b/apps/predbat/tests/test_agent_tools.py
@@ -23,8 +23,8 @@ import time
 from datetime import datetime
 
 from agent_tools import TOOL_DEFS, PredbatTools, format_plan_rows_table, mcp_tool_list, openai_tool_list, slim_plan, slim_plan_rows, compile_filter_argument, MCPArgumentError, FILTER_PATTERN_MAX, parse_log_time_bound
-from components import Components
-from utils import mask_secret_args
+from components import Components, secret_config_names
+from utils import is_secret_key, mask_secret_args
 from web_mcp import MCPServerWrapper
 
 GOLDEN_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_tools_golden.json")
@@ -753,6 +753,131 @@ def test_args_from_apps_yaml_snapshot_is_redacted(my_predbat):
     return failed
 
 
+def test_registry_secret_flags_drive_redaction(my_predbat):
+    """Every arg the component registry flags "secret": True is redacted everywhere.
+
+    SECRET_KEY_SUBSTRINGS can only catch what a key *name* reveals (_key/password/secret/token),
+    so credentials named after what they identify sailed through in the clear: account numbers
+    (octopus_api_account, kraken_account_id), meter point numbers (kraken_mpan), site/system/plant
+    ids, login identifiers (deye_username, kraken_email, ohme_login, and myenergi_hub_serial,
+    which is the digest auth username) and the id half of an id/secret pair (deye_app_id,
+    solax_client_id). components.py now flags these explicitly and is_secret_key() honours it.
+
+    Mutation check: dropping the registry_secret_key_names() consultation from is_secret_key(),
+    or a "secret": True flag from any of the named args, fails an assertion below.
+    """
+    failed = False
+    print("**** Testing registry secret flags drive redaction ****")
+
+    declared = secret_config_names()
+    if not declared:
+        print("ERROR: the registry declared no secret args at all - the flag is not wired up")
+        failed = True
+
+    # The flag is the contract: whatever it marks must redact, or the declaration is a lie.
+    for name in sorted(declared):
+        if not is_secret_key(name):
+            print("ERROR: {} is flagged secret in components.py but is_secret_key() returns False".format(name))
+            failed = True
+
+    # The names that motivated the flag - none of these match any substring.
+    newly_covered = [
+        "octopus_api_account",
+        "kraken_account_id",
+        "kraken_export_account_id",
+        "kraken_mpan",
+        "kraken_export_mpan",
+        "kraken_email",
+        "myenergi_hub_serial",
+        "ohme_login",
+        "deye_username",
+        "deye_app_id",
+        "deye_company_id",
+        "sunsynk_username",
+        "alphaess_app_id",
+        "enphase_username",
+        "enphase_site_id",
+        "axle_site_id",
+        "axle_partner_username",
+        "sigenergy_system_id",
+        "teslemetry_site_id",
+        "solax_client_id",
+        "solax_plant_id",
+    ]
+    for name in newly_covered:
+        if name not in declared:
+            print("ERROR: {} is no longer flagged secret in components.py".format(name))
+            failed = True
+        if not is_secret_key(name):
+            print("ERROR: {} is a credential but is not redacted".format(name))
+            failed = True
+
+    # Over-redaction is its own bug: a serial addresses hardware rather than authenticating it,
+    # and it is what makes an integration bug report diagnosable. Same call as the token-expiry
+    # exemption - these must stay readable.
+    must_stay_visible = [
+        "solis_inverter_sn",
+        "deye_inverter_sn",
+        "alphaess_inverter_sn",
+        "sunsynk_inverter_sn",
+        "fox_inverter_sn",
+        "ge_cloud_serial",
+        "solax_plant_sn",
+        "kraken_base_url",
+        "kraken_provider",
+        "deye_auth_method",
+        "solis_token_expires_at",
+        "carbon_postcode",
+        "battery_size",
+    ]
+    for name in must_stay_visible:
+        if is_secret_key(name):
+            print("ERROR: {} is not a credential but is being redacted, which hides it from bug reports".format(name))
+            failed = True
+
+    # End to end, through what a user downloads and what a model is served.
+    original_args = my_predbat.args
+    try:
+        my_predbat.args = {
+            "octopus_api_account": "A-REAL-ACCOUNT",
+            "kraken_mpan": "9999999999999",
+            "myenergi_hub_serial": "REAL-HUB-SERIAL",
+            "solis_inverter_sn": "SN-STAYS-VISIBLE",
+            "battery_size": 9.5,
+        }
+        masked = mask_secret_args(my_predbat.args)
+        for key in ("octopus_api_account", "kraken_mpan", "myenergi_hub_serial"):
+            if masked[key] != "xxx":
+                print("ERROR: {} survived mask_secret_args: {}".format(key, masked[key]))
+                failed = True
+        if masked["solis_inverter_sn"] != "SN-STAYS-VISIBLE" or masked["battery_size"] != 9.5:
+            print("ERROR: redaction damaged values that must stay readable: {}".format(masked))
+            failed = True
+
+        tools = PredbatTools(my_predbat)
+        result = json.dumps(asyncio.run(tools.execute("get_apps", {})))
+        for secret in ("A-REAL-ACCOUNT", "9999999999999", "REAL-HUB-SERIAL"):
+            if secret in result:
+                print("ERROR: get_apps served {} in the clear".format(secret))
+                failed = True
+    finally:
+        my_predbat.args = original_args
+
+    # The '!secret' advice keeps the narrower scope: it is about values that grant access, and an
+    # inline account number is the documented normal setup, so warning about it would be noise.
+    # Redaction and this advice are deliberately different questions - see is_secret_key(registry=).
+    for name in ("octopus_api_account", "kraken_mpan", "myenergi_hub_serial", "enphase_site_id"):
+        if is_secret_key(name, registry=False):
+            print("ERROR: {} would now raise a plain-text !secret warning for every user who has it inline".format(name))
+            failed = True
+    for name in ("ha_key", "solcast_api_key", "kraken_password", "solis_access_token"):
+        if not is_secret_key(name, registry=False):
+            print("ERROR: {} must still raise the plain-text !secret warning".format(name))
+            failed = True
+
+    return failed
+
+
 def test_pathological_regex_arguments_are_rejected(my_predbat):
     """A nested-quantifier regex is refused before it can be compiled and run.
 
@@ -1438,6 +1563,7 @@ def run_agent_tools_tests(my_predbat):
     failed |= test_get_entity_history_lookback_clamp(my_predbat)
     failed |= test_nested_credentials_are_redacted(my_predbat)
     failed |= test_args_from_apps_yaml_snapshot_is_redacted(my_predbat)
+    failed |= test_registry_secret_flags_drive_redaction(my_predbat)
     failed |= test_get_apps_config_paths(my_predbat)
     failed |= test_get_plan_is_slimmed(my_predbat)
     failed |= test_set_config_refuses_what_it_cannot_change(my_predbat)

--- a/apps/predbat/tests/test_agent_tools.py
+++ b/apps/predbat/tests/test_agent_tools.py
@@ -812,6 +812,18 @@ def test_registry_secret_flags_drive_redaction(my_predbat):
             print("ERROR: {} is a credential but is not redacted".format(name))
             failed = True
 
+    # The registry ADDS to the substring heuristic, it does not replace it. A key belonging to no
+    # component at all - a plugin's, a new integration's, one Predbat has never heard of - must
+    # still redact on its name alone, or the registry would have narrowed the net rather than
+    # widening it. Mutation check: making is_secret_key() consult only the registry fails here.
+    for name in ("supabase_key", "some_new_integration_api_key", "whatever_password", "custom_secret", "unknown_token"):
+        if name in declared:
+            print("ERROR: test assumption broken - {} is a registry arg, so it proves nothing about unknown keys".format(name))
+            failed = True
+        if not is_secret_key(name):
+            print("ERROR: {} matches a credential substring but is no longer redacted".format(name))
+            failed = True
+
     # Over-redaction is its own bug: a serial addresses hardware rather than authenticating it,
     # and it is what makes an integration bug report diagnosable. Same call as the token-expiry
     # exemption - these must stay readable.

--- a/apps/predbat/tests/test_agent_tools.py
+++ b/apps/predbat/tests/test_agent_tools.py
@@ -14,6 +14,7 @@ before and after the extraction, or an MCP client's tool set changed without any
 """
 
 import asyncio
+import copy
 import json
 import os
 import re
@@ -679,6 +680,76 @@ def test_nested_credentials_are_redacted(my_predbat):
             failed = True
     finally:
         my_predbat.args = original_args
+    return failed
+
+
+def test_args_from_apps_yaml_snapshot_is_redacted(my_predbat):
+    """The second copy of apps.yaml kept for override detection never serves a credential.
+
+    PredBat.initialize() snapshots self.args into self.args_from_apps_yaml so set_arg_auto() can
+    tell "the user configured this" apart from "Predbat defaulted it" (PR #4500). Both dump paths
+    that walk self.__dict__ - create_debug_yaml() and the get_state tool - special-cased only the
+    field literally named "args" for masking, so this second copy went out in the clear: the
+    predbat_debug.yaml users attach to bug reports, every debug_history snapshot, and any model
+    calling get_state all received real api keys, tokens and passwords.
+
+    Mutation check: dropping "args_from_apps_yaml" from either masking tuple, or reverting the
+    snapshot in initialize() to copy.deepcopy(self.args), fails an assertion below.
+    """
+    failed = False
+    print("**** Testing the args_from_apps_yaml snapshot is redacted ****")
+
+    original_args = my_predbat.args
+    original_snapshot = getattr(my_predbat, "args_from_apps_yaml", None)
+    try:
+        secrets = {
+            "ha_key": "REAL-HA-TOKEN",
+            "solcast_api_key": "REAL-SOLCAST-KEY",
+            "givenergy_password": "REAL-PASSWORD",
+            "mcp_secret": "REAL-MCP-SECRET",
+            "forecast_solar": [{"postcode": "SW1A 1AA", "api_key": "REAL-NESTED-KEY"}],
+            "battery_size": 9.5,
+        }
+        my_predbat.args = copy.deepcopy(secrets)
+        # Planted unmasked on purpose: the guard under test is that neither dump path emits it
+        # in the clear, independently of the masking initialize() now applies at the source.
+        my_predbat.args_from_apps_yaml = copy.deepcopy(secrets)
+
+        real_values = ["REAL-HA-TOKEN", "REAL-SOLCAST-KEY", "REAL-PASSWORD", "REAL-MCP-SECRET", "REAL-NESTED-KEY"]
+
+        # The debug yaml - what a user attaches to a bug report.
+        debug_yaml = my_predbat.create_debug_yaml(write_file=False)
+        for secret in real_values:
+            if secret in debug_yaml:
+                print("ERROR: create_debug_yaml leaked {} from args_from_apps_yaml".format(secret))
+                failed = True
+        if "battery_size" not in debug_yaml:
+            print("ERROR: redaction damaged the debug yaml - non-credential args are missing")
+            failed = True
+
+        # The get_state tool - what a model asking for Predbat's state receives.
+        tools = PredbatTools(my_predbat)
+        result = json.dumps(asyncio.run(tools.execute("get_state", {"keys": ["args_from_apps_yaml"]})))
+        for secret in real_values:
+            if secret in result:
+                print("ERROR: get_state leaked {} from args_from_apps_yaml".format(secret))
+                failed = True
+        if "xxx" not in result:
+            print("ERROR: get_state returned no redaction marker, so the field was not masked: {}".format(result[:400]))
+            failed = True
+
+        # Masking must not damage the lookup set_arg_auto actually depends on.
+        masked_snapshot = mask_secret_args(secrets)
+        if masked_snapshot.get("battery_size") != 9.5:
+            print("ERROR: masking the snapshot damaged a non-credential value set_arg_auto compares against")
+            failed = True
+    finally:
+        my_predbat.args = original_args
+        if original_snapshot is None:
+            if hasattr(my_predbat, "args_from_apps_yaml"):
+                del my_predbat.args_from_apps_yaml
+        else:
+            my_predbat.args_from_apps_yaml = original_snapshot
     return failed
 
 
@@ -1366,6 +1437,7 @@ def run_agent_tools_tests(my_predbat):
     failed |= test_get_entity_history_bucket_cap(my_predbat)
     failed |= test_get_entity_history_lookback_clamp(my_predbat)
     failed |= test_nested_credentials_are_redacted(my_predbat)
+    failed |= test_args_from_apps_yaml_snapshot_is_redacted(my_predbat)
     failed |= test_get_apps_config_paths(my_predbat)
     failed |= test_get_plan_is_slimmed(my_predbat)
     failed |= test_set_config_refuses_what_it_cannot_change(my_predbat)

--- a/apps/predbat/tests/test_secrets.py
+++ b/apps/predbat/tests/test_secrets.py
@@ -103,8 +103,73 @@ def test_secrets_loading():
     return False  # False = success in Predbat test framework
 
 
+def test_mask_secret_yaml_text():
+    """The apps.yaml file download is redacted without being rewritten.
+
+    /debug_apps serves the file as the user wrote it, and it sits next to the live download as
+    the file people attach to bug reports. Redacting the parsed args would hand back a
+    regenerated document with the comments stripped, so this redacts the text instead: comments,
+    ordering and quoting survive, credential values do not.
+
+    Mutation check: dropping the TaggedScalar guard redacts '!secret' references too, and
+    removing the is_secret_key() call leaves every credential in place - both fail below.
+    """
+    from utils import mask_secret_yaml_text
+
+    failed = False
+    print("**** Testing apps.yaml text redaction ****")
+
+    source = """# My Predbat config
+pred_bat:
+  # Octopus settings
+  octopus_api_key: 'REAL-OCTOPUS-KEY'
+  octopus_api_account: A-REAL-ACCOUNT
+  ha_key: !secret ha_token
+  battery_size: 9.5
+  solis_inverter_sn: SN-VISIBLE
+  forecast_solar:
+    - postcode: SW1A 1AA
+      api_key: REAL-NESTED-KEY
+"""
+    masked = mask_secret_yaml_text(source)
+
+    for secret in ("REAL-OCTOPUS-KEY", "A-REAL-ACCOUNT", "REAL-NESTED-KEY"):
+        if secret in masked:
+            print("ERROR: {} survived text redaction:\n{}".format(secret, masked))
+            failed = True
+
+    # A '!secret' reference names a credential, it does not contain one - and which secret a key
+    # resolves to is exactly what you need when an integration will not authenticate.
+    if "!secret ha_token" not in masked:
+        print("ERROR: a '!secret' reference was redacted or rewritten:\n{}".format(masked))
+        failed = True
+
+    # The point of redacting the text rather than the args: it still reads like their own file.
+    if "# My Predbat config" not in masked or "# Octopus settings" not in masked:
+        print("ERROR: comments were lost, so the download no longer matches the user's file:\n{}".format(masked))
+        failed = True
+
+    if "9.5" not in masked or "SN-VISIBLE" not in masked or "SW1A 1AA" not in masked:
+        print("ERROR: redaction damaged values that must stay readable:\n{}".format(masked))
+        failed = True
+
+    # Unparseable input must raise, so the route fails closed rather than serving raw text.
+    try:
+        mask_secret_yaml_text("pred_bat:\n  key: [unclosed\n")
+        print("ERROR: invalid YAML was accepted instead of raising, so the route could serve it unredacted")
+        failed = True
+    except Exception:
+        pass
+
+    if not failed:
+        print("**** test_mask_secret_yaml_text PASSED ****")
+    return failed
+
+
 def run_secrets_tests(my_predbat=None):
     """
     Run all secrets tests
     """
-    return test_secrets_loading()
+    failed = test_secrets_loading()
+    failed |= test_mask_secret_yaml_text()
+    return failed

--- a/apps/predbat/tests/test_web_if.py
+++ b/apps/predbat/tests/test_web_if.py
@@ -47,8 +47,12 @@ def run_test_web_if(my_predbat):
         my_predbat.components.start("web")
         ha = my_predbat.ha_interface
 
-        # Inject a fake credential so we can verify live apps.yaml masking below
+        # Inject fake credentials so we can verify live apps.yaml masking below. Two kinds:
+        # one the key-name substrings catch, and one only the component registry's "secret"
+        # flag catches - an account number reads like ordinary config, so before the flag
+        # existed this download served it in the clear.
         my_predbat.args["octopus_api_key"] = "test_secret_value"
+        my_predbat.args["octopus_api_account"] = "test_account_number"
 
         # Define all registered endpoints from web.py
         # Format: (method, path)
@@ -330,15 +334,25 @@ def run_test_web_if(my_predbat):
         if res.status_code != 200 or "test_secret_value" in res.text or "xxx" not in res.text:
             print("ERROR: Default /debug_apps_live request was not masked")
             failed = 1
+        if "test_account_number" in res.text:
+            print("ERROR: Default /debug_apps_live request served a registry-flagged account number in the clear")
+            failed = 1
 
         res = requests.get("http://127.0.0.1:5052/debug_apps_live", params={"masked": "0"})
         if res.status_code != 200 or "test_secret_value" not in res.text:
             print("ERROR: Unmasked /debug_apps_live (masked=0) did not contain the expected credential value")
             failed = 1
+        if "test_account_number" not in res.text:
+            print("ERROR: Unmasked /debug_apps_live (masked=0) dropped the account number - the opt-out must still return everything")
+            failed = 1
 
         res = requests.get("http://127.0.0.1:5052/debug_apps_live", params={"masked": "1"})
         if res.status_code != 200 or "test_secret_value" in res.text or "xxx" not in res.text:
             print("ERROR: Masked /debug_apps_live did not redact the expected credential value")
+            failed = 1
+        # The registry flag has to reach this route too, not just the debug yaml and MCP.
+        if "test_account_number" in res.text:
+            print("ERROR: Masked /debug_apps_live did not redact the registry-flagged account number")
             failed = 1
 
         # Check endpoint coverage

--- a/apps/predbat/tests/test_web_if.py
+++ b/apps/predbat/tests/test_web_if.py
@@ -355,6 +355,74 @@ def run_test_web_if(my_predbat):
             print("ERROR: Masked /debug_apps_live did not redact the registry-flagged account number")
             failed = 1
 
+        # The file download sits next to the live one and is what people attach to bug reports,
+        # so a bare request must be redacted too - it used to serve apps.yaml verbatim.
+        # The credentials go into the file on disk, not just my_predbat.args: this route serves
+        # the file, and the shipped test apps.yaml has no credential in it, so comparing raw
+        # against redacted text would pass whether or not anything was actually redacted.
+        print("\n**** Verifying apps.yaml file download masking ****")
+        with open("apps.yaml", "a") as handle:
+            handle.write("\n  solcast_api_key: FILE-CREDENTIAL-VALUE\n  octopus_api_account: FILE-ACCOUNT-NUMBER\n")
+
+        res = requests.get("http://127.0.0.1:5052/debug_apps")
+        if res.status_code != 200:
+            print("ERROR: Default /debug_apps request failed: {}".format(res.status_code))
+            failed = 1
+        else:
+            if "FILE-CREDENTIAL-VALUE" in res.text:
+                print("ERROR: Default /debug_apps served a credential from the file in the clear")
+                failed = 1
+            # The registry flag has to reach the file download too, not just the live one.
+            if "FILE-ACCOUNT-NUMBER" in res.text:
+                print("ERROR: Default /debug_apps served a registry-flagged account number in the clear")
+                failed = 1
+            if "xxx" not in res.text:
+                print("ERROR: Default /debug_apps returned no redaction marker at all")
+                failed = 1
+            # Redacting the text rather than the parsed args is the point - the download should
+            # still read like the user's own file.
+            if "module: predbat" not in res.text:
+                print("ERROR: /debug_apps no longer returns the user's apps.yaml content")
+                failed = 1
+
+        res = requests.get("http://127.0.0.1:5052/debug_apps", params={"masked": "0"})
+        if res.status_code != 200:
+            print("ERROR: Unmasked /debug_apps (masked=0) failed: {}".format(res.status_code))
+            failed = 1
+        elif "FILE-CREDENTIAL-VALUE" not in res.text or "FILE-ACCOUNT-NUMBER" not in res.text:
+            print("ERROR: Unmasked /debug_apps (masked=0) did not return the file as written")
+            failed = 1
+
+        # The editor is deliberately NOT masked, on both halves. It shows the real file so a
+        # credential can be edited at all, and it writes back exactly what was submitted - if
+        # redaction ever leaked into this path it would save 'xxx' over the user's real
+        # credentials the first time they touched an unrelated setting. Downloads redact;
+        # the editor must not.
+        print("\n**** Verifying the apps.yaml editor is not masked ****")
+        res = requests.get("http://127.0.0.1:5052/apps_editor")
+        if res.status_code != 200:
+            print("ERROR: /apps_editor request failed: {}".format(res.status_code))
+            failed = 1
+        else:
+            if "FILE-CREDENTIAL-VALUE" not in res.text or "FILE-ACCOUNT-NUMBER" not in res.text:
+                print("ERROR: /apps_editor masked a credential - the user cannot edit what it will not show them")
+                failed = 1
+
+        editor_content = "pred_bat:\n  module: predbat\n  class: PredBat\n  solcast_api_key: EDITOR-WRITTEN-KEY\n  octopus_api_account: EDITOR-WRITTEN-ACCOUNT\n"
+        res = requests.post("http://127.0.0.1:5052/apps_editor", data={"apps_content": editor_content})
+        if res.status_code != 200:
+            print("ERROR: /apps_editor save failed: {}".format(res.status_code))
+            failed = 1
+        else:
+            with open("apps.yaml", "r") as handle:
+                written = handle.read()
+            if "EDITOR-WRITTEN-KEY" not in written or "EDITOR-WRITTEN-ACCOUNT" not in written:
+                print("ERROR: /apps_editor did not write the submitted credentials verbatim:\n{}".format(written))
+                failed = 1
+            if "xxx" in written:
+                print("ERROR: /apps_editor wrote a redaction marker into apps.yaml, destroying real credentials")
+                failed = 1
+
         # Check endpoint coverage
         print("\n**** Checking endpoint coverage ****")
         untested_endpoints = []

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -770,7 +770,7 @@ class UserInterface:
                 if is_debug_excluded_key(key):
                     pass
                 else:
-                    if key == "args":
+                    if key in ("args", "args_from_apps_yaml"):
                         debug[key] = mask_secret_args(self.__dict__[key])
                     else:
                         debug[key] = self.__dict__[key]

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -144,11 +144,51 @@ def is_debug_excluded_key(key):
     return is_secret_key(key)
 
 
-def is_secret_key(key):
+_REGISTRY_SECRET_NAMES = None
+
+
+def registry_secret_key_names():
     """
-    Return True when an apps.yaml key name looks like it holds a credential.
+    Return the apps.yaml config names components.py explicitly flags with "secret": True.
+
+    utils is imported by every component module, so components cannot be imported at module
+    scope here - it is imported on first use instead. An empty or failed result is not cached,
+    so a redaction that runs while components is still importing (a partially initialised
+    module) resolves properly on the next call rather than silently losing these names for the
+    life of the process. Standalone tools that never import components keep working on the
+    substring heuristic alone.
+    """
+    global _REGISTRY_SECRET_NAMES
+    if _REGISTRY_SECRET_NAMES is None:
+        try:
+            import components
+
+            names = components.secret_config_names()
+        except Exception:
+            names = None
+        if not names:
+            return frozenset()
+        _REGISTRY_SECRET_NAMES = frozenset(names)
+    return _REGISTRY_SECRET_NAMES
+
+
+def is_secret_key(key, registry=True):
+    """
+    Return True when an apps.yaml key name holds a credential and must not be served in the clear.
+
+    An explicit "secret": True flag in the component registry wins over both the substring
+    heuristic and the exempt-suffix list - the registry names a credential the key name alone
+    cannot reveal, such as an account number or a login identifier.
+
+    registry=False drops back to the key-name substrings alone, for callers asking the narrower
+    question "does this grant access?" rather than "must this be redacted?". Only
+    find_unmasked_secret_paths() does: an account number identifies rather than authenticates, so
+    telling every user with an inline octopus_api_account to move it into secrets.yaml would be
+    noise. Redaction is the strict default so a new caller fails safe rather than leaking.
     """
     key_lower = str(key).lower()
+    if registry and key_lower in registry_secret_key_names():
+        return True
     if key_lower.endswith(SECRET_KEY_EXEMPT_SUFFIXES):
         return False
     return any(substring in key_lower for substring in SECRET_KEY_SUBSTRINGS)
@@ -190,6 +230,12 @@ def find_unmasked_secret_paths(node, path=""):
     of every credential-like key (per is_secret_key()) whose value is a plain scalar rather
     than a '!secret' reference into secrets.yaml (loaded as a ruamel TaggedScalar).
 
+    Deliberately asks is_secret_key(registry=False): this drives the "stored in plain text,
+    consider !secret" advice, which is about values that grant access. The registry additionally
+    flags account numbers, meter point numbers and login identifiers so they are redacted out of
+    anything shared, but an inline octopus_api_account is the documented normal setup and
+    warning every user about it would be noise rather than advice.
+
     Only usable against a document loaded with ruamel's round-trip loader - a plain
     yaml.safe_load() has already resolved '!secret' tags to their real value and lost the
     distinction this depends on.
@@ -199,7 +245,7 @@ def find_unmasked_secret_paths(node, path=""):
     if isinstance(node, dict):
         for key, value in node.items():
             key_path = "{}.{}".format(path, key) if path else str(key)
-            if is_secret_key(key):
+            if is_secret_key(key, registry=False):
                 if value not in (None, "") and not isinstance(value, TaggedScalar):
                     yield key_path
             else:

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -20,6 +20,7 @@ import re
 import array
 import os
 from datetime import datetime, timedelta, timezone, time
+from io import StringIO
 from functools import lru_cache
 from const import LOW_POWER_PV_THRESHOLD, MINUTE_WATT, PREDICT_STEP, TIME_FORMAT, TIME_FORMAT_SECONDS, TIME_FORMAT_OCTOPUS, MAX_INCREMENT, TIME_FORMAT_DAILY
 import copy
@@ -253,6 +254,53 @@ def find_unmasked_secret_paths(node, path=""):
     elif isinstance(node, list):
         for index, item in enumerate(node):
             yield from find_unmasked_secret_paths(item, "{}[{}]".format(path, index))
+
+
+def _mask_secrets_in_yaml_node(node):
+    """
+    Redact credential values in a ruamel round-trip node, in place, leaving layout alone.
+
+    A '!secret name' reference (a TaggedScalar) is left exactly as written: it holds no
+    credential, only the name of one in secrets.yaml, and which secret a key resolves to is
+    what makes a misconfigured integration diagnosable.
+    """
+    from ruamel.yaml.comments import TaggedScalar
+
+    if isinstance(node, dict):
+        for key in node:
+            value = node[key]
+            if is_secret_key(key):
+                if value not in (None, "") and not isinstance(value, TaggedScalar):
+                    node[key] = SECRET_MASK
+            else:
+                _mask_secrets_in_yaml_node(value)
+    elif isinstance(node, list):
+        for item in node:
+            _mask_secrets_in_yaml_node(item)
+
+
+def mask_secret_yaml_text(text):
+    """
+    Return apps.yaml text with credential values redacted, preserving comments and layout.
+
+    mask_secret_args() redacts the parsed args Predbat is running on; this redacts the file as
+    the user wrote it, so a download still reads like their own apps.yaml - comments, ordering,
+    quoting and '!secret' references intact - with only the credential values replaced.
+
+    Raises rather than returning anything on a file that will not parse: the caller asked for
+    a redacted document, and serving unredacted text because the parse failed is exactly the
+    leak this exists to prevent.
+    """
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = YAML_DUMP_WIDTH
+    data = yaml.load(text)
+    _mask_secrets_in_yaml_node(data)
+    buf = StringIO()
+    yaml.dump(data, buf)
+    return buf.getvalue()
 
 
 def read_predbat_log(logfile=PREDBAT_LOG_FILE, logfile_prev=PREDBAT_LOG_FILE_PREV):

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -69,7 +69,7 @@ from web_helper import (
     get_dashboard_collapsible_js,
 )
 
-from utils import calc_percent_limit, str2time, dp0, dp2, dp4, format_time_ago, get_override_time_from_string, history_attribute, prune_today, mask_secret_args, read_predbat_log, classify_log_line, log_line_included
+from utils import calc_percent_limit, str2time, dp0, dp2, dp4, format_time_ago, get_override_time_from_string, history_attribute, prune_today, mask_secret_args, mask_secret_yaml_text, read_predbat_log, classify_log_line, log_line_included
 from utils import is_data_numerical, ROOT_YAML_KEY, YAML_DUMP_WIDTH, update_nested_yaml_value  # noqa: F401 - re-exported: moved to utils.py, agent_tools.py/chat_tools.py must not import from web.py
 from const import TIME_FORMAT, TIME_FORMAT_DAILY, TIME_FORMAT_HA
 from predbat import THIS_VERSION_DISPLAY
@@ -982,7 +982,7 @@ class WebInterface(ComponentBase):
         text += '<div style="flex: 1;">\n'
         text += "<h2>Debug</h2>\n"
         text += "<table>\n"
-        text += "<tr><td>Download</td><td><a href='javascript:void(0)' onclick='downloadLiveApps()'>apps.yaml (live)</a> | <a href='./debug_apps'>apps.yaml (file)</a></td></tr>\n"
+        text += "<tr><td>Download</td><td><a href='javascript:void(0)' onclick='downloadLiveApps()'>apps.yaml (live)</a> | <a href='javascript:void(0)' onclick='downloadFileApps()'>apps.yaml (file)</a></td></tr>\n"
         text += "<tr><td>Create</td><td><a href='./debug_yaml'>predbat_debug.yaml</a></td></tr>\n"
         text += "<tr><td>Download</td><td><a href='./debug_log'>predbat.log</a></td></tr>\n"
         text += "<tr><td>Download</td><td><a href='./debug_plan'>predbat_plan.html</a></td></tr>\n"
@@ -2981,7 +2981,32 @@ chart.render();
         return await self.html_file_load("predbat.1.log", also_file="predbat.log", as_file="predbat.log")
 
     async def html_debug_apps(self, request):
-        return await self.html_file_load("apps.yaml", as_file="apps.yaml.txt")
+        """
+        Return the apps.yaml file as written, with credential values redacted by default.
+
+        Masks unless ?masked=0 is passed, matching /debug_apps_live: this link sits next to that
+        one and is the file a user grabs to attach to a bug report, so a bare request - or any
+        of the plain './debug_apps' links elsewhere in the UI - must not hand over credentials.
+        Redaction is applied to the file text rather than the parsed args, so the download still
+        reads like the user's own apps.yaml, comments and '!secret' references included.
+        """
+        masked = request.query.get("masked", "1") != "0"
+        if not masked:
+            return await self.html_file_load("apps.yaml", as_file="apps.yaml.txt")
+
+        data = None
+        if os.path.exists("apps.yaml"):
+            with open("apps.yaml", "r") as f:
+                data = f.read()
+        if data:
+            try:
+                data = mask_secret_yaml_text(data)
+            except Exception as e:
+                # Fail closed - serving the raw file because the parse failed is the leak this
+                # route exists to avoid. The unmasked download is still one click away.
+                self.log("Warn: Unable to redact apps.yaml for download: {}".format(e))
+                data = "# Predbat could not parse apps.yaml to redact it, so it has not been served.\n" "# Fix the YAML error, or use the unmasked download if you intend to share credentials.\n" "# Error: {}\n".format(e)
+        return await self.html_file("apps_masked.yaml.txt", data)
 
     async def html_debug_apps_live(self, request):
         """

--- a/apps/predbat/web_helper.py
+++ b/apps/predbat/web_helper.py
@@ -8149,6 +8149,14 @@ function downloadLiveApps() {
     }
 }
 
+function downloadFileApps() {
+    if (confirm(`Download apps.yaml with real credentials?\\n\\nOK = full unmasked file\\nCancel = masked file (credentials redacted)`)) {
+        window.location.href = './debug_apps?masked=0';
+    } else {
+        window.location.href = './debug_apps?masked=1';
+    }
+}
+
 function toggleSwitch(element, fieldName) {
     // Toggle the active class
     element.classList.toggle('active');

--- a/docs/components.md
+++ b/docs/components.md
@@ -270,9 +270,14 @@ with `max_bytes`.
 | `max_bytes` | Per-variable size budget before a value is described instead of returned (default 2048, maximum 262144) |
 
 `get_state` and `get_apps` both redact credentials. `get_apps` replaces credential-like values
-(anything whose name contains `_key`, `password`, `secret` or `token`) with `xxx`, so your API
-keys are not sent to your AI provider; pass `masked: false` if you deliberately want the raw
-values. `get_state` applies the same rule *and* the debug yaml's exclusion list, so it can never
+with `xxx`, so your API keys are not sent to your AI provider; pass `masked: false` if you
+deliberately want the raw values. A value counts as a credential if its name contains `_key`,
+`password`, `secret` or `token`, **or** if the component registry flags it explicitly - which
+covers the credentials a name alone cannot reveal, such as your Octopus account number, a Kraken
+MPAN, a site or plant id, and login identifiers like `deye_username`, `kraken_email` and
+`myenergi_hub_serial` (the myenergi API's digest-auth username). Inverter serial numbers are
+deliberately *not* redacted: they identify hardware rather than authenticate it, and they are
+what makes an integration bug report diagnosable. `get_state` applies the same rule *and* the debug yaml's exclusion list, so it can never
 return anything a debug dump would not - credentials, the Home Assistant interface, loaded
 secrets and the URL caches are not reachable through it at all. `get_apps_config` uses the same
 credential check as `get_apps`, but with no `masked: false` escape hatch at all - there is no


### PR DESCRIPTION
Two related credential leaks in the apps.yaml/debug download path. Both come from the same root cause: redaction was driven by a single hardcoded field name and a key-name substring heuristic, and anything outside those two narrow rules went out in the clear.

## 1. The `args_from_apps_yaml` snapshot was dumped unredacted

PR #4500 added `self.args_from_apps_yaml` — a `copy.deepcopy(self.args)` taken at the top of `initialize()`, before Predbat's own defaulting runs — so `set_arg_auto()` can tell *"the user configured this in apps.yaml"* apart from *"Predbat defaulted it"*, and warn when auto-discovery overrides an explicit setting.

The snapshot is functionally correct, but it's a **second, unredacted copy of the entire apps.yaml**, and both dump paths that walk `self.__dict__` mask only the field *literally named* `"args"`:

```python
if key == "args":
    debug[key] = mask_secret_args(self.__dict__[key])   # masked
else:
    debug[key] = self.__dict__[key]                     # raw!
```

`is_debug_excluded_key()` doesn't catch it either — it tests the attribute *name*, and `args_from_apps_yaml` contains none of `_key`/`password`/`secret`/`token`. So the raw copy went out with real api keys, tokens and passwords via:

- **`create_debug_yaml()`** — the `predbat_debug.yaml` users attach to bug reports, plus every rolling `debug_history` snapshot
- **the `get_state` agent/MCP tool** — handed to whichever model asked

**Fixed at the source**: the snapshot is built with `mask_secret_args()` instead of `copy.deepcopy()`, so no secret ever enters the structure regardless of how it's later dumped, rather than relying on every present and future consumer to remember to mask it. This costs nothing functionally — `set_arg_auto()` is only ever called with auto-discovery targets (`battery_scaling`, `soc_max`, sensor entity ids) across alphaess, sunsynk, solis, myenergi, ohme and gecloud, never a credential-shaped key. Both dump sites also mask it explicitly, as belt-and-braces to keep them consistent about which fields are credential-bearing.

## 2. Credentials the substring heuristic can't see

`SECRET_KEY_SUBSTRINGS` only catches what a key *name* reveals, so credentials named after what they identify were served in the clear.

This adds a **`"secret": True` flag to the component registry's arg definitions** — a credential is now declared next to the arg that supplies it, rather than inferred from its spelling. `components.secret_config_names()` reads the live `COMPONENT_LIST` (so the conditionally-registered gateway component is included) and feeds `utils.is_secret_key()`.

**23 credentials that previously leaked are now redacted:**

| Kind | Config names |
|---|---|
| Account / meter numbers | `octopus_api_account`, `kraken_account_id`, `kraken_export_account_id`, `kraken_mpan`, `kraken_export_mpan` |
| Site / system / plant ids | `enphase_site_id`, `axle_site_id`, `sigenergy_system_id`, `teslemetry_site_id`, `solax_plant_id`, `gateway_device_id` |
| Login identifiers | `kraken_email`, `ohme_login`, `deye_username`, `sunsynk_username`, `enphase_username`, `axle_partner_username`, `myenergi_hub_serial` |
| Id half of an id/secret pair | `deye_app_id`, `alphaess_app_id`, `solax_client_id` |
| Private material | `sigenergy_client_pem`, `deye_company_id` |

`myenergi_hub_serial` is included because it's genuinely the digest-auth **username**, not just a device id ([myenergi.py:393](https://github.com/springfall2008/batpred/blob/main/apps/predbat/myenergi.py#L393)). The 36 args the substrings already caught are flagged too, so the registry is the single source of truth and a test asserts the two agree.

### Two deliberate scope decisions

**Redaction and the `!secret` advice are separate questions.** `is_secret_key()` defaults to `registry=True` — the strict "must this be redacted?" answer, so a new call site fails safe. `find_unmasked_secret_paths()`, which drives the *"stored in plain text, consider !secret"* banner, passes `registry=False`: that advice is about values which grant access, and an inline `octopus_api_account` is the documented normal setup, so warning every user about one would be noise rather than advice. **No existing user gets a new warning banner.**

Note this scope also binds `find_redacted_secret_overwrite()`, which must agree with the redactor — otherwise saving the apps.yaml editor form would write `xxx` over a real account number.

**Device serials stay readable** (`solis_inverter_sn`, `ge_cloud_serial`, `solax_plant_sn`, `deye_inverter_sn`, …). They address hardware rather than authenticate it, and they're what makes an integration bug report diagnosable — the same trade-off `SECRET_KEY_EXEMPT_SUFFIXES` already makes for token expiry times. Over-redaction is its own bug, and the test asserts these stay visible.

### Import direction

`utils` can't import `components` at module scope (every component module imports `utils`), so the registry is imported on first use. An empty or failed lookup is **not** cached, so a redaction running while `components` is still importing resolves properly on the next call rather than silently losing these names for the life of the process. Standalone tools that never import `components` keep working on the substring heuristic alone.

## Why the snapshot wasn't shrunk instead

Recorded since it's the obvious follow-up question:

- **A boolean "was configured" flag** loses two real behaviors: the `raw_value != value` comparison is what suppresses the warning when auto-discovery agrees with the user, and the old value is what tells them *which line to delete*.
- **Reading `self.args` at overwrite time** doesn't work: `set_arg_auto()` is only called from phase-1 components (`components.initialize(phase=1)`, predbat.py:1914), which runs *after* `auto_config()` and `load_user_config()` at lines 1910-1911. By then `self.args` may already hold a Predbat default rather than what the user wrote — even on the first overwrite of a key.
- **Copy-on-write** is feasible (exactly two mutation paths: `set_arg()` and `auto_config()`'s regex resolution) but measured against a real 3.34 MB debug dump the duplicate is **8,533 bytes — 0.26%** of the file (`args` itself is 8,675 / 0.26%). Not worth a recording hook in two mutation paths plus a silent-failure mode where a missed path makes the "original" wrong.

## 3. The apps.yaml file download served credentials verbatim

The **"apps.yaml (file)"** link served `apps.yaml` with no redaction and no warning, while **"apps.yaml (live)"** right beside it defaulted to masked and put the unmasked copy behind a confirm dialog. Someone grabbing a file to attach to a bug report had a fair chance of clicking the one that hands over every credential in their config.

`/debug_apps` now takes `?masked=` and **defaults to masked**, matching `/debug_apps_live`, plus a `downloadFileApps()` confirm dialog offering the same OK/Cancel choice. The default matters more than the dialog: the config-errors page carries its own plain `./debug_apps` link ([web.py:3673](https://github.com/springfall2008/batpred/blob/main/apps/predbat/web.py#L3673)), so defaulting to masked covers that one too rather than only fixing the link the dialog is attached to.

Redaction is applied to the **file text**, not the parsed args — `mask_secret_yaml_text()` round-trips through ruamel so the download still reads like the user's own apps.yaml, with comments, ordering and quoting intact and only credential values replaced. A `!secret name` reference is left exactly as written: it holds no credential, only the *name* of one, and which secret a key resolves to is what makes a misconfigured integration diagnosable. Unparseable YAML raises and the route **fails closed** with an explanatory comment block rather than falling back to the raw file.

### The editor is deliberately not masked

`/apps_editor` shows the real file (a credential you cannot see is one you cannot edit) and writes back exactly what was submitted. Redaction applies only to *downloads*, which produce a file for someone else; the editor produces the file Predbat runs on, so masking it would save `xxx` over real credentials the first time a user touched an unrelated setting. `test_web_if` now pins that invariant on both halves — mutation-verified by wrapping the editor's write in `mask_secret_yaml_text()`, which fails both new assertions.

The chat write path was already protected by `find_redacted_secret_overwrite()`, which refuses a write that would put `xxx` over a real value — and because it shares `is_secret_key()` with the redactor, it covers the newly-flagged account numbers automatically.

### Unknown keys still redact by name

The registry **adds to** the substring heuristic rather than replacing it, so a key belonging to no component at all — a plugin's, a new integration's, `supabase_key` — still redacts on its name. Asserted explicitly, and mutation-verified: collapsing `is_secret_key()` to registry-only fails those assertions plus the existing nested-credential test.

### Not changed

`/download?file=apps.yaml` ([web.py:5518](https://github.com/springfall2008/batpred/blob/main/apps/predbat/web.py#L5518)) serves any file under the working directory verbatim, apps.yaml included. Left alone deliberately: it is a general-purpose filesystem browser for the owner rather than an "attach this to a bug report" affordance, and redacting there would break its purpose.

## Testing

Four new tests plus two extended, all mutation-verified:

- `test_args_from_apps_yaml_snapshot_is_redacted` — plants an unmasked snapshot, asserts neither `create_debug_yaml()` nor `get_state` emits it. Reverting either masking tuple fails all ten leak assertions (5 secrets × 2 paths).
- `test_registry_secret_flags_drive_redaction` — asserts every flagged arg redacts, the newly covered names redact end-to-end through `mask_secret_args` and `get_apps`, serials and other non-credentials stay readable, and the `!secret` banner keeps its narrower scope. Removing the registry consultation fails 50 assertions; dropping one `"secret": True` flag fails 2.

- `test_mask_secret_yaml_text` — comments and `!secret` references survive, credentials do not, invalid YAML raises rather than falling through to raw text.
- `test_web_if` — extended to cover the file download (masked by default, raw under `masked=0`), the registry flag reaching the live download, and the editor staying unmasked on read and write.

One bug caught in the tests themselves rather than the code: the first `/debug_apps` assertion compared the response against the file on disk, which passed for the wrong reason — the shipped test apps.yaml has no credential in it, and an earlier `POST /apps_editor` had already ruamel-round-tripped the file, so masked output matched byte-for-byte. It could not distinguish "not redacted" from "nothing to redact". It now writes real credentials into the file first.

`./run_all --quick` and `./run_pre_commit` both clean.

## Note on existing bug reports

Committed golden fixtures predate these fields and contain only test-fixture keys, so nothing needs scrubbing there. But users who generated a `predbat_debug.yaml` on an affected version and attached it to a GitHub issue will have published whatever their apps.yaml holds — worth scanning recent issue attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
