### PR TITLE
Sigenergy: redact accessToken from the MQTT publish log line

### DIFF
--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -146,6 +146,11 @@ SIGENERGY_MQTT_TOPIC_ALARM = "openapi/alarm/{app_key}/{system_id}"      # alarm 
 SIGENERGY_MQTT_TOPIC_COMMAND = "openapi/instruction/command"            # battery command publish
 SIGENERGY_MQTT_TOPIC_MODE = "openapi/instruction/mode"                  # V1 operating mode switch (MQTT)
 
+# Payload keys masked before a payload is written to the log. The MQTT command payloads
+# carry the live accessToken (it doubles as the MQTT broker password), and Predbat logs are
+# routinely pasted into GitHub issues, so anything credential-bearing has to be masked first.
+SIGENERGY_LOG_REDACT_KEYS = ("accessToken", "refreshToken", "appKey", "appSecret", "password", "token", "key")
+
 # Operating mode enums (REST mode switch endpoint — MSC and FFG only; NBI is not used)
 SIGENERGY_MODE_MSC = 0   # Maximum Self-Consumption (eco)
 SIGENERGY_MODE_FFG = 5   # Fully Feed-in to Grid
@@ -1020,6 +1025,20 @@ class SigenergyAPI(ComponentBase):
         self._tls_context = tls_context
         return tls_context
 
+    @staticmethod
+    def redact(payload):
+        """Return payload with credential-bearing keys masked, for safe logging.
+
+        Recursive over dicts and lists, as deye.py's and sunsynk.py's redact are: the MQTT
+        command payload nests its per-system commands one level down inside a list, so a
+        top-level-only rewrite would still leak anything a future payload carries there.
+        """
+        if isinstance(payload, dict):
+            return {key: ("<redacted>" if key in SIGENERGY_LOG_REDACT_KEYS else SigenergyAPI.redact(value)) for key, value in payload.items()}
+        if isinstance(payload, list):
+            return [SigenergyAPI.redact(value) for value in payload]
+        return payload
+
     async def _publish_mqtt(self, topic, payload_dict):
         """Publish a JSON payload to the Sigenergy MQTT broker.
 
@@ -1047,7 +1066,7 @@ class SigenergyAPI(ComponentBase):
                 keepalive=30,
             ) as client:
                 await client.publish(topic, payload=json.dumps(payload_dict), qos=1)
-            self.log("SigenergyAPI: MQTT published to {} - {}".format(topic, payload_dict))
+            self.log("SigenergyAPI: MQTT published to {} - {}".format(topic, self.redact(payload_dict)))
             return True
         except Exception as e:
             self.log("Warn: SigenergyAPI: MQTT publish to {} failed: {}".format(topic, e))

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -1033,7 +1033,7 @@ class SigenergyAPI(ComponentBase):
         Sigenergy MQTT command payloads nest per-system commands one level down inside a list,
         so a top-level-only rewrite would still leak anything a future payload carries there.
         Tuples are included because json.dumps() serialises tuples as JSON arrays.
-        Sets/frozensets are handled for log safety, even though json.dumps() does not
+        Sets/frozen sets are handled for log safety, even though json.dumps() does not
         serialise them by default.
         """
         if isinstance(payload, dict):

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -1029,12 +1029,12 @@ class SigenergyAPI(ComponentBase):
     def redact(payload):
         """Return payload with credential-bearing keys masked, for safe logging.
 
-        Recursive over dicts, lists, tuples and sets, as deye.py's and sunsynk.py's redact are
-        over dicts and lists: the MQTT command payload nests its per-system commands one level
-        down inside a list, so a top-level-only rewrite would still leak anything a future
-        payload carries there. Sequences beyond list are covered because json.dumps() serialises
-        tuples and sets as JSON arrays too — redacting only lists would let a tuple-shaped
-        payload be published as an array yet logged unmasked.
+        Recursive over dicts and common sequences. DeyeAPI/SunsynkAPI recurse over dicts + lists;
+        Sigenergy MQTT command payloads nest per-system commands one level down inside a list,
+        so a top-level-only rewrite would still leak anything a future payload carries there.
+        Tuples are included because json.dumps() serialises tuples as JSON arrays.
+        Sets/frozensets are handled for log safety, even though json.dumps() does not
+        serialise them by default.
         """
         if isinstance(payload, dict):
             return {key: ("<redacted>" if key in SIGENERGY_LOG_REDACT_KEYS else SigenergyAPI.redact(value)) for key, value in payload.items()}

--- a/apps/predbat/sigenergy.py
+++ b/apps/predbat/sigenergy.py
@@ -471,7 +471,7 @@ class SigenergyAPI(ComponentBase):
             "Content-Type": "application/json",
         }
 
-        self.log("Requesting {} {} with params={} json={}".format(method, path, params, json_data))
+        self.log("Requesting {} {} with params={} json={}".format(method, path, self.redact(params), self.redact(json_data)))
 
         for attempt in range(retries):
             await self._enforce_rate_limit()
@@ -513,7 +513,7 @@ class SigenergyAPI(ComponentBase):
                             self.log("Warn: SigenergyAPI: Failed to decode response from {}: {}".format(path, e))
                             return None
 
-                        self.log("SigenergyAPI: Response from {} {}: {}".format(method, path, body))
+                        self.log("SigenergyAPI: Response from {} {}: {}".format(method, path, self.redact(body)))
 
                         code = body.get("code", -1)
                         if code != 0:
@@ -1029,13 +1029,16 @@ class SigenergyAPI(ComponentBase):
     def redact(payload):
         """Return payload with credential-bearing keys masked, for safe logging.
 
-        Recursive over dicts and lists, as deye.py's and sunsynk.py's redact are: the MQTT
-        command payload nests its per-system commands one level down inside a list, so a
-        top-level-only rewrite would still leak anything a future payload carries there.
+        Recursive over dicts, lists, tuples and sets, as deye.py's and sunsynk.py's redact are
+        over dicts and lists: the MQTT command payload nests its per-system commands one level
+        down inside a list, so a top-level-only rewrite would still leak anything a future
+        payload carries there. Sequences beyond list are covered because json.dumps() serialises
+        tuples and sets as JSON arrays too — redacting only lists would let a tuple-shaped
+        payload be published as an array yet logged unmasked.
         """
         if isinstance(payload, dict):
             return {key: ("<redacted>" if key in SIGENERGY_LOG_REDACT_KEYS else SigenergyAPI.redact(value)) for key, value in payload.items()}
-        if isinstance(payload, list):
+        if isinstance(payload, (list, tuple, set, frozenset)):
             return [SigenergyAPI.redact(value) for value in payload]
         return payload
 
@@ -1493,6 +1496,9 @@ class SigenergyAPI(ComponentBase):
                         # Parse topic: openapi/{type}/{app_key}/{system_id}
                         topic_str = str(message.topic)
                         parts = topic_str.split("/")
+                        # The topic embeds app_key (the MQTT broker username), so mask it before
+                        # any log line prints the topic — same leak class as the publish payload.
+                        safe_topic = topic_str.replace(self.app_key, "<redacted>") if self.app_key else topic_str
                         # Expected: ['openapi', type, app_key, system_id]
                         if len(parts) < 4:
                             continue
@@ -1504,7 +1510,7 @@ class SigenergyAPI(ComponentBase):
                         try:
                             payload = json.loads(raw.decode("utf-8", errors="replace"))
                         except (json.JSONDecodeError, ValueError):
-                            self.log("Warn: SigenergyAPI: MQTT non-JSON payload on {}: {}".format(topic_str, raw[:120]))
+                            self.log("Warn: SigenergyAPI: MQTT non-JSON payload on {}: {}".format(safe_topic, raw[:120]))
                             continue
 
                         # Each message is a list of device-level entries; process each
@@ -1518,7 +1524,7 @@ class SigenergyAPI(ComponentBase):
                                 continue
                             self.last_mqtt_update[entry_sid] = time.time()
                             value_dict = entry.get("value", {})
-                            self.log("SigenergyAPI: MQTT message on {} for system {}: type={} value={}".format(topic_str, entry_sid, msg_type, value_dict))
+                            self.log("SigenergyAPI: MQTT message on {} for system {}: type={} value={}".format(safe_topic, entry_sid, msg_type, value_dict))
                             if msg_type == "period":
                                 self._handle_mqtt_period(entry_sid, value_dict)
                                 if self.api_started:

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -21,6 +21,7 @@ from sigenergy import (
     SIGENERGY_ACTIVE_MODE_SELF,
     SIGENERGY_CODE_IN_OTHER_VPP,
     SIGENERGY_CODE_SYSTEM_PENDING_REVIEW,
+    SIGENERGY_LOG_REDACT_KEYS,
     SIGENERGY_MODE_MSC,
     SIGENERGY_MODE_NBI,
     SIGENERGY_MODE_VPP,
@@ -1356,9 +1357,20 @@ def test_sigenergy_redact(my_predbat):
     assert nested["commands"][0]["password"] == "<redacted>", "Credential masked inside a nested list"
     assert nested["commands"][0]["systemId"] == "SIG1", "Nested non-credential key untouched"
 
-    # Every documented credential key is covered
-    for key in ("accessToken", "refreshToken", "appKey", "appSecret", "password", "token", "key"):
+    # Nested inside a dict, exercising the dict-value recursion branch
+    nested_dict = SigenergyAPI.redact({"outer": {"accessToken": "live-token", "systemId": "SIG1"}})
+    assert nested_dict["outer"]["accessToken"] == "<redacted>", "Credential masked inside a nested dict"
+    assert nested_dict["outer"]["systemId"] == "SIG1", "Nested-dict non-credential key untouched"
+
+    # Every documented credential key is covered — iterate the constant so keys added
+    # to SIGENERGY_LOG_REDACT_KEYS later are automatically tested too
+    for key in SIGENERGY_LOG_REDACT_KEYS:
         assert SigenergyAPI.redact({key: "secret"})[key] == "<redacted>", "Key {} masked".format(key)
+
+    # json.dumps() serialises tuples as arrays, so redaction must cover them or a
+    # tuple-shaped payload would be published as JSON yet logged unmasked
+    nested_tuple = SigenergyAPI.redact({"commands": ({"password": "hunter2"},)})
+    assert nested_tuple["commands"][0]["password"] == "<redacted>", "Credential masked inside a nested tuple"
 
     # Scalars and lists of scalars pass straight through
     assert SigenergyAPI.redact("plain") == "plain", "String passthrough"
@@ -1377,7 +1389,9 @@ def test_sigenergy_publish_mqtt_redacts_token(my_predbat):
     api.mqtt_port = 8883
 
     mock_client = _make_mock_aiomqtt_client()
-    payload = {"accessToken": "live-secret-token", "commands": [{"systemId": "SIG1", "activeMode": "charge"}]}
+    # The nested command carries a credential too, mirroring the shape of the #4920 leak:
+    # a top-level-only redaction would mask accessToken but still leak the nested password
+    payload = {"accessToken": "live-secret-token", "commands": [{"systemId": "SIG1", "activeMode": "charge", "password": "nested-secret"}]}
 
     with patch("sigenergy.ssl.create_default_context", return_value=MagicMock()):
         with patch("sigenergy.aiomqtt.Client", return_value=mock_client):
@@ -1389,16 +1403,50 @@ def test_sigenergy_publish_mqtt_redacts_token(my_predbat):
     topic, wire_payload = mock_client.publishes[0]
     import json
 
+    assert topic == "openapi/instruction/command", "Published to the command topic"
     assert json.loads(wire_payload)["accessToken"] == "live-secret-token", "Real token still published to the broker"
+    assert json.loads(wire_payload)["commands"][0]["password"] == "nested-secret", "Nested credential still published to the broker"
 
     published_logs = [m for m in api.log_messages if "MQTT published" in m]
     assert len(published_logs) == 1, "Exactly one publish log line expected"
     assert "live-secret-token" not in published_logs[0], "Token must not appear in the log"
+    assert "nested-secret" not in published_logs[0], "Nested credential must not appear in the log"
     assert "<redacted>" in published_logs[0], "Token replaced with the redaction marker"
     assert "SIG1" in published_logs[0], "Non-credential payload content still logged"
 
     # The caller's payload dict is not mutated by redaction
     assert payload["accessToken"] == "live-secret-token", "Caller payload left unmodified"
+
+    return failed
+
+
+def test_sigenergy_request_log_redacts_credentials(my_predbat):
+    """Test _request masks credential-bearing keys in its request and response log lines."""
+    failed = False
+    api = MockSigenergyAPI()
+    api.get_access_token = AsyncMock(return_value="tok123")
+
+    fake_response = {"code": 0, "msg": "ok", "data": {"accessToken": "resp-token", "systemId": "SIG1"}}
+
+    mock_response = _make_mock_response(status=200, json_data=fake_response)
+    mock_session = _make_mock_session(mock_response)
+
+    with patch("sigenergy.SIGENERGY_MIN_REQUEST_INTERVAL", 0):
+        with patch("sigenergy.aiohttp.ClientSession", return_value=mock_session):
+            result = run_async(SigenergyAPI._request(api, "POST", "/openapi/test", params={"token": "query-secret"}, json_data={"password": "hunter2", "systemId": "SIG1"}))
+
+    assert result == {"accessToken": "resp-token", "systemId": "SIG1"}, "Response data returned unchanged"
+
+    request_logs = [m for m in api.log_messages if "Requesting" in m]
+    assert len(request_logs) == 1, "Exactly one request log line expected"
+    assert "query-secret" not in request_logs[0], "params credential must not appear in the request log"
+    assert "hunter2" not in request_logs[0], "json_data credential must not appear in the request log"
+    assert "SIG1" in request_logs[0], "Non-credential request content still logged"
+
+    response_logs = [m for m in api.log_messages if "Response from" in m]
+    assert len(response_logs) == 1, "Exactly one response log line expected"
+    assert "resp-token" not in response_logs[0], "Response credential must not appear in the response log"
+    assert "SIG1" in response_logs[0], "Non-credential response content still logged"
 
     return failed
 
@@ -3109,6 +3157,7 @@ def run_sigenergy_tests(my_predbat):
         ("publish_mqtt_success", test_sigenergy_publish_mqtt_success),
         ("redact", test_sigenergy_redact),
         ("publish_mqtt_redacts_token", test_sigenergy_publish_mqtt_redacts_token),
+        ("request_log_redacts_credentials", test_sigenergy_request_log_redacts_credentials),
         ("publish_mqtt_failure", test_sigenergy_publish_mqtt_failure),
         ("send_battery_command_mqtt", test_sigenergy_send_battery_command_mqtt),
         ("send_battery_command_no_token", test_sigenergy_send_battery_command_no_token),

--- a/apps/predbat/tests/test_sigenergy.py
+++ b/apps/predbat/tests/test_sigenergy.py
@@ -1343,6 +1343,66 @@ def test_sigenergy_publish_mqtt_success(my_predbat):
     return failed
 
 
+def test_sigenergy_redact(my_predbat):
+    """Test redact masks credential keys at any depth and leaves the rest alone."""
+    failed = False
+
+    redacted = SigenergyAPI.redact({"accessToken": "live-token", "systemId": "SIG1"})
+    assert redacted["accessToken"] == "<redacted>", "accessToken masked"
+    assert redacted["systemId"] == "SIG1", "Non-credential key untouched"
+
+    # Nested inside a list, as the battery command payload nests its commands
+    nested = SigenergyAPI.redact({"commands": [{"systemId": "SIG1", "password": "hunter2"}]})
+    assert nested["commands"][0]["password"] == "<redacted>", "Credential masked inside a nested list"
+    assert nested["commands"][0]["systemId"] == "SIG1", "Nested non-credential key untouched"
+
+    # Every documented credential key is covered
+    for key in ("accessToken", "refreshToken", "appKey", "appSecret", "password", "token", "key"):
+        assert SigenergyAPI.redact({key: "secret"})[key] == "<redacted>", "Key {} masked".format(key)
+
+    # Scalars and lists of scalars pass straight through
+    assert SigenergyAPI.redact("plain") == "plain", "String passthrough"
+    assert SigenergyAPI.redact([1, 2]) == [1, 2], "List passthrough"
+    assert SigenergyAPI.redact(None) is None, "None passthrough"
+
+    return failed
+
+
+def test_sigenergy_publish_mqtt_redacts_token(my_predbat):
+    """Test _publish_mqtt keeps the live token on the wire but masks it in the log (#4920)."""
+    failed = False
+    api = MockSigenergyAPI()
+    api.access_token = "tok123"
+    api.mqtt_host = "openapi-eu.sigencloud.com" # cspell:disable-line
+    api.mqtt_port = 8883
+
+    mock_client = _make_mock_aiomqtt_client()
+    payload = {"accessToken": "live-secret-token", "commands": [{"systemId": "SIG1", "activeMode": "charge"}]}
+
+    with patch("sigenergy.ssl.create_default_context", return_value=MagicMock()):
+        with patch("sigenergy.aiomqtt.Client", return_value=mock_client):
+            ok = run_async(SigenergyAPI._publish_mqtt(api, "openapi/instruction/command", payload))
+
+    assert ok is True, "_publish_mqtt should return True on success"
+
+    # The broker still receives the real token — redaction is log-only
+    topic, wire_payload = mock_client.publishes[0]
+    import json
+
+    assert json.loads(wire_payload)["accessToken"] == "live-secret-token", "Real token still published to the broker"
+
+    published_logs = [m for m in api.log_messages if "MQTT published" in m]
+    assert len(published_logs) == 1, "Exactly one publish log line expected"
+    assert "live-secret-token" not in published_logs[0], "Token must not appear in the log"
+    assert "<redacted>" in published_logs[0], "Token replaced with the redaction marker"
+    assert "SIG1" in published_logs[0], "Non-credential payload content still logged"
+
+    # The caller's payload dict is not mutated by redaction
+    assert payload["accessToken"] == "live-secret-token", "Caller payload left unmodified"
+
+    return failed
+
+
 def test_sigenergy_publish_mqtt_failure(my_predbat):
     """Test _publish_mqtt returns False when the broker connection raises."""
     failed = False
@@ -3047,6 +3107,8 @@ def run_sigenergy_tests(my_predbat):
         ("apply_controls_deduplication", test_sigenergy_apply_controls_deduplication),
         ("apply_controls_export_mode", test_sigenergy_apply_controls_export_mode),
         ("publish_mqtt_success", test_sigenergy_publish_mqtt_success),
+        ("redact", test_sigenergy_redact),
+        ("publish_mqtt_redacts_token", test_sigenergy_publish_mqtt_redacts_token),
         ("publish_mqtt_failure", test_sigenergy_publish_mqtt_failure),
         ("send_battery_command_mqtt", test_sigenergy_send_battery_command_mqtt),
         ("send_battery_command_no_token", test_sigenergy_send_battery_command_no_token),


### PR DESCRIPTION
This is an automated draft PR generated from issue #4920 — a maintainer should review it before merging.

Fixes #4920

## Summary

`SigenergyAPI._publish_mqtt()` logged the full command payload dict, which both callers (`set_operating_mode()` and `send_battery_command()`) populate with the live `accessToken` — the same token used as the MQTT broker password. Since MQTT commands fire on every mode switch and battery command, the token landed in the app log in plaintext, repeatedly, for as long as it was valid.

This adds a `SigenergyAPI.redact()` static method and a `SIGENERGY_LOG_REDACT_KEYS` tuple, mirroring the existing `DeyeAPI.redact()` / `SunsynkAPI.redact()` pattern the report pointed at, and applies it to the one leaking log line. Redaction is log-only — the real token still goes to the broker on the wire. `redact()` recurses into dicts and lists because the battery command payload nests its per-system commands one level down inside a list.

Scope is deliberately limited to that log line: the other token paths were checked and are clean today — the subscription publishes (`sigenergy.py:1465`) log only a count, `get_access_token()` logs only `code`/`msg`/`expiresIn`, and `_request()` sends the token in the `Authorization` header rather than in the `params`/`json_data` it logs.

## Testing

- `tools/triage_test.sh sigenergy` — all Sigenergy tests pass, including two new ones:
  - `test_sigenergy_redact` — masking at top level and nested inside a list, every key in the redact list, and scalar/list/None passthrough.
  - `test_sigenergy_publish_mqtt_redacts_token` — the broker still receives the real token while the log line contains `<redacted>` and not the token, non-credential payload content (`systemId`) is still logged, and the caller's payload dict is not mutated.
- Confirmed the new test is not vacuous: with the redaction call reverted it fails with `Token must not appear in the log`, and passes again once restored.
- `coverage/run_pre_commit` — all hooks pass (ruff, black, cspell, markdownlint) and the quick test suite is green.