### PR TITLE
Solis: keep a PV-only inverter in pv_today/pv_power (#4922)

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -1455,6 +1455,16 @@ class SolisAPI(ComponentBase, OAuthMixin):
         # Convert SNs to lowercase for entity naming
         devices = [sn.lower() for sn in batteries]
 
+        # PV totals are summed across every entry in the arg list, so an inverter with no battery still
+        # belongs in them - its generation is part of the same array (issue #4922). Only the control and
+        # battery args are battery-filtered; a PV-only inverter is still never written to. load/import/
+        # export stay battery-only deliberately: on a shared-CT site those registers can overlap between
+        # inverters, so summing them risks double-counting the house load.
+        pv_devices = [sn.lower() for sn in self.inverter_sn]
+        pv_only_devices = [device for device in pv_devices if device not in devices]
+        if pv_only_devices:
+            self.log("Solis API: Including {} inverter(s) with no battery in the PV totals: {}".format(len(pv_only_devices), ", ".join(pv_only_devices)))
+
         # Configure base Predbat settings
         self.set_arg_auto("inverter_type", ["SolisCloud" for _ in range(num_inverters)])
         self.set_arg_auto("num_inverters", num_inverters)
@@ -1471,9 +1481,9 @@ class SolisAPI(ComponentBase, OAuthMixin):
         # if solis_cloud_pv_load_ignore is set to true, override Solis cloud sensors and use load/pv_today/power entries defined in apps.yaml
         if not self.get_arg("solis_cloud_pv_load_ignore", default=False):
             self.set_arg_auto("load_today", [f"sensor.{self.prefix}_solis_{device}_total_load_energy" for device in devices])
-            self.set_arg_auto("pv_today", [f"sensor.{self.prefix}_solis_{device}_pv_energy_total" for device in devices])
+            self.set_arg_auto("pv_today", [f"sensor.{self.prefix}_solis_{device}_pv_energy_total" for device in pv_devices])
             self.set_arg_auto("load_power", [f"sensor.{self.prefix}_solis_{device}_load_power" for device in devices])
-            self.set_arg_auto("pv_power", [f"sensor.{self.prefix}_solis_{device}_pv_power" for device in devices])
+            self.set_arg_auto("pv_power", [f"sensor.{self.prefix}_solis_{device}_pv_power" for device in pv_devices])
         self.set_arg_auto("import_today", [f"sensor.{self.prefix}_solis_{device}_today_import_energy" for device in devices])
         self.set_arg_auto("export_today", [f"sensor.{self.prefix}_solis_{device}_today_export_energy" for device in devices])
 

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -1348,6 +1348,77 @@ async def test_automatic_config_keeps_real_battery_reporting_zero_soh():
     return failed
 
 
+async def test_automatic_config_keeps_no_battery_inverter_in_pv_totals():
+    """Issue #4922: a PV-only inverter must stay out of battery control but stay in the PV totals.
+
+    Predbat sums pv_today/pv_power across the whole arg list, so a second inverter's generation is
+    simply added to the array total - dropping it hid ~45% of the generation on the reporting site.
+    load/import/export stay battery-only: those registers can overlap on a shared-CT install.
+    """
+    failed = False
+    print("**** Testing automatic_config keeps a No Battery inverter in the PV totals ****")
+
+    with_batt = "1031260253072197"
+    no_batt = "6031042245160206"
+    recorded, api = await _run_automatic_config({with_batt: _DETAIL_WITH_BATTERY, no_batt: _DETAIL_NO_BATTERY})
+
+    if recorded.get("num_inverters") != 1:
+        print("ERROR: expected num_inverters 1 - the PV-only inverter must not become a battery inverter, got {}".format(recorded.get("num_inverters")))
+        failed = True
+
+    expect_pv_today = [f"sensor.predbat_solis_{with_batt.lower()}_pv_energy_total", f"sensor.predbat_solis_{no_batt.lower()}_pv_energy_total"]
+    if recorded.get("pv_today") != expect_pv_today:
+        print("ERROR: expected pv_today to cover both inverters {}, got {}".format(expect_pv_today, recorded.get("pv_today")))
+        failed = True
+
+    expect_pv_power = [f"sensor.predbat_solis_{with_batt.lower()}_pv_power", f"sensor.predbat_solis_{no_batt.lower()}_pv_power"]
+    if recorded.get("pv_power") != expect_pv_power:
+        print("ERROR: expected pv_power to cover both inverters {}, got {}".format(expect_pv_power, recorded.get("pv_power")))
+        failed = True
+
+    # Control and battery args must not have widened along with the PV ones
+    for arg in ("soc_percent", "charge_limit", "reserve", "grid_power", "load_today", "load_power", "import_today", "export_today"):
+        entities = recorded.get(arg) or []
+        if len(entities) != 1 or no_batt.lower() in " ".join(entities):
+            print("ERROR: {} must stay on the battery inverter alone, got {}".format(arg, entities))
+            failed = True
+
+    if not any("in the PV totals" in message for message in api.log_messages):
+        print("ERROR: expected a log line naming the battery-less inverter(s) added to the PV totals")
+        failed = True
+
+    if not failed:
+        print("PASSED: automatic_config keeps a No Battery inverter in the PV totals")
+    return failed
+
+
+async def test_automatic_config_pv_totals_unchanged_when_all_have_batteries():
+    """With no PV-only inverter present the PV args must still be exactly the battery inverters."""
+    failed = False
+    print("**** Testing automatic_config leaves the PV totals alone when every inverter has a battery ****")
+
+    first = "1031260253072197"
+    second = "6031052256280133"
+    recorded, api = await _run_automatic_config({first: _DETAIL_WITH_BATTERY, second: _DETAIL_WITH_BATTERY_ALT_FIRMWARE})
+
+    if recorded.get("num_inverters") != 2:
+        print("ERROR: expected num_inverters 2, got {}".format(recorded.get("num_inverters")))
+        failed = True
+
+    expect_pv_today = [f"sensor.predbat_solis_{first.lower()}_pv_energy_total", f"sensor.predbat_solis_{second.lower()}_pv_energy_total"]
+    if recorded.get("pv_today") != expect_pv_today:
+        print("ERROR: expected pv_today {}, got {}".format(expect_pv_today, recorded.get("pv_today")))
+        failed = True
+
+    if any("in the PV totals" in message for message in api.log_messages):
+        print("ERROR: the PV-only inclusion must not be logged when there is no PV-only inverter")
+        failed = True
+
+    if not failed:
+        print("PASSED: automatic_config leaves the PV totals alone when every inverter has a battery")
+    return failed
+
+
 def run_solis_tests(my_predbat):
     """
     Run all Solis API tests
@@ -1372,6 +1443,8 @@ def run_solis_tests(my_predbat):
         failed |= asyncio.run(test_automatic_config_skips_no_battery_named_only_in_battery_list())
         failed |= asyncio.run(test_automatic_config_keeps_battery_when_battery_list_contradicts_battery_type())
         failed |= asyncio.run(test_automatic_config_keeps_real_battery_reporting_zero_soh())
+        failed |= asyncio.run(test_automatic_config_keeps_no_battery_inverter_in_pv_totals())
+        failed |= asyncio.run(test_automatic_config_pv_totals_unchanged_when_all_have_batteries())
         failed |= asyncio.run(test_read_cid())
         failed |= asyncio.run(test_read_batch())
         failed |= asyncio.run(test_read_and_write_cid())

--- a/docs/components.md
+++ b/docs/components.md
@@ -1177,6 +1177,7 @@ Integrates with Solis inverters for monitoring and controlling Solis battery sys
     - Leave `soc_max` unset and allow Predbat to automatically detect battery size from historical charging data (requires several days of data)
 - Supports both V1 (older firmware) and V2 (newer firmware) time window formats
 - Automatic configuration available - sets up all required Predbat sensors automatically
+- **PV-only inverters**: an inverter Solis Cloud reports as having no battery is never managed as a battery inverter and is never written to, but its generation is still included in `pv_today` and `pv_power` so the array total covers the whole roof. Its load and grid readings are left out, as those registers can overlap with the battery inverter's on a shared-CT installation - set `pv_today`/`pv_power`/`load_today` manually with `solis_cloud_pv_load_ignore: true` if you need something different
 - **Inverter timezone must match Predbat's `timezone` setting**: charge/discharge slot times are written to the inverter as plain `HH:MM` values with no timezone attached. The inverter interprets these using its own configured timezone, not Predbat's. If your inverter's timezone is set to UTC (or anything other than Predbat's `timezone`, `Europe/London` by default), the resulting charge/discharge windows will be offset by the difference - for example, a full hour out whenever British Summer Time is in effect. Set the inverter's own timezone to match Predbat's `timezone` setting to avoid this.
 
 #### Configuration Options (solis)


### PR DESCRIPTION
This is an automated draft PR generated from issue #4922 — a maintainer should review it before merging.

Fixes #4922

## Summary

`SolisAPI.automatic_config()` built one `devices` list from the battery-filtered inverters and used it for every arg, so an inverter Solis Cloud reports as having no battery was dropped from the PV totals as well as from battery control. `pv_today`/`pv_power` now use a separate `pv_devices` list covering every discovered inverter — Predbat sums those arg lists, so a PV-only inverter's generation is simply added to the array total. Nothing else changes: `num_inverters`, `inverter_type` and all control/battery args stay battery-only, so a PV-only inverter is still never written to.

Per the maintainer's note on the issue, this is the PV half only. `load_today`/`load_power`/`import_today`/`export_today`/`grid_power` deliberately stay on the battery inverters, since on a shared-CT installation those registers can overlap between inverters and summing them would risk double-counting. A one-line log names any battery-less inverters folded into the PV totals, and `docs/components.md` records the split (including the `solis_cloud_pv_load_ignore` escape hatch for sites that need something different).

## Testing

- `cd coverage && ./run_pre_commit` — all hooks Passed, and the quick suite it runs reported `All tests passed (4 slow tests skipped, total time: 107.37s)`.
- `tools/triage_test.sh solis` — exit 0, `All tests passed`.

Two new tests in `apps/predbat/tests/test_solis.py` (both registered in `run_solis_tests()`):

- `test_automatic_config_keeps_no_battery_inverter_in_pv_totals` — a two-inverter site with one "No Battery" unit gets both inverters in `pv_today`/`pv_power`, while `soc_percent`, `charge_limit`, `reserve`, `grid_power`, `load_today`, `load_power`, `import_today` and `export_today` stay on the battery inverter alone.
- `test_automatic_config_pv_totals_unchanged_when_all_have_batteries` — with no PV-only inverter present the PV args are unchanged and the new log line is not emitted.