### PR TITLE
fix(gecloud): honour battery_rate_max over charge_rate's max attribute

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -406,10 +406,14 @@ class Inverter:
             self.nominal_capacity = self.base.get_arg("soc_max", default=0.0, index=self.id)
             self.soc_max = self.nominal_capacity * self.battery_scaling
 
-            if self.inverter_type in ["GE", "GEC", "GEE"]:
-                self.battery_rate_max_raw = self.base.get_arg("charge_rate", attribute="max", index=self.id, default=2600.0, required_unit="W")
-            elif "battery_rate_max" in self.base.args:
+            if "battery_rate_max" in self.base.args:
+                # battery_rate_max, when configured, is a more authoritative source than the charge_rate
+                # entity's max attribute - e.g. GECloud (GEC/GEE) always populates it from the device's
+                # reported model/capability data, whereas the charge_rate entity's max attribute there
+                # reflects a live register limit that can read back as a stale/wrong low value (#4908).
                 self.battery_rate_max_raw = self.base.get_arg("battery_rate_max", index=self.id, default=2600.0, required_unit="W")
+            elif self.inverter_type in ["GE", "GEC", "GEE"]:
+                self.battery_rate_max_raw = self.base.get_arg("charge_rate", attribute="max", index=self.id, default=2600.0, required_unit="W")
             else:
                 self.battery_rate_max_raw = 2600.0
 

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -2760,6 +2760,54 @@ def test_inverter_type_default_warning(test_name, my_predbat):
     return failed
 
 
+def test_gecloud_battery_rate_max_priority(test_name, my_predbat):
+    """
+    GECloud (GEC/GEE) always publishes an accurate battery_rate_max sensor derived from the
+    device's reported model/capability data. The charge_rate entity's max attribute for GEC
+    instead reflects a live register limit that can read back low/stale (e.g. 2600W on a 20kW
+    3-phase inverter, despite GECloud's own logs correctly showing 20000W) - issue #4908.
+    battery_rate_max must take priority over charge_rate's max attribute when both are configured,
+    while GE (local GivTCP), which never sets battery_rate_max, keeps using charge_rate's max
+    attribute as before.
+    """
+    failed = False
+    print("**** Running Test: {} ****".format(test_name))
+
+    ha = my_predbat.ha_interface
+    orig_args = {key: my_predbat.args.get(key) for key in ["inverter_type", "charge_rate", "battery_rate_max", "givtcp_rest"]}
+
+    try:
+        my_predbat.args["givtcp_rest"] = None
+        my_predbat.args["inverter_type"] = ["GEC"]
+        my_predbat.args["charge_rate"] = "number.gecloud_charge_rate_test"
+        my_predbat.args["battery_rate_max"] = "sensor.gecloud_battery_rate_max_test"
+        ha.dummy_items["number.gecloud_charge_rate_test"] = {"state": 2600, "max": 2600}
+        ha.dummy_items["sensor.gecloud_battery_rate_max_test"] = 20000
+
+        inv = Inverter(my_predbat, 0)
+        if inv.battery_rate_max_raw != 20000.0:
+            print("ERROR: GEC battery_rate_max_raw should use the battery_rate_max sensor (20000W), got {}".format(inv.battery_rate_max_raw))
+            failed = True
+
+        # GE (local GivTCP) never has battery_rate_max configured, so it must keep using charge_rate's max attribute
+        del my_predbat.args["battery_rate_max"]
+        my_predbat.args["inverter_type"] = ["GE"]
+        inv = Inverter(my_predbat, 0)
+        if inv.battery_rate_max_raw != 2600.0:
+            print("ERROR: GE battery_rate_max_raw should fall back to charge_rate's max attribute (2600W), got {}".format(inv.battery_rate_max_raw))
+            failed = True
+    finally:
+        del ha.dummy_items["number.gecloud_charge_rate_test"]
+        del ha.dummy_items["sensor.gecloud_battery_rate_max_test"]
+        for key, value in orig_args.items():
+            if value is None:
+                my_predbat.args.pop(key, None)
+            else:
+                my_predbat.args[key] = value
+
+    return failed
+
+
 def test_rest_battery_capacity_fallback(test_name, my_predbat):
     """
     Verify that when V3 REST data omits Battery_Capacity_kWh and battery_nominal_capacity,
@@ -3112,6 +3160,10 @@ def run_inverter_tests(my_predbat_dummy):
     failed |= test_battery_scaling_invalid_value_clamped("battery_scaling_invalid_value_clamped", my_predbat)
 
     failed |= test_inverter_type_default_warning("inverter_type_default_warning", my_predbat)
+    if failed:
+        return failed
+
+    failed |= test_gecloud_battery_rate_max_priority("gecloud_battery_rate_max_priority", my_predbat)
     if failed:
         return failed
 


### PR DESCRIPTION
- GEC/GEE (GivEnergy Cloud) inverters always derived their max charge/discharge rate from the `charge_rate` entity's `max` attribute, which GivEnergy's cloud API can report as a stale/low value (2600W on a 20kW 3-phase inverter) instead of the real capability.
- `gecloud.py` already computes and publishes an accurate `battery_rate_max` sensor from the device's model/capability data, but it was being silently ignored for GEC/GEE.
- `battery_rate_max` now takes priority over `charge_rate`'s `max` attribute when configured, fixing the incorrect 2600W cap.

**Precedent:** this brings GE-family inverters in line with how `battery_rate_max` already works for AlphaESS, which is documented as an override, in watts, for the battery's max charge/discharge rate specifically because its API doesn't reliably report one. Same situation here – an untrustworthy API-reported value with a manual correction – so this reuses the existing key rather than introducing a new, differently-named one for the same job.

**Who this affects:** I checked all three default GivEnergy templates (`givenergy_givtcp.yaml`/GE, `givenergy_cloud.yaml`/GEC, `givenergy_ems.yaml`/GEE) and none of them set `battery_rate_max`, commented or otherwise – the GEE template in fact states that apps.yaml entries in that section are ignored entirely in favour of Cloud auto-configuration. So only a user who has deliberately added `battery_rate_max` themselves (as this fix requires) would see a behaviour change; anyone on a stock template is unaffected regardless of inverter type.

Fixes #4908

## Test plan
- [x] Added `test_gecloud_battery_rate_max_priority` regression test (GEC uses the `battery_rate_max` sensor; GE still falls back to `charge_rate`'s max attribute)
- [x] `./run_all --test inverter` passes
- [x] `./run_pre_commit` – passes except two pre-existing failures confirmed to reproduce identically on a clean `main` tree, unrelated to this change (a Windows-only `triage-daemon-tests` POSIX-path bug, and a `file-contents-sorter` CRLF no-op on `requirements.txt`)
- [x] `./run_all --quick` – no regressions from this change; two further pre-existing failures confirmed environment-specific to this fresh Windows setup (a missing `encoding="utf-8"` in an unrelated test helper, and a `debug_cases` golden-plan mismatch caused by the compiled prediction kernel not being built here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Djbv5fZh1Nr7MEYF7AqznT