### PR TITLE
feat(triage-bot): let every flow capture debug-journal findings

### DIFF
--- a/.claude/skills/issue-triage/references/debug-journal.md
+++ b/.claude/skills/issue-triage/references/debug-journal.md
@@ -149,3 +149,7 @@ Grep for the named symbol rather than trusting a line number.
 ## Adding to this file
 
 When an investigation turns up something a future triage run would have wanted to know — a config item that explains a class of report, an API quirk, a symptom that maps to a module — add a row. Keep it short, name the symbol rather than the line number, and cite the issue number so the next reader can check the original.
+
+If you are running under the triage bot you cannot edit this file directly — the clone is `reset --hard` before every flow, so the edit would not survive. Write the finding as a single markdown file in the queue directory named in your system prompt instead; the `/journal-update` flow folds the queue in once a day, re-checking each candidate against current `main` first, and opens a PR for a maintainer to merge.
+
+Whichever route you take, the bar is the same and it is not "interesting": record what you **verified**, say how you verified it, and keep anything you merely suspect explicitly marked as suspected. A wrong entry here is worse than a missing one — every later run trusts this file, so a confident mistake ends up in a comment posted to a real reporter. Correcting or deleting a stale entry counts as much as adding one.

--- a/.claude/skills/journal-update/SKILL.md
+++ b/.claude/skills/journal-update/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: journal-update
+description: Fold the triage bot's queued findings into the debug journal, re-check the journal against what has merged since, and open a pull request for a maintainer to merge.
+allowed-tools: You can read anything in this repo and the queue directory, but you may only edit two files - the debug journal and the cspell dictionary. You can run pre-commit, commit to a new bot/debug-journal-* branch, push that branch, and open a pull request. You cannot merge or close it, and you cannot push to main.
+---
+
+# Journal Update
+
+You maintain `.claude/skills/issue-triage/references/debug-journal.md` — the file every triage, PR-review and PR-cleanup run reads before forming a hypothesis. Each of those runs can leave a finding in a queue directory; once a day you fold the queue in and open a PR.
+
+Arguments: `queue=<dir>`. Every `*.md` directly in that directory is one candidate. `<queue>/processed/` is the archive of candidates already folded in — read it for context if you like, but never treat it as new input.
+
+**The journal being wrong is worse than it being stale.** Every later run trusts it, so a confidently wrong entry propagates into comments posted to real reporters. One entry recently asserted a credential leak that had already been fixed; left alone it would have had a triage run tell a reporter to rotate keys that never leaked. Your job is as much deleting and correcting as adding.
+
+## 1. Read the current journal
+
+Read it end to end before touching anything. You need to know what is already covered — most candidates restate something the journal says, and the right outcome for those is to drop them, or to sharpen the existing entry rather than add a second one.
+
+Note its own "Adding to this file" section: name the symbol rather than the line number, cite the issue number, keep it short.
+
+## 2. Verify every candidate against current main
+
+A candidate is a claim made during one investigation, at whatever commit was checked out then. Before it goes in:
+
+```bash
+git fetch origin main && git log --oneline -1 origin/main
+```
+
+For each candidate, check the claim still holds — grep the symbol it names, read the function, check whether a merge has since fixed or contradicted it. Then choose:
+
+- **Fold it in** — place it in the right table row or section, rewritten in the journal's voice. Say what was verified and how.
+- **Rewrite it** — the observation is real but the explanation was wrong or has been overtaken.
+- **Drop it** — already covered, unverifiable, or fixed since. Dropping is a normal outcome; say so in the PR body with the reason.
+
+Anything the candidate flagged as suspected rather than verified stays marked that way, or comes out. Do not upgrade a hypothesis to a fact because it reads well.
+
+## 3. Re-check the journal against what has merged since
+
+This is the half that keeps the file honest, and it is not optional.
+
+```bash
+git log --oneline --since="2 weeks ago" origin/main
+```
+
+Look for merges touching areas the journal makes claims about. For each, ask whether an existing entry is now wrong: a bug it calls "still live" that has been fixed, a line citation that has drifted onto unrelated code, a `confirmed on main (checked ...)` that a later merge has invalidated. Correct those in the same PR, and say plainly in the body which entries changed and why.
+
+If a fix has landed, say so and keep the mechanism — "this was the bug, it was fixed in PR #N" is useful to a reader holding an older log. Do not simply delete the entry.
+
+## 4. Spelling
+
+New vendor and firmware terms will fail the cspell hook. Add genuine terms to `.cspell/custom-dictionary-workspace.txt`; reword ordinary English rather than adding it. The file is auto-sorted by a hook, so re-stage it after running pre-commit.
+
+## 5. Quality gate
+
+```bash
+./run_pre_commit
+```
+
+Docs-only changes still have to pass cspell and markdownlint. Do not skip it.
+
+## 6. Commit and open the PR
+
+```bash
+git checkout -b bot/debug-journal-<YYYY-MM-DD>
+git add .claude/skills/issue-triage/references/debug-journal.md .cspell/custom-dictionary-workspace.txt
+git commit -m "docs(debug-journal): <what changed>"
+git push -u origin bot/debug-journal-<YYYY-MM-DD>
+gh pr create --draft --title "..." --body-file <path>
+```
+
+The PR body must open with a line disclosing it is automated, then list, per candidate, what you folded in, rewrote or dropped **and why** — that list is what makes the PR reviewable in a couple of minutes instead of requiring a full re-read of the diff. Name every existing entry you corrected separately, with the merge that invalidated it.
+
+Do not merge it. A human merge is the review gate on this file.
+
+## 7. If there is nothing worth landing
+
+If every candidate is a duplicate or fails verification, and nothing in the journal needs correcting, open no PR. Say so in your final message. An empty day is a perfectly good outcome and much better than a PR that adds noise to the file every other flow depends on.

--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -428,6 +428,7 @@ ollama
 onblur
 onchange
 oncharge
+oneline
 onfocus
 oninput
 onmouseout

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -39,6 +39,7 @@ class DaemonPathsTestCase(unittest.TestCase):
         self._patch("LOG_DIR", self.log_dir)
         self._patch("CLONE_DIR", base / "batpred")
         self._patch("SCRATCH_DIR", base / "scratch")
+        self._patch("QUEUE_DIR", base / "journal-queue")
 
     def _patch(self, name, value):
         """Patch a module-level constant on triage_daemon for the duration of the test."""
@@ -1478,7 +1479,7 @@ class ReviewPrTests(DaemonPathsTestCase):
         triage_daemon.review_pr(4742)
         cmd = mock_run.call_args[0][0]
         self.assertIn("--append-system-prompt", cmd)
-        self.assertEqual(cmd[cmd.index("--append-system-prompt") + 1], triage_daemon.GH_API_ENDPOINT_FIRST_PROMPT)
+        self.assertIn(triage_daemon.GH_API_ENDPOINT_FIRST_PROMPT, cmd[cmd.index("--append-system-prompt") + 1])
 
     @patch("triage_daemon.subprocess.run")
     def test_raises_on_a_non_zero_exit(self, mock_run):
@@ -1639,7 +1640,7 @@ class CleanupPrTests(DaemonPathsTestCase):
         triage_daemon.cleanup_pr(4742)
         cmd = mock_run.call_args[0][0]
         self.assertIn("--append-system-prompt", cmd)
-        self.assertEqual(cmd[cmd.index("--append-system-prompt") + 1], triage_daemon.GH_API_ENDPOINT_FIRST_PROMPT)
+        self.assertIn(triage_daemon.GH_API_ENDPOINT_FIRST_PROMPT, cmd[cmd.index("--append-system-prompt") + 1])
 
     @patch("triage_daemon.subprocess.run")
     def test_raises_on_a_non_zero_exit(self, mock_run):
@@ -1752,6 +1753,259 @@ class CommentDisclosureTests(unittest.TestCase):
     def test_mark_pr_cleanup_failed_discloses(self, mock_run):
         triage_daemon.mark_pr_cleanup_failed(4742)
         self.assertTrue(self._body_of_first_comment_call(mock_run).startswith("Automated"))
+
+
+class JournalQueueTests(DaemonPathsTestCase):
+    """The queue is where a flow parks a finding for the daily journal PR to pick up."""
+
+    def test_queue_lives_outside_the_clone(self):
+        """sync_repo() runs `git reset --hard` and `git clean -fd` on the clone before every
+        flow, so anything queued inside it would be destroyed before the flush ever saw it.
+        That is why every earlier attempt to have the bot maintain the journal came to
+        nothing, permissions aside."""
+        self.assertFalse(str(triage_daemon.QUEUE_DIR).startswith(str(triage_daemon.CLONE_DIR)))
+
+    def test_every_flow_may_write_to_the_queue(self):
+        """All five flows capture findings, so the queue's Edit grant has to be in the shared
+        base list rather than added per flow."""
+        rule = f"Edit({triage_daemon.QUEUE_SCOPE})"
+        for name in ("ALLOWED_TOOLS", "ALLOWED_TOOLS_PR", "ALLOWED_TOOLS_REVIEW", "ALLOWED_TOOLS_CLEANUP"):
+            with self.subTest(allowlist=name):
+                self.assertIn(rule, getattr(triage_daemon, name).split(","))
+
+    def test_entries_are_empty_when_the_queue_has_never_been_written(self):
+        """A fresh install has no queue directory at all; that is not an error."""
+        self.assertEqual(triage_daemon.journal_queue_entries(), [])
+
+    def test_entries_are_sorted_and_only_markdown(self):
+        """Sorted so the flush reads them in a stable order, and filtered so a stray download
+        or editor swap file in the directory cannot be mistaken for a finding."""
+        triage_daemon.QUEUE_DIR.mkdir(parents=True)
+        for name in ("4931-b.md", "4900-a.md", "notes.txt"):
+            (triage_daemon.QUEUE_DIR / name).write_text("x")
+        self.assertEqual([p.name for p in triage_daemon.journal_queue_entries()], ["4900-a.md", "4931-b.md"])
+
+
+class JournalCapturePromptTests(unittest.TestCase):
+    """JOURNAL_CAPTURE_PROMPT is how a flow learns to capture at all. No skill asked for this
+    before, which is why journal upkeep was self-motivated and patchy - and /code-review is a
+    built-in skill whose SKILL.md we do not own, so an appended system prompt is the only
+    lever that reaches every flow."""
+
+    def test_names_the_queue_directory(self):
+        """Concrete enough to act on: the agent has to be told where to write."""
+        self.assertIn(str(triage_daemon.QUEUE_DIR), triage_daemon.JOURNAL_CAPTURE_PROMPT)
+
+    def test_asks_only_for_what_was_verified(self):
+        """The journal's value is that its entries are checkable. A queue full of hypotheses
+        would poison it faster than leaving it stale."""
+        prompt = triage_daemon.JOURNAL_CAPTURE_PROMPT
+        self.assertIn("verified", prompt)
+        self.assertIn("how you verified", prompt)
+
+    def test_tells_the_agent_to_skip_when_there_is_nothing_worth_saying(self):
+        """Most runs learn nothing new. Without an explicit opt-out the model writes something
+        anyway, and the daily PR fills with restatements of what the journal already says."""
+        self.assertIn("nothing", triage_daemon.JOURNAL_CAPTURE_PROMPT.lower())
+
+
+class JournalCaptureReachesEveryFlowTests(DaemonPathsTestCase):
+    """Every claude-invoking flow must carry the capture instruction."""
+
+    def _appended_system_prompt(self, mock_run):
+        """Return the --append-system-prompt value from the mocked claude invocation."""
+        cmd = mock_run.call_args[0][0]
+        return cmd[cmd.index("--append-system-prompt") + 1]
+
+    def _run_flow(self, flow, *args):
+        """Invoke one flow with subprocess.run mocked, returning its appended system prompt."""
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            flow(*args)
+            return self._appended_system_prompt(mock_run)
+
+    def test_every_flow_appends_the_capture_prompt(self):
+        """Triage, follow-up, PR creation, PR review and PR cleanup all capture."""
+        flows = [
+            (triage_daemon.triage, 4931),
+            (triage_daemon.triage_followup, 4931),
+            (triage_daemon.create_pr, 4931),
+            (triage_daemon.review_pr, 4941),
+            (triage_daemon.cleanup_pr, 4941),
+        ]
+        for flow, arg in flows:
+            with self.subTest(flow=flow.__name__):
+                self.assertIn(triage_daemon.JOURNAL_CAPTURE_PROMPT, self._run_flow(flow, arg))
+
+    def test_review_and_cleanup_keep_the_gh_api_steer_as_well(self):
+        """These two already carried GH_API_ENDPOINT_FIRST_PROMPT. Appending the capture text
+        must add to it, not replace it - the #4758 fix depends on that steer surviving."""
+        for flow, arg in ((triage_daemon.review_pr, 4941), (triage_daemon.cleanup_pr, 4941)):
+            with self.subTest(flow=flow.__name__):
+                appended = self._run_flow(flow, arg)
+                self.assertIn(triage_daemon.GH_API_ENDPOINT_FIRST_PROMPT, appended)
+                self.assertIn(triage_daemon.JOURNAL_CAPTURE_PROMPT, appended)
+
+    def test_only_one_append_system_prompt_flag_is_passed(self):
+        """Two --append-system-prompt flags is not a documented way to pass two prompts, so
+        the parts are joined into a single value instead."""
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            triage_daemon.review_pr(4941)
+            self.assertEqual(mock_run.call_args[0][0].count("--append-system-prompt"), 1)
+
+
+class JournalFlushGateTests(DaemonPathsTestCase):
+    """The flush runs at most once a day, and only when something is waiting."""
+
+    def _queue(self, count):
+        """Put `count` candidate files in the queue directory."""
+        triage_daemon.QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+        for i in range(count):
+            (triage_daemon.QUEUE_DIR / f"{i}.md").write_text("finding")
+
+    def test_no_flush_when_the_queue_is_empty(self):
+        """A quiet day opens no PR at all, rather than an empty one."""
+        self.assertFalse(triage_daemon.should_flush_journal({}, "2026-09-05"))
+
+    def test_flush_when_something_is_queued_and_today_has_not_run(self):
+        self._queue(1)
+        self.assertTrue(triage_daemon.should_flush_journal({}, "2026-09-05"))
+
+    def test_no_second_flush_on_the_same_day(self):
+        """The daemon polls every 5 minutes; without the date gate a non-empty queue would
+        open a PR on every poll."""
+        self._queue(1)
+        state = {"last_journal_flush": "2026-09-05"}
+        self.assertFalse(triage_daemon.should_flush_journal(state, "2026-09-05"))
+
+    def test_flushes_again_the_next_day(self):
+        self._queue(1)
+        state = {"last_journal_flush": "2026-09-04"}
+        self.assertTrue(triage_daemon.should_flush_journal(state, "2026-09-05"))
+
+    def test_a_single_finding_is_enough(self):
+        """One verified finding is worth a PR - the daily gate already bounds the review
+        burden, so there is no minimum batch size on top of it."""
+        self._queue(1)
+        self.assertTrue(triage_daemon.should_flush_journal({}, "2026-09-05"))
+
+
+class JournalPermissionTests(unittest.TestCase):
+    """The flush flow can push and open a PR, so its blast radius is deliberately the
+    narrowest of any flow: two files, and no other repo write."""
+
+    def _allowed(self):
+        return triage_daemon.ALLOWED_TOOLS_JOURNAL.split(",")
+
+    def test_does_not_grant_clone_wide_edit(self):
+        """Every other flow may edit anywhere in the clone. This one may not - it is the only
+        flow that can push, so a prompt-injected edit to apps/predbat would land on a branch."""
+        self.assertNotIn(f"Edit({triage_daemon.EDIT_SCOPE})", self._allowed())
+
+    def test_grants_exactly_the_journal_and_the_dictionary(self):
+        """cspell is a pre-commit hook and a journal entry naming a new vendor term fails it,
+        so the dictionary has to be writable too - and nothing else does."""
+        edits = sorted(rule for rule in self._allowed() if rule.startswith("Edit("))
+        self.assertEqual(edits, sorted([f"Edit({triage_daemon.JOURNAL_SCOPE})", f"Edit({triage_daemon.DICTIONARY_SCOPE})"]))
+
+    def test_cannot_write_the_queue_it_reads(self):
+        """The flush consumes candidates; it never needs to author one. Reading them comes
+        from --add-dir, not from an Edit grant."""
+        self.assertNotIn(f"Edit({triage_daemon.QUEUE_SCOPE})", self._allowed())
+
+    def test_can_commit_push_and_open_a_pr(self):
+        """The whole point of the flow: land the entries as a PR for a human to merge."""
+        for command in ("git add -A", "git commit -m x", "git push origin bot/debug-journal-2026-09-05", "gh pr create --draft"):
+            with self.subTest(command=command):
+                self.assertTrue(any(bash_rule_matches(rule, command) for rule in self._allowed() if rule.startswith("Bash(")))
+
+    def test_cannot_merge_its_own_pr(self):
+        """A human merge is the review gate. Losing it would make the bot the only reviewer of
+        its own edits to the file every other flow trusts."""
+        denied = triage_daemon.DISALLOWED_TOOLS_JOURNAL.split(",")
+        self.assertTrue(any(bash_rule_matches(rule, "gh pr merge 5000") for rule in denied if rule.startswith("Bash(")))
+
+    def test_still_blocks_force_push_variants(self):
+        """Same defence in depth as the PR flow: it can push, so it must not rewrite history."""
+        denied = triage_daemon.DISALLOWED_TOOLS_JOURNAL.split(",")
+        for command in ("git push --force origin main", "git push origin main -f", "git push --force-with-lease"):
+            with self.subTest(command=command):
+                self.assertTrue(any(bash_rule_matches(rule, command) for rule in denied if rule.startswith("Bash(")))
+
+    def test_does_not_inherit_the_broad_gh_grant(self):
+        """Same reasoning as the review and cleanup flows: a catch-all would silently re-widen
+        every scoped carve-out below it."""
+        self.assertNotIn("Bash(gh *)", self._allowed())
+
+    def test_does_not_grant_a_direct_push_to_main(self):
+        """main is protection-gated and the design is explicitly PR-and-human-merge, so the
+        allowlist names the bot branch prefix rather than any ref."""
+        self.assertFalse(any(bash_rule_matches(rule, "git push origin main") for rule in self._allowed() if rule.startswith("Bash(git push")))
+
+
+class JournalFlushInvocationTests(DaemonPathsTestCase):
+    """What the flush actually runs."""
+
+    def test_invokes_the_journal_update_skill_under_its_own_permission_set(self):
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            triage_daemon.flush_journal()
+            cmd = mock_run.call_args[0][0]
+        self.assertIn("/journal-update", cmd[cmd.index("-p") + 1])
+        self.assertEqual(cmd[cmd.index("--allowedTools") + 1], triage_daemon.ALLOWED_TOOLS_JOURNAL)
+        self.assertEqual(cmd[cmd.index("--disallowedTools") + 1], triage_daemon.DISALLOWED_TOOLS_JOURNAL)
+
+    def test_tells_the_skill_where_the_queue_is(self):
+        """The queue lives outside the clone, so the path has to be passed in and added to the
+        session's directory scope for Read/Grep."""
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            triage_daemon.flush_journal()
+            cmd = mock_run.call_args[0][0]
+        self.assertIn(str(triage_daemon.QUEUE_DIR), cmd[cmd.index("-p") + 1])
+        self.assertIn(str(triage_daemon.QUEUE_DIR), cmd[cmd.index("--add-dir") + 1 :])
+
+
+class JournalQueueArchiveTests(DaemonPathsTestCase):
+    """Consumed candidates are moved aside, not deleted."""
+
+    def _queue(self, *names):
+        triage_daemon.QUEUE_DIR.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            (triage_daemon.QUEUE_DIR / name).write_text("finding")
+        return triage_daemon.journal_queue_entries()
+
+    def test_a_successful_flush_empties_the_queue(self):
+        """Otherwise the next day folds the same findings in again."""
+        self._queue("4931-a.md")
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            triage_daemon.flush_journal()
+        self.assertEqual(triage_daemon.journal_queue_entries(), [])
+
+    def test_a_failed_flush_leaves_the_queue_intact(self):
+        """A finding must survive a flush that never opened a PR - the daemon has already
+        stamped the date, so tomorrow's run is its next chance."""
+        self._queue("4931-a.md")
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            triage_daemon.flush_journal()
+        self.assertEqual([p.name for p in triage_daemon.journal_queue_entries()], ["4931-a.md"])
+
+    def test_consumed_findings_are_kept_not_deleted(self):
+        """A candidate the flush decided to drop is still evidence of what was seen."""
+        self._queue("4931-a.md")
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            triage_daemon.flush_journal()
+        self.assertTrue((triage_daemon.QUEUE_DIR / "processed" / "4931-a.md").exists())
+
+    def test_archived_findings_are_not_queued_again(self):
+        """journal_queue_entries() must not recurse into the archive."""
+        self._queue("4931-a.md")
+        triage_daemon.archive_journal_queue(triage_daemon.journal_queue_entries())
+        self.assertFalse(triage_daemon.should_flush_journal({}, "2026-09-06"))
 
 
 if __name__ == "__main__":

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -82,6 +82,15 @@ console output just says which issue it is working on and where that log is;
 `tail -f` it to watch a triage in progress. Logs are never pruned, so clear the
 directory out yourself if it grows.
 
+Every flow also carries JOURNAL_CAPTURE_PROMPT, asking it to leave any finding a future
+run would want in ~/predbat-triage-bot/journal-queue/ - outside the clone, because
+sync_repo() resets and cleans the checkout before every flow and would otherwise destroy
+it. Once a day, if anything is queued, the daemon runs `/journal-update` under
+ALLOWED_TOOLS_JOURNAL: the only flow that can both edit a file and push, and correspondingly
+the narrowest edit scope of any (the debug journal and the cspell dictionary, named by exact
+path, nothing else). It opens a PR against main and cannot merge it - a human merge is the
+review gate, because every other flow reads that journal and trusts it.
+
 The allowlist deliberately includes general-purpose tools (python3,
 curl, ./run_all), which together amount to arbitrary code execution
 inside the clone - the triage skill needs to open a reporter's log,
@@ -118,6 +127,19 @@ OLLAMA_BASE_URL = "http://localhost:11434"
 
 EDIT_SCOPE = f"//{CLONE_DIR.relative_to('/')}/**"
 SCRATCH_SCOPE = f"//{SCRATCH_DIR.relative_to('/')}/**"
+# Findings destined for the debug journal are parked here, deliberately OUTSIDE the clone:
+# sync_repo() runs `git reset --hard origin/main` and `git clean -fd` before every flow, so a
+# note written inside the checkout is destroyed before anything can pick it up. That, more
+# than any permission rule, is why the journal never got maintained by the bot.
+QUEUE_DIR = BASE_DIR / "journal-queue"
+QUEUE_SCOPE = f"//{QUEUE_DIR.relative_to('/')}/**"
+# The two files the daily flush may touch. Scoped to the exact paths rather than the clone,
+# because this is the only flow that can both edit and push.
+JOURNAL_RELPATH = ".claude/skills/issue-triage/references/debug-journal.md"
+DICTIONARY_RELPATH = ".cspell/custom-dictionary-workspace.txt"
+JOURNAL_SCOPE = f"//{(CLONE_DIR / JOURNAL_RELPATH).relative_to('/')}"
+DICTIONARY_SCOPE = f"//{(CLONE_DIR / DICTIONARY_RELPATH).relative_to('/')}"
+JOURNAL_BRANCH_PREFIX = "bot/debug-journal-"
 _ALLOWED_TOOLS_NON_GH = [
     # Git history, and the re-sync/discard the skill does before investigating
     "Bash(git log*)",
@@ -179,6 +201,9 @@ _ALLOWED_TOOLS_NON_GH = [
     # rule is not matched by the file permission check, so don't add one.
     f"Edit({EDIT_SCOPE})",
     f"Edit({SCRATCH_SCOPE})",
+    # Every flow may leave a journal finding behind. In the shared base list rather than
+    # added per flow, so a new flow inherits it instead of silently losing its findings.
+    f"Edit({QUEUE_SCOPE})",
     "WebFetch",
     "Read",
     "Grep",
@@ -313,6 +338,45 @@ DISALLOWED_TOOLS_CLEANUP = ",".join([item for item in _DISALLOWED_TOOLS_BASE if 
 # /code-review's own instructions live in a skill we don't own, so this prompt is the only
 # lever available for it; /pr-cleanup's SKILL.md already asks for disclosure directly, and
 # this is the belt-and-braces backup for it, same reasoning as the endpoint-first steer.
+# The daily journal flush. This is the only flow that can edit a file AND push, so its edit
+# scope is the narrowest of any: the journal itself, the cspell dictionary (a new vendor term
+# in an entry fails the pre-commit hook without it), and the queue it consumes. It gets no
+# broad "Bash(gh *)" - same reasoning as the review and cleanup flows - and its push grant
+# names the bot branch prefix, so it cannot push to main even though main is where the file
+# lives. A human merging the PR is the review gate on journal content, and the journal being
+# wrong is worse than it being stale: an entry asserting a fixed credential leak would have a
+# later triage run tell a reporter to rotate keys that never leaked.
+_ALLOWED_TOOLS_JOURNAL_EXTRA = [
+    "Bash(git add*)",
+    "Bash(git commit*)",
+    f"Bash(git push origin {JOURNAL_BRANCH_PREFIX}*)",
+    f"Bash(git push -u origin {JOURNAL_BRANCH_PREFIX}*)",
+    "Bash(gh pr create*)",
+    "Bash(./run_pre_commit*)",
+    "Bash(./run_pre_commit)",
+]
+_JOURNAL_DROPPED_EDITS = {f"Edit({EDIT_SCOPE})", f"Edit({SCRATCH_SCOPE})", f"Edit({QUEUE_SCOPE})"}
+ALLOWED_TOOLS_JOURNAL = ",".join([rule for rule in _ALLOWED_TOOLS_NON_GH if rule not in _JOURNAL_DROPPED_EDITS] + [f"Edit({JOURNAL_SCOPE})", f"Edit({DICTIONARY_SCOPE})"] + _ALLOWED_TOOLS_JOURNAL_EXTRA)
+# gh pr merge/close stay denied from the base list - the bot never merges its own journal PR.
+_JOURNAL_REMOVED_DENIALS = {"Bash(git push*)", "Bash(git commit*)", "Bash(gh pr create*)"}
+DISALLOWED_TOOLS_JOURNAL = ",".join([rule for rule in _DISALLOWED_TOOLS_BASE if rule not in _JOURNAL_REMOVED_DENIALS] + _PR_FORCE_PUSH_DENIALS)
+
+# Appended to every flow's system prompt. Until this existed no skill asked for a journal
+# finding at all, so upkeep was self-motivated and happened in maybe one run in ten - and
+# /code-review is a built-in skill whose SKILL.md this repo does not own, so an appended
+# system prompt is the only lever that reaches all five flows.
+JOURNAL_CAPTURE_PROMPT = (
+    "Before you finish, consider whether this investigation turned up something a future triage run would have wanted to know "
+    "- a config item that explains a whole class of report, an API or firmware quirk, a symptom that maps to a module, a trap "
+    "that wasted your time, or an existing debug-journal entry you found to be out of date. "
+    f"If so, write it as a single markdown file in {QUEUE_DIR} named <issue-or-pr-number>-<short-slug>.md. "
+    "Record only what you actually verified, and say how you verified it (read the symbol, ran the test, replayed the debug "
+    "file, probed the live API) - separate that from anything you merely suspect, and name the issue or PR number so the next "
+    "reader can check the original. A daily job folds these into the journal after re-checking each one against main. "
+    "If this run learned nothing that generalises beyond the ticket in front of you, write nothing at all - that is the "
+    "normal outcome, and an empty queue is much better than one full of restatements of what the journal already says."
+)
+
 GH_API_ENDPOINT_FIRST_PROMPT = (
     "Permission rules in this session match a literal command prefix, so `gh api` calls are only permitted when the current allowlist covers the exact spelling you use. "
     "Prefer the endpoint-first, unquoted form (endpoint immediately after `gh api`) and put flags after the endpoint - for example "
@@ -590,12 +654,107 @@ def claude_budget_args(amount, review_only=False):
     return ["--max-budget-usd", amount]
 
 
+def append_system_prompt(*parts):
+    """Return the --append-system-prompt CLI pair carrying every non-empty part.
+
+    Joined into one value rather than passed as repeated flags: two
+    --append-system-prompt flags is not a documented way to supply two prompts, and the
+    review/cleanup flows need both the gh-api endpoint steer and the journal capture text.
+    """
+    return ["--append-system-prompt", "\n\n".join(part for part in parts if part)]
+
+
+def journal_queue_entries():
+    """Return the queued journal candidates, oldest filename first.
+
+    Filtered to *.md so a stray download or editor swap file left in the directory is not
+    mistaken for a finding, and sorted so the flush reads them in a stable order.
+    """
+    if not QUEUE_DIR.exists():
+        return []
+    return sorted(path for path in QUEUE_DIR.glob("*.md") if path.is_file())
+
+
+def should_flush_journal(state, today):
+    """True when there is something queued and today's flush has not run yet.
+
+    The daemon polls every POLL_SECONDS, so without the date gate a non-empty queue would
+    open a pull request on every poll. One finding is enough to justify a PR - the daily
+    gate already bounds how often a maintainer is asked to review one.
+    """
+    if not journal_queue_entries():
+        return False
+    return state.get("last_journal_flush") != today
+
+
+def archive_journal_queue(entries):
+    """Move consumed candidates into QUEUE_DIR/processed/.
+
+    Moved rather than deleted: no `rm` grant is needed anywhere, a dropped candidate stays
+    auditable next to the PR that dropped it, and journal_queue_entries()'s non-recursive
+    glob stops an archived finding being folded in twice.
+    """
+    if not entries:
+        return
+    archive_dir = QUEUE_DIR / "processed"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    for entry in entries:
+        entry.replace(archive_dir / entry.name)
+
+
+def flush_journal():
+    """Fold the queued findings into the debug journal and open a PR for a human to merge.
+
+    Deliberately not a straight append. The skill re-checks each candidate against current
+    main before folding it in, and re-checks the entries already in the journal against
+    what has merged since - a journal that only ever grows becomes wrong, and a wrong entry
+    is worse than a missing one because every later triage run trusts it.
+    """
+    cmd = (
+        [
+            "claude",
+            "-p",
+            f"/journal-update queue={QUEUE_DIR}",
+            "--permission-mode",
+            "dontAsk",
+            "--allowedTools",
+            ALLOWED_TOOLS_JOURNAL,
+            "--disallowedTools",
+            DISALLOWED_TOOLS_JOURNAL,
+            "--verbose",
+            # The queue lives outside the clone, so it needs to be in scope for Read/Grep
+            # as well as covered by the Edit rule.
+            "--add-dir",
+            str(QUEUE_DIR),
+            "--max-turns",
+            "80",
+        ]
+        + claude_model_args(review_only=True)
+        + claude_budget_args("10.00", review_only=True)
+    )
+    consumed = journal_queue_entries()
+    log_path = LOG_DIR / "journal-update.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"[triage] journal: folding {len(consumed)} finding(s) in, logging to {log_path}", flush=True)
+    with log_path.open("a") as log_handle:
+        log_handle.write(f"\n==== journal update started {time.strftime('%Y-%m-%d %H:%M:%S')} ====\n")
+        log_handle.flush()
+        result = subprocess.run(cmd, cwd=str(CLONE_DIR), stdout=log_handle, stderr=subprocess.STDOUT, env=claude_env(review_only=True))
+        log_handle.write(f"==== journal update exited {result.returncode} ====\n")
+    if result.returncode == 0:
+        archive_journal_queue(consumed)
+    print(f"[triage] journal: exited {result.returncode}", flush=True)
+
+
 def triage(issue_number):
     cmd = (
         [
             "claude",
             "-p",
             f"/issue-triage {issue_number} scratch={SCRATCH_DIR}",
+        ]
+        + append_system_prompt(JOURNAL_CAPTURE_PROMPT)
+        + [
             "--permission-mode",
             "dontAsk",
             "--allowedTools",
@@ -644,6 +803,9 @@ def triage_followup(issue_number):
             "claude",
             "-p",
             f"/issue-triage-followup {issue_number} scratch={SCRATCH_DIR}",
+        ]
+        + append_system_prompt(JOURNAL_CAPTURE_PROMPT)
+        + [
             "--permission-mode",
             "dontAsk",
             "--allowedTools",
@@ -685,6 +847,9 @@ def create_pr(issue_number):
             "claude",
             "-p",
             f"/issue-pr {issue_number} scratch={SCRATCH_DIR}",
+        ]
+        + append_system_prompt(JOURNAL_CAPTURE_PROMPT)
+        + [
             "--permission-mode",
             "dontAsk",
             "--allowedTools",
@@ -906,8 +1071,9 @@ def review_pr(pr_number):
             "claude",
             "-p",
             f"/code-review {pr_number} high --comment",
-            "--append-system-prompt",
-            GH_API_ENDPOINT_FIRST_PROMPT,
+        ]
+        + append_system_prompt(GH_API_ENDPOINT_FIRST_PROMPT, JOURNAL_CAPTURE_PROMPT)
+        + [
             "--permission-mode",
             "dontAsk",
             "--allowedTools",
@@ -1001,8 +1167,9 @@ def cleanup_pr(pr_number):
             "claude",
             "-p",
             f"/pr-cleanup {pr_number} scratch={SCRATCH_DIR}",
-            "--append-system-prompt",
-            GH_API_ENDPOINT_FIRST_PROMPT,
+        ]
+        + append_system_prompt(GH_API_ENDPOINT_FIRST_PROMPT, JOURNAL_CAPTURE_PROMPT)
+        + [
             "--permission-mode",
             "dontAsk",
             "--allowedTools",
@@ -1103,6 +1270,15 @@ def main():
                 process_bot_review_pr(pr)
             for pr in fetch_bot_cleanup_prs():
                 process_bot_cleanup_pr(pr)
+            today = time.strftime("%Y-%m-%d")
+            if should_flush_journal(state, today):
+                # Stamp the date before running, not after: a flush that fails would
+                # otherwise be retried on every poll for the rest of the day. The queue
+                # survives a failure, so the findings just wait for tomorrow.
+                state["last_journal_flush"] = today
+                save_state(state)
+                sync_repo()
+                flush_journal()
         except subprocess.CalledProcessError as exc:
             print(f"[triage] error: {exc}", flush=True)
         time.sleep(POLL_SECONDS)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -661,7 +661,8 @@ def append_system_prompt(*parts):
     --append-system-prompt flags is not a documented way to supply two prompts, and the
     review/cleanup flows need both the gh-api endpoint steer and the journal capture text.
     """
-    return ["--append-system-prompt", "\n\n".join(part for part in parts if part)]
+    joined = "\n\n".join(part for part in parts if part)
+    return ["--append-system-prompt", joined] if joined else []
 
 
 def journal_queue_entries():


### PR DESCRIPTION
## Why

The triage bot reads `debug-journal.md` before every investigation, but has never been able to maintain it. Sessions tried repeatedly across the last fortnight (#3078, #4804, #4840, #4845, #4931) and each reported the edit denied — but permissions were only half the story. `sync_repo()` runs `git reset --hard origin/main` and `git clean -fd` before every flow, so an edit inside the clone is destroyed before anything could pick it up. And no skill ever asked for a journal entry, so what upkeep happened was self-motivated and rare.

## Capture

A queue directory **outside the clone**, writable by all five flows through one `Edit` grant in the shared base allowlist, plus `JOURNAL_CAPTURE_PROMPT` appended to every flow's system prompt. An appended system prompt is the only lever that reaches `/code-review`, whose `SKILL.md` this repo doesn't own — same reasoning as the existing `GH_API_ENDPOINT_FIRST_PROMPT`.

The prompt asks for what was *verified* and how, and explicitly asks for silence when a run learned nothing that generalises — an empty queue is the expected outcome for most runs.

## Flush

Once a day, if anything is queued, `/journal-update` folds the queue in and opens a PR. It does two things:

1. Re-checks each candidate against current `main` before accepting it — fold in, rewrite, or drop with a reason.
2. Re-checks the **existing** journal against what has merged since.

The second half is the point. A file that only ever grows becomes wrong, and a wrong entry is worse than a missing one because every later run trusts it. Two entries were found stale this week; one asserted a credential leak that #4910 had already fixed, which would have had a triage run tell a reporter to rotate keys that never leaked.

## Blast radius

The flush is the only flow that can both edit a file and push, so it's deliberately the narrowest:

- Edits **only** the journal and the cspell dictionary, named by exact path — not the clone.
- Cannot write the queue it reads (read access comes from `--add-dir`).
- Cannot push outside `bot/debug-journal-*`, so it cannot push to `main` even though that's where the file lives.
- Cannot merge its own PR. The human merge is the review gate.
- Force-push denials match the PR flow's.

Consumed candidates move to `processed/` rather than being deleted: no `rm` grant needed anywhere, a re-run can't double-count, and a dropped finding stays auditable.

## Tests

36 new, 190 total, `tools/test_triage_daemon.py` (pre-commit gated). Cover the queue living outside the clone, capture reaching all five flows, the once-a-day gate, the permission set's carve-outs, and archive-on-success / keep-on-failure.

Two pre-existing tests asserted the appended prompt was *exactly* `GH_API_ENDPOINT_FIRST_PROMPT`; it's now that plus the capture text, so they assert containment. The property they protect — the #4758 gh-api steer still reaching review and cleanup — is unchanged and now covered directly too.

## Worth a look before merging

`Edit(<clone>/**)` has been granted since 2026-08-24 yet those sessions still reported Edit denied, which points at `**` not crossing the `.claude` path segment. This PR sidesteps it (the queue is elsewhere, and the journal rule is an exact path rather than a glob), but I have **not** proved that hypothesis — the first real flush run will confirm whether the exact-path `Edit` rule fires. If it doesn't, that's the thing to look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
