### PR TITLE
fix(chargers): isolate car plans and preserve composed measurements

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -408,6 +408,7 @@ nord
 nordpool
 noreferrer
 nosc
+nosuch
 nosuchrun
 notgithub
 notsn

--- a/apps/predbat/charger_registry.py
+++ b/apps/predbat/charger_registry.py
@@ -1,0 +1,553 @@
+# -----------------------------------------------------------------------------
+# Predbat Home Battery System
+# Copyright Trefor Southwell 2026 - All Rights Reserved
+# This application maybe used for personal use only and not for commercial use
+# -----------------------------------------------------------------------------
+# fmt off
+# pylint: disable=consider-using-f-string
+# pylint: disable=line-too-long
+# pylint: disable=attribute-defined-outside-init
+# -----------------------------------------------------------------------------
+# Charger registry - composes EV chargers discovered by several components into
+# the flat car_charging_* arrays that fetch.py consumes, and tells each component
+# which car slot its own charger was given.
+#
+# Before this existed, every charger component assigned its own discovered list
+# straight to car_charging_planned/_energy/_power, so the last component to run
+# erased the others' chargers; and num_cars was composed as a max of each
+# component's local count, so one GivEnergy charger plus one Ohme charger gave
+# num_cars=1 with both claiming slot 0.
+# -----------------------------------------------------------------------------
+
+
+"""Charger registry - one car slot per physical EV charger, across every component."""
+
+import re
+import threading
+
+from const import PREDBAT_MAX_CARS
+
+LEGACY_SOURCE = "legacy"
+
+# Slot-aligned args: one entry per car, so a gap cannot be represented. apps.yaml
+# validation rejects non-string list elements (predbat.py:1644), so a slot the registry
+# would have to invent a value for makes the whole key drop out (see materialise). A
+# legacy slot's raw value is not such a gap - it is written back exactly as the user's
+# own config produced it, None included.
+SLOT_ALIGNED = ("planned", "now", "soc")
+
+# Site aggregates: minute_data_import_export() sums the list, so gaps are simply
+# dropped rather than padded.
+AGGREGATE = ("energy", "power")
+
+# Shortest device_id that may be matched inside a legacy entity id to call the two the same
+# charger (_drop_duplicated_legacy). Real manufacturer serials are far longer; anything this short
+# would collide with unrelated entities by chance.
+MIN_IDENTITY_MATCH_LENGTH = 4
+
+# Sources whose device_id is a manufacturer serial that third-party integrations embed verbatim in
+# their own entity names, so finding it inside a legacy entity id really is evidence of the same
+# hardware: myenergi's Zappi serial and GivEnergy Cloud's charger serial.
+#
+# The gateway is deliberately absent. Its device_id is an OCPP charge-point id, which the charger's
+# own installer chooses - it can be anything from "1" to an English word - so a substring of it
+# turning up in an unrelated entity id says nothing about identity. Gateway chargers are still
+# deduped against a legacy slot that names the exact same entity; only the looser
+# serial-inside-the-name match is withheld.
+SERIAL_IDENTITY_SOURCES = ("myenergi", "gecloud")
+
+
+class ChargerEntry:
+    """One physical charger, as reported by the component that discovered it.
+
+    Identity is (source, device_id) - a durable, source-native pair. Deliberately NOT
+    the entity-id suffix, which for the gateway is a 6-character slug its own docstring
+    documents as collision-prone.
+    """
+
+    __slots__ = ("source", "device_id", "planned", "now", "energy", "power", "soc", "max_rate_kw")
+
+    def __init__(self, source, device_id, planned=None, now=None, energy=None, power=None, soc=None, max_rate_kw=None):
+        self.source = source
+        self.device_id = str(device_id)
+        self.planned = planned
+        self.now = now
+        self.energy = energy
+        self.power = power
+        self.soc = soc
+        self.max_rate_kw = max_rate_kw
+
+    def key(self):
+        """The identity this charger is deduped and slot-mapped by."""
+        return (self.source, self.device_id)
+
+    def sort_key(self):
+        """Legacy slots keep their apps.yaml positions; everything else sorts by identity.
+
+        Sorting rather than discovery order matters because automatic_config() is not
+        centrally orchestrated - each component calls its own at a different time and
+        re-calls it on rediscovery - so insertion order is not reproducible across restarts.
+        """
+        if self.source == LEGACY_SOURCE:
+            return (0, "", int(self.device_id))
+        return (1, self.source, self.device_id)
+
+
+class ChargerRegistry:
+    """Collects chargers from every component and materialises the flat car_charging_* args.
+
+    Components each run on their own thread (hass.py:223 starts them) and the gateway
+    registers its chargers from an MQTT callback, so every public entry point that reads or
+    mutates the shared state takes ``self._lock``. It is an RLock rather than a plain Lock
+    because replace_source() holds the lock across materialise(), which in turn calls
+    entries() - all three are public, so the lock has to be re-entrant or the outer call
+    would deadlock on the inner one.
+    """
+
+    def __init__(self, base):
+        self.base = base
+        self._lock = threading.RLock()
+        self._by_source = {}
+        self._slots = {}
+        self._legacy_aggregates = {"energy": [], "power": []}
+        # Aggregate key -> the exact value the registry last wrote there, so a key some other
+        # component has overwritten since can be recognised as no longer ours to restore.
+        self._aggregates_written = {}
+        # Slot-aligned fields the registry has actually written. A key holding only legacy slots
+        # is left alone (materialise), so this is what tells the difference between "untouched
+        # user config" and "we put a discovered charger in there and it has since gone away",
+        # which does have to be rewritten or the vanished charger's entity would stay behind.
+        self._slot_args_written = set()
+        self._populated = False
+        # The last value the registry wrote to num_cars, or None if it never has. Distinct from
+        # _populated, which is only about having held a charger: an external-only claim writes
+        # num_cars with no entries behind it, and releasing it has to be able to write again.
+        self._num_cars_written = None
+        # Cars other components own outright, which the registry has no charger for, by source
+        # name - declared through set_external_num_cars() rather than inferred.
+        self._external_counts = {}
+        # A floor carried over from hand-written apps.yaml num_cars (see preregister_legacy).
+        self._declared_floor = 0
+        # Legacy slots already dropped as duplicates of a discovered charger, so that the
+        # explanation is logged once rather than on every rediscovery.
+        self._deduped_legacy = set()
+
+    def replace_source(self, source, entries):
+        """Atomically replace everything `source` contributes, then re-materialise.
+
+        One call covers add, update and removal, and is idempotent - which is what makes it
+        safe for a component to call on every rediscovery, including with an empty list when
+        its chargers have gone away. Atomic in the real sense: the lock is held across the
+        materialise() too, so a component registering on another thread can neither observe
+        nor interleave with a half-composed set of args.
+        """
+        with self._lock:
+            deduped = {}
+            for entry in entries or []:
+                deduped[entry.key()] = entry
+            if deduped:
+                self._by_source[source] = list(deduped.values())
+            else:
+                self._by_source.pop(source, None)
+            self.materialise()
+
+    def set_external_num_cars(self, source, count):
+        """Declare that `source` needs num_cars held at `count` for cars it owns itself.
+
+        Octopus Intelligent and Kraken wire dispatch sensors for cars that have no charger in
+        this registry (octopus.py:1341, kraken.py:1271), and fetch.py only reads
+        octopus_intelligent_slot for car indices below num_cars - so those cars disappear if
+        num_cars is written as the registered charger count alone.
+
+        Ownership is declared, not inferred. Inferring it from "num_cars has moved since we
+        last wrote it" was blind to an external raise that happened to equal our own write,
+        and since both callers are raise-only they could never take the claim back either, so
+        the floor it produced could never be released. A `count` of 0 or None drops the claim.
+        """
+        with self._lock:
+            try:
+                count = int(count or 0)
+            except (TypeError, ValueError):
+                count = 0
+            if count > 0:
+                self._external_counts[source] = count
+            else:
+                self._external_counts.pop(source, None)
+            self.materialise()
+
+    def entries(self):
+        """Every registered charger, in deterministic slot order, clamped to the kernel ceiling."""
+        with self._lock:
+            out = []
+            for source_entries in self._by_source.values():
+                out.extend(source_entries)
+            out.sort(key=lambda entry: entry.sort_key())
+            out = self._drop_duplicated_legacy(out)
+            if len(out) > PREDBAT_MAX_CARS:
+                self.base.log("Warn: ChargerRegistry: {} chargers registered but PREDBAT_MAX_CARS is {} - ignoring the excess".format(len(out), PREDBAT_MAX_CARS))
+                out = out[:PREDBAT_MAX_CARS]
+            return out
+
+    def _drop_duplicated_legacy(self, entries):
+        """Drop a legacy slot that names the same physical charger as a discovered one.
+
+        The stock apps.yaml car_charging_planned regex matches the third-party ha-myenergi
+        integration's Zappi entities. On a site running that integration alongside Predbat's
+        own myenergi component the regex resolves, so the same physical Zappi arrives twice -
+        once as a legacy slot, once as a registered charger - and its energy is counted for
+        two cars. The component's entry is the one kept: it carries a real identity, so
+        control can address it, where the legacy slot has only its position.
+
+        The two never name the *same* entity in practice, though: ha-myenergi publishes
+        sensor.myenergi_zappi_<serial>_plug_status while our own component registers
+        sensor.predbat_myenergi_zappi_<serial>_plug_status. What they share is the serial, so
+        the match is on the discovered charger's device_id appearing inside the legacy entity id.
+        Three things keep that from firing on a coincidence:
+
+        - Only sources whose device_id *is* a manufacturer serial are eligible for it
+          (SERIAL_IDENTITY_SOURCES); an installer-chosen OCPP charge-point id is not evidence.
+        - Short ids are excluded (MIN_IDENTITY_MATCH_LENGTH), since a two- or three-character one
+          would appear in any entity that happens to contain those characters.
+        - The match is on a word boundary, not a bare substring. Entity ids separate their parts
+          with "_", so requiring a non-alphanumeric on each side is a real boundary - and without
+          it serial 10000001 would swallow a legacy slot naming Zappi 100000010, dropping a car
+          that genuinely is a different charger.
+
+        An exact entity match still counts for every source, for a hand-written slot that names
+        our own entity directly.
+
+        The limit is honest: a legacy slot naming the same charger through an entity that
+        carries no device id (a user-renamed entity, or a helper) cannot be recognised and
+        stays as its own car.
+        """
+        component_planned = set()
+        component_ids = set()
+        for entry in entries:
+            if entry.source == LEGACY_SOURCE:
+                continue
+            if entry.planned:
+                component_planned.add(entry.planned)
+            # Only a manufacturer serial, and only one long enough that finding it inside an
+            # unrelated entity id would not happen by chance, is evidence of identity.
+            if entry.source in SERIAL_IDENTITY_SOURCES and entry.device_id and len(entry.device_id) >= MIN_IDENTITY_MATCH_LENGTH:
+                component_ids.add(entry.device_id)
+        if not component_planned and not component_ids:
+            return entries
+        kept = []
+        for entry in entries:
+            if entry.source == LEGACY_SOURCE and self._names_a_discovered_charger(entry, component_planned, component_ids):
+                if entry.key() not in self._deduped_legacy:
+                    self._deduped_legacy.add(entry.key())
+                    self.base.log("Info: ChargerRegistry: legacy car slot {} names {}, which a discovered charger already supplies - dropping the legacy slot so the car is not counted twice".format(entry.device_id, entry.planned))
+                continue
+            kept.append(entry)
+        return kept
+
+    @staticmethod
+    def _names_a_discovered_charger(entry, component_planned, component_ids):
+        """True when this legacy slot's planned entity is a discovered charger's, by id or name.
+
+        The serial has to sit on a word boundary in the entity id - no alphanumeric immediately
+        either side of it. Entity ids join their parts with "_", so that is exactly the boundary
+        an embedded serial has, while a bare substring test would read serial 10000001 as naming
+        sensor.myenergi_zappi_100000010_plug_status and drop a different charger's car.
+        """
+        if not entry.planned:
+            return False
+        if entry.planned in component_planned:
+            return True
+        if not isinstance(entry.planned, str):
+            return False
+        return any(re.search(r"(?<![0-9a-zA-Z])" + re.escape(device_id) + r"(?![0-9a-zA-Z])", entry.planned) for device_id in component_ids)
+
+    def slot_for(self, source, device_id):
+        """The car index this charger was given, or None if it is not registered.
+
+        Control loops MUST use this rather than assuming their own charger is car 0 or that
+        their Nth charger is car N. Getting it wrong drives a charger from another car's plan.
+        """
+        with self._lock:
+            return self._slots.get((source, str(device_id)))
+
+    def _write_num_cars(self, count):
+        """Write num_cars: the registry's own count, floored by every declared claim on it.
+
+        Both floors are explicit: `_declared_floor` is what hand-written apps.yaml asked for
+        (preregister_legacy) and `_external_counts` is what other components have claimed for
+        cars of their own (set_external_num_cars). Nothing else is treated as a floor, so a
+        count the registry itself wrote is always its own to lower - which is what lets a
+        charger that has gone away reduce the number of cars again.
+        """
+        num_cars = max(count, self._declared_floor, max(self._external_counts.values(), default=0))
+        self._num_cars_written = num_cars
+        self.base.set_arg("num_cars", num_cars)
+
+    def _owns_num_cars(self):
+        """True when the num_cars standing in the args is one the registry may write over.
+
+        Only consulted on a site where no charger has ever been registered, so the registry has
+        composed nothing and cannot simply assume the key is its own. Three values qualify:
+
+        - nothing there at all, so writing one takes nobody's config away;
+        - the single most recent value the registry itself wrote;
+        - the largest claim standing *right now*. Both claimants raise num_cars directly the
+          instant before declaring (octopus.py:1352, kraken.py:1287), so on a site the registry
+          has never written that raise is the only thing behind num_cars - without recognising
+          it, a claim could be honoured but never released.
+
+        Every term is bounded in time: the last write is a single value, replaced on each write,
+        and the live claims empty out the moment they are released. An earlier version kept every
+        count ever claimed, which let a long-released claim of N vouch for an unrelated num_cars
+        of N that somebody else set much later - a released claim must leave no residue behind it.
+
+        Anything else belongs to whoever put it there and is left alone. This is the same
+        ownership doctrine _write_aggregates applies to car_charging_energy/_power, and not the
+        rejected inference of "num_cars has moved, so somebody must have raised it": every value
+        accepted here is one the registry or a currently-standing claim is answerable for.
+
+        The residual limit is honest and unavoidable: if another owner happens to set num_cars to
+        exactly the count a claim is declaring, the two are indistinguishable from here. Writing
+        is harmless then (it is the same number); the release afterwards would lower it.
+
+        The user's own apps.yaml num_cars needs none of this - preregister_legacy reads it into
+        _declared_floor, which every write is floored by.
+        """
+        current = self.base.get_arg("num_cars", None, indirect=False)
+        if current is None or current == self._num_cars_written:
+            return True
+        return bool(self._external_counts) and current == max(self._external_counts.values())
+
+    def _write_aggregates(self, entries):
+        """Write the site-aggregate args, but only the keys the registry actually owns.
+
+        car_charging_energy/_power are not slot aligned, so they are the one place another
+        component can legitimately be the author: alphaess sets car_charging_energy from its own
+        discovery at runtime, and ohme deliberately backs off when somebody else already owns it.
+        Replaying the legacy snapshot on every materialise would clobber both. So a key is
+        written while some registered charger supplies it, plus exactly one more time - to put
+        the legacy value back, or clear the key - when the last contributing charger goes away.
+
+        That last write is guarded on the key still holding the value we put there. Having
+        written a key once is not ownership of it forever: alphaess.py:805 can set
+        car_charging_energy at any point afterwards, and restoring over the top of that would
+        silently unmap its EV charger. A value that is no longer ours ends our claim on it.
+        """
+        for field in AGGREGATE:
+            arg = "car_charging_{}".format(field)
+            discovered = [getattr(entry, field) for entry in entries if getattr(entry, field)]
+            if discovered:
+                values = list(self._legacy_aggregates[field]) + discovered
+                self.base.set_arg(arg, values)
+                self._aggregates_written[field] = list(values)
+            elif field in self._aggregates_written:
+                current = self.base.get_arg(arg, None, indirect=False)
+                if current != self._aggregates_written[field]:
+                    self.base.log("Info: ChargerRegistry: {} has been set by another component since the registry wrote it - leaving it alone".format(arg))
+                    self._aggregates_written.pop(field, None)
+                    continue
+                restore = list(self._legacy_aggregates[field])
+                self.base.set_arg(arg, restore if restore else None)
+                self._aggregates_written.pop(field, None)
+
+    def materialise(self):
+        """Write the flat car_charging_* args from the current registry contents.
+
+        Uses set_arg (not set_arg_auto) to avoid the autodiscovery warning (#4494/#4500).
+        The warning exists because autodiscovery used to discard user config; the registry
+        merges instead, so the warning would fire misleadingly. Legacy config is preserved:
+        a slot-aligned key holding only legacy slots is not written at all, and where a
+        composed list mixes legacy and discovered slots the legacy ones carry their raw
+        apps.yaml values through verbatim.
+
+        Takes the lock, so it is safe to call directly; replace_source() already holds it,
+        which is why the lock is re-entrant.
+        """
+        with self._lock:
+            entries = self.entries()
+            slots = {entry.key(): slot for slot, entry in enumerate(entries)}
+            if slots != self._slots:
+                # Only on a change: this runs on every rediscovery, and the map is what a support
+                # log needs to explain which charger a car number refers to.
+                self.base.log("Info: ChargerRegistry: slots {}".format({"{}/{}".format(source, device_id): slot for (source, device_id), slot in sorted(slots.items(), key=lambda item: item[1])}))
+            self._slots = slots
+            if not entries:
+                if self._populated:
+                    # The registry held chargers before and is now empty - clear the stale args,
+                    # but only the ones the registry itself wrote. A key holding nothing but the
+                    # user's own legacy config was never ours, so clearing it would delete config
+                    # the registry only ever read.
+                    self._write_num_cars(0)
+                    for field in SLOT_ALIGNED:
+                        if field in self._slot_args_written:
+                            self.base.set_arg("car_charging_{}".format(field), None)
+                    self._write_aggregates([])
+                elif (self._num_cars_written is not None or self._external_counts) and self._owns_num_cars():
+                    # No charger has ever been registered here, so num_cars is carrying nothing but
+                    # declared claims - Octopus/Kraken cars that have no charger of their own. That
+                    # still has to be written from here, with no entries behind it, and lowered
+                    # again when the claim is released; gating it on _populated meant such a claim
+                    # could be raised but never taken back, holding a phantom car up for the rest
+                    # of the run. Slot-aligned and aggregate keys are untouched: a claim never
+                    # composed any, so there is nothing there that is the registry's to clear.
+                    #
+                    # A registry that has never written num_cars and holds no claim does nothing at
+                    # all - a site with neither chargers nor claims is left exactly as its
+                    # apps.yaml configured it.
+                    self._write_num_cars(0)
+                return
+
+            self._populated = True
+            self._write_num_cars(len(entries))
+
+            for field in SLOT_ALIGNED:
+                values = [getattr(entry, field) for entry in entries]
+                arg = "car_charging_{}".format(field)
+                if all(entry.source == LEGACY_SOURCE for entry in entries) and field not in self._slot_args_written:
+                    # Nothing here but the user's own apps.yaml slots, and the registry has never
+                    # written this key: it already holds exactly what their config produced, so
+                    # leave it completely alone rather than round-tripping it through here. That
+                    # matters because auto_config() runs first and turns an unmatched list regex
+                    # into a None (userinterface.py:1098), which the all-or-omit rule below would
+                    # otherwise read as a gap and drop the whole key - taking the *valid* sensors
+                    # in the other slots with it.
+                    continue
+                # Only a component slot with no value is a gap the registry would have to invent
+                # something for. A legacy slot's value - including that auto_config None - is the
+                # user's own config, and goes back verbatim, which is precisely what Predbat read
+                # from the key before the registry existed.
+                missing = [entry.key() for entry, value in zip(entries, values) if not value and entry.source != LEGACY_SOURCE]
+                if missing:
+                    # A component-caused gap cannot be expressed: None fails validation and a
+                    # placeholder would be read as a real entity. Omit the list and let
+                    # car_charging_manual_soc (or the plan, for "now") cover the slots that do
+                    # have one.
+                    self.base.log("Warn: ChargerRegistry: not setting {} - no value for {}".format(arg, missing))
+                    self.base.set_arg(arg, None)
+                elif any(values):
+                    self.base.set_arg(arg, values)
+                else:
+                    self.base.set_arg(arg, None)
+                self._slot_args_written.add(field)
+
+            self._write_aggregates(entries)
+
+            # car_charging_rate is a UI config item (input_number), not an arg - get_arg consults
+            # the UI config before args, so set_arg would be ignored here.
+            expose = getattr(self.base, "expose_config", None)
+            if expose is not None:
+                for slot, entry in enumerate(entries):
+                    if entry.max_rate_kw:
+                        expose("car_charging_rate" if slot == 0 else "car_charging_rate_{}".format(slot), entry.max_rate_kw)
+
+
+def is_unconfigured(value):
+    """True when this apps.yaml value is not real config the user chose.
+
+    The stock apps.yaml template ships car_charging_planned and car_charging_energy as `re:`
+    patterns matching third-party Zappi/Wallbox entities, and auto_config() only strips the ones
+    it cannot match on its final pass. So between the two passes an unmatched pattern is still
+    sitting there as its literal "re:" string, and reading it as configuration invents a car for
+    virtually every installation. Same idiom as ohme.py's owns_energy check.
+
+    This answers "is this slot droppable" only. It is deliberately not used to null out values:
+    a legacy slot that survives keeps whatever the user actually wrote, unresolved pattern and
+    all, so materialise() puts back exactly what Predbat read before the registry existed.
+    """
+    return value is None or (isinstance(value, str) and value.startswith("re:"))
+
+
+def preregister_legacy(registry, base):
+    """Seed the registry from hand-written apps.yaml car_charging_* config.
+
+    Position is all the identity legacy config has: an index cannot say whether two entries
+    mean two chargers, two cars sharing a charger, or two profiles watching one sensor - and
+    shared-charger households deliberately do the last of these. So these are recorded as
+    degraded slots that keep their positions and make no identity claims, and autodiscovery
+    appends after them.
+    """
+    # Aggregates are not per-slot, so they are held aside and concatenated ahead of every
+    # discovered charger's sensor rather than round-tripped through entries. Capture them
+    # first so they survive component registration even if num_cars is 0.
+    for field in AGGREGATE:
+        existing = base.get_arg("car_charging_{}".format(field), None, indirect=False)
+        if not isinstance(existing, list):
+            existing = [existing]
+        # An unmatched template regex is not a sensor, and prepending it to every discovered
+        # charger's sensor would put a "re:" string into a list apps.yaml validation requires
+        # to be entity names.
+        registry._legacy_aggregates[field] = [value for value in existing if not is_unconfigured(value)]
+
+    # Determine slot count: explicit num_cars if present; implicit 1 if any car_charging config
+    # is set and num_cars is absent (to match fetch.py:2834's default); else 0.
+    raw_num_cars = base.get_arg("num_cars", None, indirect=False)
+    if raw_num_cars is not None:
+        declared = int(raw_num_cars or 0)
+    else:
+
+        def is_configured(arg):
+            """True when this apps.yaml key holds at least one value the user actually chose."""
+            value = base.get_arg(arg, None, indirect=False)
+            if isinstance(value, list):
+                return any(not is_unconfigured(item) for item in value)
+            return not is_unconfigured(value)
+
+        # num_cars is absent - default to 1 if any car config is present.
+        has_car_config = is_configured("car_charging_planned") or is_configured("car_charging_now") or is_configured("car_charging_soc")
+        declared = 1 if has_car_config else 0
+
+    if declared <= 0:
+        return
+
+    def slot_values(arg):
+        """Read one apps.yaml key into exactly `declared` raw values, matching today's semantics.
+
+        A scalar resolves for every index in resolve_arg(), so it is broadcast rather than
+        padded - padding would silently blank every car after the first. A list is truncated
+        to num_cars, because fetch.py reads no further than that today. Values are kept exactly
+        as written, unresolved "re:" patterns included, because a legacy slot is written back
+        verbatim; nulling them here would rewrite the user's own config.
+        """
+        value = base.get_arg(arg, None, indirect=False)
+        if value is None:
+            return [None] * declared
+        if not isinstance(value, list):
+            return [value] * declared
+        return [value[index] if index < len(value) else None for index in range(declared)]
+
+    planned = slot_values("car_charging_planned")
+    now = slot_values("car_charging_now")
+    soc = slot_values("car_charging_soc")
+
+    def is_slot_configured(index):
+        """True when slot `index` has at least one value behind it the user actually chose."""
+        return not (is_unconfigured(planned[index]) and is_unconfigured(now[index]) and is_unconfigured(soc[index]))
+
+    # A slot with nothing behind it is a count, not a charger: the stock template declares
+    # num_cars: 1 with only unmatched regexes, and turning that into an entry both pushed a real
+    # auto-discovered charger down to slot 1 and left a slot supplying no car_charging_soc - which
+    # makes the omit-on-gap rule drop the SoC list entirely, so Predbat plans a full charge into
+    # a car whose level it cannot see. The declared count is still honoured, as a floor on
+    # num_cars, so nothing that used to be planned for stops being planned for.
+    #
+    # Only the *trailing* empty slots go, though. An interior hole - "nothing matched for car 0,
+    # here is car 1" - cannot be compacted away: per-car settings (battery size, charge limit,
+    # exclusive, manual SoC) are addressed by position, so moving car 1 down to slot 0 hands it
+    # car 0's settings and hands slot 1 to the next charger discovered. The hole keeps its place
+    # and its raw value.
+    last_configured = -1
+    for index in range(declared):
+        if is_slot_configured(index):
+            last_configured = index
+
+    registry._declared_floor = declared
+    entries = [ChargerEntry(LEGACY_SOURCE, index, planned=planned[index], now=now[index], soc=soc[index]) for index in range(last_configured + 1)]
+    registry.replace_source(LEGACY_SOURCE, entries)
+
+
+def slot_entity_suffix(slot):
+    """The entity-id suffix Predbat publishes for a given car slot.
+
+    publish_car_plan() names car 0's entities with no suffix and car N's with "_N"
+    (output.py:80-88), so a control loop reading its own car's plan must build the same.
+    """
+    return "" if not slot else "_{}".format(slot)

--- a/apps/predbat/charger_registry.py
+++ b/apps/predbat/charger_registry.py
@@ -109,6 +109,8 @@ class ChargerRegistry:
         self._lock = threading.RLock()
         self._by_source = {}
         self._slots = {}
+        self.generation = 0
+        self.plan_generation = None
         self._legacy_aggregates = {"energy": [], "power": []}
         # Aggregate key -> the exact value the registry last wrote there, so a key some other
         # component has overwritten since can be recognised as no longer ours to restore.
@@ -269,6 +271,27 @@ class ChargerRegistry:
         with self._lock:
             return self._slots.get((source, str(device_id)))
 
+    def snapshot_generation(self):
+        """Read the allocation version after any in-flight materialisation finishes."""
+        with self._lock:
+            return self.generation
+
+    def confirm_plan(self, generation):
+        """Enable control only after publishing a plan built with the current slot map."""
+        with self._lock:
+            if generation == self.generation:
+                self.plan_generation = generation
+
+    def plan_is_current(self, generation=None):
+        """Whether published car windows belong to the current charger allocation."""
+        with self._lock:
+            return self.plan_generation == self.generation and (generation is None or generation == self.generation)
+
+    def owns_aggregate(self, field):
+        """Whether the live aggregate still equals the last value composed here."""
+        with self._lock:
+            return field in self._aggregates_written and self.base.get_arg("car_charging_" + field, None, indirect=False) == self._aggregates_written[field]
+
     def _write_num_cars(self, count):
         """Write num_cars: the registry's own count, floored by every declared claim on it.
 
@@ -336,7 +359,9 @@ class ChargerRegistry:
             arg = "car_charging_{}".format(field)
             discovered = [getattr(entry, field) for entry in entries if getattr(entry, field)]
             if discovered:
-                values = list(self._legacy_aggregates[field]) + discovered
+                serials = {entry.device_id for entry in entries if getattr(entry, field) and entry.source in SERIAL_IDENTITY_SOURCES and len(entry.device_id) >= MIN_IDENTITY_MATCH_LENGTH}
+                legacy = [value for value in self._legacy_aggregates[field] if not self._names_a_discovered_charger(ChargerEntry(LEGACY_SOURCE, "0", planned=value), set(discovered), serials)]
+                values = list(dict.fromkeys(legacy + discovered))
                 self.base.set_arg(arg, values)
                 self._aggregates_written[field] = list(values)
             elif field in self._aggregates_written:
@@ -366,6 +391,7 @@ class ChargerRegistry:
             entries = self.entries()
             slots = {entry.key(): slot for slot, entry in enumerate(entries)}
             if slots != self._slots:
+                self.generation += 1
                 # Only on a change: this runs on every rediscovery, and the map is what a support
                 # log needs to explain which charger a car number refers to.
                 self.base.log("Info: ChargerRegistry: slots {}".format({"{}/{}".format(source, device_id): slot for (source, device_id), slot in sorted(slots.items(), key=lambda item: item[1])}))

--- a/apps/predbat/component_base.py
+++ b/apps/predbat/component_base.py
@@ -109,6 +109,25 @@ class ComponentBase(ABC):
             self.log(f"Note: apps.yaml sets '{arg}: {raw_value}' but auto-discovery is using '{value}' instead - auto-discovery always wins currently; remove the apps.yaml entry to avoid this message")
         return self.set_arg(arg, value)
 
+    def register_chargers(self, source, entries):
+        """Register every EV charger this component has discovered.
+
+        Replaces everything `source` previously contributed, so it is safe - and expected -
+        to call on every rediscovery, including with an empty list when the chargers are gone.
+        Components must use this rather than assigning car_charging_* directly: direct
+        assignment is what made the last component to run erase every other one's chargers.
+        """
+        return self.base.charger_registry.replace_source(source, entries)
+
+    def charger_slot(self, source, device_id):
+        """The car index this component's charger was allocated, or None if unregistered.
+
+        Control loops MUST use this. Assuming your own charger is car 0, or that your Nth
+        charger is car N, drives a charger from another car's plan once a second source
+        registers.
+        """
+        return self.base.charger_registry.slot_for(source, device_id)
+
     def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
         """
         Retrieve a configuration argument from the base system.

--- a/apps/predbat/component_base.py
+++ b/apps/predbat/component_base.py
@@ -128,6 +128,10 @@ class ComponentBase(ABC):
         """
         return self.base.charger_registry.slot_for(source, device_id)
 
+    def charger_plan_ready(self, generation=None):
+        """Wait for a published plan using the current charger allocation."""
+        return self.base.charger_registry.plan_is_current(generation)
+
     def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
         """
         Retrieve a configuration argument from the base system.

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -2831,6 +2831,9 @@ class Fetch:
         self.previous_status = self.get_state_wrapper(self.prefix + ".status")
         forecast_hours = max(self.get_arg("forecast_hours", 48), 24)
 
+        # Capture before reading car configuration. Discovery may change slots while
+        # planning runs; such a plan must not drive the new allocation.
+        self.car_charger_generation = self.charger_registry.snapshot_generation()
         self.num_cars = self.get_arg("num_cars", 1)
         if self.num_cars > PREDBAT_MAX_CARS:
             self.log("Warn: num_cars {} exceeds the {} cars Predbat supports - clamping to {}".format(self.num_cars, PREDBAT_MAX_CARS, PREDBAT_MAX_CARS))

--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -460,6 +460,7 @@ class GatewayMQTT(ComponentBase):
         now = datetime.datetime.now(self.local_tz)
         current_year = now.year
         new_windows = {}
+        generation = self.base.charger_registry.snapshot_generation()
         for cp_id in sorted(self._configured_ev_chargers):
             slot = self.charger_slot("gateway", cp_id)
             if slot is None:
@@ -487,6 +488,7 @@ class GatewayMQTT(ComponentBase):
                     continue
             new_windows[slot] = windows
         self._ev_windows = new_windows
+        self._ev_windows_generation = generation
 
     def _should_ev_charge_now(self, slot):
         """Return True if the current local time falls inside the given car slot's planned charge window."""
@@ -534,6 +536,8 @@ class GatewayMQTT(ComponentBase):
             if slot is None:
                 continue
             any_slotted = True
+            if not self.charger_plan_ready(getattr(self, "_ev_windows_generation", None)):
+                continue
             if slot not in self._ev_windows:
                 continue
             should_charge = self._should_ev_charge_now(slot)

--- a/apps/predbat/gateway.py
+++ b/apps/predbat/gateway.py
@@ -17,6 +17,7 @@ import uuid
 import traceback
 from utils import calc_percent_limit
 from const import EXPORT_LIMIT_FREEZE, EXPORT_LIMIT_IDLE
+from charger_registry import ChargerEntry, slot_entity_suffix
 import pytz as _pytz
 
 from component_base import ComponentBase
@@ -275,8 +276,10 @@ class GatewayMQTT(ComponentBase):
         self._configured_ev_chargers = frozenset()  # EV charge point ids registered at the last auto-config
         self._last_published_plan = None
         self._pending_plan = None
-        self._ev_windows: list = []  # parsed (start_dt, end_dt) charge windows from HA plan attribute
-        self._ev_charging_active: bool = False  # last commanded state; avoids duplicate start/stop sends
+        self._ev_windows: dict = {}  # car slot -> parsed (start_dt, end_dt) charge windows from that slot's HA plan attribute
+        self._ev_charging_active: dict = {}  # charge_point_id -> last commanded state; avoids duplicate start/stop sends
+        self._ev_no_slot_warned = False  # True once the "control on, no charger has a slot" warning has fired; cleared when the condition clears
+        self._ev_no_id_warned = False  # True once the "charge point reported with no id" warning has fired
         self._ev_max_current: dict = {}  # charge_point_id → last known max_current_a from telemetry
         self._suffix_to_serial = {}  # maps entity suffix (last 6 chars of serial) -> full serial string
         self._command_id = 0  # incrementing counter included in every published command
@@ -427,12 +430,25 @@ class GatewayMQTT(ComponentBase):
             self._pending_plan = (plan_entries, timezone)
 
     def _refresh_ev_windows(self):
-        """Re-read the PredBat car-charging-slot planned windows from HA and cache them.
+        """Re-read Predbat's planned car-charging-slot windows for every registered charge point.
 
         Called once per run() cycle so the minute-level check always has up-to-date window
-        boundaries without polling HA every second.  The ``planned`` attribute of
-        ``binary_sensor.<prefix>_car_charging_slot`` is a list of ``{start, end, ...}`` dicts
-        with datetime strings in ``"%m-%d %H:%M:%S"`` format (produced by output.py).
+        boundaries without polling HA every second.  Each charge point reads its own car
+        slot's ``planned`` attribute — ``binary_sensor.<prefix>_car_charging_slot`` for slot
+        0, ``..._slot_N`` for car N (produced by output.py) — keyed by the slot the charger
+        registry allocated it via ``charger_slot()``.  Reading the unindexed slot-0 entity
+        for every charge point would drive every charger from car 0's plan regardless of
+        which car it was actually registered as.  A charge point with no registry slot yet
+        (discovered mid-cycle, before automatic_config has re-run) is skipped.
+
+        A slot whose ``planned`` attribute has never been published is left out of
+        ``_ev_windows`` entirely rather than recorded as an empty window list.  The two are
+        not the same thing: an empty list is a real plan that says "do not charge now", while
+        a missing attribute only says the plan for that car has not been written yet - which
+        is exactly what a charger sees in the moments after another source registers and
+        shifts it to a higher slot.  Treating the second as the first sent a
+        RemoteStopTransaction to a car that was mid-charge.  gecloud and myenergi draw the
+        same distinction (gecloud.py evc_control_charge, myenergi.py control_charge).
 
         Datetimes are localized using ``self.local_tz`` so comparisons respect the component
         timezone and DST transitions.  Year boundaries are handled: if a parsed start is more
@@ -441,68 +457,118 @@ class GatewayMQTT(ComponentBase):
         localization the end year is incremented to handle windows that straddle midnight
         on New Year's Eve.
         """
-        planned = self.get_state_wrapper(f"binary_sensor.{self.prefix}_car_charging_slot", attribute="planned") or []
         now = datetime.datetime.now(self.local_tz)
         current_year = now.year
-        windows = []
-        for w in planned:
-            try:
-                start_naive = datetime.datetime.strptime(w["start"], "%m-%d %H:%M:%S").replace(year=current_year)
-                end_naive = datetime.datetime.strptime(w["end"], "%m-%d %H:%M:%S").replace(year=current_year)
-                start_dt = self.local_tz.localize(start_naive)
-                end_dt = self.local_tz.localize(end_naive)
-                # If start is far in the past the plan crossed a year boundary (Dec 31 → Jan 1)
-                if start_dt < now - datetime.timedelta(hours=23):
-                    start_dt = start_dt.replace(year=start_dt.year + 1)
-                    end_dt = end_dt.replace(year=end_dt.year + 1)
-                elif end_dt < start_dt:
-                    # end crossed into the new year but start did not (e.g. 23:30 → 00:30)
-                    end_dt = end_dt.replace(year=end_dt.year + 1)
-                windows.append((start_dt, end_dt))
-            except (KeyError, ValueError):
+        new_windows = {}
+        for cp_id in sorted(self._configured_ev_chargers):
+            slot = self.charger_slot("gateway", cp_id)
+            if slot is None:
                 continue
-        self._ev_windows = windows
+            planned = self.get_state_wrapper(f"binary_sensor.{self.prefix}_car_charging_slot{slot_entity_suffix(slot)}", attribute="planned")
+            if planned is None:
+                # Never published for this slot - leave the key absent so control skips it.
+                continue
+            windows = []
+            for w in planned:
+                try:
+                    start_naive = datetime.datetime.strptime(w["start"], "%m-%d %H:%M:%S").replace(year=current_year)
+                    end_naive = datetime.datetime.strptime(w["end"], "%m-%d %H:%M:%S").replace(year=current_year)
+                    start_dt = self.local_tz.localize(start_naive)
+                    end_dt = self.local_tz.localize(end_naive)
+                    # If start is far in the past the plan crossed a year boundary (Dec 31 → Jan 1)
+                    if start_dt < now - datetime.timedelta(hours=23):
+                        start_dt = start_dt.replace(year=start_dt.year + 1)
+                        end_dt = end_dt.replace(year=end_dt.year + 1)
+                    elif end_dt < start_dt:
+                        # end crossed into the new year but start did not (e.g. 23:30 → 00:30)
+                        end_dt = end_dt.replace(year=end_dt.year + 1)
+                    windows.append((start_dt, end_dt))
+                except (KeyError, ValueError):
+                    continue
+            new_windows[slot] = windows
+        self._ev_windows = new_windows
 
-    def _should_ev_charge_now(self):
-        """Return True if the current local time falls inside any planned charge window."""
+    def _should_ev_charge_now(self, slot):
+        """Return True if the current local time falls inside the given car slot's planned charge window."""
         now = datetime.datetime.now(self.local_tz)
-        for start_dt, end_dt in self._ev_windows:
+        for start_dt, end_dt in self._ev_windows.get(slot, []):
             if start_dt <= now < end_dt:
                 return True
         return False
 
     async def _apply_ev_charging_state(self):
-        """Start or stop EVC charging when the window state transitions.
+        """Start or stop each registered charge point when its own slot's window state transitions.
 
-        Called every run() cycle (once per minute).  On a start transition, sets the
-        charging profile to the configured max current then issues RemoteStartTransaction
-        so the charger begins a session at that rate.  On a stop transition, issues
-        RemoteStopTransaction; the firmware falls back to its internal transaction ID when
-        none is supplied.  No command is sent when the desired state already matches
-        ``self._ev_charging_active``.
+        Called every run() cycle (once per minute), once per configured charge point.  Each
+        charge point is judged against the plan for its own car slot — the slot the charger
+        registry allocated it, via ``charger_slot()`` — never car 0's or another charger's,
+        so a charge point registered as (say) car 2 is only ever started and stopped from
+        car 2's plan.  On a start transition, sets the charging profile to the configured
+        max current then issues RemoteStartTransaction so the charger begins a session at
+        that rate.  On a stop transition, issues RemoteStopTransaction; the firmware falls
+        back to its internal transaction ID when none is supplied.  Every command carries
+        the target ``charge_point_id`` so multi-charger firmware routes it to the right
+        physical charger — the same convention ``publish_command()`` uses for
+        inverter_reset's ``serial`` field to route a shared-topic command to one device.  No
+        command is sent for a charge point whose desired state already matches its last
+        commanded state in ``self._ev_charging_active``, and a charge point with no
+        registry slot yet is skipped rather than commanded.  So is one whose slot has no
+        published plan at all: ``_refresh_ev_windows()`` leaves such a slot out of
+        ``_ev_windows`` rather than recording it as empty, and reading an absent key as an
+        empty plan would stop a car that is charging simply because its slot moved and the
+        new slot entity has not been published yet.  A key that is present but empty is a
+        real empty plan, and does stop the charger.
+
+        Control requires ``gateway_evc_automatic`` (documented in ``initialize()``) because
+        it is auto-config that gives each charge point its registry slot — that gating is
+        intentional and not changed here. But turning control on without automatic is a
+        silent, permanent no-op: every charge point is skipped for lack of a slot and
+        nothing is ever logged, which looks identical to "nothing to do" rather than
+        "misconfigured". If none of the currently-configured charge points has a slot, one
+        warning is logged (and cleared once any charge point does get a slot, so a later
+        recurrence — e.g. automatic gets disabled again — is reported afresh).
         """
-        if not self._configured_ev_chargers:
-            return
-        should_charge = self._should_ev_charge_now()
-        if should_charge == self._ev_charging_active:
-            return
-        # min() gives a deterministic choice when multiple chargers are present
-        cp_id = min(self._configured_ev_chargers)
-        if should_charge:
-            current_a = self._ev_max_current.get(cp_id, 32)
-            self.log(f"Info: GatewayMQTT: EVC start charging — current_a={current_a} for '{cp_id}'")
-            await self._send_ev_command({"action": "SetChargingProfile", "current_a": int(current_a)})
-            await self._send_ev_command({"action": "RemoteStartTransaction", "id_tag": "predbat"})
+        any_slotted = False
+        for cp_id in sorted(self._configured_ev_chargers):
+            slot = self.charger_slot("gateway", cp_id)
+            if slot is None:
+                continue
+            any_slotted = True
+            if slot not in self._ev_windows:
+                continue
+            should_charge = self._should_ev_charge_now(slot)
+            if should_charge == self._ev_charging_active.get(cp_id, False):
+                continue
+            if should_charge:
+                current_a = self._ev_max_current.get(cp_id, 32)
+                self.log(f"Info: GatewayMQTT: EVC start charging — current_a={current_a} for '{cp_id}' (car {slot})")
+                await self._send_ev_command({"action": "SetChargingProfile", "current_a": int(current_a), "charge_point_id": cp_id})
+                await self._send_ev_command({"action": "RemoteStartTransaction", "id_tag": "predbat", "charge_point_id": cp_id})
+            else:
+                self.log(f"Info: GatewayMQTT: EVC stop charging for '{cp_id}' (car {slot})")
+                await self._send_ev_command({"action": "RemoteStopTransaction", "charge_point_id": cp_id})
+            self._ev_charging_active[cp_id] = should_charge
+
+        if self._configured_ev_chargers and not any_slotted:
+            if not self._ev_no_slot_warned:
+                self._ev_no_slot_warned = True
+                self.log("Warn: GatewayMQTT: EVC control is enabled but no charge point has a registered car slot - is gateway_evc_automatic off?")
         else:
-            self.log(f"Info: GatewayMQTT: EVC stop charging for '{cp_id}'")
-            await self._send_ev_command({"action": "RemoteStopTransaction"})
-        self._ev_charging_active = should_charge
+            self._ev_no_slot_warned = False
 
     async def _send_ev_command(self, command):
-        """Publish a single EV command dict as JSON to the EV command topic.
+        """Publish a single EV command dict as JSON to the shared EV command topic.
+
+        All EV commands share one topic (``topic_ev_command``) regardless of how many
+        charge points are configured, so ``command`` must carry a ``charge_point_id`` key
+        whenever more than one charge point may be present — the same convention
+        ``publish_command()`` uses for inverter_reset's ``serial`` field, which routes a
+        shared-topic command to one physical device by embedding its identity in the JSON
+        payload rather than the topic.  ``_apply_ev_charging_state()`` always includes it.
 
         Args:
-            command: Dict with ``action`` key and any command-specific fields.
+            command: Dict with ``action`` key, any command-specific fields, and (for
+                multi-charger installs) ``charge_point_id``.
         """
         await self._publish_raw(self.topic_ev_command, json.dumps(command).encode())
 
@@ -1319,9 +1385,9 @@ class GatewayMQTT(ComponentBase):
             self.set_state_wrapper(hybrid_entity, "off" if ac_coupled else "on")
             self.log(f"Info: GatewayMQTT: model '{model_name}' -> ac_coupled={ac_coupled}, set {hybrid_entity} {'off' if ac_coupled else 'on'}")
 
-        # Register the gateway's OCPP EV charger as a PredBat car (opt-in). Done after the
-        # inverter config so a failure here never blocks battery control.
-        self._register_ev_car(status)
+        # Register the gateway's OCPP EV charger(s) as PredBat car(s) (opt-in). Done after
+        # the inverter config so a failure here never blocks battery control.
+        self._register_ev_chargers(status)
 
         self._auto_configured = True
         self._configured_inverter_serials = frozenset(inv.serial for inv in all_inverters)
@@ -1329,14 +1395,18 @@ class GatewayMQTT(ComponentBase):
         self.log(f"Info: GatewayMQTT: auto-config complete: {num_inverters} inverter(s) registered")
         return num_inverters
 
-    def _register_ev_car(self, status):
-        """Register a connected OCPP EV charger as a PredBat car.
+    def _register_ev_chargers(self, status):
+        """Register every OCPP EV charger reported in telemetry as its own PredBat car.
 
-        Maps the gateway's EV telemetry entities onto the ``car_charging_*`` args so the
-        optimizer plans for the charger.  Gated behind ``gateway_evc_automatic``; does
-        nothing when no EV charger is present in telemetry.  Battery size, target SoC and
-        ready-time have no source from the charger and are left to the existing
-        ``car_charging_battery_size`` / ``car_charging_limit`` settings.
+        Maps each charger's gateway telemetry entities onto its own car_charging_* slot
+        via the charger registry, so the optimizer plans for every charge point present —
+        not just the first. Gated behind ``gateway_evc_automatic``; does nothing when no EV
+        charger is present in telemetry. Every charge point gets its own slot regardless of
+        connection state: whether a charger is a live session or merely offline right now,
+        it is registered so it still appears once it reconnects. Battery size, target SoC
+        and ready-time have no source from the charger and are left to the existing
+        ``car_charging_battery_size`` / ``car_charging_limit`` settings (shared across every
+        car, since the charger cannot report per-car values).
 
         Args:
             status: A decoded GatewayStatus protobuf message.
@@ -1344,38 +1414,39 @@ class GatewayMQTT(ComponentBase):
         if not self.gateway_evc_automatic:
             return
 
-        # Prefer a connected charger. Gateway firmware now reports known-but-offline
-        # chargers with connected=false (previously it omitted them entirely), so
-        # slot 0 can be a stale entry — registering that as the car would wire
-        # car_charging_* to a charger that is not there. Fall back to the first
-        # entry so a charger that is merely offline right now still registers.
         chargers = list(status.ev_chargers)
         if not chargers:
             return
 
-        # For now we overwrite the first charger only; multi-charger support needs work
-        ev = next((c for c in chargers if c.connected), chargers[0])
-        pfx = f"{self.prefix}_gateway_{self._ev_suffix(ev, multi=False)}"
-        self.set_arg("num_cars", 1)
-        # Entity-reference args (resolved by get_arg indirect lookup at fetch time).
-        # Battery size and target limit are deliberately left to the existing
-        # car_charging_battery_size / car_charging_limit settings — the charger cannot
-        # report them, so overwriting them here would only swap one default for another.
-        # "Planned"/"now" both derive from the connected binary sensor; many OCPP cars do
-        # not report SoC, so the manual-SoC path supplies a starting value.
-        self.set_arg("car_charging_planned", [f"binary_sensor.{pfx}_connected"])
-        if not self.gateway_evc_control:
-            self.set_arg("car_charging_now", [f"binary_sensor.{pfx}_session_active"])
-        self.set_arg("car_charging_soc", [f"sensor.{pfx}_soc"])
-        self.set_arg("car_charging_energy", f"sensor.{pfx}_session_energy")
-        # Live charge power - display only, for the web power flow diagram
-        self.set_arg("car_charging_power", f"sensor.{pfx}_power")
-        # car_charging_rate is a UI config item (input_number), so update it via
-        # expose_config. get_arg() consults HA/UI config before args, so set_arg() would
-        # be ignored (and indirect entity resolution would never run).
-        self.base.expose_config("car_charging_rate", self._ev_charge_rate_kw(ev))
+        entries = []
+        for ev in sorted(chargers, key=lambda item: item.charge_point_id or ""):
+            if not ev.charge_point_id:
+                # Every other path keys off charge_point_id: _configured_ev_chargers excludes a
+                # charger without one, and _send_ev_command routes on it. Registering such a
+                # charger under a fallback name would consume a car slot for something control
+                # can never reach - a phantom car Predbat plans for and nothing ever charges.
+                if not self._ev_no_id_warned:
+                    self._ev_no_id_warned = True
+                    self.log("Warn: GatewayMQTT: telemetry reported an EV charger with no charge_point_id - skipping it, it cannot be addressed or controlled")
+                continue
+            pfx = "{}_gateway_{}".format(self.prefix, self._ev_suffix(ev, multi=False))
+            entries.append(
+                ChargerEntry(
+                    "gateway",
+                    ev.charge_point_id,
+                    planned="binary_sensor.{}_connected".format(pfx),
+                    # When Predbat drives the charger itself, "now" is Predbat's own decision
+                    # rather than an observation, so it is left to the plan.
+                    now=None if self.gateway_evc_control else "binary_sensor.{}_session_active".format(pfx),
+                    soc="sensor.{}_soc".format(pfx),
+                    energy="sensor.{}_session_energy".format(pfx),
+                    power="sensor.{}_power".format(pfx),
+                    max_rate_kw=self._ev_charge_rate_kw(ev),
+                )
+            )
 
-        self.log(f"Info: GatewayMQTT: registered EV charger '{ev.charge_point_id or 'unknown'}' as car 1")
+        self.register_chargers("gateway", entries)
+        self.log("Info: GatewayMQTT: registered {} EV charger(s): {}".format(len(entries), ", ".join(entry.device_id for entry in entries)))
 
     async def _publish_predbat_data(self):
         """Publish price/timeline data to the gateway device for display.

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -23,6 +23,7 @@ import json
 import random
 from component_base import ComponentBase
 from mock_base import MockBase as SharedMockBase
+from charger_registry import ChargerEntry
 
 """
 GE Cloud data download
@@ -1435,11 +1436,12 @@ class GECloudDirect(ComponentBase):
         return in_car_plan_window(self.evc_control_windows.get(car_n, []), now)
 
     def controlled_evc_devices(self):
-        """The chargers to drive, in serial order, so charger N is auto-config's Nth car.
+        """The chargers to drive, in serial order.
 
-        async_automatic_config_evc() wires car_charging_energy and car_charging_planned as
-        per-car lists in this same order, so the two cannot disagree about which charger
-        is which car.
+        Serial order only makes the iteration reproducible - it no longer says which car a
+        charger is. Slots are allocated by the shared charger registry across every component
+        that discovers chargers, so evc_control_charge() asks charger_slot() for each device
+        rather than reading anything into this position.
         """
         known = [uuid for uuid in self.evc_device_list if self.evc_device.get(uuid, {}).get("serial_number", None)]
         return sorted(known, key=lambda uuid: str(self.evc_device[uuid]["serial_number"]))
@@ -1492,12 +1494,19 @@ class GECloudDirect(ComponentBase):
         """
         if not self.refresh_evc_car_windows(now):
             return
-        # Only as far as there are cars to follow. async_automatic_config_evc() raises
-        # num_cars to the charger count, but that reaches the base object a cycle later,
-        # so there is a window where a charger has no plan of its own - and a charger with
-        # no plan would read as "not planned" and be stopped while its car was charging.
-        for car_n, uuid in enumerate(self.controlled_evc_devices()[: self.num_cars]):
+        # The slot comes from the registry rather than this component's own ordering: with
+        # another source registered, our Nth charger is not car N. The registry is immediate
+        # while self.num_cars is a cached copy refreshed once a cycle, so a slot allocated
+        # since the last fetch has no entry in evc_control_windows yet - and an absent key
+        # would read as an empty plan and stop a charging car. Skip it until the plan for
+        # that car has actually been published; a key present but empty is a real empty plan.
+        for uuid in self.controlled_evc_devices():
             device = self.evc_device[uuid]
+            car_n = self.charger_slot("gecloud", device.get("serial_number", None))
+            if car_n is None:
+                continue
+            if car_n not in self.evc_control_windows:
+                continue
             if not self.evc_car_connected(device.get("status", None)):
                 continue
             wanted = EVC_COMMAND_START if self.evc_should_charge_now(car_n, now) else EVC_COMMAND_STOP
@@ -1514,45 +1523,41 @@ class GECloudDirect(ComponentBase):
         battery inverter is found: a GivEnergy charger paired with somebody else's battery
         is a normal setup, and folding this in there would leave it unconfigured.
 
-        Chargers are taken in serial order so charger N is always the same car as entry N
-        of both lists, and so the mapping does not shuffle when the API returns the
-        devices in a different order. car_charging_energy lets car_charging_hold subtract
-        the charging precisely instead of falling back to the car_charging_threshold
-        heuristic; car_charging_planned tells Predbat when there is actually a car to plan
-        for; car_charging_power is display-only and drives the web power flow diagram. Both go through set_arg_auto so an apps.yaml entry that auto-discovery is
-        about to override is logged rather than silently discarded.
+        Each charger is registered with the shared charger registry as one ChargerEntry keyed
+        by its serial, and the registry composes those with any other component's chargers into
+        the flat car_charging_* args and hands back the slot each one was given - which is what
+        evc_control_charge() drives from, rather than assuming a charger's position among its
+        own siblings is its car index. Serial order here only keeps the iteration reproducible
+        when the API returns the devices in a different order. car_charging_energy lets
+        car_charging_hold subtract the charging precisely instead of falling back to the
+        car_charging_threshold heuristic; car_charging_planned tells Predbat when there is
+        actually a car to plan for; car_charging_power is display-only and drives the web power
+        flow diagram.
         """
-        energy_entities = []
-        power_entities = []
-        connected_entities = []
+        entries = []
         for uuid in sorted(self.evc_device_list, key=lambda item: str(self.evc_device.get(item, {}).get("serial_number", "") or "")):
             serial = self.evc_device.get(uuid, {}).get("serial_number", None)
             if not serial:
                 # The serial is read from the device endpoint, so a charger that has not
-                # answered yet has no entity name to point at - skip it rather than wire
-                # up a name with a hole in it.
+                # answered yet has no entity name to point at - skip it rather than wire up
+                # a name with a hole in it.
                 self.log("GECloud: Warn: EV charger {} has no serial number yet, skipping it in automatic configuration".format(uuid))
                 continue
             entity_name = "{}_gecloud_{}".format(self.prefix, serial).lower()
-            energy_entities.append("sensor." + entity_name + "_evc_energy_active_import_register")
-            power_entities.append("sensor." + entity_name + "_evc_power_active_import")
-            connected_entities.append("binary_sensor." + entity_name + "_evc_car_connected")
+            entries.append(
+                ChargerEntry(
+                    "gecloud",
+                    serial,
+                    planned="binary_sensor." + entity_name + "_evc_car_connected",
+                    energy="sensor." + entity_name + "_evc_energy_active_import_register",
+                    power="sensor." + entity_name + "_evc_power_active_import",
+                )
+            )
 
-        if not energy_entities:
-            return
-
-        # Only ever raised, never lowered, as ohme and octopus do with the same setting -
-        # another component may already have registered cars of its own that are not this
-        # charger, and shrinking the count would drop them off the plan.
-        if self.get_arg("num_cars", 0) < len(energy_entities):
-            self.set_arg("num_cars", len(energy_entities))
-
-        self.log("GECloud: Setting car_charging_energy to {}".format(energy_entities))
-        self.set_arg_auto("car_charging_energy", energy_entities)
-        self.log("GECloud: Setting car_charging_planned to {}".format(connected_entities))
-        self.set_arg_auto("car_charging_planned", connected_entities)
-        self.log("GECloud: Setting car_charging_power to {}".format(power_entities))
-        self.set_arg_auto("car_charging_power", power_entities)
+        # num_cars is now derived by the registry, which composes across components. The old
+        # raise-only logic took a max of each component's local count, so one GivEnergy
+        # charger plus one Ohme charger yielded num_cars=1 with both claiming slot 0.
+        self.register_chargers("gecloud", entries)
 
     async def run(self, seconds, first):
         """

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -1492,6 +1492,9 @@ class GECloudDirect(ComponentBase):
         planned window, stopped outside one. A charger with no car plugged in is left
         alone - commanding it would achieve nothing and every command costs a retry loop.
         """
+        generation = self.base.charger_registry.snapshot_generation()
+        if not self.charger_plan_ready(generation):
+            return
         if not self.refresh_evc_car_windows(now):
             return
         # The slot comes from the registry rather than this component's own ordering: with
@@ -1503,6 +1506,8 @@ class GECloudDirect(ComponentBase):
         for uuid in self.controlled_evc_devices():
             device = self.evc_device[uuid]
             car_n = self.charger_slot("gecloud", device.get("serial_number", None))
+            if not self.charger_plan_ready(generation):
+                return
             if car_n is None:
                 continue
             if car_n not in self.evc_control_windows:

--- a/apps/predbat/kraken.py
+++ b/apps/predbat/kraken.py
@@ -278,6 +278,11 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
         # case of an account with no connected EV/charger. Cached to storage so it survives restart.
         self.intelligent_devices = {}
         self.dispatch_fetched_at = None
+        # The octopus_intelligent_slot list last wired for those devices, so run() can tell a cycle
+        # that has a claim standing from one that never wired anything (and so has nothing to
+        # release). Holding the list rather than a bare flag also means the release can check the
+        # arg still holds our value before clearing it - see _release_dispatch_wiring.
+        self.dispatch_slot_list = []
 
         # Export account/MPAN from SaaS config (matched by address at onboarding time).
         # Tariff is always discovered dynamically via GraphQL so changes are detected.
@@ -1248,6 +1253,10 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
         provider-scheduled windows as cheap car-charging slots, exactly like Octopus Intelligent Go.
         """
         if not self.intelligent_devices:
+            # Nothing to publish. run() only calls this method while the device map is non-empty,
+            # so in production the release below is driven from there instead; it is repeated here
+            # so a direct call cannot leave a stale claim standing either.
+            self._release_dispatch_wiring()
             return
         now = datetime.now(timezone.utc)
         slot_list = []
@@ -1273,8 +1282,42 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
         # list, and fetch.py only reads it for car indices within num_cars — so, like octopus, bump
         # num_cars up to the device count or the sensors would be connected but never consumed.
         self.set_arg("octopus_intelligent_slot", slot_list)
+        self.dispatch_slot_list = list(slot_list)
         if self.get_arg("num_cars", 0) < len(slot_list):
             self.set_arg("num_cars", len(slot_list))
+        # That raise only lasts until the charger registry next materialises, since it writes
+        # num_cars from the chargers it holds and a SmartFlex EV has none. Claim the count with
+        # the registry so it survives as an explicit floor, and is released when the devices go.
+        registry = getattr(self.base, "charger_registry", None)
+        if registry is not None:
+            registry.set_external_num_cars("kraken", len(slot_list))
+
+    def _release_dispatch_wiring(self):
+        """Undo the car-slot wiring and num_cars claim made for SmartFlex devices that have gone.
+
+        Unenrolled, or the account simply stopped returning them. Left standing, the car slots keep
+        watching a dispatch sensor for a device that no longer exists, and the num_cars floor
+        claimed with the charger registry holds that phantom car up for the rest of the run - the
+        registry cannot lower it on its own, because a declared claim is deliberately only ever
+        released by the component that made it (charger_registry.set_external_num_cars).
+
+        A no-op when nothing was wired, so the idle no-EV account - the common case - does not
+        re-run this every cycle. Clearing octopus_intelligent_slot is further guarded on the arg
+        still holding the list we put there: the Octopus component wires the same key for its own
+        Intelligent devices, and blanking its wiring on our way out would drop its IOG windows.
+        """
+        if not self.dispatch_slot_list:
+            return
+        current = self.get_arg("octopus_intelligent_slot", None, indirect=False)
+        if current == self.dispatch_slot_list:
+            self.set_arg("octopus_intelligent_slot", None)
+            self.log("Kraken: SmartFlex devices have gone, cleared the car slot wiring and released the num_cars claim")
+        else:
+            self.log("Kraken: SmartFlex devices have gone, releasing the num_cars claim - octopus_intelligent_slot has been set by something else, so leaving it alone")
+        self.dispatch_slot_list = []
+        registry = getattr(self.base, "charger_registry", None)
+        if registry is not None:
+            registry.set_external_num_cars("kraken", 0)
 
     async def run(self, seconds, first):
         """Component run method — called by ComponentBase.start() every 60s.
@@ -1357,6 +1400,12 @@ class KrakenAPI(ComponentBase, _AUTH_BASE):
             had_success = True
         if self.intelligent_devices and (first or dispatch_due):
             self._publish_dispatch_sensors()
+        elif not self.intelligent_devices and self.dispatch_slot_list:
+            # The devices have gone since the cycle that wired them. The release has to be driven
+            # from here: _publish_dispatch_sensors is only reached while the device map is
+            # non-empty, so a car being unenrolled would otherwise never reach the registry at all
+            # and the num_cars floor claimed for it would stand for the rest of the run.
+            self._release_dispatch_wiring()
 
         # Wire import into fetch.py once tariff is discovered (retries until successful)
         if not self.wired and self.current_tariff:

--- a/apps/predbat/mock_base.py
+++ b/apps/predbat/mock_base.py
@@ -25,6 +25,8 @@ standalone run.
 from datetime import datetime
 import json
 
+from charger_registry import ChargerRegistry
+
 
 class MockHAInterface:
     """Minimal stand-in for the HA interface, used by the standalone CLI harnesses.
@@ -62,6 +64,7 @@ class MockBase:
         self.had_errors = False
         self.components = None
         self.num_cars = 0
+        self.charger_registry = ChargerRegistry(self)
         self.currency_symbols = "£p"
         self.arg_errors = {}
         self.args = {key: value for key, value in kwargs.items() if value is not None}

--- a/apps/predbat/myenergi.py
+++ b/apps/predbat/myenergi.py
@@ -33,6 +33,7 @@ from typing import Optional
 import aiohttp
 
 from component_base import ComponentBase
+from charger_registry import ChargerEntry, slot_entity_suffix
 from mock_base import MockBase
 from oauth_mixin import OAuthMixin
 from predbat_metrics import record_api_call
@@ -816,14 +817,16 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
     def automatic_config(self):
         """Wire the device sensors into Predbat's load and car planning inputs.
 
-        Zappi charging energy is subtracted from house load as car charging, so it
-        goes to car_charging_energy - as a list, because minute_data_import_export
-        accepts one and sums the entities. The matching plug status sensors go to
-        car_charging_planned, which is indexed per car, so entry N is the Nth Zappi;
-        without it Predbat falls back to the car_charging_threshold heuristic, because
-        the regex the apps.yaml templates ship targets the third-party ha-myenergi
-        integration's entity names rather than the ones this component publishes. Eddi
-        diverted energy feeds iboost_energy_today.
+        Each Zappi is registered with the shared charger registry as one ChargerEntry, keyed
+        by its serial. The registry composes those entries with any other component's
+        chargers into the flat car_charging_* args - energy and power as concatenated
+        aggregates, planned as a slot-aligned list - and hands back the slot each Zappi was
+        given, which control_charge() and controlled_zappis() use rather than assuming a
+        Zappi's position among its own siblings is its car index. Without a planned entity
+        wired, Predbat falls back to the car_charging_threshold heuristic, because the regex
+        the apps.yaml templates ship targets the third-party ha-myenergi integration's entity
+        names rather than the ones this component publishes. Eddi diverted energy feeds
+        iboost_energy_today, unaffected by the registry - an Eddi is not a car charger.
 
         These sensors are session-scoped and reset to zero when a session ends. That is
         handled: get_from_incrementing() clamps negative deltas to zero for the
@@ -839,26 +842,26 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
         The Zappi live power sensors go to car_charging_power, which is display-only: it feeds
         the web power flow diagram and the predbat.car_charging_power sensor, never the plan.
         """
-        zappi_energy_entities = []
-        zappi_power_entities = []
-        zappi_plug_entities = []
+        zappi_entries = []
         eddi_entity = None
         for device in sorted(self.devices.values(), key=lambda item: item.serial):
             prefix = self.entity_prefix(device)
             if device.kind == DEVICE_KIND_ZAPPI:
-                zappi_energy_entities.append("sensor.{}_session_energy".format(prefix))
-                zappi_power_entities.append("sensor.{}_power".format(prefix))
-                zappi_plug_entities.append("sensor.{}_plug_status".format(prefix))
+                zappi_entries.append(
+                    ChargerEntry(
+                        "myenergi",
+                        device.serial,
+                        planned="sensor.{}_plug_status".format(prefix),
+                        energy="sensor.{}_session_energy".format(prefix),
+                        power="sensor.{}_power".format(prefix),
+                    )
+                )
             elif device.kind == DEVICE_KIND_EDDI and eddi_entity is None:
                 eddi_entity = "sensor.{}_session_energy".format(prefix)
 
-        if zappi_energy_entities:
-            self.log("Info: myenergi: setting car_charging_energy to {}".format(zappi_energy_entities))
-            self.set_arg_auto("car_charging_energy", zappi_energy_entities)
-            self.log("Info: myenergi: setting car_charging_planned to {}".format(zappi_plug_entities))
-            self.set_arg_auto("car_charging_planned", zappi_plug_entities)
-            self.log("Info: myenergi: setting car_charging_power to {}".format(zappi_power_entities))
-            self.set_arg_auto("car_charging_power", zappi_power_entities)
+        if zappi_entries:
+            self.log("Info: myenergi: registering {} Zappi charger(s)".format(len(zappi_entries)))
+        self.register_chargers("myenergi", zappi_entries)
         if eddi_entity:
             self.log("Info: myenergi: setting iboost_energy_today to {}".format(eddi_entity))
             self.set_arg_auto("iboost_energy_today", eddi_entity)
@@ -876,8 +879,7 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
         windows = {}
         found = False
         for car_n in range(self.num_cars):
-            postfix = "" if car_n == 0 else "_{}".format(car_n)
-            planned = self.get_state_wrapper("binary_sensor.{}_car_charging_slot{}".format(self.prefix, postfix), attribute="planned")
+            planned = self.get_state_wrapper("binary_sensor.{}_car_charging_slot{}".format(self.prefix, slot_entity_suffix(car_n)), attribute="planned")
             if planned is None:
                 continue
             found = True
@@ -980,7 +982,7 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
         mode neither API accepts back - so a released Zappi always lands somewhere useful
         rather than being left Stopped.
         """
-        for device in self.controlled_zappis():
+        for _slot, device in self.controlled_zappis():
             if device.device_id not in self.control_modes:
                 continue
             mode = self.control_saved_modes.get(device.device_id)
@@ -992,12 +994,21 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
         self.control_saved_modes = {}
 
     def controlled_zappis(self):
-        """The Zappis to drive, in serial order, so Zappi N is the same car as auto-config's Nth.
+        """The Zappis to drive, paired with the car slot each was allocated.
 
-        automatic_config() wires car_charging_energy and car_charging_planned as per-car
-        lists in this same order, so the two cannot disagree about which Zappi is which car.
+        This used to return Zappis in serial order and rely on "Zappi N is car N". That
+        stopped being true once chargers from several components share the slot space, so
+        the slot now comes from the registry - the same allocation automatic_config() made.
         """
-        return [device for device in sorted(self.devices.values(), key=lambda item: item.serial) if device.kind == DEVICE_KIND_ZAPPI]
+        pairs = []
+        for device in sorted(self.devices.values(), key=lambda item: item.serial):
+            if device.kind != DEVICE_KIND_ZAPPI:
+                continue
+            slot = self.charger_slot("myenergi", device.serial)
+            if slot is None:
+                continue
+            pairs.append((slot, device))
+        return pairs
 
     async def control_charge(self, now):
         """Drive every controlled Zappi from its car's charge plan.
@@ -1010,7 +1021,14 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
         """
         if not self.refresh_car_windows(now):
             return
-        for car_n, device in enumerate(self.controlled_zappis()):
+        for car_n, device in self.controlled_zappis():
+            # The registry allocates slots immediately, while self.num_cars - which the window
+            # refresh loops over - is a cached copy refreshed once a cycle. So a Zappi that has
+            # just moved to a higher slot has no entry in control_windows yet, and an absent key
+            # would read as an empty plan and stop a charging car. Skip it until that car's plan
+            # has been published; a key present but empty is a real empty plan, and does stop.
+            if car_n not in self.control_windows:
+                continue
             wanted = ZAPPI_MODE_CHARGING if self.should_charge_now(car_n, now) else ZAPPI_MODE_STOPPED
             asked = self.control_modes.get(device.device_id)
             if asked == wanted and device.mode == wanted:

--- a/apps/predbat/myenergi.py
+++ b/apps/predbat/myenergi.py
@@ -1019,9 +1019,14 @@ class MyEnergiAPI(ComponentBase, OAuthMixin):
 
         The caller passes now so every Zappi is judged against one instant.
         """
+        generation = self.base.charger_registry.snapshot_generation()
+        if not self.charger_plan_ready(generation):
+            return
         if not self.refresh_car_windows(now):
             return
         for car_n, device in self.controlled_zappis():
+            if not self.charger_plan_ready(generation):
+                return
             # The registry allocates slots immediately, while self.num_cars - which the window
             # refresh loops over - is a cached copy refreshed once a cycle. So a Zappi that has
             # just moved to a higher slot has no entry in control_windows yet, and an absent key

--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -1316,6 +1316,14 @@ class OctopusAPI(ComponentBase):
         slot_owner = getattr(self.base, "car_slot_owner", None)
         if slot_owner and slot_owner != "octopus":
             self.log("OctopusAPI: Car slots are wired by the {} component, leaving them alone".format(slot_owner))
+            # Leaving the args alone must also mean letting go of the num_cars floor claimed for
+            # them on an earlier call, when octopus did own the slots. The owning component (Ohme
+            # takes the Intelligent slots when configured to) registers its own chargers, so the
+            # registry counts those cars itself - holding our stale claim on top would only keep
+            # num_cars raised for devices we are no longer wiring.
+            registry = getattr(self.base, "charger_registry", None)
+            if registry is not None:
+                registry.set_external_num_cars("octopus", 0)
         elif devices or self.intelligent_config_devices:
             # Suspended devices (e.g. an old/decommissioned charger still linked to the Octopus
             # account) aren't actively charging, so exclude them from the entity lists and from
@@ -1342,6 +1350,15 @@ class OctopusAPI(ComponentBase):
             num_cars = self.get_arg("num_cars", 0)
             if num_cars < len(active_devices):
                 self.set_arg("num_cars", len(active_devices))
+            # The raise above is only good until the charger registry next materialises: it writes
+            # num_cars from the chargers it holds, and an Intelligent car has no charger in there.
+            # So claim the count with the registry too, which keeps it as an explicit floor for as
+            # long as these devices are active and releases it when they go. The bare raise is kept
+            # for the case where no component ever registers a charger and the registry therefore
+            # never writes num_cars at all.
+            registry = getattr(self.base, "charger_registry", None)
+            if registry is not None:
+                registry.set_external_num_cars("octopus", len(active_devices))
             if active_devices:
                 self.log("OctopusAPI: Car slots wired to intelligent devices {}".format(sorted(active_devices)))
             else:

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -420,9 +420,14 @@ class OhmeAPI(ComponentBase):
             self.log("Info: Ohme API: Read only mode cleared, resuming charge control")
         self.control_read_only = False
 
+        generation = self.base.charger_registry.snapshot_generation()
+        if not self.charger_plan_ready(generation):
+            return
         if not self.refresh_car_windows():
             return
 
+        if not self.charger_plan_ready(generation):
+            return
         should_charge = self.should_charge_now()
         drifted = self.control_drifted(should_charge)
         if should_charge == self.control_charging and not drifted:
@@ -485,7 +490,7 @@ class OhmeAPI(ComponentBase):
         existing = self.get_arg("car_charging_energy", default=None, indirect=False)
         if isinstance(existing, list) and len(existing) == 1:
             existing = existing[0]
-        owns_energy = (not existing) or (isinstance(existing, str) and existing.startswith("re:")) or existing == ENERGY_TODAY_ENTITY
+        owns_energy = self.base.charger_registry.owns_aggregate("energy") or (not existing) or (isinstance(existing, str) and existing.startswith("re:")) or existing == ENERGY_TODAY_ENTITY
         if not owns_energy:
             self.log("Info: Ohme API: Leaving car_charging_energy set to {} rather than using {}".format(existing, ENERGY_TODAY_ENTITY))
 

--- a/apps/predbat/ohme.py
+++ b/apps/predbat/ohme.py
@@ -27,6 +27,7 @@ from typing import Dict, List, Union
 from datetime import timedelta, timezone
 from const import TIME_FORMAT_HA
 from component_base import ComponentBase
+from charger_registry import ChargerEntry, slot_entity_suffix
 from predbat_metrics import record_api_call
 
 GOOGLE_API_KEY = "AIzaSyC8ZeZngm33tpOXLpbXeKfwtyZ1WrkbdBY"  # cspell:disable-line
@@ -61,6 +62,9 @@ ohme_attribute_table = {
 # Ohme's own energy figure cannot be used for this
 ENERGY_TODAY_ENTITY = "sensor.predbat_ohme_energy_today"
 POWER_WATTS_ENTITY = "sensor.predbat_ohme_power_watts"
+
+# Ohme drives exactly one charger per account, so its registry device id is fixed.
+OHME_DEVICE_ID = "ohme0"
 
 # How often the Predbat-led control loop re-evaluates the plan. The plan is minute-granular so a
 # finer cadence buys nothing, and this matches the gateway EV charger control loop
@@ -327,7 +331,13 @@ class OhmeAPI(ComponentBase):
         Returns True once a plan has been read, False while the sensor has never been published -
         which is what stops the loop pausing a car on startup before it knows anything.
         """
-        planned = self.get_state_wrapper("binary_sensor." + self.prefix + "_car_charging_slot", attribute="planned")
+        # Follow this charger's own car, not car 0. Once a second component registers a
+        # charger, Ohme's slot moves - and reading car 0's plan would drive this charger
+        # from another car's schedule.
+        slot = self.charger_slot("ohme", OHME_DEVICE_ID)
+        if slot is None:
+            return False
+        planned = self.get_state_wrapper("binary_sensor." + self.prefix + "_car_charging_slot" + slot_entity_suffix(slot), attribute="planned")
         if planned is None:
             return False
 
@@ -465,32 +475,33 @@ class OhmeAPI(ComponentBase):
         wiring is deliberately separate - see automatic_config_octopus_intelligent().
         """
         self.log("Info: Ohme API: Registering the Ohme charger as a car")
-        if self.get_arg("num_cars", 0) < 1:
-            self.set_arg("num_cars", 1)
-        self.set_arg("car_charging_planned", ["binary_sensor.predbat_ohme_connected"])
-        self.set_arg("car_charging_soc", ["sensor.predbat_ohme_battery_percent"])
 
-        # Wire up the delivered-energy sensor so car_charging_hold can subtract car charging
-        # precisely instead of falling back to the car_charging_threshold heuristic. This runs
-        # before auto_config(final=True), so an unmatched regex from the apps.yaml default is
-        # still present as its literal "re:" string rather than having been removed yet - treat
-        # that as unconfigured, but leave a real charger (Zappi, Wallbox, hand-set sensor) alone.
-        # A list of one is how several components hand over a single entity, so unwrap it before
-        # comparing - otherwise an explicit ["sensor.predbat_ohme_energy_today"] looks third-party
+        # The energy sensor is only ours to claim when no other charger already owns it.
+        # This runs before auto_config(final=True), so an unmatched regex from the apps.yaml
+        # default is still present as its literal "re:" string rather than having been
+        # removed yet - treat that as unconfigured, but leave a real charger (Zappi, Wallbox,
+        # hand-set sensor) alone. A list of one is how several components hand over a single
+        # entity, so unwrap it before comparing.
         existing = self.get_arg("car_charging_energy", default=None, indirect=False)
         if isinstance(existing, list) and len(existing) == 1:
             existing = existing[0]
-        # Ohme already owns the energy figure when the entity configured is its own, whether that
-        # was set here on a previous run or written into apps.yaml by hand (#4715 review)
-        if (not existing) or (isinstance(existing, str) and existing.startswith("re:")) or existing == ENERGY_TODAY_ENTITY:
-            self.set_arg_auto("car_charging_energy", ENERGY_TODAY_ENTITY)
-            # Live charge power, for the web power flow diagram and the predbat.car_charging_power
-            # sensor. Deliberately tied to the same decision as the energy sensor above: the two
-            # have to describe the same charger, so when another charger owns the energy figure
-            # Ohme's own power reading is left out rather than reported beside it.
-            self.set_arg_auto("car_charging_power", POWER_WATTS_ENTITY)
-        else:
+        owns_energy = (not existing) or (isinstance(existing, str) and existing.startswith("re:")) or existing == ENERGY_TODAY_ENTITY
+        if not owns_energy:
             self.log("Info: Ohme API: Leaving car_charging_energy set to {} rather than using {}".format(existing, ENERGY_TODAY_ENTITY))
+
+        self.register_chargers(
+            "ohme",
+            [
+                ChargerEntry(
+                    "ohme",
+                    OHME_DEVICE_ID,
+                    planned="binary_sensor.predbat_ohme_connected",
+                    soc="sensor.predbat_ohme_battery_percent",
+                    energy=ENERGY_TODAY_ENTITY if owns_energy else None,
+                    power=POWER_WATTS_ENTITY if owns_energy else None,
+                )
+            ],
+        )
 
     async def automatic_config_octopus_intelligent(self):
         """

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -76,9 +76,9 @@ class Output:
         """
         Publish the car charging plan
         """
-        plan = []
         postfix = ""
         for car_n in range(self.num_cars):
+            plan = []
             if car_n > 0:
                 postfix = "_" + str(car_n)
             if not self.car_charging_slots[car_n]:
@@ -155,6 +155,8 @@ class Output:
                         "icon": "mdi:home-lightning-bolt-outline",
                     },
                 )
+
+        self.charger_registry.confirm_plan(getattr(self, "car_charger_generation", None))
 
     def publish_rates_export(self):
         """

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -81,6 +81,7 @@ from predheat import PredHeat
 from octopus import Octopus
 from energydataservice import Energidataservice
 from stromligning import Stromligning
+from charger_registry import ChargerRegistry, preregister_legacy
 from components import Components, COMPONENT_LIST
 from execute import Execute
 from marginal import Marginal
@@ -295,6 +296,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.validate_config_next_retry_time = None
         self.ha_interface = None
         self.num_cars = 0
+        self.charger_registry = ChargerRegistry(self)
         self.fatal_error = False
         self.components = None
         self.CONFIG_ITEMS = copy.deepcopy(CONFIG_ITEMS)
@@ -1911,6 +1913,15 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
 
             self.ha_interface.update_states()
             self.auto_config()
+
+            # Snapshot hand-written car_charging_* config as legacy slots. Runs after
+            # auto_config() so the snapshot sees entity ids the regex templates resolved to
+            # rather than the raw "re:" patterns, and still before any component's
+            # automatic_config() - phase 0 is storage/db/ha/web, none of which touch a
+            # car_charging_* key - so autodiscovery appends after the user's own config
+            # rather than displacing it.
+            preregister_legacy(self.charger_registry, self)
+
             self.load_user_config(quiet=False, register=False, load_config=True)
             self.comparison = Compare(self)
 

--- a/apps/predbat/tests/test_charger_registry.py
+++ b/apps/predbat/tests/test_charger_registry.py
@@ -1047,3 +1047,118 @@ def test_charger_registry(my_predbat=None):
 # calls, running the whole file twice per session and reporting a pass/fail count that does
 # not match the tests. unit_test.py calls it directly by name, which this does not affect.
 test_charger_registry.__test__ = False
+
+
+def test_ohme_energy_survives_both_discovery_orders_and_rediscovery():
+    """Registry-owned energy lists must not make Ohme drop its own contribution."""
+    import asyncio
+    from tests.test_ohme import MockOhmeAPI, ENERGY_TODAY_ENTITY, POWER_WATTS_ENTITY
+
+    for ohme_first in (True, False):
+        api = MockOhmeAPI()
+        registry = api.base.charger_registry
+        if ohme_first:
+            asyncio.run(api.automatic_config())
+        registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.ce1234", energy="sensor.ce1234_energy", power="sensor.ce1234_power")])
+        for _ in range(2):
+            asyncio.run(api.automatic_config())
+            assert api.args["car_charging_energy"] == ["sensor.ce1234_energy", ENERGY_TODAY_ENTITY]
+            assert api.args["car_charging_power"] == ["sensor.ce1234_power", POWER_WATTS_ENTITY]
+
+
+def test_legacy_and_discovered_energy_are_counted_once():
+    """Two integrations measuring the same serial must not double the site total."""
+    for legacy in ("sensor.myenergi_zappi_10000001_charge_added_session", "sensor.predbat_myenergi_zappi_10000001_session_energy"):
+        base = MockBase(car_charging_energy=[legacy, "sensor.myenergi_zappi_100000010_charge_added_session"])
+        registry = _registry(base)
+        preregister_legacy(registry, base)
+        registry.replace_source("myenergi", [ChargerEntry("myenergi", "10000001", planned="sensor.zappi_connected", energy="sensor.predbat_myenergi_zappi_10000001_session_energy")])
+        assert base.args["car_charging_energy"] == ["sensor.myenergi_zappi_100000010_charge_added_session", "sensor.predbat_myenergi_zappi_10000001_session_energy"]
+        registry.replace_source("myenergi", [])
+        assert base.args["car_charging_energy"] == [legacy, "sensor.myenergi_zappi_100000010_charge_added_session"]
+
+
+def test_plan_publication_is_per_car_and_confirms_only_its_allocation():
+    """Publishing isolates car windows and cannot approve a mapping changed mid-plan."""
+    from datetime import datetime, timezone
+    from types import SimpleNamespace
+    from output import Output
+
+    registry = _registry()
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0")])
+    generation = registry.snapshot_generation()
+    captured = {}
+    base = SimpleNamespace(
+        num_cars=3, prefix="predbat", minutes_now=0, forecast_minutes=1440,
+        midnight_utc=datetime(2026, 9, 4, tzinfo=timezone.utc),
+        car_charging_slots=[
+            [{"start": 60, "end": 120, "kwh": 1, "average": 10, "cost": 10}],
+            [{"start": 180, "end": 240, "kwh": 2, "average": 20, "cost": 40}],
+            [],
+        ],
+        charger_registry=registry, car_charger_generation=generation,
+        time_abs_str=str,
+        dashboard_item=lambda entity, state, attributes: captured.update({entity: attributes}),
+    )
+    # The plan is in flight when another source takes slot 0.
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234")])
+    Output.publish_car_plan(base)
+    assert [window["start"] for window in captured["binary_sensor.predbat_car_charging_slot"]["planned"]] == ["60"]
+    assert [window["start"] for window in captured["binary_sensor.predbat_car_charging_slot_1"]["planned"]] == ["180"]
+    assert captured["binary_sensor.predbat_car_charging_slot_2"]["planned"] == []
+    assert not registry.plan_is_current()
+    base.car_charger_generation = registry.snapshot_generation()
+    Output.publish_car_plan(base)
+    assert registry.plan_is_current()
+
+
+def test_all_charger_controls_wait_after_slot_reallocation():
+    """Existing slot sensors cannot authorise control after their car identities change."""
+    import asyncio
+    from unittest.mock import AsyncMock
+    from tests.test_ohme import _ohme_control_api
+    from tests.test_gateway import TestEvControl
+    from tests.test_myenergi import _controlling_component, IN_WINDOW, NIGHT_WINDOW
+    from tests.test_ge_cloud import _evc_control_component, _register_gecloud_chargers, EVC_PLAN_SENSOR
+
+    ohme = _ohme_control_api(windows=[])
+    ohme.base.charger_registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234")])
+    ohme.states[("binary_sensor.predbat_car_charging_slot_1", "planned")] = []
+    asyncio.run(ohme.control_charge())
+    assert not ohme.client.request_log
+    ohme.base.charger_registry.confirm_plan(ohme.base.charger_registry.generation)
+    asyncio.run(ohme.control_charge())
+    assert ohme.client.request_log
+
+    gateway = TestEvControl()._make_gateway(configured_chargers=["CP-A", "CP-B"])
+    gateway._ev_charging_active = {"CP-B": True}
+    gateway._ev_windows = {0: [], 1: []}
+    gateway._send_ev_command = AsyncMock()
+    gateway.base.charger_registry.replace_source("gateway", [ChargerEntry("gateway", "CP-B")])
+    asyncio.run(gateway._apply_ev_charging_state())
+    gateway._send_ev_command.assert_not_awaited()
+    gateway.base.charger_registry.confirm_plan(gateway.base.charger_registry.generation)
+    asyncio.run(gateway._apply_ev_charging_state())
+    gateway._send_ev_command.assert_awaited_once()
+
+    myenergi = _controlling_component(plans={0: [NIGHT_WINDOW], 1: []})
+    myenergi.base.charger_registry.confirm_plan(myenergi.base.charger_registry.generation)
+    myenergi.base.charger_registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234")])
+    asyncio.run(myenergi.control_charge(IN_WINDOW))
+    myenergi.transport.set_mode.assert_not_awaited()
+    myenergi.base.charger_registry.confirm_plan(myenergi.base.charger_registry.generation)
+    asyncio.run(myenergi.control_charge(IN_WINDOW))
+    myenergi.transport.set_mode.assert_awaited_once()
+
+    commands = []
+    gecloud = _evc_control_component(commands)
+    gecloud.evc_device_list = ["charger"]
+    gecloud.evc_device = {"charger": {"serial_number": "EVC200", "status": "charging"}}
+    gecloud.entity_attributes = {EVC_PLAN_SENSOR: {"planned": []}}
+    _register_gecloud_chargers(gecloud, ["EVC100", "EVC200"])
+    gecloud.base.charger_registry.replace_source("gecloud", [ChargerEntry("gecloud", "EVC200")])
+    asyncio.run(gecloud.evc_control_charge(IN_WINDOW))
+    assert commands == []
+    gecloud.base.charger_registry.confirm_plan(gecloud.base.charger_registry.generation)
+    asyncio.run(gecloud.evc_control_charge(IN_WINDOW))
+    assert commands == [("charger", "stop-charge")]

--- a/apps/predbat/tests/test_charger_registry.py
+++ b/apps/predbat/tests/test_charger_registry.py
@@ -1,0 +1,1049 @@
+# fmt: off
+# pylint: disable=line-too-long
+"""Unit tests for the charger registry."""
+
+import predbat  # noqa: F401  (import first - avoids circular import: config.py does `from predbat import THIS_VERSION`)
+from mock_base import MockBase
+from charger_registry import ChargerEntry, ChargerRegistry, preregister_legacy
+from userinterface import UserInterface
+from utils import is_debug_excluded_key
+
+
+def _registry(base=None):
+    """A registry over the given MockBase, or a fresh one when the test does not need the base."""
+    return ChargerRegistry(base if base is not None else MockBase())
+
+
+class AutoConfigBase(MockBase):
+    """A MockBase that runs Predbat's own auto_config() over its args before the registry sees them.
+
+    Borrowed from UserInterface rather than reimplemented: what makes preregister_legacy's input
+    awkward is precisely what the real resolve_arg_re() does to an unmatched list element, so a
+    hand-written stand-in for it would be testing the fixture rather than the code. The full
+    PredBat object cannot be used here - PredBat.__init__ reads an apps.yaml from the working
+    directory, which exists under coverage/ but not where pytest runs this file from - so the two
+    real methods are bound onto the mock instead.
+    """
+
+    auto_config = UserInterface.auto_config
+    resolve_arg_re = UserInterface.resolve_arg_re
+
+    def get_state_wrapper(self, entity_id=None, default=None, attribute=None, refresh=False, required_unit=None, raw=False):
+        """Return the whole entity map when asked for it, as PredBat's own wrapper does.
+
+        auto_config() calls this with no entity_id to get the state keys its regexes match
+        against; MockBase's version looks up the key None and returns {}, which would make every
+        pattern fail to match for the wrong reason.
+        """
+        if entity_id is None:
+            return self.entities
+        return super().get_state_wrapper(entity_id=entity_id, default=default, attribute=attribute, refresh=refresh, required_unit=required_unit, raw=raw)
+
+
+def test_two_sources_compose_into_two_slots():
+    """The bug this registry exists to fix: two components, two chargers, two slots."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected", energy="sensor.predbat_ohme_energy_today")])
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.predbat_gecloud_ce1234_evc_car_connected", energy="sensor.predbat_gecloud_ce1234_evc_energy")])
+
+    assert base.args["num_cars"] == 2
+    # Deterministic order: sorted by (source, device_id), so gecloud precedes ohme.
+    assert base.args["car_charging_planned"] == ["binary_sensor.predbat_gecloud_ce1234_evc_car_connected", "binary_sensor.predbat_ohme_connected"]
+    # Site aggregates: concatenated, not slot-aligned.
+    assert base.args["car_charging_energy"] == ["sensor.predbat_gecloud_ce1234_evc_energy", "sensor.predbat_ohme_energy_today"]
+
+
+def test_slot_for_returns_the_allocated_slot():
+    """Components must be able to find their own car index - this is what keeps control safe."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.a")])
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.b")])
+
+    assert registry.slot_for("gecloud", "CE1234") == 0
+    assert registry.slot_for("ohme", "ohme0") == 1
+    assert registry.slot_for("ohme", "nosuch") is None
+
+
+def test_never_writes_none_into_a_list():
+    """apps.yaml validation rejects non-string list elements (predbat.py:1644)."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.b")])
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.a", soc="sensor.predbat_ohme_battery_percent")])
+
+    for key in ("car_charging_planned", "car_charging_now", "car_charging_soc", "car_charging_energy", "car_charging_power"):
+        assert None not in base.args.get(key, [])
+    # Only one of two slots can report SoC, so the slot-aligned list is omitted entirely
+    # rather than padded - car_charging_manual_soc covers the gap.
+    assert "car_charging_soc" not in base.args
+
+
+def test_slot_aligned_list_written_when_every_slot_has_one():
+    """The list is written whole when every slot has a value - the normal case."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("gateway", [
+        ChargerEntry("gateway", "CP-AAAAAA", planned="binary_sensor.a", soc="sensor.a_soc"),
+        ChargerEntry("gateway", "CP-BBBBBB", planned="binary_sensor.b", soc="sensor.b_soc"),
+    ])
+    assert base.args["car_charging_soc"] == ["sensor.a_soc", "sensor.b_soc"]
+
+
+def test_replace_source_is_idempotent_and_dedupes():
+    """Re-running discovery must not duplicate chargers, even if the source repeats one."""
+    base = MockBase()
+    registry = _registry(base)
+    entry = ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")
+    registry.replace_source("ohme", [entry, entry])
+    registry.replace_source("ohme", [entry])
+
+    assert base.args["num_cars"] == 1
+    assert base.args["car_charging_planned"] == ["binary_sensor.predbat_ohme_connected"]
+
+
+def test_empty_replace_clears_the_source_and_rewrites_args():
+    """A vanished charger must lower num_cars AND clear its stale entities."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("myenergi", [
+        ChargerEntry("myenergi", "Z1", planned="sensor.z1_plug", energy="sensor.z1_energy"),
+        ChargerEntry("myenergi", "Z2", planned="sensor.z2_plug", energy="sensor.z2_energy"),
+    ])
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.ohme")])
+
+    registry.replace_source("myenergi", [])
+
+    assert base.args["num_cars"] == 1
+    assert base.args["car_charging_planned"] == ["binary_sensor.ohme"]
+    assert "sensor.z1_energy" not in base.args.get("car_charging_energy", [])
+
+
+def test_clamped_to_max_cars():
+    """PREDBAT_MAX_CARS is a kernel array bound, so the excess is dropped, not written."""
+    from const import PREDBAT_MAX_CARS
+
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "Z{:02d}".format(n), planned="sensor.z{}".format(n)) for n in range(PREDBAT_MAX_CARS + 3)])
+
+    assert base.args["num_cars"] == PREDBAT_MAX_CARS
+    assert len(base.args["car_charging_planned"]) == PREDBAT_MAX_CARS
+
+
+def test_max_rate_is_exposed_per_slot():
+    """car_charging_rate is a UI config item, indexed _1.._7 after slot 0 (config.py)."""
+    base = MockBase()
+    exposed = {}
+    base.expose_config = lambda name, value: exposed.__setitem__(name, value)
+    registry = _registry(base)
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.a", max_rate_kw=7.4)])
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.b", max_rate_kw=22.0)])
+
+    assert exposed["car_charging_rate"] == 7.4
+    assert exposed["car_charging_rate_1"] == 22.0
+
+
+def test_clearing_the_last_source_resets_args():
+    """When the registry becomes empty after being populated, stale args must be cleared."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "Z1", planned="sensor.z1_plug")])
+
+    assert base.args["num_cars"] == 1
+    assert base.args["car_charging_planned"] == ["sensor.z1_plug"]
+
+    registry.replace_source("myenergi", [])
+
+    assert base.args["num_cars"] == 0
+    assert "car_charging_planned" not in base.args or base.args["car_charging_planned"] is None
+
+
+def test_never_populated_registry_is_a_noop():
+    """A registry that has never held anything must not write num_cars or car_charging_* args."""
+    base = MockBase()
+    registry = _registry(base)
+
+    assert "num_cars" not in base.args
+    assert "car_charging_planned" not in base.args
+
+
+def test_legacy_only_config_is_a_noop():
+    """Existing apps.yaml users must see identical args. This is the compat guarantee."""
+    import copy
+
+    base = MockBase(
+        num_cars=2,
+        car_charging_planned=["binary_sensor.my_car_a", "binary_sensor.my_car_b"],
+        car_charging_soc=["sensor.my_car_a_soc", "sensor.my_car_b_soc"],
+        car_charging_energy=["sensor.my_charger_energy"],
+    )
+    before = copy.deepcopy(base.args)
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    assert base.args == before
+
+
+def test_legacy_scalar_is_broadcast_not_padded():
+    """A scalar feeds every index today (resolve_arg), so it must keep doing so.
+
+    The arg itself is left exactly as the user wrote it - a key holding only legacy slots is
+    never rewritten - so the broadcast shows up where it matters: in the composed list once a
+    charger is discovered, where car 1 is still the user's scalar and not an empty slot.
+    """
+    base = MockBase(num_cars=2, car_charging_planned="binary_sensor.my_car_a")
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    assert base.args["num_cars"] == 2
+    assert base.args["car_charging_planned"] == "binary_sensor.my_car_a", "the user's own scalar is not rewritten"
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["car_charging_planned"] == ["binary_sensor.my_car_a", "binary_sensor.my_car_a", "binary_sensor.predbat_ohme_connected"]
+    assert registry.slot_for("ohme", "ohme0") == 2
+
+
+def test_legacy_slot_count_comes_from_num_cars_only():
+    """A planned list longer than num_cars is ignored today; do not activate the extras.
+
+    Ignored, not deleted: fetch.py simply reads no index past num_cars, so the surplus entry
+    stays in the user's config untouched - and the slot it never got goes to the discovered
+    charger, which is what proves it was not activated.
+    """
+    base = MockBase(num_cars=1, car_charging_planned=["binary_sensor.a", "binary_sensor.b"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    assert base.args["num_cars"] == 1
+    assert base.args["car_charging_planned"] == ["binary_sensor.a", "binary_sensor.b"], "the surplus entry is ignored, not rewritten away"
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["car_charging_planned"] == ["binary_sensor.a", "binary_sensor.predbat_ohme_connected"]
+    assert registry.slot_for("ohme", "ohme0") == 1
+
+
+def test_legacy_aggregates_survive_a_component_registering():
+    """A hand-configured energy sensor must not be replaced by a discovered one."""
+    base = MockBase(num_cars=1, car_charging_planned=["binary_sensor.my_car_a"], car_charging_energy=["sensor.my_charger_energy"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.ce1234", energy="sensor.ce1234_energy")])
+
+    assert base.args["car_charging_energy"] == ["sensor.my_charger_energy", "sensor.ce1234_energy"]
+
+
+def test_autodiscovery_appends_after_legacy_slots():
+    """A discovered charger must not displace a hand-configured one from slot 0."""
+    base = MockBase(num_cars=1, car_charging_planned=["binary_sensor.my_car_a"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["car_charging_planned"] == ["binary_sensor.my_car_a", "binary_sensor.predbat_ohme_connected"]
+    assert registry.slot_for("ohme", "ohme0") == 1
+
+
+def test_legacy_preregistration_with_no_config_does_nothing():
+    """No car config at all means the registry stays empty and writes nothing."""
+    base = MockBase()
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    assert "num_cars" not in base.args or base.args["num_cars"] == 0
+
+
+def test_legacy_scalar_config_without_num_cars_defaults_to_one_slot():
+    """car_charging_planned without num_cars key defaults to 1 slot, matching fetch.py:2834."""
+    base = MockBase(car_charging_planned="binary_sensor.my_car")
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    assert base.args["num_cars"] == 1
+    # One slot, and the arg is left as the user wrote it - see the append test below for the
+    # slot itself, which is what the count is actually for.
+    assert base.args["car_charging_planned"] == "binary_sensor.my_car"
+
+
+def test_legacy_energy_without_cars_survives_component_registration():
+    """Hand-configured car_charging_energy without cars is protected and prepended to discovered chargers."""
+    base = MockBase(car_charging_energy="sensor.my_charger_energy")
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected", energy="sensor.predbat_ohme_energy_today")])
+
+    assert base.args["car_charging_energy"] == ["sensor.my_charger_energy", "sensor.predbat_ohme_energy_today"]
+
+
+def test_legacy_scalar_appends_discovered_chargers():
+    """Discovered chargers append after implicit single legacy slot when num_cars is absent."""
+    base = MockBase(car_charging_planned="binary_sensor.my_car_a")
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["car_charging_planned"] == ["binary_sensor.my_car_a", "binary_sensor.predbat_ohme_connected"]
+    assert registry.slot_for("ohme", "ohme0") == 1
+
+
+def test_mock_base_exposes_a_registry():
+    """Every component reaches the registry through the base, so MockBase must carry one."""
+    base = MockBase()
+    assert isinstance(base.charger_registry, ChargerRegistry)
+
+
+def test_component_base_helpers_use_the_registry():
+    """Components register and look up their slot through the base; never touch args."""
+    from component_base import ComponentBase
+
+    class TestComponent(ComponentBase):
+        """Test implementation of ComponentBase."""
+
+        def initialize(self, **kwargs):
+            """No-op initialize for testing."""
+            pass
+
+    base = MockBase()
+    component = TestComponent(base)
+
+    component.register_chargers("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["num_cars"] == 1
+    assert component.charger_slot("ohme", "ohme0") == 0
+    assert component.charger_slot("ohme", "nosuch") is None
+
+
+def test_ohme_control_follows_its_own_slot():
+    """Ohme at slot 1 must read car 1's plan entity, not the unindexed car-0 one.
+
+    Reading the wrong entity starts or stops a physical charger from another car's plan.
+    """
+    from charger_registry import slot_entity_suffix
+
+    assert slot_entity_suffix(0) == ""
+    assert slot_entity_suffix(1) == "_1"
+    assert slot_entity_suffix(7) == "_7"
+
+
+def test_myenergi_zappis_get_distinct_slots_after_another_source():
+    """Zappi N is no longer car N once another component holds an earlier slot."""
+    base = MockBase()
+    registry = base.charger_registry
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.ce1234")])
+    registry.replace_source("myenergi", [
+        ChargerEntry("myenergi", "10000001", planned="sensor.z1_plug"),
+        ChargerEntry("myenergi", "10000002", planned="sensor.z2_plug"),
+    ])
+
+    assert registry.slot_for("myenergi", "10000001") == 1
+    assert registry.slot_for("myenergi", "10000002") == 2
+    assert base.args["num_cars"] == 3
+
+
+def test_gecloud_and_ohme_do_not_collapse_into_one_slot():
+    """The exact bug: gecloud's raise-only num_cars took a max, so both claimed slot 0."""
+    base = MockBase()
+    registry = base.charger_registry
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.predbat_gecloud_ce1234_evc_car_connected")])
+
+    assert base.args["num_cars"] == 2
+    assert len(set(base.args["car_charging_planned"])) == 2
+    assert registry.slot_for("gecloud", "CE1234") != registry.slot_for("ohme", "ohme0")
+
+
+def test_gateway_registers_every_charge_point_with_its_own_slot():
+    """The gateway used to register only the first charger and force num_cars=1."""
+    base = MockBase()
+    registry = base.charger_registry
+    registry.replace_source(
+        "gateway",
+        [
+            ChargerEntry("gateway", "CP-AAAAAA", planned="binary_sensor.predbat_gateway_ev_aaaaaa_connected", soc="sensor.predbat_gateway_ev_aaaaaa_soc", max_rate_kw=7.4),
+            ChargerEntry("gateway", "CP-BBBBBB", planned="binary_sensor.predbat_gateway_ev_bbbbbb_connected", soc="sensor.predbat_gateway_ev_bbbbbb_soc", max_rate_kw=22.0),
+        ],
+    )
+
+    assert base.args["num_cars"] == 2
+    assert registry.slot_for("gateway", "CP-AAAAAA") == 0
+    assert registry.slot_for("gateway", "CP-BBBBBB") == 1
+    assert base.args["car_charging_soc"] == ["sensor.predbat_gateway_ev_aaaaaa_soc", "sensor.predbat_gateway_ev_bbbbbb_soc"]
+
+
+def test_all_four_sources_compose_with_distinct_slots():
+    """Four components, four chargers, four distinct slots, no entity lost.
+
+    Before the registry, whichever component ran last owned car_charging_planned outright
+    and num_cars was the largest single component's count - so this site planned for one
+    car and ignored three chargers.
+    """
+    base = MockBase()
+    registry = base.charger_registry
+    registry.replace_source("gateway", [ChargerEntry("gateway", "CP-AAAAAA", planned="binary_sensor.gw_a", energy="sensor.gw_a_energy")])
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.ce1234", energy="sensor.ce1234_energy")])
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.ohme", energy="sensor.ohme_energy")])
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "10000001", planned="sensor.z1_plug", energy="sensor.z1_energy")])
+
+    assert base.args["num_cars"] == 4
+    assert len(set(base.args["car_charging_planned"])) == 4
+    assert len(base.args["car_charging_energy"]) == 4
+    assert len({registry.slot_for("gateway", "CP-AAAAAA"), registry.slot_for("gecloud", "CE1234"), registry.slot_for("ohme", "ohme0"), registry.slot_for("myenergi", "10000001")}) == 4
+
+
+def test_iog_arrays_are_untouched_by_the_registry():
+    """IOG is not part of the collision and must stay that way.
+
+    Octopus writes its own octopus_* arrays and consumes car_charging_planned rather than
+    supplying it, so the registry must never write an octopus_* key.
+    """
+    base = MockBase(octopus_intelligent_slot=["binary_sensor.octopus_slot"], octopus_ready_time="07:00:00", octopus_charge_limit=80)
+    base.charger_registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["octopus_intelligent_slot"] == ["binary_sensor.octopus_slot"]
+    assert base.args["octopus_ready_time"] == "07:00:00"
+    assert base.args["octopus_charge_limit"] == 80
+
+
+def test_legacy_car_charging_rate_is_left_alone():
+    """An existing car_charging_rate is an already-effective cap, never re-derived."""
+    base = MockBase(num_cars=1, car_charging_planned=["binary_sensor.my_car_a"])
+    exposed = {}
+    base.expose_config = lambda name, value: exposed.__setitem__(name, value)
+    preregister_legacy(base.charger_registry, base)
+
+    assert exposed == {}
+
+
+def test_adding_an_earlier_sorting_charger_shifts_later_slots():
+    """Documented, deliberate consequence of deterministic ordering.
+
+    A charger discovered later whose (source, device_id) sorts earlier takes a lower slot
+    and shifts the rest. Per-car settings (limit, battery size, manual SoC, exclusive) are
+    addressed by slot, so they follow the position, not the car. Components are safe because
+    they re-read slot_for() every cycle; a user's per-car *settings* are not. This is why
+    slot_for() is authoritative and nothing may cache a slot across cycles.
+    """
+    base = MockBase()
+    registry = base.charger_registry
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.ohme")])
+    assert registry.slot_for("ohme", "ohme0") == 0
+
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.ce1234")])
+
+    assert registry.slot_for("ohme", "ohme0") == 1
+    assert registry.slot_for("gecloud", "CE1234") == 0
+
+
+def test_charger_registry_excluded_from_debug_dumps():
+    """Charger registry holds a back-reference to base, forming a cycle.
+
+    Walking this cycle during YAML serialization (userinterface.py:768 create_debug_yaml)
+    encounters coroutine objects that cannot be pickled, causing a 500 error on /debug_yaml.
+    The registry must be in DEBUG_EXCLUDE_LIST to prevent this.
+    """
+    assert is_debug_excluded_key("charger_registry") is True
+
+
+def test_stock_apps_yaml_template_does_not_invent_a_car():
+    """The shipped apps.yaml declares num_cars: 1 with only unmatched template regexes.
+
+    Reading that as a hand-configured car gave virtually every installation a phantom slot 0:
+    an auto-discovered charger landed at slot 1, and because the phantom slot supplies no SoC
+    the omit-on-gap rule dropped car_charging_soc altogether - so Predbat planned a full
+    charge into a car whose level it could not see.
+    """
+    base = MockBase(
+        num_cars=1,
+        car_charging_planned=["re:(sensor.wallbox_portal_status_description|sensor.myenergi_zappi_[0-9a-z]+_plug_status)"],
+        car_charging_energy="re:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)",
+    )
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected", soc="sensor.predbat_ohme_battery_percent", energy="sensor.predbat_ohme_energy_today")])
+
+    assert base.args["num_cars"] == 1
+    assert registry.slot_for("ohme", "ohme0") == 0
+    assert base.args["car_charging_planned"] == ["binary_sensor.predbat_ohme_connected"]
+    assert base.args["car_charging_soc"] == ["sensor.predbat_ohme_battery_percent"]
+    # The unmatched template regex is not a sensor either, so it is not prepended to the aggregate.
+    assert base.args["car_charging_energy"] == ["sensor.predbat_ohme_energy_today"]
+
+
+def test_hand_configured_car_keeps_its_slot_alongside_a_discovered_charger():
+    """A real entity id is real config: it keeps slot 0 and the discovered charger appends."""
+    base = MockBase(num_cars=1, car_charging_planned=["binary_sensor.my_car_a"], car_charging_soc=["sensor.my_car_a_soc"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected", soc="sensor.predbat_ohme_battery_percent")])
+
+    assert base.args["num_cars"] == 2
+    assert registry.slot_for("ohme", "ohme0") == 1
+    assert base.args["car_charging_planned"] == ["binary_sensor.my_car_a", "binary_sensor.predbat_ohme_connected"]
+    assert base.args["car_charging_soc"] == ["sensor.my_car_a_soc", "sensor.predbat_ohme_battery_percent"]
+
+
+def test_declared_num_cars_survives_as_a_floor_when_its_slots_are_empty():
+    """num_cars the user declared is honoured even when nothing was configured behind it.
+
+    Dropping the empty slots must not quietly reduce the number of cars Predbat plans for -
+    the count is kept as a floor, the phantom entities are what go away.
+    """
+    base = MockBase(num_cars=2, car_charging_planned=["re:(sensor.nothing_matched)"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    # Nothing registered at all: apps.yaml is left untouched, so fetch.py still reads 2.
+    assert base.args["num_cars"] == 2
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["num_cars"] == 2
+    assert registry.slot_for("ohme", "ohme0") == 0
+
+
+def test_registry_does_not_lower_num_cars_claimed_by_octopus():
+    """octopus.py and kraken.py own IOG cars the registry has no charger for.
+
+    Those cars are wired through octopus_intelligent_slot, which fetch.py only reads for car
+    indices below num_cars - so overwriting num_cars with the registered charger count dropped
+    them, deterministically, for every site whose chargers register after the raise.
+    """
+    base = MockBase()
+    registry = _registry(base)
+    # Exactly what OctopusAPI.automatic_config() now does for two intelligent devices.
+    registry.set_external_num_cars("octopus", 2)
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["num_cars"] == 2
+    assert registry.slot_for("ohme", "ohme0") == 0
+
+    # And the claim has to survive: components re-register on every rediscovery, so honouring
+    # it for one cycle and dropping the IOG car on the next fixes nothing.
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["num_cars"] == 2
+
+
+def test_external_claim_is_held_when_chargers_go_away():
+    """The whole point of the claim: four IOG cars survive the chargers dropping to one.
+
+    The old inference read "num_cars differs from what we last wrote" as somebody else's raise,
+    which was blind whenever the external raise landed on the same number we had just written -
+    exactly the four-and-four case here.
+    """
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "Z{}".format(n), planned="sensor.z{}_plug".format(n)) for n in range(4)])
+    assert base.args["num_cars"] == 4
+
+    registry.set_external_num_cars("octopus", 4)
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "Z0", planned="sensor.z0_plug")])
+
+    assert base.args["num_cars"] == 4
+
+
+def test_external_claim_can_be_lowered_and_dropped():
+    """A raise-only writer can never take its own floor back; an explicit claim can."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.set_external_num_cars("octopus", 4)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+    assert base.args["num_cars"] == 4
+
+    # One of the intelligent devices goes away: the claim drops to 2, and so does num_cars,
+    # because the registry's own charger only accounts for one car.
+    registry.set_external_num_cars("octopus", 2)
+    assert base.args["num_cars"] == 2
+
+    # All of them go: num_cars follows the registered chargers again.
+    registry.set_external_num_cars("octopus", 0)
+    assert base.args["num_cars"] == 1
+
+
+def test_external_only_claim_writes_and_releases_num_cars_with_no_chargers():
+    """Kraken/IOG on a site with no registered charger at all: the claim IS num_cars.
+
+    The registry only wrote num_cars once it had held a charger, so on a site whose only cars are
+    provider-enrolled ones the claim went in through the component's own raise and the registry
+    never touched the key - which meant the release had nowhere to land and the phantom car stayed
+    for the rest of the run. The claim has to be able to write num_cars with zero entries behind
+    it, and to lower it again.
+    """
+    base = MockBase()
+    registry = _registry(base)
+
+    registry.set_external_num_cars("kraken", 3)
+
+    assert base.args["num_cars"] == 3
+
+    registry.set_external_num_cars("kraken", 0)
+
+    assert base.args["num_cars"] == 0
+    # Releasing a claim is not a charger going away: nothing slot-aligned was ever composed for
+    # those cars, so those keys are not the registry's to clear.
+    for field in ("car_charging_planned", "car_charging_now", "car_charging_soc"):
+        assert field not in base.args
+
+
+def test_external_only_claim_release_respects_the_declared_floor():
+    """A release drops the claim, not the user's own apps.yaml num_cars."""
+    base = MockBase(num_cars=2, car_charging_planned=["binary_sensor.my_car_a", "binary_sensor.my_car_b"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    registry.set_external_num_cars("kraken", 4)
+    assert base.args["num_cars"] == 4
+
+    registry.set_external_num_cars("kraken", 0)
+
+    # Back to what the user declared, not to zero.
+    assert base.args["num_cars"] == 2
+    assert base.args["car_charging_planned"] == ["binary_sensor.my_car_a", "binary_sensor.my_car_b"]
+
+
+def test_a_claim_does_not_lower_a_num_cars_nobody_declared():
+    """With nothing registered, a num_cars the registry did not write is not its to lower.
+
+    The registry has composed no chargers here, so it has no count of its own to be authoritative
+    with - the number in the args was put there by something else, and a claim for fewer cars than
+    that is not evidence the rest have gone.
+    """
+    base = MockBase()
+    registry = _registry(base)
+    base.set_arg("num_cars", 4)
+
+    registry.set_external_num_cars("octopus", 3)
+
+    assert base.args["num_cars"] == 4
+
+
+def test_a_claim_can_lower_the_raise_its_own_component_made():
+    """The claimants raise num_cars themselves the instant before declaring, so that IS the claim.
+
+    octopus.py:1352 and kraken.py:1287 both set num_cars directly and then declare the same count.
+    On a site with no registered charger that raise is the only thing behind num_cars, so if the
+    registry treated it as somebody else's the claim could never be released.
+    """
+    base = MockBase()
+    registry = _registry(base)
+
+    # Exactly the order kraken uses: raise, then declare.
+    base.set_arg("num_cars", 2)
+    registry.set_external_num_cars("kraken", 2)
+    assert base.args["num_cars"] == 2
+
+    registry.set_external_num_cars("kraken", 0)
+
+    assert base.args["num_cars"] == 0
+
+
+def test_a_released_claim_leaves_no_ownership_residue():
+    """A count the registry once wrote must not vouch for the same number set later by someone else.
+
+    Ownership has to be bounded in time. Tracking every count ever claimed meant a claim of 3,
+    long since released, still marked a num_cars of 3 as the registry's - so when a different
+    owner set 3 much later, the next claim overwrote it with its own smaller count. Only the
+    single most recent write and the claims standing right now may confer ownership.
+    """
+    base = MockBase()
+    registry = _registry(base)
+
+    registry.set_external_num_cars("kraken", 3)
+    assert base.args["num_cars"] == 3
+    registry.set_external_num_cars("kraken", 0)
+    assert base.args["num_cars"] == 0
+
+    # An unrelated owner now puts 3 there - the same number the released claim used to hold.
+    base.set_arg("num_cars", 3)
+
+    registry.set_external_num_cars("octopus", 1)
+
+    assert base.args["num_cars"] == 3, "the historical claim of 3 must not make this value ours"
+
+    registry.set_external_num_cars("octopus", 0)
+
+    assert base.args["num_cars"] == 3, "and releasing that claim must not lower it either"
+
+
+def test_a_claim_that_was_never_held_writes_nothing():
+    """Dropping a claim that never existed must not create num_cars out of nothing.
+
+    Both octopus and kraken call set_external_num_cars(source, 0) on their release path whether or
+    not they ever claimed anything, so this runs on every site that has either component and no
+    enrolled car. It must stay as much of a no-op as an untouched registry.
+    """
+    base = MockBase()
+    registry = _registry(base)
+
+    registry.set_external_num_cars("kraken", 0)
+
+    assert "num_cars" not in base.args
+    assert base.args == {}
+
+
+def test_external_claims_from_two_sources_do_not_erase_each_other():
+    """Octopus and Kraken can both be configured; the floor is the larger claim, not the last."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    registry.set_external_num_cars("octopus", 3)
+    registry.set_external_num_cars("kraken", 2)
+
+    assert base.args["num_cars"] == 3
+
+    registry.set_external_num_cars("octopus", 0)
+
+    assert base.args["num_cars"] == 2
+
+
+def test_registry_still_lowers_the_num_cars_it_wrote_itself():
+    """The floor is other people's raises only - our own previous count is still ours to lower."""
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("myenergi", [
+        ChargerEntry("myenergi", "Z1", planned="sensor.z1_plug"),
+        ChargerEntry("myenergi", "Z2", planned="sensor.z2_plug"),
+    ])
+    assert base.args["num_cars"] == 2
+
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "Z1", planned="sensor.z1_plug")])
+
+    assert base.args["num_cars"] == 1
+
+
+def test_legacy_interior_hole_keeps_its_position_and_raw_value():
+    """An unconfigured slot in the middle of a legacy list must not compact away or vanish.
+
+    'nothing matched for car 0, here is car 1' is a real config. Dropping slot 0 moved the
+    second car down into it, so it inherited car 0's battery size, charge limit, exclusive
+    flag and manual SoC, and handed slot 1 to the next charger discovered - the two cars'
+    settings simply swapped. Only trailing empty slots are droppable.
+
+    The hole reaching the registry is a None, not the raw 're:' string: auto_config() runs
+    first and turns a list element whose regex did not match into one (userinterface.py:1098).
+    Reading that as a gap and applying the all-or-omit rule deleted the whole key, losing car
+    1's perfectly valid sensor; pre-branch Predbat kept [None, valid] and car 1 worked.
+
+    This is the unit-level version, seeded with the post-auto_config state directly.
+    test_legacy_interior_hole_through_the_real_auto_config covers the same case with Predbat's
+    own auto_config() producing that None, so this fixture cannot drift away from what the real
+    sequence hands the registry.
+    """
+    # Post-auto_config state: slot 0's pattern did not match and has been nulled in place.
+    base = MockBase(num_cars=2, car_charging_planned=[None, "binary_sensor.second_car"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    assert base.args["car_charging_planned"] == [None, "binary_sensor.second_car"]
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    # Slot 0 keeps its hole verbatim, the hand-configured car keeps slot 1, and the discovered
+    # charger appends at slot 2.
+    assert base.args["car_charging_planned"] == [None, "binary_sensor.second_car", "binary_sensor.predbat_ohme_connected"]
+    assert registry.slot_for("ohme", "ohme0") == 2
+    assert base.args["num_cars"] == 3
+
+
+def test_legacy_interior_hole_through_the_real_auto_config():
+    """The interior-hole case again, with Predbat's own auto_config() producing the hole.
+
+    The unit-level twin above seeds [None, 'binary_sensor.second_car'] by hand, which only
+    protects the registry if that really is the state auto_config() leaves behind. Here the args
+    start as the user wrote them - an unmatched 're:' pattern in slot 0 - and the None is made by
+    resolve_arg_re() itself, so the whole sequence apps.yaml -> auto_config -> preregister_legacy
+    -> component registration is exercised end to end.
+    """
+    base = AutoConfigBase(num_cars=2, car_charging_planned=["re:(binary_sensor\\.zappi_.*_plug_status)", "binary_sensor.second_car"])
+    # A populated state map, so the pattern fails for the reason it fails in the field - no Zappi
+    # on this site - rather than because there is nothing at all to match against.
+    base.set_state_wrapper("binary_sensor.second_car", "off")
+    base.set_state_wrapper("sensor.house_load", "1200")
+
+    base.auto_config()
+
+    assert base.args["car_charging_planned"] == [None, "binary_sensor.second_car"], "auto_config nulls the unmatched element in place"
+
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    assert base.args["car_charging_planned"] == [None, "binary_sensor.second_car"], "a legacy-only key is not rewritten"
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    # Identical to the hand-seeded test's expectations: the hole keeps slot 0 verbatim, the
+    # hand-configured car keeps slot 1, and the discovered charger appends at slot 2.
+    assert base.args["car_charging_planned"] == [None, "binary_sensor.second_car", "binary_sensor.predbat_ohme_connected"]
+    assert registry.slot_for("ohme", "ohme0") == 2
+    assert base.args["num_cars"] == 3
+
+
+def test_legacy_only_slot_aligned_args_are_never_rewritten():
+    """A key holding nothing but legacy slots is left byte-identical, not round-tripped.
+
+    The args already hold exactly what the user's apps.yaml (plus auto_config) produced, so
+    there is nothing for the registry to add - and writing anyway would put the all-or-omit
+    rule in charge of config the registry did not compose.
+    """
+    import copy
+
+    base = MockBase(num_cars=2, car_charging_planned=[None, "binary_sensor.second_car"], car_charging_soc=["sensor.a_soc", "sensor.b_soc"])
+    before = copy.deepcopy(base.args)
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    assert base.args["car_charging_planned"] == before["car_charging_planned"]
+    assert base.args["car_charging_soc"] == before["car_charging_soc"]
+    assert "car_charging_now" not in base.args
+
+
+def test_trailing_unconfigured_legacy_slots_are_still_dropped():
+    """The stock-template rule is unchanged: an empty tail is a count, not a charger."""
+    base = MockBase(num_cars=3, car_charging_planned=["binary_sensor.my_car_a", "re:(unmatched)"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected")])
+
+    assert base.args["car_charging_planned"] == ["binary_sensor.my_car_a", "binary_sensor.predbat_ohme_connected"]
+    assert registry.slot_for("ohme", "ohme0") == 1
+    # The declared count is still honoured as a floor, so nothing planned for stops being planned for.
+    assert base.args["num_cars"] == 3
+
+
+def test_legacy_slot_duplicating_a_discovered_charger_is_dropped():
+    """One Zappi must be one car even when the stock regex resolves onto it.
+
+    The shipped car_charging_planned pattern matches the third-party ha-myenergi integration's
+    entity names. On a site running that integration and Predbat's own myenergi component, the
+    same physical charger arrived twice - once as a legacy slot, once as a registered charger -
+    so its session energy was subtracted from house load for two cars.
+
+    The two entity ids are never identical in the field: ha-myenergi publishes
+    sensor.myenergi_zappi_<serial>_plug_status and our own component registers it under
+    sensor.predbat_myenergi_zappi_<serial>_plug_status. The serial is what identifies the
+    hardware, so that is what the match is made on.
+    """
+    ha_myenergi_zappi = "sensor.myenergi_zappi_10000001_plug_status"
+    predbat_zappi = "sensor.predbat_myenergi_zappi_10000001_plug_status"
+    base = MockBase(num_cars=1, car_charging_planned=[ha_myenergi_zappi])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+    assert base.args["car_charging_planned"] == [ha_myenergi_zappi]
+
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "10000001", planned=predbat_zappi, energy="sensor.predbat_myenergi_zappi_10000001_session_energy")])
+
+    # One car, and it is the component's - the legacy slot has no identity for control to use.
+    assert base.args["num_cars"] == 1
+    assert base.args["car_charging_planned"] == [predbat_zappi]
+    assert registry.slot_for("myenergi", "10000001") == 0
+    assert registry.slot_for("legacy", 0) is None
+    assert base.args["car_charging_energy"] == ["sensor.predbat_myenergi_zappi_10000001_session_energy"]
+
+
+def test_a_different_legacy_entity_is_not_treated_as_a_duplicate():
+    """The identity has to actually appear in the legacy entity; a second real car keeps its slot."""
+    base = MockBase(num_cars=1, car_charging_planned=["sensor.some_other_car"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "10000002", planned="sensor.predbat_myenergi_zappi_10000002_plug_status")])
+
+    assert base.args["num_cars"] == 2
+    assert registry.slot_for("myenergi", "10000002") == 1
+
+
+def test_a_serial_that_is_a_prefix_of_another_serial_is_not_a_duplicate():
+    """Serial 10000001 must not claim Zappi 100000010's legacy slot - that is a different charger.
+
+    myenergi serials are consecutive, so a site with two Zappis can easily hold one whose serial
+    is a prefix of the other's. An unbounded substring test read the shorter one as naming the
+    longer one's entity and silently deleted a real car; the match is on a word boundary, and
+    entity ids separate their parts with "_", so the digit either side of it is what tells them
+    apart.
+    """
+    other_zappi = "sensor.myenergi_zappi_100000010_plug_status"
+    base = MockBase(num_cars=1, car_charging_planned=[other_zappi])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    registry.replace_source("myenergi", [ChargerEntry("myenergi", "10000001", planned="sensor.predbat_myenergi_zappi_10000001_plug_status")])
+
+    assert base.args["num_cars"] == 2
+    assert base.args["car_charging_planned"] == [other_zappi, "sensor.predbat_myenergi_zappi_10000001_plug_status"]
+    assert registry.slot_for("myenergi", "10000001") == 1
+
+
+def test_a_gateway_charge_point_id_is_not_matched_inside_a_legacy_entity():
+    """An OCPP charge point id is a name its installer typed, not a high-entropy serial.
+
+    myenergi and GivEnergy Cloud device ids are manufacturer serials, so finding one inside an
+    entity id is real evidence of the same hardware. A gateway charge point id can be anything -
+    'garage', 'CP1', the customer's surname - so the same test would delete any car whose entity
+    happened to contain that word. Gateway chargers are still deduped against a legacy slot
+    naming the exact same entity; only the looser match is withheld.
+    """
+    base = MockBase(num_cars=1, car_charging_planned=["binary_sensor.garage_car_connected"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    registry.replace_source("gateway", [ChargerEntry("gateway", "garage", planned="binary_sensor.predbat_gateway_ev_garage_connected")])
+
+    assert base.args["num_cars"] == 2
+    assert base.args["car_charging_planned"] == ["binary_sensor.garage_car_connected", "binary_sensor.predbat_gateway_ev_garage_connected"]
+    assert registry.slot_for("gateway", "garage") == 1
+
+
+def test_a_gateway_charger_still_dedupes_a_legacy_slot_naming_its_own_entity():
+    """Withholding the serial match must not cost the exact-entity match, which is unambiguous."""
+    gateway_entity = "binary_sensor.predbat_gateway_ev_garage_connected"
+    base = MockBase(num_cars=1, car_charging_planned=[gateway_entity])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    registry.replace_source("gateway", [ChargerEntry("gateway", "garage", planned=gateway_entity)])
+
+    assert base.args["num_cars"] == 1
+    assert base.args["car_charging_planned"] == [gateway_entity]
+    assert registry.slot_for("gateway", "garage") == 0
+
+
+def test_a_short_device_id_is_not_matched_inside_a_legacy_entity():
+    """A two- or three-character id would collide by chance, so it is not identity evidence.
+
+    'sensor.my_car_a' contains '_a'; a device_id that short naming the same hardware is not
+    something the substring match can tell apart from a coincidence, so the legacy slot stays.
+    """
+    base = MockBase(num_cars=1, car_charging_planned=["sensor.my_car_a"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "_a", planned="binary_sensor.predbat_gecloud_evc_car_connected")])
+
+    assert base.args["num_cars"] == 2
+    assert base.args["car_charging_planned"] == ["sensor.my_car_a", "binary_sensor.predbat_gecloud_evc_car_connected"]
+
+
+def test_aggregate_set_by_another_component_is_not_clobbered():
+    """A key no registered charger supplies is not the registry's to write.
+
+    alphaess sets car_charging_energy from its own discovery at runtime, and ohme deliberately
+    backs off when somebody else owns it - replaying the legacy snapshot on every materialise
+    undid both.
+    """
+    base = MockBase(num_cars=1, car_charging_planned=["binary_sensor.my_car_a"])
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+
+    # A third party writes the aggregate after the snapshot was taken.
+    base.set_arg("car_charging_energy", "sensor.alphaess_car_charging_energy")
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.predbat_ohme_connected", energy=None)])
+
+    assert base.args["car_charging_energy"] == "sensor.alphaess_car_charging_energy"
+
+
+def test_the_registry_still_clears_an_aggregate_it_wrote_itself():
+    """Ownership is what gates the write, so removal still restores the legacy value."""
+    base = MockBase(car_charging_energy="sensor.my_charger_energy")
+    registry = _registry(base)
+    preregister_legacy(registry, base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.ohme", energy="sensor.predbat_ohme_energy_today")])
+    assert base.args["car_charging_energy"] == ["sensor.my_charger_energy", "sensor.predbat_ohme_energy_today"]
+
+    registry.replace_source("ohme", [])
+
+    assert base.args["car_charging_energy"] == ["sensor.my_charger_energy"]
+
+
+def test_aggregate_overwritten_after_we_wrote_it_is_left_alone():
+    """Having written a key once is not ownership of it forever.
+
+    alphaess.py:805 sets car_charging_energy from its own EV-charger discovery at any point.
+    Tracking only that the registry had *ever* written the key meant the last charger leaving
+    restored over the top of alphaess's value, silently disconnecting its charger.
+    """
+    base = MockBase()
+    registry = _registry(base)
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.ohme", energy="sensor.predbat_ohme_energy_today")])
+    assert base.args["car_charging_energy"] == ["sensor.predbat_ohme_energy_today"]
+
+    # alphaess wires its own charger afterwards.
+    base.set_arg("car_charging_energy", ["sensor.alphaess_ev_energy_today"])
+
+    registry.replace_source("ohme", [])
+
+    assert base.args["car_charging_energy"] == ["sensor.alphaess_ev_energy_today"]
+
+
+def test_slot_map_is_logged_only_when_it_changes():
+    """Support logs need the map, but this runs on every rediscovery - so log the changes."""
+    base = MockBase()
+    messages = []
+    base.log = lambda message, quiet=True: messages.append(message)
+    registry = _registry(base)
+
+    def slot_logs():
+        """Just the slot-map lines out of everything the registry logged."""
+        return [message for message in messages if "ChargerRegistry: slots" in message]
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.ohme")])
+    assert len(slot_logs()) == 1, slot_logs()
+    assert "ohme/ohme0" in slot_logs()[0]
+
+    registry.replace_source("ohme", [ChargerEntry("ohme", "ohme0", planned="binary_sensor.ohme")])
+    assert len(slot_logs()) == 1, "An unchanged map must not be re-logged"
+
+    registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.ce1234")])
+    assert len(slot_logs()) == 2, "A reallocation must be logged"
+
+
+def test_charger_registry(my_predbat=None):
+    """Aggregate runner for unit_test.py, which is the only test gate upstream CI runs.
+
+    pytest is not run in CI, so a test file that is not reachable from unit_test.py's
+    TEST_REGISTRY is not actually protecting anything. The sub-tests are discovered from the
+    module rather than hand-listed, so a test added here cannot silently drop out of CI the
+    way this whole file did.
+
+    Returns a truthy value when anything failed, which is what unit_test.py's runner reads.
+    """
+    print("\n" + "=" * 70)
+    print("CHARGER REGISTRY TEST SUITE")
+    print("=" * 70)
+
+    sub_tests = [(name, func) for name, func in sorted(globals().items()) if name.startswith("test_") and name != "test_charger_registry" and callable(func)]
+
+    passed = 0
+    failed = 0
+    for name, test_func in sub_tests:
+        print(f"\n[{name}] {test_func.__doc__.splitlines()[0] if test_func.__doc__ else ''}")
+        print("-" * 70)
+        try:
+            test_func()
+            print(f"✓ PASSED: {name}")
+            passed += 1
+        except Exception as e:
+            print(f"✗ FAILED: {name}: {e}")
+            import traceback
+
+            traceback.print_exc()
+            failed += 1
+
+    print("\n" + "=" * 70)
+    print(f"RESULTS: {passed} passed, {failed} failed out of {len(sub_tests)} tests")
+    print("=" * 70)
+
+    return failed > 0
+
+
+# Not a test itself: pytest would otherwise collect this runner alongside the sub-tests it
+# calls, running the whole file twice per session and reporting a pass/fail count that does
+# not match the tests. unit_test.py calls it directly by name, which this does not affect.
+test_charger_registry.__test__ = False

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -4096,31 +4096,33 @@ class TestEvTelemetry:
 
 
 class TestEvAutoConfig:
-    """Tests for GatewayMQTT._register_ev_car() — conservative car registration."""
+    """Tests for GatewayMQTT._register_ev_chargers() — every charge point gets its own slot."""
 
-    def _make_gateway(self, ev_enable=True, num_cars=0, args=None, evc_control=False):
+    def _make_gateway(self, ev_enable=True, evc_control=False):
+        """A GatewayMQTT wired to a real registry, so slot allocation is the real thing."""
         from gateway import GatewayMQTT
         from unittest.mock import MagicMock
+        from charger_registry import ChargerRegistry
 
         gw = GatewayMQTT.__new__(GatewayMQTT)
         gw.base = MagicMock()
+        # register_chargers()/charger_slot() go through base.charger_registry, and the
+        # registry writes back via base.set_arg — route that to the same gw._args dict
+        # the tests assert on, same pattern as Tasks 4 and 6.
+        gw.base.charger_registry = ChargerRegistry(gw.base)
         gw.log = MagicMock()
         gw.prefix = "predbat"
         gw.gateway_evc_automatic = ev_enable
         gw.gateway_evc_control = evc_control
-        gw.args = args if args is not None else {}
+        gw._ev_no_id_warned = False
+        gw.args = {}
         gw._args = {}
 
         def capture_set_arg(key, value):
             gw._args[key] = value
 
-        def fake_get_arg(key, default=None, **kwargs):
-            if key == "num_cars":
-                return num_cars
-            return default
-
         gw.set_arg = capture_set_arg
-        gw.get_arg = fake_get_arg
+        gw.base.set_arg = capture_set_arg
         return gw
 
     def _status_with_ev(self, charge_point_id="CP1", max_current_a=32, voltage_v=240):
@@ -4132,11 +4134,12 @@ class TestEvAutoConfig:
         ev.voltage_v = voltage_v
         return status
 
-    def test_registers_connected_charger_not_a_stale_slot(self):
-        """A disconnected charger in slot 0 must not be registered over a connected one.
+    def test_registers_every_charger_regardless_of_connection_state(self):
+        """A disconnected charger and a connected one both get their own slot.
 
-        Gateway firmware now reports known-but-offline chargers with connected=false
-        (it used to omit them), so the first entry is no longer guaranteed to be live.
+        Gateway firmware reports known-but-offline chargers with connected=false; the
+        registry (not connection state) now decides how many cars exist, so both register
+        — there is no more "prefer the connected one" selection to get wrong.
         """
         status = pb.GatewayStatus()
         stale = status.ev_chargers.add()
@@ -4146,28 +4149,19 @@ class TestEvAutoConfig:
         live.connected = True
         live.charge_point_id = "CP0001"
 
-        gw = self._make_gateway(ev_enable=True, num_cars=0)
-        gw._register_ev_car(status)
+        gw = self._make_gateway(ev_enable=True)
+        gw._register_ev_chargers(status)
 
-        assert gw._args["car_charging_planned"] == ["binary_sensor.predbat_gateway_ev_cp0001_connected"]
-
-    def test_registers_offline_charger_when_none_connected(self):
-        """A charger that is merely offline right now still registers, so it reappears."""
-        status = pb.GatewayStatus()
-        offline = status.ev_chargers.add()
-        offline.connected = False
-        offline.charge_point_id = "CP0002"
-
-        gw = self._make_gateway(ev_enable=True, num_cars=0)
-        gw._register_ev_car(status)
-
-        assert gw._args["num_cars"] == 1
-        assert gw._args["car_charging_planned"] == ["binary_sensor.predbat_gateway_ev_cp0002_connected"]
+        assert gw._args["num_cars"] == 2
+        assert gw._args["car_charging_planned"] == [
+            "binary_sensor.predbat_gateway_ev_cp0000_connected",
+            "binary_sensor.predbat_gateway_ev_cp0001_connected",
+        ]
 
     def test_registers_car_when_none_configured(self):
-        """With the flag on and no existing cars, the charger is registered as car 1."""
-        gw = self._make_gateway(ev_enable=True, num_cars=0)
-        gw._register_ev_car(self._status_with_ev())
+        """With the flag on and a single charger, it is registered as the only car."""
+        gw = self._make_gateway(ev_enable=True)
+        gw._register_ev_chargers(self._status_with_ev())
 
         assert gw._args["num_cars"] == 1
         assert gw._args["car_charging_planned"] == ["binary_sensor.predbat_gateway_ev_cp1_connected"]
@@ -4176,57 +4170,128 @@ class TestEvAutoConfig:
         # car_charging_rate is a UI config item — set via expose_config, not set_arg
         assert "car_charging_rate" not in gw._args
         gw.base.expose_config.assert_called_once_with("car_charging_rate", 7.68)  # 32A * 240V / 1000
-        # Session energy sensor for subtracting EV load from history
-        assert gw._args["car_charging_energy"] == "sensor.predbat_gateway_ev_cp1_session_energy"
-        # Live charge power, display-only: drives the web power flow diagram
-        assert gw._args["car_charging_power"] == "sensor.predbat_gateway_ev_cp1_power"
+        # Session energy / power are site aggregates in the registry: one-element lists
+        # for a single charger rather than the old bare scalars.
+        assert gw._args["car_charging_energy"] == ["sensor.predbat_gateway_ev_cp1_session_energy"]
+        assert gw._args["car_charging_power"] == ["sensor.predbat_gateway_ev_cp1_power"]
         # Battery size and target limit are left to the existing car_charging_* settings
         assert "car_charging_battery_size" not in gw._args
         assert "car_charging_limit" not in gw._args
 
     def test_disabled_flag_does_nothing(self):
         """With the opt-in flag off, no car args are set."""
-        gw = self._make_gateway(ev_enable=False, num_cars=0)
-        gw._register_ev_car(self._status_with_ev())
+        gw = self._make_gateway(ev_enable=False)
+        gw._register_ev_chargers(self._status_with_ev())
         assert gw._args == {}
 
     def test_no_chargers_does_nothing(self):
         """No EV charger in telemetry means no registration."""
-        gw = self._make_gateway(ev_enable=True, num_cars=0)
+        gw = self._make_gateway(ev_enable=True)
         status = pb.GatewayStatus()
-        gw._register_ev_car(status)
+        gw._register_ev_chargers(status)
+        assert gw._args == {}
+
+    def test_charge_point_without_an_id_is_skipped(self):
+        """A charger with no charge_point_id cannot be controlled, so it must not take a car slot.
+
+        _configured_ev_chargers filters out chargers with no id, so registering one under a
+        fallback name created a car Predbat plans for that control can never reach.
+        """
+        gw = self._make_gateway(ev_enable=True)
+        status = pb.GatewayStatus()
+        nameless = status.ev_chargers.add()
+        nameless.connected = True
+        nameless.charge_point_id = ""
+        real = status.ev_chargers.add()
+        real.connected = True
+        real.charge_point_id = "CP1"
+
+        gw._register_ev_chargers(status)
+
+        assert gw._args["num_cars"] == 1
+        assert gw._args["car_charging_planned"] == ["binary_sensor.predbat_gateway_ev_cp1_connected"]
+        assert any("no charge_point_id" in str(call) for call in gw.log.call_args_list)
+
+    def test_only_charge_point_without_an_id_registers_nothing(self):
+        """The one reported charger having no id leaves the car args untouched, not zeroed."""
+        gw = self._make_gateway(ev_enable=True)
+        status = pb.GatewayStatus()
+        nameless = status.ev_chargers.add()
+        nameless.connected = True
+        nameless.charge_point_id = ""
+
+        gw._register_ev_chargers(status)
+
         assert gw._args == {}
 
     def test_car_charging_now_set_when_not_controlling(self):
         """car_charging_now is wired to session_active when gateway_evc_control is False."""
-        gw = self._make_gateway(ev_enable=True, num_cars=0, evc_control=False)
-        gw._register_ev_car(self._status_with_ev())
+        gw = self._make_gateway(ev_enable=True, evc_control=False)
+        gw._register_ev_chargers(self._status_with_ev())
         assert gw._args["car_charging_now"] == ["binary_sensor.predbat_gateway_ev_cp1_session_active"]
 
     def test_car_charging_now_omitted_when_controlling(self):
-        """car_charging_now is not set when gateway_evc_control is True to prevent feedback loop."""
-        gw = self._make_gateway(ev_enable=True, num_cars=0, evc_control=True)
-        gw._register_ev_car(self._status_with_ev())
-        assert "car_charging_now" not in gw._args
+        """now=None per-charger when gateway_evc_control is True, to prevent a feedback loop.
+
+        The registry writes an explicit None for a slot-aligned field with no values at
+        all (not skip the key), unlike the old set_arg-only path which never touched it.
+        """
+        gw = self._make_gateway(ev_enable=True, evc_control=True)
+        gw._register_ev_chargers(self._status_with_ev())
+        assert gw._args["car_charging_now"] is None
 
     def test_charge_rate_falls_back_to_7_4_when_capability_unknown(self):
         """car_charging_rate expose_config uses 7.4kW fallback when max_current_a is 0."""
-        gw = self._make_gateway(ev_enable=True, num_cars=0)
-        gw._register_ev_car(self._status_with_ev(max_current_a=0, voltage_v=0))
+        gw = self._make_gateway(ev_enable=True)
+        gw._register_ev_chargers(self._status_with_ev(max_current_a=0, voltage_v=0))
         assert "car_charging_rate" not in gw._args
         gw.base.expose_config.assert_called_once_with("car_charging_rate", 7.4)
 
     def test_charge_rate_computed_from_max_current_and_voltage(self):
         """car_charging_rate expose_config uses max_current_a * voltage_v when both are set."""
-        gw = self._make_gateway(ev_enable=True, num_cars=0)
-        gw._register_ev_car(self._status_with_ev(max_current_a=16, voltage_v=230))
+        gw = self._make_gateway(ev_enable=True)
+        gw._register_ev_chargers(self._status_with_ev(max_current_a=16, voltage_v=230))
         gw.base.expose_config.assert_called_once_with("car_charging_rate", 3.68)  # 16A * 230V / 1000
 
     def test_charge_rate_uses_230v_default_when_voltage_missing(self):
         """car_charging_rate expose_config uses 230V default when voltage_v is 0."""
-        gw = self._make_gateway(ev_enable=True, num_cars=0)
-        gw._register_ev_car(self._status_with_ev(max_current_a=32, voltage_v=0))
+        gw = self._make_gateway(ev_enable=True)
+        gw._register_ev_chargers(self._status_with_ev(max_current_a=32, voltage_v=0))
         gw.base.expose_config.assert_called_once_with("car_charging_rate", 7.36)  # 32A * 230V / 1000
+
+    def test_two_charge_points_each_get_their_own_slot_and_rate(self):
+        """Two connected chargers each get a distinct slot, distinct entities and their own car_charging_rate_N.
+
+        This is the exact bug the registry exists to fix: the old code forced num_cars=1
+        and overwrote car_charging_* with whichever charger it picked, so a second
+        charge point was invisible to the optimizer entirely.
+        """
+        status = pb.GatewayStatus()
+        a = status.ev_chargers.add()
+        a.connected = True
+        a.charge_point_id = "AAAAAA"
+        a.max_current_a = 32
+        a.voltage_v = 230
+        b = status.ev_chargers.add()
+        b.connected = True
+        b.charge_point_id = "BBBBBB"
+        b.max_current_a = 16
+        b.voltage_v = 230
+
+        gw = self._make_gateway(ev_enable=True)
+        gw._register_ev_chargers(status)
+
+        assert gw._args["num_cars"] == 2
+        assert gw._args["car_charging_planned"] == [
+            "binary_sensor.predbat_gateway_ev_aaaaaa_connected",
+            "binary_sensor.predbat_gateway_ev_bbbbbb_connected",
+        ]
+        assert gw._args["car_charging_energy"] == [
+            "sensor.predbat_gateway_ev_aaaaaa_session_energy",
+            "sensor.predbat_gateway_ev_bbbbbb_session_energy",
+        ]
+        gw.base.expose_config.assert_any_call("car_charging_rate", 7.36)  # slot 0: 32A * 230V / 1000
+        gw.base.expose_config.assert_any_call("car_charging_rate_1", 3.68)  # slot 1: 16A * 230V / 1000
 
 
 class TestEvInitialize:
@@ -4321,21 +4386,34 @@ class TestEvNeedsReconfigure:
 
 
 class TestEvControl:
-    """Tests for GatewayMQTT EVC minute-level control — _refresh_ev_windows, _should_ev_charge_now, _apply_ev_charging_state."""
+    """Tests for GatewayMQTT EVC minute-level control — _refresh_ev_windows, _should_ev_charge_now, _apply_ev_charging_state.
+
+    Each configured charge point is judged against its own car slot's plan, so the fixture
+    registers every configured charge point with the charger registry (same as
+    automatic_config() would) rather than assuming car 0.
+    """
 
     def _make_gateway(self, evc_control=True, evc_automatic=True, configured_chargers=None, ev_max_current=None):
         from gateway import GatewayMQTT
         from unittest.mock import MagicMock
+        from charger_registry import ChargerEntry, ChargerRegistry
 
         gw = GatewayMQTT.__new__(GatewayMQTT)
         gw.log = MagicMock()
         gw.prefix = "predbat"
         gw.gateway_evc_control = evc_control
         gw.gateway_evc_automatic = evc_automatic
-        gw._configured_ev_chargers = frozenset(configured_chargers or ["CP10000001"])
+        gw.base = MagicMock()
+        gw.base.charger_registry = ChargerRegistry(gw.base)
+        cp_ids = sorted(configured_chargers or ["CP10000001"])
+        gw._configured_ev_chargers = frozenset(cp_ids)
+        # Give each configured charge point a registry slot, same as _register_ev_chargers
+        # would in production — control reads charger_slot(), so it needs one to act at all.
+        gw.register_chargers("gateway", [ChargerEntry("gateway", cp_id) for cp_id in cp_ids])
         gw._ev_max_current = ev_max_current if ev_max_current is not None else {"CP10000001": 32}
-        gw._ev_windows = []
-        gw._ev_charging_active = False
+        gw._ev_windows = {}
+        gw._ev_charging_active = {}
+        gw._ev_no_slot_warned = False
         gw.local_tz = pytz.timezone("Europe/London")
         return gw
 
@@ -4347,7 +4425,7 @@ class TestEvControl:
         return result
 
     def test_refresh_ev_windows_parses_planned(self):
-        """_refresh_ev_windows parses the planned attribute into (start_dt, end_dt) pairs."""
+        """_refresh_ev_windows parses the planned attribute into (start_dt, end_dt) pairs, keyed by slot."""
 
         gw = self._make_gateway()
         planned = self._planned([("06-28 02:00:00", "06-28 05:30:00"), ("06-28 22:00:00", "06-28 23:00:00")])
@@ -4355,49 +4433,88 @@ class TestEvControl:
 
         gw._refresh_ev_windows()
 
-        assert len(gw._ev_windows) == 2
-        assert gw._ev_windows[0][0].hour == 2 and gw._ev_windows[0][0].minute == 0
-        assert gw._ev_windows[0][1].hour == 5 and gw._ev_windows[0][1].minute == 30
+        windows = gw._ev_windows[0]  # the single configured charge point's slot
+        assert len(windows) == 2
+        assert windows[0][0].hour == 2 and windows[0][0].minute == 0
+        assert windows[0][1].hour == 5 and windows[0][1].minute == 30
 
     def test_refresh_ev_windows_empty_plan(self):
-        """_refresh_ev_windows clears windows when planned is empty."""
+        """_refresh_ev_windows clears a slot's windows when planned is empty."""
         gw = self._make_gateway()
         gw.get_state_wrapper = lambda entity, attribute=None: [] if attribute == "planned" else "off"
-        gw._ev_windows = [("dummy", "dummy")]
+        gw._ev_windows = {0: [("dummy", "dummy")]}
 
         gw._refresh_ev_windows()
 
-        assert gw._ev_windows == []
+        assert gw._ev_windows == {0: []}
+
+    def test_refresh_ev_windows_reads_each_charge_points_own_slot(self):
+        """Two charge points read their own car slot's plan entity, not both car 0's.
+
+        Reading the unindexed entity for every charger would drive every charger from
+        car 0's plan regardless of which car it was actually registered as.
+        """
+        gw = self._make_gateway(configured_chargers=["CP-AAAAAA", "CP-BBBBBB"])
+        seen_entities = []
+
+        def fake_get_state(entity, attribute=None):
+            """Record which entity the code asked for, and answer for car 1 only."""
+            seen_entities.append(entity)
+            if entity.endswith("_1"):
+                return self._planned([("06-28 04:00:00", "06-28 05:00:00")])
+            return self._planned([("06-28 02:00:00", "06-28 03:00:00")])
+
+        gw.get_state_wrapper = fake_get_state
+        gw._refresh_ev_windows()
+
+        slot_a = gw.charger_slot("gateway", "CP-AAAAAA")
+        slot_b = gw.charger_slot("gateway", "CP-BBBBBB")
+        assert slot_a == 0 and slot_b == 1
+        assert "binary_sensor.predbat_car_charging_slot" in seen_entities
+        assert "binary_sensor.predbat_car_charging_slot_1" in seen_entities
+        assert gw._ev_windows[slot_a][0][0].hour == 2
+        assert gw._ev_windows[slot_b][0][0].hour == 4
 
     def test_should_charge_now_inside_window(self):
-        """_should_ev_charge_now returns True when now() is within a window."""
+        """_should_ev_charge_now returns True when now() is within the given slot's window."""
         import datetime as dt_mod
 
         gw = self._make_gateway()
         now = dt_mod.datetime.now(gw.local_tz)
         start = now - dt_mod.timedelta(minutes=30)
         end = now + dt_mod.timedelta(minutes=30)
-        gw._ev_windows = [(start, end)]
+        gw._ev_windows = {0: [(start, end)]}
 
-        assert gw._should_ev_charge_now() is True
+        assert gw._should_ev_charge_now(0) is True
 
     def test_should_charge_now_outside_window(self):
-        """_should_ev_charge_now returns False when now() is outside all windows."""
+        """_should_ev_charge_now returns False when now() is outside all of the slot's windows."""
         import datetime as dt_mod
 
         gw = self._make_gateway()
         now = dt_mod.datetime.now(gw.local_tz)
         start = now + dt_mod.timedelta(hours=2)
         end = now + dt_mod.timedelta(hours=4)
-        gw._ev_windows = [(start, end)]
+        gw._ev_windows = {0: [(start, end)]}
 
-        assert gw._should_ev_charge_now() is False
+        assert gw._should_ev_charge_now(0) is False
 
     def test_should_charge_now_no_windows(self):
-        """_should_ev_charge_now returns False when there are no windows."""
+        """_should_ev_charge_now returns False when there are no cached windows for the slot."""
         gw = self._make_gateway()
-        gw._ev_windows = []
-        assert gw._should_ev_charge_now() is False
+        gw._ev_windows = {}
+        assert gw._should_ev_charge_now(0) is False
+
+    def test_should_charge_now_reads_the_given_slot_not_another(self):
+        """A slot with no cached windows returns False even while another slot is mid-window."""
+        import datetime as dt_mod
+
+        gw = self._make_gateway()
+        now = dt_mod.datetime.now(gw.local_tz)
+        gw._ev_windows = {0: [(now - dt_mod.timedelta(minutes=5), now + dt_mod.timedelta(minutes=5))]}
+
+        assert gw._should_ev_charge_now(0) is True
+        assert gw._should_ev_charge_now(1) is False
 
     def test_refresh_ev_windows_year_boundary(self):
         """Windows whose parsed start would be >23 h in the past get their year bumped."""
@@ -4415,13 +4532,14 @@ class TestEvControl:
 
         gw._refresh_ev_windows()
 
-        assert len(gw._ev_windows) == 1
-        start_dt, end_dt = gw._ev_windows[0]
+        windows = gw._ev_windows[0]
+        assert len(windows) == 1
+        start_dt, end_dt = windows[0]
         # After year bump, start should be in the future (next year)
         assert start_dt > now
 
     def test_apply_sends_start_on_transition(self):
-        """_apply_ev_charging_state sends SetChargingProfile then RemoteStartTransaction when entering a window."""
+        """_apply_ev_charging_state sends SetChargingProfile then RemoteStartTransaction, routed to the charge point, when entering a window."""
         import asyncio
         import datetime as dt_mod
         import json
@@ -4430,24 +4548,25 @@ class TestEvControl:
         published = []
 
         async def fake_publish_raw(topic, payload, **kwargs):
+            """Capture the decoded schedule payload the gateway publishes."""
             published.append(json.loads(payload.decode()))
 
         gw._publish_raw = fake_publish_raw
         gw.topic_ev_command = "predbat/devices/test/ev/command"
 
         now = dt_mod.datetime.now(gw.local_tz)
-        gw._ev_windows = [(now - dt_mod.timedelta(minutes=5), now + dt_mod.timedelta(hours=1))]
-        gw._ev_charging_active = False
+        gw._ev_windows = {0: [(now - dt_mod.timedelta(minutes=5), now + dt_mod.timedelta(hours=1))]}
+        gw._ev_charging_active = {}
 
         asyncio.run(gw._apply_ev_charging_state())
 
         assert len(published) == 2
-        assert published[0] == {"action": "SetChargingProfile", "current_a": 32}
-        assert published[1] == {"action": "RemoteStartTransaction", "id_tag": "predbat"}
-        assert gw._ev_charging_active is True
+        assert published[0] == {"action": "SetChargingProfile", "current_a": 32, "charge_point_id": "CP10000001"}
+        assert published[1] == {"action": "RemoteStartTransaction", "id_tag": "predbat", "charge_point_id": "CP10000001"}
+        assert gw._ev_charging_active == {"CP10000001": True}
 
     def test_apply_sends_stop_on_transition(self):
-        """_apply_ev_charging_state sends RemoteStopTransaction when leaving a window."""
+        """_apply_ev_charging_state sends RemoteStopTransaction, routed to the charge point, when leaving a window."""
         import asyncio
         import json
 
@@ -4455,18 +4574,84 @@ class TestEvControl:
         published = []
 
         async def fake_publish_raw(topic, payload, **kwargs):
+            """Capture the decoded schedule payload the gateway publishes."""
             published.append(json.loads(payload.decode()))
 
         gw._publish_raw = fake_publish_raw
         gw.topic_ev_command = "predbat/devices/test/ev/command"
-        gw._ev_windows = []  # no active window
-        gw._ev_charging_active = True  # was charging
+        gw._ev_windows = {0: []}  # no active window
+        gw._ev_charging_active = {"CP10000001": True}  # was charging
 
         asyncio.run(gw._apply_ev_charging_state())
 
         assert len(published) == 1
-        assert published[0] == {"action": "RemoteStopTransaction"}
-        assert gw._ev_charging_active is False
+        assert published[0] == {"action": "RemoteStopTransaction", "charge_point_id": "CP10000001"}
+        assert gw._ev_charging_active == {"CP10000001": False}
+
+    def test_refresh_leaves_a_never_published_slot_out_of_the_windows(self):
+        """A slot whose planned attribute has never been written is absent, not empty.
+
+        The two are different: an empty list is a real plan saying "not now", while a missing
+        attribute only means the plan for that car has not been published yet.
+        """
+        gw = self._make_gateway()
+        gw.get_state_wrapper = lambda entity, attribute=None: None
+
+        gw._refresh_ev_windows()
+
+        assert gw._ev_windows == {}
+
+    def test_apply_does_not_stop_a_charging_car_whose_plan_is_unpublished(self):
+        """The regression: a never-published slot must not read as an empty plan and stop the car.
+
+        Another source registering shifts a gateway charger to a higher slot; for the moments
+        before that slot's entity is published, `planned` is absent. Treating that as an empty
+        plan sent RemoteStopTransaction to a car that was mid-charge.
+        """
+        import asyncio
+
+        gw = self._make_gateway()
+        published = []
+
+        async def fake_publish_raw(topic, payload, **kwargs):
+            """Capture the raw payload so the test can assert nothing was published."""
+            published.append(payload)
+
+        gw._publish_raw = fake_publish_raw
+        gw.topic_ev_command = "predbat/devices/test/ev/command"
+        gw.get_state_wrapper = lambda entity, attribute=None: None
+        gw._ev_charging_active = {"CP10000001": True}  # actively charging
+
+        gw._refresh_ev_windows()
+        asyncio.run(gw._apply_ev_charging_state())
+
+        assert published == [], "A charging car must not be stopped for want of a published plan"
+        assert gw._ev_charging_active == {"CP10000001": True}
+        # It has a slot, so the "no charge point has a slot" warning must not fire either.
+        assert gw._ev_no_slot_warned is False
+
+    def test_apply_does_stop_a_charging_car_on_a_published_empty_plan(self):
+        """The other half: a published-but-empty plan is a real decision and does stop the car."""
+        import asyncio
+        import json
+
+        gw = self._make_gateway()
+        published = []
+
+        async def fake_publish_raw(topic, payload, **kwargs):
+            """Capture the decoded payload of whatever control message is sent."""
+            published.append(json.loads(payload.decode()))
+
+        gw._publish_raw = fake_publish_raw
+        gw.topic_ev_command = "predbat/devices/test/ev/command"
+        gw.get_state_wrapper = lambda entity, attribute=None: [] if attribute == "planned" else "off"
+        gw._ev_charging_active = {"CP10000001": True}
+
+        gw._refresh_ev_windows()
+        asyncio.run(gw._apply_ev_charging_state())
+
+        assert published == [{"action": "RemoteStopTransaction", "charge_point_id": "CP10000001"}]
+        assert gw._ev_charging_active == {"CP10000001": False}
 
     def test_apply_no_command_when_state_unchanged(self):
         """_apply_ev_charging_state sends nothing when desired state matches last state."""
@@ -4480,12 +4665,161 @@ class TestEvControl:
 
         gw._publish_raw = fake_publish_raw
         gw.topic_ev_command = "predbat/devices/test/ev/command"
-        gw._ev_windows = []
-        gw._ev_charging_active = False  # already stopped
+        gw._ev_windows = {0: []}
+        gw._ev_charging_active = {"CP10000001": False}  # already stopped
 
         asyncio.run(gw._apply_ev_charging_state())
 
         assert published == []
+
+    def test_apply_defaults_to_stopped_on_first_ever_check(self):
+        """A charge point never seen before is treated as already-stopped, not commanded.
+
+        _ev_charging_active starts empty, so a naive dict.get(cp_id) (defaulting to None)
+        would send a spurious RemoteStopTransaction on the very first cycle for a charger
+        that was never charging. The default must match should_charge=False so nothing is
+        sent until there is an actual transition.
+        """
+        import asyncio
+
+        gw = self._make_gateway()
+        published = []
+
+        async def fake_publish_raw(topic, payload, **kwargs):
+            """Capture each published (topic, payload) so the stop can be identified."""
+            published.append((topic, payload))
+
+        gw._publish_raw = fake_publish_raw
+        gw.topic_ev_command = "predbat/devices/test/ev/command"
+        gw._ev_windows = {0: []}  # no active window
+        gw._ev_charging_active = {}  # never commanded before
+
+        asyncio.run(gw._apply_ev_charging_state())
+
+        assert published == []
+
+    def test_apply_skips_a_charge_point_with_no_registry_slot(self):
+        """A configured charge point not yet registered (slot None) is skipped, not commanded.
+
+        This can happen mid-cycle: a charger appears in _configured_ev_chargers before
+        automatic_config() has re-run and given it a slot. _ev_charging_active is
+        deliberately pre-set to True for the unregistered charge point: without the
+        `if slot is None: continue` guard, its cached (stale, from before it lost its
+        slot) should_charge=False would differ from that True and a RemoteStopTransaction
+        would be sent for a charger the registry no longer even knows about — the skip
+        must suppress that, not merely coincide with "nothing to do" via an empty window.
+        """
+        import asyncio
+        from charger_registry import ChargerEntry
+
+        gw = self._make_gateway(configured_chargers=["CP10000001", "CP-UNREGISTERED"])
+        # De-register the second, simulating a charger discovered but not yet slotted.
+        gw.base.charger_registry.replace_source("gateway", [ChargerEntry("gateway", "CP10000001")])
+        assert gw.charger_slot("gateway", "CP-UNREGISTERED") is None
+        published = []
+
+        async def fake_publish_raw(topic, payload, **kwargs):
+            """Capture each published (topic, payload) so the skip can be proved silent."""
+            published.append((topic, payload))
+
+        gw._publish_raw = fake_publish_raw
+        gw.topic_ev_command = "predbat/devices/test/ev/command"
+        gw._ev_windows = {0: []}
+        gw._ev_charging_active = {"CP-UNREGISTERED": True}
+
+        asyncio.run(gw._apply_ev_charging_state())
+
+        assert published == []  # no crash, and CP10000001 has no active window either
+
+    def test_apply_warns_once_when_control_enabled_but_no_charger_has_a_slot(self):
+        """gateway_evc_control=True with gateway_evc_automatic=False was a silent no-op.
+
+        _configured_ev_chargers can be non-empty (populated from telemetry regardless of
+        the automatic flag) while every charger has no registry slot (only
+        _register_ev_chargers, gated on gateway_evc_automatic, ever gives one) - every
+        charge point was silently skipped forever, with nothing in the log to say why.
+        This must warn once, then stay quiet on repeat cycles while the condition holds.
+        """
+        import asyncio
+        from unittest.mock import call
+
+        gw = self._make_gateway(configured_chargers=["CP-NEVER-SLOTTED"])
+        # Undo what the fixture's automatic-config stand-in did, so no charge point has a
+        # slot - the exact state gateway_evc_automatic=False leaves control in.
+        gw.base.charger_registry.replace_source("gateway", [])
+        assert gw.charger_slot("gateway", "CP-NEVER-SLOTTED") is None
+
+        async def fake_publish_raw(topic, payload, **kwargs):
+            """Swallow the publish - this test asserts on the log, not on MQTT traffic."""
+            pass
+
+        gw._publish_raw = fake_publish_raw
+        gw.topic_ev_command = "predbat/devices/test/ev/command"
+        gw._ev_windows = {}
+        gw._ev_charging_active = {}
+
+        asyncio.run(gw._apply_ev_charging_state())
+        asyncio.run(gw._apply_ev_charging_state())
+        asyncio.run(gw._apply_ev_charging_state())
+
+        warn_calls = [c for c in gw.log.call_args_list if c == call("Warn: GatewayMQTT: EVC control is enabled but no charge point has a registered car slot - is gateway_evc_automatic off?")]
+        assert len(warn_calls) == 1
+
+    def test_apply_silent_when_every_configured_charger_has_a_slot(self):
+        """No "no slot" warning when charge points are (as normal) actually registered."""
+        import asyncio
+
+        gw = self._make_gateway()  # default fixture registers CP10000001 with a slot
+        published = []
+
+        async def fake_publish_raw(topic, payload, **kwargs):
+            """Capture each published (topic, payload) so the test can assert on the traffic."""
+            published.append((topic, payload))
+
+        gw._publish_raw = fake_publish_raw
+        gw.topic_ev_command = "predbat/devices/test/ev/command"
+        gw._ev_windows = {0: []}
+        gw._ev_charging_active = {}
+
+        asyncio.run(gw._apply_ev_charging_state())
+
+        assert not any("no charge point has a registered car slot" in str(c) for c in gw.log.call_args_list)
+
+    def test_apply_drives_two_charge_points_independently(self):
+        """Two charge points are started/stopped independently, each from its own slot's window.
+
+        This is the safety-critical case: commanding the wrong physical charger, or one
+        charger's window leaking into another's decision, is the bug class this task exists
+        to remove.
+        """
+        import asyncio
+        import datetime as dt_mod
+        import json
+
+        gw = self._make_gateway(configured_chargers=["CP-AAAAAA", "CP-BBBBBB"], ev_max_current={"CP-AAAAAA": 32, "CP-BBBBBB": 16})
+        published = []
+
+        async def fake_publish_raw(topic, payload, **kwargs):
+            """Capture the decoded payload of every command, one per charge point."""
+            published.append(json.loads(payload.decode()))
+
+        gw._publish_raw = fake_publish_raw
+        gw.topic_ev_command = "predbat/devices/test/ev/command"
+
+        now = dt_mod.datetime.now(gw.local_tz)
+        # slot 0 = CP-AAAAAA (inside its window), slot 1 = CP-BBBBBB (outside)
+        gw._ev_windows = {0: [(now - dt_mod.timedelta(minutes=5), now + dt_mod.timedelta(hours=1))], 1: []}
+        gw._ev_charging_active = {}
+
+        asyncio.run(gw._apply_ev_charging_state())
+
+        started = [p for p in published if p["action"] == "RemoteStartTransaction"]
+        stopped = [p for p in published if p["action"] == "RemoteStopTransaction"]
+        assert started == [{"action": "RemoteStartTransaction", "id_tag": "predbat", "charge_point_id": "CP-AAAAAA"}]
+        # CP-BBBBBB matches its default-stopped state, so it is skipped entirely — no
+        # command sent and no entry written for it — only CP-AAAAAA transitions.
+        assert stopped == []
+        assert gw._ev_charging_active == {"CP-AAAAAA": True}
 
     def test_max_current_fallback_32a(self):
         """Falls back to 32 A in SetChargingProfile when max_current_a not in cache for the charge point."""
@@ -4503,12 +4837,13 @@ class TestEvControl:
         gw.topic_ev_command = "predbat/devices/test/ev/command"
 
         now = dt_mod.datetime.now(gw.local_tz)
-        gw._ev_windows = [(now - dt_mod.timedelta(minutes=5), now + dt_mod.timedelta(hours=1))]
-        gw._ev_charging_active = False
+        gw._ev_windows = {0: [(now - dt_mod.timedelta(minutes=5), now + dt_mod.timedelta(hours=1))]}
+        gw._ev_charging_active = {}
 
         asyncio.run(gw._apply_ev_charging_state())
 
         assert published[0]["current_a"] == 32
+        assert published[0]["charge_point_id"] == "CP10000001"
 
 
 class TestRateAnchors(unittest.TestCase):

--- a/apps/predbat/tests/test_gateway.py
+++ b/apps/predbat/tests/test_gateway.py
@@ -4410,6 +4410,7 @@ class TestEvControl:
         # Give each configured charge point a registry slot, same as _register_ev_chargers
         # would in production — control reads charger_slot(), so it needs one to act at all.
         gw.register_chargers("gateway", [ChargerEntry("gateway", cp_id) for cp_id in cp_ids])
+        gw.base.charger_registry.confirm_plan(gw.base.charger_registry.generation)
         gw._ev_max_current = ev_max_current if ev_max_current is not None else {"CP10000001": 32}
         gw._ev_windows = {}
         gw._ev_charging_active = {}

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -21,6 +21,7 @@ import tempfile
 from datetime import datetime, timedelta, timezone
 from tests.test_infra import create_aiohttp_mock_response, create_aiohttp_mock_session, run_async
 from storage import StorageLocalFiles
+from charger_registry import ChargerEntry, ChargerRegistry
 
 
 class MockGECloudDirect(GECloudDirect):
@@ -88,11 +89,29 @@ class MockGECloudDirect(GECloudDirect):
                 self.external_states[entity_id] = state
 
         class MockBase:
-            def __init__(self):
+            def __init__(self, api):
                 self.ha_interface = MockHAInterface()
                 self.num_cars = 0
+                self.api = api
+                # register_chargers()/charger_slot() go through base.charger_registry, and
+                # the registry writes back via base.set_arg/base.log - route both to the
+                # owning mock API so registry-materialised args land in the same
+                # api.config_args the tests assert on.
+                self.charger_registry = ChargerRegistry(self)
 
-        self.base = MockBase()
+            def set_arg(self, arg, value):
+                """Delegate to the owning mock API's stub args"""
+                self.api.set_arg(arg, value)
+
+            def get_arg(self, arg, default=None, **kwargs):
+                """Delegate to the owning mock API's stub args"""
+                return self.api.get_arg(arg, default=default, **kwargs)
+
+            def log(self, message):
+                """Delegate to the owning mock API's captured log messages"""
+                self.api.log(message)
+
+        self.base = MockBase(self)
 
     @property
     def now_utc_exact(self):
@@ -4513,20 +4532,34 @@ def _test_async_automatic_config_evc(my_predbat):
         ], "car_charging_power should list both chargers in serial order, got {}".format(ge.config_args.get("car_charging_power"))
         assert ge.config_args.get("num_cars") == 2, "num_cars should be raised to the number of chargers"
 
-        # Test 2: an existing larger num_cars is left alone - another component may own those cars
-        ge.config_args = {"num_cars": 3}
+        # Test 2: cars another component owns are a floor, not a stale value.
+        # octopus.py and kraken.py claim their intelligent device count so fetch.py reads the
+        # dispatch sensors they just wired - those cars have no charger in the registry, so
+        # overwriting with the registered count dropped them every time a GivEnergy charger
+        # was rediscovered. The claim is explicit (set_external_num_cars) rather than inferred
+        # from num_cars having moved, which was blind to a raise equal to our own last write.
+        ge.config_args = {}
+        ge.base.charger_registry.set_external_num_cars("octopus", 3)
         await ge.async_automatic_config_evc()
-        assert ge.config_args.get("num_cars") == 3, "num_cars should not be reduced to the charger count"
+        assert ge.config_args.get("num_cars") == 3, "num_cars claimed by another source should be kept as a floor, got {}".format(ge.config_args.get("num_cars"))
 
-        # Test 3: no chargers configures nothing at all
+        # And releasing the claim lets the count fall back to the registered chargers.
+        ge.base.charger_registry.set_external_num_cars("octopus", 0)
+        await ge.async_automatic_config_evc()
+        assert ge.config_args.get("num_cars") == 2, "num_cars should follow the chargers once the claim is released, got {}".format(ge.config_args.get("num_cars"))
+
+        # Test 3: no chargers clears everything - the registry had previously been
+        # populated by Tests 1/2, so going back to empty clears the stale values rather
+        # than leaving them in place (registering an empty list is how a source's
+        # chargers going away is expressed).
         ge.config_args = {}
         ge.evc_device_list = []
         ge.evc_device = {}
         await ge.async_automatic_config_evc()
-        assert ge.config_args.get("car_charging_energy") is None, "car_charging_energy should be left alone with no chargers"
-        assert ge.config_args.get("car_charging_planned") is None, "car_charging_planned should be left alone with no chargers"
-        assert ge.config_args.get("car_charging_power") is None, "car_charging_power should be left alone with no chargers"
-        assert ge.config_args.get("num_cars") is None, "num_cars should be left alone with no chargers"
+        assert ge.config_args.get("car_charging_energy") is None, "car_charging_energy should be cleared with no chargers"
+        assert ge.config_args.get("car_charging_planned") is None, "car_charging_planned should be cleared with no chargers"
+        assert ge.config_args.get("car_charging_power") is None, "car_charging_power should be cleared with no chargers"
+        assert ge.config_args.get("num_cars") == 0, "num_cars should be cleared to 0 with no chargers, got {}".format(ge.config_args.get("num_cars"))
 
         # Test 4: a charger whose serial has not been read yet is skipped rather than
         # publishing an entity name with a hole in it
@@ -4562,6 +4595,16 @@ def _evc_control_component(commands, num_cars=1):
     return ge
 
 
+def _register_gecloud_chargers(ge, serials):
+    """Give a mock component the registry slots evc_control_charge now reads from.
+
+    In production these come from async_automatic_config_evc(); these tests exercise
+    control in isolation, so they register directly. Pass order does not matter - the
+    registry sorts by serial, same as automatic config does.
+    """
+    ge.register_chargers("gecloud", [ChargerEntry("gecloud", serial) for serial in serials])
+
+
 def _test_evc_control(my_predbat):
     """Test Predbat-led start/stop control of GivEnergy EV chargers from the car plan"""
 
@@ -4590,6 +4633,7 @@ def _test_evc_control(my_predbat):
         ge.evc_device_list = ["evc-001"]
         ge.evc_device = {"evc-001": {"serial_number": "EVC100", "status": "charging"}}
         ge.entity_attributes = plan
+        _register_gecloud_chargers(ge, ["EVC100"])
 
         await ge.evc_control_charge(inside)
         assert commands == [("evc-001", "start-charge")], "A planned window should start the charge, got {}".format(commands)
@@ -4620,6 +4664,7 @@ def _test_evc_control(my_predbat):
         ge.evc_device_list = ["evc-001"]
         ge.evc_device = {"evc-001": {"serial_number": "EVC100", "status": "charging"}}
         ge.entity_attributes = plan
+        _register_gecloud_chargers(ge, ["EVC100"])
         await ge.evc_control_charge(outside)
         commands.clear()
         await ge.switch_event("switch.predbat_gecloud_evc_control", "turn_off")
@@ -4633,6 +4678,7 @@ def _test_evc_control(my_predbat):
         ge.evc_device_list = ["evc-001"]
         ge.evc_device = {"evc-001": {"serial_number": "EVC100", "status": "idle"}}
         ge.entity_attributes = plan
+        _register_gecloud_chargers(ge, ["EVC100"])
         await ge.evc_control_charge(inside)
         assert commands == [], "An empty charger should not be commanded, got {}".format(commands)
 
@@ -4642,6 +4688,7 @@ def _test_evc_control(my_predbat):
         ge = _evc_control_component(commands)
         ge.evc_device_list = ["evc-001"]
         ge.evc_device = {"evc-001": {"serial_number": "EVC100", "status": "charging"}}
+        _register_gecloud_chargers(ge, ["EVC100"])
         await ge.evc_control_charge(inside)
         assert commands == [], "With no plan published nothing should be commanded, got {}".format(commands)
 
@@ -4654,13 +4701,15 @@ def _test_evc_control(my_predbat):
             "evc-second": {"serial_number": "EVC100", "status": "charging"},
         }
         ge.entity_attributes = {EVC_PLAN_SENSOR: plan[EVC_PLAN_SENSOR], EVC_PLAN_SENSOR_CAR_1: {"planned": []}}
+        _register_gecloud_chargers(ge, ["EVC100", "EVC200"])
 
         await ge.evc_control_charge(inside)
         assert sorted(commands) == sorted([("evc-second", "start-charge"), ("evc-first", "stop-charge")]), "The lower serial should be car 0, got {}".format(commands)
 
-        # Test 10: a charger with no car index yet is left alone rather than stopped.
-        # num_cars is raised by async_automatic_config_evc, but that lands on the base
-        # object a cycle later, so briefly there can be more chargers than cars.
+        # Test 10: a charger with no registry slot yet is left alone rather than stopped.
+        # Slots come from async_automatic_config_evc() registering the charger; a charger
+        # discovered since the last registration - e.g. on the very first control tick of
+        # a session, which runs before the one-shot auto-config call - simply has none yet.
         commands = []
         ge = _evc_control_component(commands, num_cars=1)
         ge.evc_device_list = ["evc-first", "evc-second"]
@@ -4669,9 +4718,38 @@ def _test_evc_control(my_predbat):
             "evc-second": {"serial_number": "EVC200", "status": "charging"},
         }
         ge.entity_attributes = {EVC_PLAN_SENSOR: plan[EVC_PLAN_SENSOR]}
+        _register_gecloud_chargers(ge, ["EVC100"])  # evc-second (EVC200) deliberately not registered
 
         await ge.evc_control_charge(inside)
-        assert commands == [("evc-first", "start-charge")], "Only the charger with a car should be commanded, got {}".format(commands)
+        assert commands == [("evc-first", "start-charge")], "Only the charger with a slot should be commanded, got {}".format(commands)
+
+        # Test 11: a charger whose slot is beyond the windows read this cycle is left alone.
+        # The registry allocates immediately while self.num_cars is a cached copy refreshed
+        # once a cycle, so refresh_evc_car_windows() can loop over fewer cars than there are
+        # slots. Without the key check the missing entry reads as an empty plan, and Predbat
+        # stops a car that is charging perfectly legitimately.
+        commands = []
+        ge = _evc_control_component(commands, num_cars=1)
+        ge.evc_device_list = ["evc-first", "evc-second"]
+        ge.evc_device = {
+            "evc-first": {"serial_number": "EVC100", "status": "charging"},
+            "evc-second": {"serial_number": "EVC200", "status": "charging"},
+        }
+        ge.entity_attributes = {EVC_PLAN_SENSOR: plan[EVC_PLAN_SENSOR]}
+        _register_gecloud_chargers(ge, ["EVC100", "EVC200"])
+
+        await ge.evc_control_charge(inside)
+        assert ge.charger_slot("gecloud", "EVC200") == 1, "EVC200 should hold slot 1"
+        assert commands == [("evc-first", "start-charge")], "A slot with no plan published yet must not be commanded, got {}".format(commands)
+
+        # Test 12: but a published empty plan is a real answer, not a missing one - car 1 is
+        # not charging, so its charger is stopped.
+        commands.clear()
+        ge.base.num_cars = 2
+        ge.entity_attributes = {EVC_PLAN_SENSOR: plan[EVC_PLAN_SENSOR], EVC_PLAN_SENSOR_CAR_1: {"planned": []}}
+
+        await ge.evc_control_charge(inside)
+        assert commands == [("evc-second", "stop-charge")], "An empty published plan should still stop the charger, got {}".format(commands)
 
         return 0
 

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -4603,6 +4603,7 @@ def _register_gecloud_chargers(ge, serials):
     registry sorts by serial, same as automatic config does.
     """
     ge.register_chargers("gecloud", [ChargerEntry("gecloud", serial) for serial in serials])
+    ge.base.charger_registry.confirm_plan(ge.base.charger_registry.generation)
 
 
 def _test_evc_control(my_predbat):

--- a/apps/predbat/tests/test_kraken.py
+++ b/apps/predbat/tests/test_kraken.py
@@ -1716,6 +1716,140 @@ def test_publish_dispatch_sensors_active_state_and_wiring():
     assert captured["num_cars"] == 1
 
 
+def _kraken_ready_to_run(api):
+    """Stub out the tariff/rate work so run() reaches the dispatch section and nothing else."""
+    from datetime import datetime
+
+    api.current_tariff = {"tariff_code": "E-1R-VAR-01", "product_code": "VAR-01"}
+    api.import_rates = [{"value_inc_vat": 24.5}]
+    api.tariff_fetched_at = datetime.now()  # fresh → no tariff work / device re-discovery
+    api.rates_fetched_at = datetime.now()  # fresh → no rate work
+    api.async_find_tariffs = AsyncMock(return_value=None)
+    api.async_discover_smart_devices = AsyncMock()
+    api.async_fetch_dispatches = AsyncMock()
+    api.dashboard_item = MagicMock()
+    api.update_success_timestamp = MagicMock()
+    api.save_kraken_cache = AsyncMock()
+    return api
+
+
+def test_run_releases_the_num_cars_claim_when_the_devices_go():
+    """The release must be driven from run(), because that is what gates the publish method.
+
+    run() only calls _publish_dispatch_sensors while the device map is non-empty, so a release
+    living solely inside that method could never fire on the transition it exists for: the car is
+    unenrolled, the device map empties, and the num_cars floor claimed while it was enrolled holds
+    a phantom car up for the rest of the run.
+    """
+    api = _kraken_ready_to_run(make_kraken_api())
+    args = {}
+    api.set_arg = MagicMock(side_effect=lambda k, v: args.pop(k, None) if v is None else args.__setitem__(k, v))
+    api.get_arg = MagicMock(side_effect=lambda k, default=None, **kwargs: args.get(k, default))
+    registry = MagicMock()
+    api.base.charger_registry = registry
+
+    # Cycle one: one enrolled device, wired and claimed.
+    api.intelligent_devices = {"dev-1": {"device_id": "dev-1", "planned_dispatches": [], "completed_dispatches": []}}
+    api.dispatch_fetched_at = None  # dispatch due
+    assert asyncio.run(api.run(120, False)) is True
+
+    slot_entity = api.get_entity_name("binary_sensor", "intelligent_dispatch_1")
+    assert args["octopus_intelligent_slot"] == [slot_entity]
+    registry.set_external_num_cars.assert_called_with("kraken", 1)
+
+    # Cycle two: the car has unenrolled, so the device map is empty.
+    registry.set_external_num_cars.reset_mock()
+    api.intelligent_devices = {}
+
+    assert asyncio.run(api.run(120, False)) is True
+
+    registry.set_external_num_cars.assert_called_once_with("kraken", 0)
+    assert "octopus_intelligent_slot" not in args, "the wiring pointed at a device that no longer exists"
+
+    # Cycle three: still no devices. The release is a transition, not something to redo forever.
+    registry.set_external_num_cars.reset_mock()
+
+    assert asyncio.run(api.run(120, False)) is True
+
+    registry.set_external_num_cars.assert_not_called()
+
+
+def test_run_with_no_devices_never_wired_releases_nothing():
+    """The common no-EV account must not touch the registry or the args at all.
+
+    Most Kraken accounts have never had a SmartFlex device, so this path runs every cycle for
+    them. Releasing a claim that was never made would write num_cars where the component had no
+    business writing one.
+    """
+    api = _kraken_ready_to_run(make_kraken_api())
+    api.intelligent_devices = {}
+    api.set_arg = MagicMock()
+    api.get_arg = MagicMock(return_value=0)
+    registry = MagicMock()
+    api.base.charger_registry = registry
+
+    assert asyncio.run(api.run(120, False)) is True
+
+    registry.set_external_num_cars.assert_not_called()
+    assert not any(call.args[0] == "octopus_intelligent_slot" for call in api.set_arg.call_args_list)
+
+
+def test_release_leaves_the_slot_wiring_alone_when_something_else_owns_it():
+    """Octopus wires the same key for its own Intelligent devices - do not blank its wiring.
+
+    The num_cars claim is still released either way: that one is keyed by source name, so
+    dropping ours cannot disturb anyone else's.
+    """
+    api = _kraken_ready_to_run(make_kraken_api())
+    args = {}
+    api.set_arg = MagicMock(side_effect=lambda k, v: args.pop(k, None) if v is None else args.__setitem__(k, v))
+    api.get_arg = MagicMock(side_effect=lambda k, default=None, **kwargs: args.get(k, default))
+    registry = MagicMock()
+    api.base.charger_registry = registry
+
+    api.intelligent_devices = {"dev-1": {"device_id": "dev-1", "planned_dispatches": [], "completed_dispatches": []}}
+    api.dispatch_fetched_at = None
+    asyncio.run(api.run(120, False))
+
+    # Something else takes the key over before the devices go away.
+    octopus_wiring = ["binary_sensor.octopus_energy_abc_intelligent_dispatching"]
+    args["octopus_intelligent_slot"] = octopus_wiring
+    registry.set_external_num_cars.reset_mock()
+    api.intelligent_devices = {}
+
+    asyncio.run(api.run(120, False))
+
+    assert args["octopus_intelligent_slot"] == octopus_wiring
+    registry.set_external_num_cars.assert_called_once_with("kraken", 0)
+
+
+def test_publish_dispatch_sensors_releases_the_num_cars_claim_when_called_directly():
+    """The publish method's own empty-device guard still releases, for a direct caller.
+
+    run() is the real gate (see test_run_releases_the_num_cars_claim_when_the_devices_go); this
+    covers the method not leaving a stale claim standing if it is ever called on its own.
+    """
+    api = make_kraken_api()
+    api.dashboard_item = MagicMock()
+    args = {}
+    api.set_arg = MagicMock(side_effect=lambda k, v: args.pop(k, None) if v is None else args.__setitem__(k, v))
+    api.get_arg = MagicMock(side_effect=lambda k, default=None, **kwargs: args.get(k, default))
+    registry = MagicMock()
+    api.base.charger_registry = registry
+
+    api.intelligent_devices = {"aaa-bbb-12345": {"device_id": "aaa-bbb-12345", "planned_dispatches": [], "completed_dispatches": []}}
+    api._publish_dispatch_sensors()
+    assert args["octopus_intelligent_slot"] == [api.get_entity_name("binary_sensor", "intelligent_dispatch_12345")]
+
+    registry.set_external_num_cars.reset_mock()
+    api.intelligent_devices = {}
+
+    api._publish_dispatch_sensors()
+
+    registry.set_external_num_cars.assert_called_once_with("kraken", 0)
+    assert "octopus_intelligent_slot" not in args
+
+
 def test_run_fetches_and_wires_dispatches():
     """On a dispatch-due cycle, run() fetches dispatches and wires octopus_intelligent_slot."""
     from datetime import datetime

--- a/apps/predbat/tests/test_myenergi.py
+++ b/apps/predbat/tests/test_myenergi.py
@@ -19,6 +19,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tests.test_infra import run_async
 from mock_base import MockBase
+from charger_registry import ChargerEntry
 
 from myenergi import (
     BOOST_ENERGY_MAX,
@@ -1073,6 +1074,7 @@ def test_control_charge_sets_fast_inside_and_stopped_outside():
     """
     component = _control_component(plans={0: [NIGHT_WINDOW]})
     component.devices = {"Z12345678": _zappi(12345678)}
+    component.automatic_config()  # registers the Zappi with the charger registry, giving it a slot
     component.transport.set_mode = AsyncMock(return_value=True)
 
     run_async(component.control_charge(IN_WINDOW))
@@ -1091,6 +1093,7 @@ def test_control_charge_maps_each_zappi_to_its_own_car():
     """
     component = _control_component(plans={0: [NIGHT_WINDOW], 1: []})
     component.devices = {"Z12345678": _zappi(12345678), "Z22223333": _zappi(22223333)}
+    component.automatic_config()  # registers both Zappis, giving each its own slot
     component.transport.set_mode = AsyncMock(return_value=True)
 
     run_async(component.control_charge(IN_WINDOW))
@@ -1107,6 +1110,7 @@ def test_control_charge_is_edge_triggered_but_corrects_drift():
     """
     component = _control_component(plans={0: [NIGHT_WINDOW]})
     component.devices = {"Z12345678": _zappi(12345678)}
+    component.automatic_config()  # registers the Zappi with the charger registry, giving it a slot
     component.transport.set_mode = AsyncMock(return_value=True)
 
     run_async(component.control_charge(IN_WINDOW))
@@ -1150,12 +1154,48 @@ def test_control_charge_does_nothing_before_a_plan_exists():
     print("  ✓ Nothing is commanded before Predbat has published a plan")
 
 
+def test_control_charge_skips_a_slot_whose_plan_has_not_been_read():
+    """A Zappi allocated a slot beyond this cycle's windows is left alone, not stopped.
+
+    The registry allocates slots immediately, while self.num_cars - which refresh_car_windows()
+    loops over - is a cached copy refreshed once a cycle. So the cycle a charger from another
+    component takes a lower slot, the Zappi's new slot has no windows entry yet, and reading
+    the absent key as an empty plan stops a car that is charging legitimately.
+    """
+    component = _control_component(plans={0: [NIGHT_WINDOW]})
+    component.devices = {"Z12345678": _zappi(12345678)}
+    component.automatic_config()
+    # A gecloud charger registers and sorts ahead of "myenergi", pushing the Zappi to slot 1
+    component.base.charger_registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.ce1234")])
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    assert component.charger_slot("myenergi", "12345678") == 1, "The Zappi should have been pushed to slot 1"
+    run_async(component.control_charge(IN_WINDOW))
+    component.transport.set_mode.assert_not_awaited()
+    print("  ✓ A slot with no plan published yet is not commanded")
+
+
+def test_control_charge_stops_on_a_published_empty_plan():
+    """A published but empty plan is a real answer - the Zappi is stopped, not skipped."""
+    component = _control_component(plans={0: [NIGHT_WINDOW], 1: []})
+    component.devices = {"Z12345678": _zappi(12345678)}
+    component.automatic_config()
+    component.base.charger_registry.replace_source("gecloud", [ChargerEntry("gecloud", "CE1234", planned="binary_sensor.ce1234")])
+    component.transport.set_mode = AsyncMock(return_value=True)
+
+    assert component.charger_slot("myenergi", "12345678") == 1
+    run_async(component.control_charge(IN_WINDOW))
+    assert component.transport.set_mode.await_args.args[1] == "Stopped", component.transport.set_mode.await_args
+    print("  ✓ An empty published plan still stops the charger")
+
+
 def _controlling_component(plans=None, **overrides):
     """Build a component with Zappi control fully enabled and one Zappi already held."""
     args = {"zappi_control": True}
     args.update(overrides)
     component = _control_component(plans=plans, **args)
     component.devices = {"Z12345678": _zappi(12345678)}
+    component.automatic_config()  # registers the Zappi with the charger registry, giving it a slot
     component.transport.set_mode = AsyncMock(return_value=True)
     # Capture the component's own log so the gating reasons can be asserted on
     component.log_messages = []
@@ -1636,21 +1676,33 @@ def test_automatic_config_eddi_only():
 
 
 def test_automatic_config_uses_set_arg_auto():
-    """An explicit apps.yaml value is reported via apps_yaml_override_warned, proving set_arg_auto (not set_arg) is used.
+    """Zappis are registered with the charger registry; Eddi's iboost wiring still uses set_arg_auto.
 
-    MockBase has neither args_from_apps_yaml nor apps_yaml_override_warned, so
-    set_arg_auto() silently degrades to plain set_arg() unless the test supplies
-    them - meaning swapping set_arg_auto() for set_arg() in automatic_config()
-    would leave every other auto-config test green. This test pins the call to
-    set_arg_auto specifically.
+    car_charging_* no longer goes through set_arg_auto() for Zappis - the registry writes
+    those args itself (via plain set_arg(), to avoid the autodiscovery override warning
+    misfiring on a merge rather than a clobber - see charger_registry.materialise()), so
+    the Zappi half of this contract is now "the Zappi ends up at its registry slot", not
+    "apps_yaml_override_warned fires". The Eddi branch is untouched: an explicit apps.yaml
+    iboost_energy_today is still reported via apps_yaml_override_warned, proving
+    set_arg_auto (not set_arg) is still used there. MockBase has neither
+    args_from_apps_yaml nor apps_yaml_override_warned, so set_arg_auto() silently degrades
+    to plain set_arg() unless the test supplies them - meaning swapping set_arg_auto() for
+    set_arg() in the Eddi branch would leave every other auto-config test green.
     """
     component = _make_component()
-    component.base.args_from_apps_yaml = {"car_charging_energy": ["sensor.explicit"]}
+    component.base.args_from_apps_yaml = {"iboost_energy_today": "sensor.explicit"}
     component.base.apps_yaml_override_warned = set()
-    component.devices = {"Z12345678": normalise_direct_device(MOCK_DIRECT_ZAPPI, DEVICE_KIND_ZAPPI)}
+    component.devices = {
+        "Z12345678": normalise_direct_device(MOCK_DIRECT_ZAPPI, DEVICE_KIND_ZAPPI),
+        "E87654321": normalise_direct_device(MOCK_DIRECT_EDDI, DEVICE_KIND_EDDI),
+    }
     component.automatic_config()
-    assert "car_charging_energy" in component.base.apps_yaml_override_warned, component.base.apps_yaml_override_warned
-    print("  ✓ Automatic configuration uses set_arg_auto, not set_arg")
+
+    assert component.charger_slot("myenergi", "12345678") == 0
+    assert component.base.args["car_charging_planned"] == ["sensor.predbat_myenergi_zappi_12345678_plug_status"]
+
+    assert "iboost_energy_today" in component.base.apps_yaml_override_warned, component.base.apps_yaml_override_warned
+    print("  ✓ Zappis are registered with the charger registry; Eddi wiring still uses set_arg_auto")
 
 
 def test_automatic_config_disabled():

--- a/apps/predbat/tests/test_myenergi.py
+++ b/apps/predbat/tests/test_myenergi.py
@@ -1077,9 +1077,11 @@ def test_control_charge_sets_fast_inside_and_stopped_outside():
     component.automatic_config()  # registers the Zappi with the charger registry, giving it a slot
     component.transport.set_mode = AsyncMock(return_value=True)
 
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     assert component.transport.set_mode.await_args.args[1] == "Fast", component.transport.set_mode.await_args
 
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(OUT_OF_WINDOW))
     assert component.transport.set_mode.await_args.args[1] == "Stopped", component.transport.set_mode.await_args
     print("  ✓ Fast inside a planned window, Stopped outside it")
@@ -1096,6 +1098,7 @@ def test_control_charge_maps_each_zappi_to_its_own_car():
     component.automatic_config()  # registers both Zappis, giving each its own slot
     component.transport.set_mode = AsyncMock(return_value=True)
 
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     by_serial = {call.args[0].serial: call.args[1] for call in component.transport.set_mode.await_args_list}
     assert by_serial == {"12345678": "Fast", "22223333": "Stopped"}, by_serial
@@ -1113,15 +1116,18 @@ def test_control_charge_is_edge_triggered_but_corrects_drift():
     component.automatic_config()  # registers the Zappi with the charger registry, giving it a slot
     component.transport.set_mode = AsyncMock(return_value=True)
 
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     assert component.transport.set_mode.await_count == 1
     # The poll now reports Fast, matching what was set, so nothing more is sent
     component.devices["Z12345678"] = _zappi(12345678, mode_index=1)
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     assert component.transport.set_mode.await_count == 1, "A settled charger must not be re-commanded"
 
     # Someone switches it to Eco+ in the myenergi app - Predbat puts it back
     component.devices["Z12345678"] = _zappi(12345678, mode_index=3)
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     assert component.transport.set_mode.await_count == 2, "Drift away from the set mode must be corrected"
     assert component.transport.set_mode.await_args.args[1] == "Fast"
@@ -1134,6 +1140,7 @@ def test_control_charge_ignores_eddis():
     component.devices = {"E87654321": normalise_direct_device(MOCK_DIRECT_EDDI, DEVICE_KIND_EDDI)}
     component.transport.set_mode = AsyncMock(return_value=True)
 
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     component.transport.set_mode.assert_not_awaited()
     print("  ✓ Eddis are never driven by car charge control")
@@ -1149,6 +1156,7 @@ def test_control_charge_does_nothing_before_a_plan_exists():
     component.devices = {"Z12345678": _zappi(12345678)}
     component.transport.set_mode = AsyncMock(return_value=True)
 
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     component.transport.set_mode.assert_not_awaited()
     print("  ✓ Nothing is commanded before Predbat has published a plan")
@@ -1170,6 +1178,7 @@ def test_control_charge_skips_a_slot_whose_plan_has_not_been_read():
     component.transport.set_mode = AsyncMock(return_value=True)
 
     assert component.charger_slot("myenergi", "12345678") == 1, "The Zappi should have been pushed to slot 1"
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     component.transport.set_mode.assert_not_awaited()
     print("  ✓ A slot with no plan published yet is not commanded")
@@ -1184,6 +1193,7 @@ def test_control_charge_stops_on_a_published_empty_plan():
     component.transport.set_mode = AsyncMock(return_value=True)
 
     assert component.charger_slot("myenergi", "12345678") == 1
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_charge(IN_WINDOW))
     assert component.transport.set_mode.await_args.args[1] == "Stopped", component.transport.set_mode.await_args
     print("  ✓ An empty published plan still stops the charger")
@@ -1223,11 +1233,13 @@ def test_control_gating_refuses_with_a_reason():
 def test_control_releases_to_the_saved_mode():
     """Releasing puts the Zappi back where it was before Predbat first moved it."""
     component = _controlling_component(plans={0: [NIGHT_WINDOW]})
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_tick(IN_WINDOW))
     assert component.transport.set_mode.await_args.args[1] == "Fast"
 
     # The switch going off is a release, not just a pause in commanding
     component.control_enabled = False
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_tick(IN_WINDOW))
     assert component.transport.set_mode.await_args.args[1] == "Eco+", "The Zappi was in Eco+ before Predbat took over"
     assert component.control_modes == {}, "A released Zappi is no longer held"
@@ -1241,6 +1253,7 @@ def test_control_releases_to_eco_plus_when_nothing_was_saved():
     component.control_saved_modes = {}
     component.control_enabled = False
 
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_tick(IN_WINDOW))
     assert component.transport.set_mode.await_args.args[1] == "Eco+", component.transport.set_mode.await_args
     print("  ✓ Release falls back to Eco+ when there is nothing saved")
@@ -1249,18 +1262,22 @@ def test_control_releases_to_eco_plus_when_nothing_was_saved():
 def test_control_stops_and_resumes_on_read_only():
     """Read only mode releases the Zappis, and clearing it resumes control."""
     component = _controlling_component(plans={0: [NIGHT_WINDOW]})
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_tick(IN_WINDOW))
     assert component.transport.set_mode.await_count == 1
 
     component.base.args["set_read_only"] = True
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_tick(IN_WINDOW))
     assert component.transport.set_mode.await_args.args[1] == "Eco+", "Read only must release, not just stop commanding"
 
     # Still read only - nothing more is sent, there is nothing left to release
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_tick(IN_WINDOW))
     assert component.transport.set_mode.await_count == 2
 
     component.base.args["set_read_only"] = False
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
     run_async(component.control_tick(IN_WINDOW))
     assert component.transport.set_mode.await_args.args[1] == "Fast", "Clearing read only must resume control"
     print("  ✓ Read only releases the Zappis and clearing it resumes control")
@@ -1344,7 +1361,10 @@ def test_run_enables_control_and_drives_the_zappi():
     assert run_async(component.run(0, True)) is True
     assert component.control_active is True
     component.load_control_enabled.assert_awaited_once()
-    # A real poll drove the Zappi from the plan without waiting for a second cycle
+    # Discovery invalidates old slot sensors until the planner publishes for this map.
+    component.transport.set_mode.assert_not_awaited()
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
+    assert run_async(component.run(60, False)) is True
     assert component.transport.set_mode.await_count == 1, component.transport.set_mode.await_args_list
     print("  ✓ The run loop enables control and drives the Zappi from the plan")
 
@@ -1418,7 +1438,10 @@ def test_control_failure_does_not_break_the_poll():
     component.transport.set_mode = AsyncMock(side_effect=MyEnergiApiError("myenergi refused the mode"))
     component.load_control_enabled = AsyncMock()
 
-    assert run_async(component.run(0, True)) is True, "A refused mode must not fail the cycle"
+    assert run_async(component.run(0, True)) is True
+    component.base.charger_registry.confirm_plan(component.base.charger_registry.generation)
+    assert run_async(component.run(60, False)) is True, "A refused mode must not fail the cycle"
+    component.transport.set_mode.assert_awaited_once()
     assert component.last_success_timestamp is not None, "Monitoring still succeeded, so the poll counts"
     # Nothing was recorded as set, so the next cycle tries again rather than assuming it stuck
     assert component.control_modes == {}, component.control_modes

--- a/apps/predbat/tests/test_octopus_misc.py
+++ b/apps/predbat/tests/test_octopus_misc.py
@@ -2161,6 +2161,21 @@ def test_octopus_automatic_config_respects_slot_claim(my_predbat):
         print("ERROR: Expected saving session wiring to still happen while the slots are claimed")
         failed = True
 
+    print("\n*** Test 2b: The num_cars claim is released when another component takes the slots ***")
+    # A spy registry rather than the real one: this fixture is shared with the rest of the
+    # suite, so the assertion is on the call and no registry state is left behind.
+    original_registry = getattr(my_predbat, "charger_registry", None)
+    spy_registry = MagicMock()
+    my_predbat.charger_registry = spy_registry
+    api_claimed = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)
+    api_claimed.intelligent_devices = {"device-aaa1": {"suspended": False}}
+    api_claimed.automatic_config(["import"])
+    my_predbat.charger_registry = original_registry
+
+    # Octopus is no longer wiring these cars, so the floor it claimed for them has to go -
+    # the owning component registers its own chargers and the registry counts those itself.
+    spy_registry.set_external_num_cars.assert_called_once_with("octopus", 0)
+
     print("\n*** Test 3: No claim wires the slots as normal ***")
     my_predbat.car_slot_owner = None
     api2 = OctopusAPI(my_predbat, key="test-api-key", account_id="test-account", automatic=False)

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -22,6 +22,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ohme import (
     ENERGY_TODAY_ENTITY,
     MAX_ENERGY_GAP_SECONDS,
+    OHME_DEVICE_ID,
     POWER_WATTS_ENTITY,
     OhmeAPI,
     OhmeApiClient,
@@ -33,6 +34,7 @@ from ohme import (
     slot_list,
     vehicle_to_name,
 )
+from charger_registry import ChargerEntry, ChargerRegistry, preregister_legacy
 
 
 # ============================================================================
@@ -282,6 +284,7 @@ def test_ohme(my_predbat=None):
         ("connected_sensor", _test_ohme_connected_sensor, "connected binary sensor tracks plug state"),
         ("control_enable", _test_ohme_control_enable_rules, "ohme_control enable rules"),
         ("control_windows", _test_ohme_control_window_parsing, "control window parsing"),
+        ("control_no_slot", _test_ohme_control_without_a_registry_slot, "control waits for a registry slot"),
         ("control_midnight", _test_ohme_control_window_year_rollover, "control windows across new year"),
         ("control_startup", _test_ohme_control_waits_for_plan, "control waits for a published plan"),
         ("control_edges", _test_ohme_control_edge_triggered, "control only acts on transitions"),
@@ -1573,10 +1576,26 @@ class MockOhmeBase:
         self.api = api
         self.car_slot_owner = None
         self.components = MockComponents()
+        # register_chargers()/charger_slot() go through base.charger_registry, and the
+        # registry writes back via base.set_arg/base.log - route both to the owning mock
+        # API so registry-materialised args land in the same api.args the tests assert on.
+        self.charger_registry = ChargerRegistry(self)
 
     def load_previous_value_from_ha(self, entity, attribute=None):
         """Return whatever the test staged for this entity/attribute"""
         return self.api.previous_values.get((entity, attribute))
+
+    def set_arg(self, arg, value):
+        """Delegate to the owning mock API's stub args"""
+        self.api.set_arg(arg, value)
+
+    def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):
+        """Delegate to the owning mock API's stub args - needed by preregister_legacy()"""
+        return self.api.get_arg(arg, default=default, indirect=indirect, combine=combine, attribute=attribute, index=index, domain=domain, can_override=can_override, required_unit=required_unit)
+
+    def log(self, message):
+        """Delegate to the owning mock API's captured log messages"""
+        self.api.log(message)
 
 
 class MockOhmeAPI(OhmeAPI):
@@ -1657,6 +1676,9 @@ def _ohme_control_api(windows=None, now=None, read_only=False):
     api.control_active = True
     api.base.set_read_only = read_only
     api._now_override = now or datetime.datetime(2026, 8, 22, 23, 0, 0, tzinfo=datetime.timezone.utc).astimezone(api.local_tz)
+    # refresh_car_windows() now reads its own allocated slot rather than assuming car 0 -
+    # register it as the only charger so it lands at slot 0, matching the staged entity below.
+    api.register_chargers("ohme", [ChargerEntry("ohme", OHME_DEVICE_ID, planned="binary_sensor.predbat_ohme_connected")])
     if windows is not None:
         api.states[("binary_sensor.predbat_car_charging_slot", "planned")] = windows
     # A plugged-in car so charger_mode() has something to read
@@ -1730,6 +1752,41 @@ def _test_ohme_control_window_parsing(my_predbat=None):
     assert len(api.control_windows) == 1, f"Expected the good window to survive, got {api.control_windows}"
 
     print("PASS: control window parsing handled the plan")
+    return 0
+
+
+def _test_ohme_control_without_a_registry_slot(my_predbat=None):
+    """Test no plan is read at all until the charger has been allocated a car slot"""
+    print("**** Running test_ohme_control_without_a_registry_slot ****")
+
+    tz = pytz.timezone("Europe/London")
+    now = tz.localize(datetime.datetime(2026, 8, 22, 23, 30, 0))
+    inside = _ohme_plan_window(datetime.datetime(2026, 8, 22, 23, 0), datetime.datetime(2026, 8, 23, 1, 0))
+
+    # Everything staged except the registration - automatic_config() has not run yet. Falling
+    # back to car 0's plan here would drive this charger from whatever car another component
+    # later puts in slot 0, so the plan is not read at all until the slot is known.
+    api = MockOhmeAPI()
+    api.ohme_automatic = True
+    api.ohme_control = True
+    api.control_active = True
+    api._now_override = now
+    api.states[("binary_sensor.predbat_car_charging_slot", "planned")] = [inside]
+    api.client._charge_session = {"mode": "SMART_CHARGE", "power": {"watt": 0}}
+
+    assert api.charger_slot("ohme", OHME_DEVICE_ID) is None, "Expected no slot before registration"
+    assert api.refresh_car_windows() is False, "Expected no plan to be read without a slot"
+    assert not api.control_windows, f"Expected no windows without a slot, got {api.control_windows}"
+
+    run_async(api.control_charge())
+    assert len(api.client.request_log) == 0, f"Expected no commands without a slot, got {api.client.request_log}"
+
+    # Once registered the very same staged plan is read, so the guard is the slot and nothing else
+    api.register_chargers("ohme", [ChargerEntry("ohme", OHME_DEVICE_ID, planned="binary_sensor.predbat_ohme_connected")])
+    assert api.refresh_car_windows() is True, "Expected the plan to be read once a slot exists"
+    assert len(api.control_windows) == 1, f"Expected one window, got {api.control_windows}"
+
+    print("PASS: control waited for a registry slot")
     return 0
 
 
@@ -2273,17 +2330,18 @@ def _test_ohme_auto_config_wires_car_charging_energy(my_predbat=None):
     """Test car registration points car_charging_energy at the delivered-energy sensor"""
     print("**** Running test_ohme_auto_config_wires_car_charging_energy ****")
 
-    # Nothing configured at all
+    # Nothing configured at all. car_charging_energy is a registry aggregate now, so even a
+    # single charger's sensor comes back as a one-element list rather than a bare scalar.
     api = MockOhmeAPI()
     run_async(api.automatic_config())
-    assert api.args.get("car_charging_energy") == ENERGY_TODAY_ENTITY, f"Expected {ENERGY_TODAY_ENTITY}, got {api.args.get('car_charging_energy')}"
+    assert api.args.get("car_charging_energy") == [ENERGY_TODAY_ENTITY], f"Expected [{ENERGY_TODAY_ENTITY}], got {api.args.get('car_charging_energy')}"
 
     # The apps.yaml default regex, still unresolved because no Zappi or Wallbox matched it.
     # auto_config(final=True) has not run yet at this point in startup, so it is still present
     api = MockOhmeAPI()
     api.args["car_charging_energy"] = "re:(sensor.myenergi_zappi_[0-9a-z]+_charge_added_session|sensor.wallbox_portal_added_energy)"
     run_async(api.automatic_config())
-    assert api.args.get("car_charging_energy") == ENERGY_TODAY_ENTITY, f"Expected unmatched regex to be replaced, got {api.args.get('car_charging_energy')}"
+    assert api.args.get("car_charging_energy") == [ENERGY_TODAY_ENTITY], f"Expected unmatched regex to be replaced, got {api.args.get('car_charging_energy')}"
 
     # The rest of the car registration happens too
     assert api.args.get("num_cars") == 1, f"Expected num_cars 1, got {api.args.get('num_cars')}"
@@ -2302,11 +2360,18 @@ def _test_ohme_auto_config_keeps_existing_car_charging_energy(my_predbat=None):
     print("**** Running test_ohme_auto_config_keeps_existing_car_charging_energy ****")
 
     # A resolved Zappi sensor means the user has another charger measuring car energy - taking
-    # that over with an Ohme-only figure would lose the car charging it is already reporting
+    # that over with an Ohme-only figure would lose the car charging it is already reporting.
+    # preregister_legacy() must run first, exactly as it does at real startup (predbat.py),
+    # so the pre-existing sensor is captured as a legacy aggregate before Ohme registers -
+    # otherwise Ohme's registration (which omits energy here) would recompute the aggregate
+    # from nothing and wipe the Zappi sensor out.
     api = MockOhmeAPI()
     api.args["car_charging_energy"] = "sensor.myenergi_zappi_1234_charge_added_session"
+    preregister_legacy(api.base.charger_registry, api.base)
     run_async(api.automatic_config())
 
+    # Left exactly as the user wrote it, scalar and all: with no registered charger supplying
+    # an energy sensor the registry does not own the key, so it does not rewrite it.
     assert api.args.get("car_charging_energy") == "sensor.myenergi_zappi_1234_charge_added_session", f"Expected the Zappi sensor to be kept, got {api.args.get('car_charging_energy')}"
     assert any("Leaving car_charging_energy" in msg for msg in api.log_messages), f"Expected a note about keeping it, got {api.log_messages}"
 
@@ -2318,9 +2383,11 @@ def _test_ohme_auto_config_wires_car_charging_power(my_predbat=None):
     """Test car registration points car_charging_power at the live charge power sensor"""
     print("**** Running test_ohme_auto_config_wires_car_charging_power ****")
 
+    # car_charging_power is a registry aggregate too, so a single charger's sensor comes back
+    # as a one-element list rather than a bare scalar.
     api = MockOhmeAPI()
     run_async(api.automatic_config())
-    assert api.args.get("car_charging_power") == POWER_WATTS_ENTITY, f"Expected {POWER_WATTS_ENTITY}, got {api.args.get('car_charging_power')}"
+    assert api.args.get("car_charging_power") == [POWER_WATTS_ENTITY], f"Expected [{POWER_WATTS_ENTITY}], got {api.args.get('car_charging_power')}"
 
     # The energy and power sensors have to describe the same charger, so when a real third-party
     # energy sensor is kept, Ohme's own power figure must not be wired in beside it
@@ -2334,13 +2401,13 @@ def _test_ohme_auto_config_wires_car_charging_power(my_predbat=None):
     api = MockOhmeAPI()
     api.args["car_charging_energy"] = ENERGY_TODAY_ENTITY
     run_async(api.automatic_config())
-    assert api.args.get("car_charging_power") == POWER_WATTS_ENTITY, f"Expected power wiring alongside Ohme's own energy entity, got {api.args.get('car_charging_power')}"
+    assert api.args.get("car_charging_power") == [POWER_WATTS_ENTITY], f"Expected power wiring alongside Ohme's own energy entity, got {api.args.get('car_charging_power')}"
 
     # The same entity handed over as a single-item list, which is how it round-trips through apps.yaml
     api = MockOhmeAPI()
     api.args["car_charging_energy"] = [ENERGY_TODAY_ENTITY]
     run_async(api.automatic_config())
-    assert api.args.get("car_charging_power") == POWER_WATTS_ENTITY, f"Expected power wiring for the list form, got {api.args.get('car_charging_power')}"
+    assert api.args.get("car_charging_power") == [POWER_WATTS_ENTITY], f"Expected power wiring for the list form, got {api.args.get('car_charging_power')}"
 
     print("PASS: auto config wired car_charging_power")
     return 0

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -1681,6 +1681,7 @@ def _ohme_control_api(windows=None, now=None, read_only=False):
     api.register_chargers("ohme", [ChargerEntry("ohme", OHME_DEVICE_ID, planned="binary_sensor.predbat_ohme_connected")])
     if windows is not None:
         api.states[("binary_sensor.predbat_car_charging_slot", "planned")] = windows
+        api.base.charger_registry.confirm_plan(api.base.charger_registry.generation)
     # A plugged-in car so charger_mode() has something to read
     api.client._charge_session = {"mode": "SMART_CHARGE", "power": {"watt": 0}}
     return api
@@ -1823,6 +1824,7 @@ def _test_ohme_control_waits_for_plan(my_predbat=None):
 
     # An empty plan is a real answer, not a missing one - the charger is held paused
     api.states[("binary_sensor.predbat_car_charging_slot", "planned")] = []
+    api.base.charger_registry.confirm_plan(api.base.charger_registry.generation)
     run_async(api.control_charge())
     assert len(api.client.request_log) == 1, f"Expected a pause once the plan is known, got {api.client.request_log}"
     assert "stop" in api.client.request_log[0]["url"], f"Expected a pause command, got {api.client.request_log[0]['url']}"

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -253,6 +253,7 @@ from tests.test_github import test_github
 from tests.test_download import test_download
 from tests.test_ohme import test_ohme
 from tests.test_myenergi import test_myenergi
+from tests.test_charger_registry import test_charger_registry
 from tests.test_component_base import test_component_base_all
 from tests.test_components import test_components_all
 from tests.test_mock_base import test_mock_base_all
@@ -646,6 +647,8 @@ def main():
         ("ohme", test_ohme, "Ohme EV charger comprehensive tests (helper functions, client methods, API operations, event handlers)", False),
         # myenergi Zappi and Eddi unit tests
         ("myenergi", test_myenergi, "myenergi Zappi and Eddi comprehensive tests (normalisation, transports, publishing, auto-config, controls)", False),
+        # Charger registry composition tests
+        ("charger_registry", test_charger_registry, "Charger registry composition tests (slots, legacy, floors, aggregates)", False),
         # ComponentBase lifecycle tests
         ("component_base", test_component_base_all, "ComponentBase tests (all)", False),
         ("components", test_components_all, "Components registry tests (all)", False),

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -112,6 +112,7 @@ class MinuteArray:
 DEBUG_EXCLUDE_LIST = [
     "ha_interface",
     "components",
+    "charger_registry",
     "prediction",
     "logfile",
     "predheat",

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -534,7 +534,9 @@ Use this if you have a separate PV-only inverter alongside your battery inverter
 
 - **ge_cloud_automatic_evc** - Optional, defaults to false. When set to `true`, any GivEnergy EV charger on your account is wired into
 Predbat's car planning, so **car_charging_energy**, **car_charging_planned** and **num_cars** need no `apps.yaml` entries of your own.
-Chargers are taken in serial order, so charger N is car N, and this happens whether or not you have a GivEnergy battery.
+Each charger takes one car slot, allocated centrally across every component that discovers chargers
+(see [Car charging - How charger slots are allocated](car-charging.md#how-charger-slots-are-allocated)), and this happens
+whether or not you have a GivEnergy battery.
 Everything else about your car - **car_charging_battery_size**, **car_charging_limit** and **car_charging_soc** - still comes from
 `apps.yaml` as usual.
 This is a separate setting from **ge_cloud_automatic** because it registers a car and changes **num_cars**, so turning on inverter
@@ -542,8 +544,8 @@ auto-configuration does not silently change your car setup. The charger's own en
 See [Components - GivEnergy Cloud Direct](components.md#ev-chargers-gecloud) for the entities this publishes.
 
 - **ge_cloud_evc_control** - Optional, defaults to false. When set to `true`, Predbat starts and stops your GivEnergy EV charger from its
-car charging plan, in the same way it can drive a myenergi Zappi or an Ohme charger. Charger N follows car N. Needs **ge_cloud_automatic_evc**,
-since it is that setting which maps each charger to a car.
+car charging plan, in the same way it can drive a myenergi Zappi or an Ohme charger. Each charger follows the car slot it was
+allocated. Needs **ge_cloud_automatic_evc**, since it is that setting which registers each charger and gets it a car slot.
 A `switch.predbat_gecloud_evc_control` entity appears when this is set, on by default, so you can hand the charger back without editing
 `apps.yaml`; releasing sends a start command if Predbat had stopped the charger, so a car is never left unable to charge.
 Read only mode releases the chargers in the same way.

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -245,6 +245,47 @@ Multiple cars can be planned with Predbat, in which case you should set **num_ca
 - Each car will have its own Home Assistant slot sensor created e.g. **binary_sensor.predbat_car_charging_slot_1**,
 SoC planning sensor e.g **predbat.car_soc_1** and **predbat.car_soc_best_1** for car 1
 
+### How charger slots are allocated
+
+Several components can discover EV chargers for themselves - GivEnergy Cloud, myenergi, Ohme and the GivEnergy
+Gateway - and they all feed the same set of car slots. Predbat allocates those slots centrally rather than letting
+each component number its own chargers:
+
+- Anything you configured by hand in `apps.yaml` comes first, keeping the exact position you wrote it in, and is
+  written back exactly as you wrote it. If no component has discovered anything, the key is not rewritten at all -
+  it already holds your config. Trailing slots with nothing behind them are dropped - the shipped template
+  declares `num_cars: 1` with only an unmatched `re:` pattern, which is a count rather than a car. A gap in the
+  *middle* of your list is kept, holes and all, because per-car settings are addressed by slot number and closing
+  the gap would shift your second car onto your first car's settings
+- One exception: an entry that names a charger a component has also discovered is dropped, so a charger found
+  twice - once through a third-party integration's sensor, once by Predbat's own component - is one car rather
+  than two with its energy counted twice. The two are recognised as the same charger when the discovered
+  charger's manufacturer serial appears as a whole word in the entity you configured - no letter or digit
+  immediately either side of it - which is what happens in practice: `ha-myenergi` publishes
+  `sensor.myenergi_zappi_10000001_plug_status` while Predbat's own myenergi component publishes
+  `sensor.predbat_myenergi_zappi_10000001_plug_status` - different entities, same serial. The whole-word rule is
+  what keeps serial `10000001` from also claiming `sensor.myenergi_zappi_100000010_plug_status`, which is a
+  different charger. Only myenergi and GivEnergy Cloud chargers are matched this way, since their ids are
+  manufacturer serials; a Gateway charge point id is chosen by whoever installed it, so a Gateway charger is only
+  matched against an entry naming the exact same entity. An entity that names the same charger without carrying
+  its serial (one you have renamed, or a template helper) cannot be recognised and stays as its own car - remove
+  it from `car_charging_planned` yourself if the component has found that charger
+- Discovered chargers follow, sorted by (component, charger id) so the same set of chargers always produces the
+  same slot numbers across restarts, whatever order the various APIs happened to answer in
+- **num_cars** is derived from that composed list, floored by any value you set in `apps.yaml` and by cars another
+  part of Predbat owns outright - Octopus Intelligent and Kraken claim the number of cars enrolled, since those
+  cars have no charger of their own. Such a claim is released when the cars go, so the count can come back down
+- Each component asks for its own charger's slot every cycle, so a charger is always driven from its own car's plan
+
+The consequence to be aware of: discovering a charger that sorts ahead of an existing one moves the later ones down
+a slot. Per-car settings (**car_charging_limit**, **car_charging_battery_size**, **car_charging_exclusive**, manual
+SoC entry) are addressed by slot number, so check they still line up after adding a charger. Predbat logs the map
+whenever it changes:
+
+```text
+ChargerRegistry: slots {'gecloud/CE1234': 0, 'ohme/ohme0': 1}
+```
+
 ### Multiple cars with Octopus Intelligent Go (IOG)
 
 If you have **two or more EVs enrolled in Octopus Intelligent Go**, Predbat can track the scheduled dispatch slots for each car independently.
@@ -298,10 +339,12 @@ reports as live. Devices that Octopus reports as suspended are skipped, and the 
 car slots in a fixed order, so the same set of cars always produces the same car indexes.
 
 Slots are re-packed when a car goes away, so removing or suspending a car can move the cars after it up an index -
-for example if car 0 is removed, the car that was car 1 becomes car 0. `num_cars` is never reduced automatically, so
-the now-unused slot at the end simply falls back to Predbat-led charging. If you set per-car options in `apps.yaml`
-(**car_charging_battery_size**, **car_charging_limit**, **car_charging_exclusive**) or use manual SoC entry, check
-they still line up after adding or removing a car.
+for example if car 0 is removed, the car that was car 1 becomes car 0. `num_cars` is derived from the cars and
+chargers Predbat currently knows about (see [How charger slots are allocated](#how-charger-slots-are-allocated)),
+floored by anything you set in `apps.yaml` and by the count Octopus Intelligent needs, so removing an intelligent
+device can reduce it - what it will not do is drop below the number of cars another part of Predbat has asked for.
+If you set per-car options in `apps.yaml` (**car_charging_battery_size**, **car_charging_limit**,
+**car_charging_exclusive**) or use manual SoC entry, check they still line up after adding or removing a car.
 
 Predbat re-checks this on every device poll (roughly every 2 minutes) and re-wires the slots if the set of live,
 non-suspended devices changes - for example when you enrol a second EV, remove one, or suspend one car in favour of

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -275,7 +275,11 @@ each component number its own chargers:
 - **num_cars** is derived from that composed list, floored by any value you set in `apps.yaml` and by cars another
   part of Predbat owns outright - Octopus Intelligent and Kraken claim the number of cars enrolled, since those
   cars have no charger of their own. Such a claim is released when the cars go, so the count can come back down
-- Each component asks for its own charger's slot every cycle, so a charger is always driven from its own car's plan
+- Each component asks for its own charger's slot every cycle. After the mapping changes, automatic control waits
+  for a plan calculated and published for that mapping, so old slot sensors cannot drive a different charger
+- Energy and power aggregates count identical entity references only once. Legacy measurements carrying a
+  discovered manufacturer's serial are replaced by that charger's corresponding measurement. Ohme keeps its
+  contribution when other components register chargers or discovery runs again
 
 The consequence to be aware of: discovering a charger that sorts ahead of an existing one moves the later ones down
 a slot. Per-car settings (**car_charging_limit**, **car_charging_battery_size**, **car_charging_exclusive**, manual

--- a/docs/components.md
+++ b/docs/components.md
@@ -535,15 +535,17 @@ Those two entities are published whatever your settings say — they are new ent
 change nothing that already exists.
 
 Setting `ge_cloud_automatic_evc` to `true` additionally wires the chargers into Predbat's
-car planning, in serial order so charger N is car N:
+car planning, each charger taking one car slot:
 
 - **car_charging_energy** — each charger's `_evc_energy_active_import_register`, so
   `car_charging_hold` subtracts the car charging from house load precisely instead of
   falling back to the `car_charging_threshold` heuristic
 - **car_charging_planned** — each charger's `_evc_car_connected`, so Predbat only plans
   car charging when there is actually a car on the cable
-- **num_cars** — raised to the number of chargers if it is currently lower, never reduced,
-  since another component may have registered cars of its own
+- **num_cars** — derived from every charger Predbat knows about, not just GivEnergy's, and
+  floored by anything you set in `apps.yaml` or that another component has raised it to.
+  Which slot each charger gets is decided centrally — see
+  [How charger slots are allocated](car-charging.md#how-charger-slots-are-allocated)
 
 This is deliberately a separate setting from `ge_cloud_automatic` rather than part of it:
 it registers a car and moves `num_cars`, which would change the plan for existing users
@@ -562,9 +564,12 @@ connected and logged once, so please report the value from the log so it can be 
 #### Charger control (gecloud)
 
 With `ge_cloud_evc_control` set to `true`, Predbat drives each charger from its own car's
-plan: `start-charge` inside a planned charging window, `stop-charge` outside one. Charger N
-follows car N, in the same serial order the automatic configuration uses, so the two cannot
-disagree about which charger is which car.
+plan: `start-charge` inside a planned charging window, `stop-charge` outside one. Each charger
+follows the car slot it was allocated (see
+[How charger slots are allocated](car-charging.md#how-charger-slots-are-allocated)), which is
+the same allocation the automatic configuration wired the entities from, so the two cannot
+disagree about which charger is which car — including when a charger from another component
+holds an earlier slot.
 
 `ge_cloud_automatic_evc` must also be on, since it is that configuration which establishes
 the charger to car mapping. Predbat says so in the log and leaves control off rather than
@@ -898,7 +903,7 @@ Predbat supports both of myenergi's APIs:
     - `car_charging_planned` — every Zappi's plug status sensor, one entry per car, so Predbat knows when the car is plugged in and due to charge. The regex the `apps.yaml` templates ship for this key matches the third-party `ha-myenergi` integration's entity names, not the ones Predbat publishes, so without this Predbat would fall back to the `car_charging_threshold` heuristic
     - `iboost_energy_today` — the first Eddi's session energy (first by serial number). This feeds the iboost model, and it is also subtracted from your historical house load whenever `switch.predbat_iboost_energy_subtract` is on (the default), which happens whether or not iboost itself is enabled
 - Auto-configuration runs once, after the first poll that returns devices. A Zappi or Eddi added later is published as entities but is not wired into those keys until Predbat restarts
-- If you set `car_charging_planned` yourself in `apps.yaml`, Predbat logs a note and auto-discovery still wins — remove your entry to silence it
+- If you set `car_charging_planned` yourself in `apps.yaml`, your entry is kept: it kicks off the list in the position you wrote it, and every discovered Zappi is added after it rather than replacing it. The one exception is an entry naming a Zappi Predbat has also discovered — typically the third-party `ha-myenergi` integration's `sensor.myenergi_zappi_<serial>_plug_status` for a Zappi Predbat publishes as `sensor.predbat_myenergi_zappi_<serial>_plug_status` — which is dropped so that one charger is not counted as two cars. The match is on the Zappi's serial appearing in the entity id as a whole word: the serial must have no letter or digit immediately either side of it, so serial `10000001` matches `sensor.myenergi_zappi_10000001_plug_status` but not `sensor.myenergi_zappi_100000010_plug_status`, which is a different Zappi. Only sources whose device id is a manufacturer serial are matched this way — myenergi and GivEnergy Cloud; a Gateway charge point id is chosen by the installer, so it is only ever matched against an entry naming the exact same entity. An entry that names the same Zappi through an entity without its serial in it (a renamed entity, or a template helper) is not recognised and stays as its own car. See [How charger slots are allocated](car-charging.md#how-charger-slots-are-allocated)
 - Predbat's shipped `car_charging_planned_response` list covers the plug states a Zappi reports when the car is connected, including `ev ready to charge`. If you maintain your own list, add that value or Predbat will treat a car that is plugged in and waiting as not planned to charge
 - Boosting a Zappi is only accepted by myenergi while it is in Eco or Eco+ mode
 - Set `myenergi_enable_controls` to `false` for monitor-only operation — the boost switches are still published but stop responding
@@ -968,7 +973,7 @@ With `myenergi_zappi_control: true` Predbat drives your Zappi from the car charg
 
 Inside a planned charging window Predbat puts the Zappi in **Fast**, and outside one it puts it in **Stopped**. Fast is used because the window was chosen for its electricity rate rather than for sunshine — Eco or Eco+ would only charge from surplus, and the car would not get what the plan assumed.
 
-Each Zappi follows its own car. Zappis are matched to cars in serial number order, the same order `car_charging_energy` and `car_charging_planned` are wired in, so your first Zappi follows car 0's plan, your second follows car 1's, and so on.
+Each Zappi follows its own car — the car slot it was allocated, which is the same allocation `car_charging_energy` and `car_charging_planned` were wired from, so the two cannot disagree about which Zappi is which car. Serial number order settles the order among your own Zappis, but "Zappi N is car N" is not a rule you can rely on: a hand-configured car in `apps.yaml`, or a charger from another component, can hold an earlier slot and move every Zappi up. See [How charger slots are allocated](car-charging.md#how-charger-slots-are-allocated).
 
 Predbat re-checks the Zappi every minute. If the mode is changed in the myenergi app while Predbat is in control, it is put back — otherwise control would drift away silently.
 


### PR DESCRIPTION
A charger moved to a different slot by #4928 can consume the previous occupant's published plan. Track the registry allocation version from configuration fetch through plan publication, and make all four charger controls wait for a plan built from the current mapping. Also keep each car's published window list separate: the previous list was shared across loop iterations, so later cars inherited earlier cars' windows.

Fix two measurement regressions: Ohme retains its energy and power contribution when another component registers first or discovery repeats; legacy and discovered measurements of the same charger are counted once. Matching uses the existing exact-entity and bounded manufacturer-serial rules, and legacy measurements are restored when discovery releases them.

Validation:
- The full `unit_test.py --quick` suite passed (four slow tests skipped).
- All seven affected component/registry suites passed, including 62 registry regressions and 97 Ohme tests.
- All pre-commit hooks for changed files passed.
- Both energy regressions were reproduced against the original PR. New tests cover each control loop waiting after reassignment and rejecting a plan published for an older allocation.

Slot numbering still follows the ordering documented in #4928; adding a charger may require adjusting per-car settings. This follow-up targets `feat/charger-registry`, keeping the review fixes separate from the original feature.
