### PR TITLE
fix(octopus): don't replenish the IO low-rate slot cap mid-window at midday

### DIFF
--- a/apps/predbat/octopus.py
+++ b/apps/predbat/octopus.py
@@ -3194,10 +3194,16 @@ class Octopus:
                         else:
                             saved_slots.add(minute)
 
-                        # Calculate which day this minute belongs to (day boundary at midday)
+                        # Calculate which day this slot belongs to (day boundary at midday)
                         # Period 0 = noon today (720) to 11:59 tomorrow (2159), etc.
                         # Python's floor division handles negative numbers correctly
-                        day_offset = (minute - 720) // (24 * 60)
+                        #
+                        # Key this on the slot's START, not the current minute: a window that opens in
+                        # the evening and runs past noon the next day would otherwise cross into the
+                        # next period part-way through and be handed a second budget, re-stamping its
+                        # tail at rate_min_base in the middle of the day-rate block. load_octopus_slots
+                        # already charges a window to its start period the same way.
+                        day_offset = (start_minutes - 720) // (24 * 60)
 
                         # Initialise counter for this day if needed
                         if day_offset not in slots_per_day:

--- a/apps/predbat/tests/test_rate_add_io_slots.py
+++ b/apps/predbat/tests/test_rate_add_io_slots.py
@@ -384,6 +384,27 @@ def run_rate_add_io_slots_tests(my_predbat):
 
     failed |= run_rate_add_io_slots_test("test19_zero_kwh_future_not_excluded", my_predbat, slots, True, 12, expected_rates)
 
+    # Test 20: The midday cap boundary must not re-stamp the day-rate tail of an overnight window.
+    # The cap counter is keyed on the current minute, so a dispatch window that starts in the evening
+    # and runs past noon the next day fills its budget against day -1 (21:00-03:00) and is then handed
+    # a *fresh* budget at 12:00, re-stamping 12:00-15:00 at the off-peak rate in the middle of the
+    # day-rate block. Reported on Octopus Intelligent Go (8p off-peak / 33.72p day): the planner saw
+    # "Best charge window [12:00-13:30 @ 8.0p]", exported the battery into a 10.08p outgoing window at
+    # 11:00-12:00 and bought it back at the real 33.72p.
+    # Here 4.0 stands for the off-peak rate and 10.0 for the day rate.
+    print("\n**** Test 20: Midday reset must not stamp the day-rate tail of an overnight window ****")
+    slot_start = midnight_utc - timedelta(hours=3)  # 21:00 yesterday, minute -180
+    slot_end = midnight_utc + timedelta(hours=15)  # 15:00 today, minute 900
+    slots = [{"start": slot_start.strftime(TIME_FORMAT), "end": slot_end.strftime(TIME_FORMAT), "charge_in_kwh": 124.04, "source": "smart-charge", "location": "AT_HOME"}]
+
+    expected_rates = {}
+    for minute in range(-180, 180):  # 21:00 -> 03:00: the first 12 slots, legitimately off-peak
+        expected_rates[minute] = 4.0
+    for minute in range(720, 900):  # 12:00 -> 15:00: day rate, must NOT be re-stamped off-peak
+        expected_rates[minute] = 10.0
+
+    failed |= run_rate_add_io_slots_test("test20_midday_reset_stamps_day_rate", my_predbat, slots, True, 12, expected_rates)
+
     # Restore original forecast_minutes
     my_predbat.forecast_minutes = original_forecast_minutes
 


### PR DESCRIPTION
Fixes #4950.

`rate_add_io_slots()` keys its low-rate slot budget on a midday day boundary using the *current
minute*, so a dispatch window that starts in the evening and runs past noon the next day has its
budget replenished at 12:00 and the tail is stamped `rate_min_base` in the middle of the day-rate
block. On Octopus Intelligent Go (8p off-peak / 33.72p day) that produced
`Best charge window [12:00-13:30 @ 8.0p]` against a real 33.72p, and the optimiser correctly solved
the wrong problem — export at 10.08p, refill at "8p", resell at 29p.

**Pushed as two commits so CI shows the defect first.**

1. `test(octopus): failing repro …` — adds `test20_midday_reset_stamps_day_rate`. **CI fails here**,
   180 mispriced minutes across 12:00–15:00.
2. `fix(octopus): …` — charges every minute of a slot to the period its **start** falls in, matching
   what `load_octopus_slots()` already does. CI green.

Tests 1–19 stay green throughout, including `test15_midday_to_midday_boundary` — the test that
motivated the midday boundary in the first place. This narrows *which* period a window is charged
to; it does not move the boundary back.

### Not addressed here

The cap is still keyed on an absolute calendar period, so adjacent *discrete* 30-minute slots that
straddle noon each get their own budget — 13 contiguous slots can yield 13 off-peak half-hours with
`octopus_slot_max = 12`. Whether that is a defect depends on whether the 6-hour cap is meant to be
per-day or per-dispatch-window. I have a failing test for it but left it out rather than guess —
happy to add it if you want that behaviour changed too.
