### PR TITLE
feat(manual): extend manual rate override horizon to 7 days

### DIFF
--- a/apps/predbat/const.py
+++ b/apps/predbat/const.py
@@ -58,6 +58,13 @@ INVERTER_REST_TIMEOUT = 10  # Seconds to wait for a REST response before giving 
 INVERTER_QUICK_UPDATE_SECONDS = 120  # Minimum seconds between quick inverter data updates
 PREDBAT_MAX_CARS = 8  # Matches PK_MAX_CARS in prediction_kernel.cpp and the car_charging_rate/_1../_7 config items - the hard ceiling on num_cars
 DEBUG_ENABLE_MAX_HOURS = 2  # Auto-disable switch.predbat_debug_enable after this long left on, to bound the raw per-cycle debug.yaml disk writes it triggers (and the C++ kernel bypass it forces) if left on by accident - the rotating debug-history buffer covers longer-term history at a coarser interval instead
+# How far ahead a manual override may be placed. The two horizons differ on purpose: a manual
+# charge/export/freeze/demand slot is bounded by the plan, since Predbat can only act on a slot the
+# plan reaches, whereas a rate override is future tariff data that only has to be REMEMBERED until
+# the plan reaches it - e.g. an energy supplier announcing a free-electricity hour several days out.
+# 7 days is the ceiling the 'Day HH:MM' selection format can express anyway.
+MANUAL_TIME_MAX_MINUTES = 48 * 60
+MANUAL_RATE_MAX_MINUTES = 7 * 24 * 60
 
 # 240v x 100 amps x 3 phases / 1000 to kW / 60 minutes in an hour is the maximum kWh in a 1 minute period
 MAX_INCREMENT = 240 * 100 * 3 / 1000 / 60

--- a/apps/predbat/tests/test_manual_times.py
+++ b/apps/predbat/tests/test_manual_times.py
@@ -400,6 +400,44 @@ def run_test_manual_times(my_predbat):
     else:
         print("PASS: T13 Selecting during the clock shift kept every slot: {}".format(manual_export_times))
 
+    # Test 14: A rate override several days out survives
+    # Rate overrides carry a 7 day horizon, not the 48 hours a manual charge/export slot gets:
+    # they are future tariff data that only has to be remembered until the plan reaches them,
+    # which is how a supplier's free-electricity hour announced days ahead can be entered.
+    print("Test 14: Rate override beyond 48 hours is retained")
+    my_predbat.midnight_utc = datetime(2025, 12, 19, 0, 0, 0, tzinfo=timezone.utc)
+    my_predbat.midnight = my_predbat.midnight_utc.astimezone(my_predbat.local_tz)
+    my_predbat.now_utc = my_predbat.midnight_utc + timedelta(minutes=0)  # Start at midnight
+    my_predbat.minutes_now = 0
+    my_predbat.manual_select("manual_import_rates", "off")
+
+    far_day = (my_predbat.now_utc + timedelta(days=4)).strftime("%a")
+    far_minute = 4 * 24 * 60 + 12 * 60
+    my_predbat.manual_select("manual_import_rates", "{} 12:00=0.0".format(far_day))
+    manual_import_far = my_predbat.manual_rates("manual_import_rates", default_rate=10.0)
+
+    if far_minute not in manual_import_far:
+        print("ERROR: T14 Expected minute {} ({} 12:00) to survive but got {}".format(far_minute, far_day, sorted(manual_import_far)))
+        failed = True
+    elif manual_import_far[far_minute] != 0.0:
+        print("ERROR: T14 Expected rate 0.0 at minute {} but got {}".format(far_minute, manual_import_far[far_minute]))
+        failed = True
+    else:
+        print("PASS: T14 Rate override 4 days ahead retained at minute {} rate {}".format(far_minute, manual_import_far[far_minute]))
+
+    # Test 15: the same distance out is still rejected for a manual TIME slot, which stays bounded
+    # by the plan horizon - Predbat can only act on a slot the plan actually reaches.
+    print("Test 15: Manual time beyond 48 hours is still dropped")
+    my_predbat.manual_select("manual_demand", "off")
+    my_predbat.manual_select("manual_demand", "{} 12:00".format(far_day))
+    manual_demand_far = my_predbat.manual_times("manual_demand")
+
+    if far_minute in manual_demand_far:
+        print("ERROR: T15 Expected minute {} to be dropped from manual_demand but got {}".format(far_minute, manual_demand_far))
+        failed = True
+    else:
+        print("PASS: T15 Manual demand 4 days ahead correctly dropped: {}".format(manual_demand_far))
+
     # Restore time context to current time
     my_predbat.now_utc = datetime.now(my_predbat.local_tz)
     my_predbat.midnight_utc =  my_predbat.now_utc.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -28,6 +28,8 @@ from const import (
     TIME_FORMAT,
     PREDBAT_MODE_OPTIONS,
     PREDBAT_MODE_MONITOR,
+    MANUAL_RATE_MAX_MINUTES,
+    MANUAL_TIME_MAX_MINUTES,
 )
 from config import APPS_SCHEMA, CONFIG_API_OVERRIDE
 from predbat import THIS_VERSION, THIS_VERSION_DISPLAY
@@ -1444,7 +1446,7 @@ class UserInterface:
         plan_interval = self.get_arg("plan_interval_minutes", 30)
         midnight_utc, minutes_now_real = self.manual_time_origin()
         minutes_now = int(minutes_now_real / plan_interval) * plan_interval
-        manual_rate_max = 48 * 60
+        manual_rate_max = MANUAL_RATE_MAX_MINUTES
 
         # Deconstruct the value into a list of minutes
         item = self.config_index.get(config_item)
@@ -1535,7 +1537,7 @@ class UserInterface:
         plan_interval = self.get_arg("plan_interval_minutes", 30)
         midnight_utc, minutes_now_real = self.manual_time_origin()
         minutes_now = int(minutes_now_real / plan_interval) * plan_interval
-        manual_time_max = 48 * 60
+        manual_time_max = MANUAL_TIME_MAX_MINUTES
 
         # Deconstruct the value into a list of minutes
         item = self.config_index.get(config_item)

--- a/apps/predbat/web.py
+++ b/apps/predbat/web.py
@@ -71,7 +71,7 @@ from web_helper import (
 
 from utils import calc_percent_limit, str2time, dp0, dp2, dp4, format_time_ago, get_override_time_from_string, history_attribute, prune_today, mask_secret_args, mask_secret_yaml_text, read_predbat_log, classify_log_line, log_line_included
 from utils import is_data_numerical, ROOT_YAML_KEY, YAML_DUMP_WIDTH, update_nested_yaml_value  # noqa: F401 - re-exported: moved to utils.py, agent_tools.py/chat_tools.py must not import from web.py
-from const import TIME_FORMAT, TIME_FORMAT_DAILY, TIME_FORMAT_HA
+from const import TIME_FORMAT, TIME_FORMAT_DAILY, TIME_FORMAT_HA, MANUAL_RATE_MAX_MINUTES, MANUAL_TIME_MAX_MINUTES
 from predbat import THIS_VERSION_DISPLAY
 from component_base import ComponentBase
 from config import APPS_SCHEMA
@@ -4639,8 +4639,9 @@ chart.render();
             override_time = get_override_time_from_string(now_utc, time_str, self.plan_interval_minutes)
 
             minutes_from_now = (override_time - now_utc).total_seconds() / 60
-            if minutes_from_now >= 48 * 60:
-                return web.json_response({"success": False, "message": "Override time must be within 48 hours from now."}, status=400)
+            if minutes_from_now >= MANUAL_RATE_MAX_MINUTES:
+                max_hours = MANUAL_RATE_MAX_MINUTES // 60
+                return web.json_response({"success": False, "message": f"Override time must be within {max_hours} hours from now."}, status=400)
 
             # Calculate minutes from midnight for looking up existing rates
             minutes_from_midnight = int((override_time - self.midnight_utc).total_seconds() / 60)
@@ -4723,8 +4724,9 @@ chart.render();
                 return web.json_response({"success": False, "message": "Invalid time format"}, status=400)
 
             minutes_from_now = (override_time - now_utc).total_seconds() / 60
-            if minutes_from_now >= 48 * 60:
-                return web.json_response({"success": False, "message": "Override time must be within 48 hours from now."}, status=400)
+            if minutes_from_now >= MANUAL_TIME_MAX_MINUTES:
+                max_hours = MANUAL_TIME_MAX_MINUTES // 60
+                return web.json_response({"success": False, "message": f"Override time must be within {max_hours} hours from now."}, status=400)
 
             selection_option = "{}".format(override_time.strftime("%a %H:%M"))
             clear_option = "[{}]".format(override_time.strftime("%a %H:%M"))


### PR DESCRIPTION
## Problem

A manual **rate** override (`select.predbat_manual_import_rates` and friends) placed more than 48 hours ahead is silently discarded.

`manual_rates()` filters on `(minutes - minutes_now_real) < manual_rate_max` where `manual_rate_max = 48 * 60`. A slot beyond that is dropped, the select value is rebuilt without it — `off` if nothing is left — and pushed back via `expose_config(..., force=True)`. No warning is logged and nothing surfaces to the user, so the entry simply vanishes shortly after being saved.

The case that motivated this: an energy supplier announces a free-electricity hour several days in advance. Users are told about it, enter the 0p override straight away, and it disappears. Repeatedly, because there is no feedback telling them why. It only starts working once the target slot drifts inside 48 hours, which looks like an intermittent bug rather than a horizon.

## Why rate overrides are different from time overrides

The 48 hour bound is right for a manual charge/export/freeze/demand slot: Predbat can only act on a slot the plan actually reaches, so there is no point holding one further out.

A rate override is not an instruction to act — it is future tariff data that only has to be **remembered** until the plan reaches it. Nothing about it needs the plan to be that long.

## Change

- Split the two horizons into named constants in `const.py`: `MANUAL_TIME_MAX_MINUTES` (48 hours, unchanged) and `MANUAL_RATE_MAX_MINUTES` (7 days).
- 7 days is the ceiling the `Day HH:MM` selection format can express anyway — `get_override_time_from_string()` resolves a weekday to the next occurrence within 7 days — so this is the natural limit rather than an arbitrary one.
- The web rate-override endpoint's own `>= 48 * 60` validation now reads the same constants (and the plan-override endpoint reads the time constant), so its error message can no longer drift away from what the engine accepts. The message is derived from the constant instead of being hardcoded.

## Safety of distant overrides

An override outside the plan window is inert until the plan reaches it:

- `apply_manual_rates()` writes into a plain dict, so an out-of-window minute key is simply never read.
- `rate_minmax()` iterates `range(minutes_now, forecast_minutes + minutes_now)` — a distant 0p slot cannot drag `rate_min`/`rate_average` down.
- `publish_rates()` iterates up to `minutes_now + forecast_minutes + 24 * 60`, so a distant slot is not published until it comes into range.

## Tests

Added to `test_manual_times` (inline in `run_test_manual_times`, so it runs under `unit_test.py`, not only under pytest):

- **T14** — a rate override 4 days ahead survives the round trip through `manual_select()` → `manual_rates()`.
- **T15** — a manual demand slot the same distance out is still dropped, pinning the deliberate asymmetry.

T14 fails against the old 48 hour value (verified by reverting the constant), so it is not vacuous.

`unit_test.py -k manual_times / manual_select / manual_api / manual_soc / manual_overrides` all pass.