### PR TITLE
fix(test): assert the ML training invariant instead of peak RSS

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -391,6 +391,7 @@ mypy
 nanmean
 nanstd
 nattribute
+nbytes
 ncalls
 nearr
 nemotron

--- a/apps/predbat/tests/test_ml_training_perf.py
+++ b/apps/predbat/tests/test_ml_training_perf.py
@@ -13,10 +13,15 @@ Run the benchmark directly for memory figures:
     venv/bin/python -c "import sys; sys.path.insert(0,'../apps/predbat'); \
         from tests.test_ml_training_perf import benchmark; benchmark()"
 
-Note when interpreting local numbers on macOS: Apple's allocator keeps freed large blocks
-in a cache rather than returning them, so a multi-pass run appears to climb without ever
-falling back. Set MallocLargeCache=0 in the environment to see the figure a Linux
-production host would report.
+Note when interpreting the memory figure anywhere: ru_maxrss is a high-water mark of pages
+ever touched, not memory held at any instant. Training frees each batch buffer immediately -
+it retains ~0MB of live arrays and peaks at ~67MB of Python-tracked memory - yet the mark
+accumulates every page those thousands of short-lived buffers ever dirtied, reporting ~280MB.
+It is also page-granular, so a 16KB-page host (Apple Silicon) inflates it several-fold
+against a 4KB-page Linux one. The figure is therefore useful for comparing runs on one
+machine and meaningless as an absolute or across machines. (MallocLargeCache=0 is sometimes
+suggested for this on macOS; measured here it changes nothing, because allocator caching is
+not what the mark is recording.)
 """
 
 import gzip
@@ -111,23 +116,94 @@ def _measure_here(epochs):
     }
 
 
-def measure_training(epochs=2):
-    """Measure one training pass in a fresh process, returning (val_mae, growth, samples, seconds).
+def _measure_allocations_here(epochs):
+    """Run one training pass in this process, watching for a materialised matrix.
 
-    A fresh process is what makes the number trustworthy. ru_maxrss is a high-water mark that
-    only rises, so measuring in a process that has already trained once reports almost no
-    growth however much the pass allocates. Spawning also keeps the measurement out of the
-    way of what it measures - unlike sampling, nothing runs alongside training.
+    Traps WindowedFeatures.__array__ (the only path that builds every row at once) and the
+    largest numpy allocation made during training, both of which are properties of the code
+    rather than of the host's page size or allocator.
     """
-    script = "import json,sys; sys.path.insert(0, {predbat!r}); from tests.test_ml_training_perf import _measure_here; print(json.dumps(_measure_here({epochs})))".format(
+    import load_predictor
+
+    counter = {"array": 0, "largest": 0}
+
+    original_array = load_predictor.WindowedFeatures.__array__
+
+    def counting_array(self, dtype=None, copy=None):
+        counter["array"] += 1
+        return original_array(self, dtype, copy)
+
+    load_predictor.WindowedFeatures.__array__ = counting_array
+
+    # np.empty/np.zeros cover how this module allocates; a view or slice allocates nothing
+    original_empty, original_zeros = np.empty, np.zeros
+
+    def watch(factory):
+        def wrapper(shape, *args, **kwargs):
+            result = factory(shape, *args, **kwargs)
+            if result.nbytes > counter["largest"]:
+                counter["largest"] = result.nbytes
+            return result
+
+        return wrapper
+
+    np.empty, np.zeros = watch(original_empty), watch(original_zeros)
+    try:
+        channels = load_ml_history_fixture()
+        predictor = LoadPredictor(learning_rate=0.001)
+        baseline = peak_rss_mb()
+        started = time.time()
+        val_mae = _train_one_pass(predictor, channels, epochs)
+        elapsed = time.time() - started
+        growth = max(peak_rss_mb() - baseline, 0.0)
+    finally:
+        np.empty, np.zeros = original_empty, original_zeros
+        load_predictor.WindowedFeatures.__array__ = original_array
+
+    return {
+        "materialised": counter["array"],
+        "largest_mb": counter["largest"] / 1e6,
+        "val_mae": val_mae,
+        "growth": growth,
+        "samples": len(channels["load"]),
+        "seconds": elapsed,
+    }
+
+
+def measure_training_allocations(epochs=2):
+    """Measure one training pass in a fresh process, returning its allocation behaviour.
+
+    A fresh process keeps the measurement clear of anything an earlier test allocated, and
+    keeps the numpy patching out of the rest of the suite.
+    """
+    payload = _run_in_fresh_process("_measure_allocations_here", epochs)
+    return payload["materialised"], payload["largest_mb"], payload["val_mae"], payload["growth"], payload["samples"], payload["seconds"]
+
+
+def _run_in_fresh_process(entry, epochs):
+    """Run one of this module's measurement entry points in a subprocess and return its payload."""
+    script = "import json,sys; sys.path.insert(0, {predbat!r}); from tests.test_ml_training_perf import {entry}; print(json.dumps({entry}({epochs})))".format(
         predbat=os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+        entry=entry,
         epochs=epochs,
     )
     result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, cwd=os.getcwd())
     if result.returncode != 0:
         raise RuntimeError("measurement subprocess failed: {}".format(result.stderr[-2000:]))
+    return json.loads(result.stdout.strip().splitlines()[-1])
 
-    payload = json.loads(result.stdout.strip().splitlines()[-1])
+
+def measure_training(epochs=2):
+    """Measure one training pass in a fresh process, returning (val_mae, growth, samples, seconds).
+
+    Used by benchmark() for the raw footprint figure. A fresh process is what makes the number
+    trustworthy: ru_maxrss only rises, so measuring in a process that has already trained once
+    reports almost no growth however much the pass allocates. Note the figure is a high-water
+    mark of pages ever touched and is page-granular, so it is much larger than the memory held
+    at any instant and is not comparable across hosts with different page sizes - see
+    test_training_does_not_copy_the_dataset_per_epoch.
+    """
+    payload = _run_in_fresh_process("_measure_here", epochs)
     return payload["val_mae"], payload["growth"], payload["samples"], payload["seconds"]
 
 
@@ -176,31 +252,45 @@ def test_ml_training_runs_at_production_scale(my_predbat=None):
 
 
 def test_training_does_not_copy_the_dataset_per_epoch(my_predbat=None):
-    """Training must not hold the feature matrix it would otherwise materialise
+    """Training must not materialise the feature matrix it assembles per batch
 
     Every feature row is five sliding windows over five short channels plus time features,
     so consecutive rows overlap in all but one value and a materialised matrix stores each
     reading roughly LOOKBACK_STEPS times over. Assembling each batch from window views
-    keeps the working set to a batch. The budget is expressed against the size that matrix
-    would have been, so it holds whatever history the fixture carries.
+    keeps the working set to a batch.
+
+    This asserts the invariant directly - that WindowedFeatures.__array__ is never reached
+    and that no single allocation approaches the matrix - rather than watching peak RSS.
+    ru_maxrss is a high-water mark of pages *ever touched*, not memory concurrently held,
+    so thousands of short-lived batch buffers accumulate into it even though each is freed
+    immediately: measured here, training peaks at 67MB of Python-tracked memory and retains
+    0.0MB of live arrays, while ru_maxrss reports ~280MB. The mark is also page-granular,
+    so a 16KB-page host (Apple Silicon) inflates it several-fold against a 4KB-page one,
+    which made the previous RSS budget fail everywhere on macOS and never run in CI at all
+    (it is a slow test, and CI runs --quick). RSS is still reported below as a diagnostic,
+    just not asserted on.
     """
     print("\n=== Testing training working set ===")
     failed = 0
 
-    val_mae, growth, samples, elapsed = measure_training(epochs=2)
+    materialised, largest_mb, val_mae, growth, samples, elapsed = measure_training_allocations(epochs=2)
     matrix_mb = samples * TOTAL_FEATURES * 4 / 1e6
-    # Materialising the matrix costs it once for the dataset and again for the epoch
-    # gather, which put growth above 2x. Assembling per batch leaves the optimiser state
-    # and gradients as the largest items, well under it.
-    budget = matrix_mb * 2.0
 
-    print("notional matrix ~{:.1f} MB, growth {:.1f} MB ({:.2f}x), {:.1f}s".format(matrix_mb, growth, growth / matrix_mb, elapsed))
+    print("notional matrix ~{:.1f} MB, largest single allocation {:.1f} MB, peak RSS growth {:.1f} MB (not asserted), {:.1f}s".format(matrix_mb, largest_mb, growth, elapsed))
 
-    if growth > budget:
-        print("ERROR: growth {:.1f} MB exceeds {:.1f} MB ({:.1f}x the notional matrix) - the matrix is being materialised".format(growth, budget, budget / matrix_mb))
+    if materialised:
+        print("ERROR: WindowedFeatures.__array__ was called {} time(s) during training - the matrix is being materialised".format(materialised))
         failed += 1
     else:
-        print("✓ working set within {:.1f}x the notional matrix".format(budget / matrix_mb))
+        print("✓ the full matrix is never materialised")
+
+    # Any single allocation at matrix scale means a row-per-sample array was built somewhere
+    # __array__ does not cover. A batch is orders of magnitude smaller than the matrix.
+    if largest_mb > matrix_mb / 2:
+        print("ERROR: a single allocation of {:.1f} MB approaches the {:.1f} MB matrix".format(largest_mb, matrix_mb))
+        failed += 1
+    else:
+        print("✓ no single allocation approaches the notional matrix")
 
     if val_mae is None or not np.isfinite(val_mae):
         print("ERROR: training did not produce a usable result: {}".format(val_mae))


### PR DESCRIPTION
> Written by Claude Code on behalf of @chalfontchubby.

## The problem

`test_training_does_not_copy_the_dataset_per_epoch` fails on macOS, **including on a clean `main`**, reporting ~280MB of growth against a 143MB budget and concluding *"the matrix is being materialised"*.

The matrix is not being materialised. I checked directly:

- `WindowedFeatures.__array__` — the only path that builds every row at once — is called **zero times** during training.
- No numpy allocation during a pass exceeds 20MB.
- After training, **live numpy arrays total 0.0MB across 2 arrays**. Nothing is retained.
- `tracemalloc` puts the peak at **67MB**, not 280MB. The largest allocations are Adam optimiser state and weight copies at ~7.1MB.

## What was actually being measured

`ru_maxrss` is a high-water mark of pages **ever touched**, not memory held at any instant. Training frees each batch buffer immediately, but the mark accumulates every page those thousands of short-lived buffers ever dirtied.

Two observations pin it:

- Growth is **264MB in the first epoch alone**; 2 epochs → 320MB, 4 epochs → 355MB. A per-epoch copy or a leak would scale with epochs — this plateaus.
- Allocating a real 65.9MB matrix moves RSS by **0MB**, because untouched pages are never counted. So the "notional matrix" budget was being compared against a quantity RSS does not measure.

The mark is also page-granular, so a 16KB-page host (Apple Silicon) inflates it several-fold against a 4KB-page Linux one — which is why this reproduces on Macs and not in CI.

It went unnoticed because this is a slow test and CI runs `--quick`, so it has never been exercised upstream: neither green nor red.

## The fix

Assert the invariant directly rather than a memory budget:

1. Count `WindowedFeatures.__array__` calls — it must never be reached during training.
2. Check no single allocation approaches the notional matrix.

Both are properties of the code rather than of the host's page size or allocator.

**Verified the guard still fails when it should.** Forcing a materialisation makes it report `materialised=1` and a 65.9MB allocation, tripping both checks. In normal operation the largest single allocation is **5.9MB against a 71.6MB matrix** — a 12x margin rather than a threshold sitting on the edge.

Peak RSS is still printed as a diagnostic, just not asserted on, and `benchmark()` still returns it for manual profiling.

## Also

The module docstring suggested `MallocLargeCache=0` to get a Linux-comparable figure on macOS. Measured, it changes nothing (279.8MB vs 282.9MB) — allocator caching is not what the mark records. Replaced with an explanation of what the number actually means.

## Testing

- `--test ml_training_perf` passes, and the **full suite including slow tests is green** (previously this was the only failure).
- Guard verified to still catch a real regression, as above.
- `run_pre_commit` clean (`nbytes` added to the workspace dictionary).