### PR TITLE
fix(solis): preserve queued window edits during startup

### DIFF
--- a/apps/predbat/solis.py
+++ b/apps/predbat/solis.py
@@ -3315,17 +3315,6 @@ class SolisAPI(ComponentBase, OAuthMixin):
                 self.log("Error: Solis API: No inverters to manage after discovery")
                 return False  # Stop further processing if no inverters
 
-        # Process events queued by the entity callbacks, on this loop. Drained after the
-        # startup block: the handlers need the ClientSession and the discovered inverter
-        # list, which only exist once the first cycle has completed. On a failed startup
-        # (the return above) the queue is left intact and drained on the next attempt.
-        while self.queued_events:
-            handler, *args = self.queued_events.pop(0)
-            try:
-                await handler(*args)
-            except Exception as e:
-                self.log("Warn: Solis API: Event handler error: {}".format(e))
-
         # Frequent polling (every minute)
         if first or (seconds % 60 == 0):
             for sn in self.inverter_sn:
@@ -3395,6 +3384,15 @@ class SolisAPI(ComponentBase, OAuthMixin):
                     success = await self.poll_inverter_data(sn, SOLIS_CID_SINGLE, batch=False)
                 if not success:
                     poll_success = False
+
+        # Apply queued edits after the initial register decode, which replaces the
+        # local window cache, and before writing those windows to the inverter.
+        while self.queued_events:
+            handler, *args = self.queued_events.pop(0)
+            try:
+                await handler(*args)
+            except Exception as e:
+                self.log("Warn: Solis API: Event handler error: {}".format(e))
 
         # Control mode
         control_success = True

--- a/apps/predbat/tests/test_solis.py
+++ b/apps/predbat/tests/test_solis.py
@@ -5475,9 +5475,11 @@ async def test_event_queued_not_executed_on_calling_loop():
     api = MockSolisAPI()
 
     executed = []
+    executing_loops = []
 
     async def spy(*args):
         executed.append(args)
+        executing_loops.append(asyncio.get_running_loop())
 
     api.select_event_handler = spy
     api.number_event_handler = spy
@@ -5494,10 +5496,9 @@ async def test_event_queued_not_executed_on_calling_loop():
         print("ERROR: expected 3 queued events, got {}".format(len(api.queued_events)))
         return 1
 
-    # Draining — which run() does on the Solis loop — is what performs the work.
-    while api.queued_events:
-        handler, *args = api.queued_events.pop(0)
-        await handler(*args)
+    # Exercise the production drain on a non-polling cycle.
+    assert await asyncio.to_thread(lambda: asyncio.run(api.run(5, False)))
+    assert all(loop is not asyncio.get_running_loop() for loop in executing_loops)
 
     if len(executed) != 3:
         print("ERROR: expected 3 handlers run on drain, got {}".format(len(executed)))
@@ -5522,12 +5523,8 @@ async def test_queued_event_failure_does_not_stop_the_queue():
     api.queued_events.append((boom, "a"))
     api.queued_events.append((ok, "b"))
 
-    while api.queued_events:
-        handler, *args = api.queued_events.pop(0)
-        try:
-            await handler(*args)
-        except Exception:
-            pass
+    assert await api.run(5, False)
+    assert any("Event handler error" in message for message in api.log_messages)
 
     if len(ran) != 1:
         print("ERROR: a failing event stranded the rest of the queue: {}".format(ran))
@@ -5555,21 +5552,29 @@ async def test_queued_event_drained_after_startup():
     async def fake_noop(*args, **kwargs):
         pass
 
+    async def fake_decode(sn):
+        """Simulate the startup register read replacing the local window cache."""
+        order.append("decode")
+        api.charge_discharge_time_windows[sn] = {1: {"charge_start_time": "01:00"}}
+
     async def fake_write_if_changed(*args, **kwargs):
         return True
 
     api.get_inverter_list = fake_get_inverter_list
     api.fetch_inverter_details = fake_poll
     api.poll_inverter_data = fake_poll
-    api.decode_time_windows = fake_noop
-    api.decode_time_windows_v2 = fake_noop
+    api.decode_time_windows = fake_decode
+    api.decode_time_windows_v2 = fake_decode
     api.startup_reset_registers = fake_noop
     api.reset_charge_windows_if_needed = fake_noop
     api.write_time_windows_if_changed = fake_write_if_changed
     api.publish_entities = fake_noop
 
+    handler = api.select_event_handler
+
     async def spy(entity_id, value):
         order.append("event")
+        await handler(entity_id, value)
         if api.session is None:
             print("ERROR: queued event drained before the ClientSession was created")
             return 1
@@ -5581,7 +5586,7 @@ async def test_queued_event_drained_after_startup():
     api.select_event_handler = spy
 
     # Queue as a real callback would, before the first run() cycle
-    api.queued_events.append((api.select_event_handler, "select.predbat_solis_1234567890_storage_mode", "Self Use"))
+    api.queued_events.append((api.select_event_handler, "select.predbat_solis_1234567890_charge_slot1_start_time", "02:00:00"))
 
     try:
         result = await api.run(0, True)
@@ -5593,7 +5598,8 @@ async def test_queued_event_drained_after_startup():
             await api.session.close()
             api.session = None
 
-    if order != ["startup", "event"]:
+    assert api.charge_discharge_time_windows["1234567890"][1]["charge_start_time"] == "02:00", "Startup decode overwrote the queued edit"
+    if order != ["startup", "decode", "event"]:
         print("ERROR: expected startup before event drain, got {}".format(order))
         return 1
     if api.queued_events:


### PR DESCRIPTION
Queued time-window edits in #4875 are applied before the first register decode, which replaces the local window cache and silently loses the edit. Drain events after polling and initial decoding, before writing the windows to the inverter.

The regressions exercise the real `run()` drain, including callbacks queued on a different event loop and continuation after a handler fails. The startup test fails on the original PR and passes with this fix.

Validation: `unit_test.py --test solis` and all pre-commit hooks for the changed files passed. The two existing unclosed-session warnings remain.

This follow-up targets `fix/solis-callback-loop-affinity` so its diff contains only the review fix for #4875.
