### PR TITLE
fix(inverter): take the GE battery rate from battery_rate_max when there is no charge power register

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -334,7 +334,16 @@ class Inverter:
         self.soc_max = self.nominal_capacity * self.battery_scaling
 
         if self.inverter_type in ["GE", "GEC", "GEE"]:
-            self.battery_rate_max_raw = self.base.get_arg("charge_rate", attribute="max", index=self.id, default=2600.0, required_unit="W")
+            # Not every GivEnergy model has an absolute charge power register to read the maximum
+            # from - the 3-phase units rate the battery as a percentage instead. GECloud leaves
+            # charge_rate unset for those, so the attribute read below silently returns the 2600W
+            # default however capable the inverter really is, and every rate Predbat plans and
+            # writes is scaled against it. Fall back to battery_rate_max, which GECloud already
+            # populates from the device's own reported max_charge_rate (GH#4908).
+            if self.base.get_arg("charge_rate", indirect=False, index=self.id):
+                self.battery_rate_max_raw = self.base.get_arg("charge_rate", attribute="max", index=self.id, default=2600.0, required_unit="W")
+            else:
+                self.battery_rate_max_raw = self.base.get_arg("battery_rate_max", index=self.id, default=2600.0, required_unit="W")
         elif "battery_rate_max" in self.base.args:
             self.battery_rate_max_raw = self.base.get_arg("battery_rate_max", index=self.id, default=2600.0, required_unit="W")
         else:

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -19,6 +19,7 @@ from predbat import PredBat
 from inverter import Inverter
 from givtcp_rest import GivTCPRest
 from config import INVERTER_DEF
+from const import MINUTE_WATT
 
 
 def test_foxess_support_discharge_freeze_matches_foxcloud():
@@ -294,6 +295,51 @@ def test_adjust_reserve_device_bounds(test_name, ha, inv, prev_reserve, reserve,
     if ha.get_state("number.reserve") != expect_reserve:
         print("ERROR: Reserve should be {} got {}".format(expect_reserve, ha.get_state("number.reserve")))
         failed = True
+
+    return failed
+
+
+def test_battery_rate_max_source(test_name, my_predbat, ha, inverter_type, charge_rate_arg, charge_rate_max, battery_rate_max_arg, expect_rate_raw):
+    """
+    Test
+       Inverter.__init__ picks the battery rate maximum from the right source for GE-family
+       inverters.
+
+    The charge_rate entity's max attribute stays authoritative when there is one. Percentage-rated
+    models (the 3-phase units) have no absolute charge power register at all, so GECloud leaves
+    charge_rate unset - there the correctly-fetched battery_rate_max must be used rather than the
+    2600W fallback, which otherwise caps planning and every rate written back (GH#4908).
+    """
+    failed = False
+    print("Test: {}".format(test_name))
+
+    saved = {arg: my_predbat.args.get(arg, None) for arg in ("inverter_type", "charge_rate", "battery_rate_max")}
+    try:
+        my_predbat.args["inverter_type"] = [inverter_type]
+        my_predbat.args["charge_rate"] = charge_rate_arg
+        my_predbat.args["battery_rate_max"] = battery_rate_max_arg
+        if charge_rate_arg:
+            ha.dummy_items["number.charge_rate"] = {"state": 1100, "max": charge_rate_max}
+        if battery_rate_max_arg:
+            ha.dummy_items["sensor.battery_rate_max"] = 9984
+
+        inv = Inverter(my_predbat, 0)
+        if inv.battery_rate_max_raw != expect_rate_raw:
+            print("ERROR: battery_rate_max_raw should be {} got {}".format(expect_rate_raw, inv.battery_rate_max_raw))
+            failed = True
+        # The planned charge/discharge/export rates are all clamped against the raw value, so a
+        # wrong source shows up as a capped plan rather than just a cosmetic attribute
+        if round(inv.battery_rate_max_charge * MINUTE_WATT) != expect_rate_raw:
+            print("ERROR: battery_rate_max_charge should be {}W got {}W".format(expect_rate_raw, round(inv.battery_rate_max_charge * MINUTE_WATT)))
+            failed = True
+    finally:
+        for arg, value in saved.items():
+            if value is None:
+                my_predbat.args.pop(arg, None)
+            else:
+                my_predbat.args[arg] = value
+        ha.dummy_items["number.charge_rate"] = 1100
+        ha.dummy_items.pop("sensor.battery_rate_max", None)
 
     return failed
 
@@ -3049,6 +3095,16 @@ def run_inverter_tests(my_predbat_dummy):
     failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_min2", ha, inv, 3, 4, device_min=5, device_max=100, expect_reserve=5)
     failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_max1", ha, inv, 10, 80, device_min=4, device_max=50, expect_reserve=50)
     failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_no_bounds", ha, inv, 4, 10, device_min=None, device_max=None, expect_reserve=10)
+    if failed:
+        return failed
+
+    # GH#4908: percentage-rated GivEnergy models publish no absolute charge power register, so the
+    # rate must come from battery_rate_max rather than the 2600W fallback - without regressing the
+    # models that do have one, where the register's own maximum stays authoritative
+    failed |= test_battery_rate_max_source("battery_rate_max_charge_rate_entity", my_predbat, ha, "GEC", "number.charge_rate", charge_rate_max=3000, battery_rate_max_arg="sensor.battery_rate_max", expect_rate_raw=3000)
+    failed |= test_battery_rate_max_source("battery_rate_max_percent_only", my_predbat, ha, "GEC", None, charge_rate_max=None, battery_rate_max_arg="sensor.battery_rate_max", expect_rate_raw=9984)
+    failed |= test_battery_rate_max_source("battery_rate_max_percent_only_ge", my_predbat, ha, "GE", None, charge_rate_max=None, battery_rate_max_arg="sensor.battery_rate_max", expect_rate_raw=9984)
+    failed |= test_battery_rate_max_source("battery_rate_max_no_source", my_predbat, ha, "GEC", None, charge_rate_max=None, battery_rate_max_arg=None, expect_rate_raw=2600)
     if failed:
         return failed
 


### PR DESCRIPTION
Fixes #4908.

### What was wrong

The GE/GEC/GEE branch of `Inverter.__init__` took the maximum battery rate solely from the `charge_rate` entity's `max` attribute:

```python
if self.inverter_type in ["GE", "GEC", "GEE"]:
    self.battery_rate_max_raw = self.base.get_arg("charge_rate", attribute="max", index=self.id, default=2600.0, required_unit="W")
elif "battery_rate_max" in self.base.args:
    ...
```

Percentage-rated GivEnergy models — the 3-phase units — have no absolute charge power register at all. They expose only `charge_power_rate` (%), so `build_entities("number", ["battery_charge_power"])` in `gecloud.py` returns `None`, `charge_rate` is left unset, and that read quietly returns the `2600.0` default however capable the inverter really is. `gecloud.py` already fetches the true figure and wires it into `battery_rate_max` from `sensor.<prefix>_gecloud_<serial>_max_charge_rate`, but the `elif` below was unreachable for these inverter types, so it was dead wiring.

Worth noting because it changes the fix: the automated triage on #4908 attributed the 2600 to the `battery_charge_power` register advertising a `max` of 2600. That register is absent entirely on these models, so correcting an advertised maximum would not have helped — only reaching `battery_rate_max` does.

### Why it matters

`battery_rate_max_charge`, `battery_rate_max_discharge` and `battery_rate_max_export` are all `min()`-clamped against the raw value, so the whole plan is built to it. A GIV-3HY-11 was planning every charge, discharge and export at 2.6 kW against a real 9.98 kW.

On these models it also corrupts the writes, not just the plan. Because they are controlled through the percentage registers, the value written is:

```python
min(int(new_rate / self.battery_rate_max_raw * 100), 100)
```

The device applies that percentage to its real maximum, but Predbat computed it against 2600 W. With a denominator 3.8x too small, any sub-maximal rate request landed far too high — a 1300 W request writes 50%, which the inverter runs as ~5 kW. Requests at or above 2600 W saturate at 100% and are harmless, so this only bit low-power charge/export and discharge-during-charge suppression. Fixing the raw value fixes this too; no separate change needed.

### The change

Fall back to `battery_rate_max` only when `charge_rate` resolves to nothing. Models that do publish a charge power register keep taking that register's own maximum as authoritative, so nothing changes for them — including the mixed multi-inverter case, where `build_entities` returns a list with `None` only in the slots that lack the register and each inverter now resolves independently.

### Verification

Reproduced against two live GIV-3HY-11 sites (9984 W and 11000 W reported by the GE Cloud device info, both planning at 2.6 kW), and against the log attached to #4908 for the GIV-3HY-20: line 55 shows `current charge rate 2600W, current discharge rate 2730W`, and 2730 is 105% x 2600 — i.e. `get_current_charge_rate()` taking the percent branch, confirming that reporter's inverter is percentage-only too.

New test `test_battery_rate_max_source` covers four cases: charge power register present (register max wins, 3000), percentage-only on GEC and on GE (`battery_rate_max` wins, 9984), and neither source configured (2600 fallback preserved). Confirmed it fails on the unpatched tree with `battery_rate_max_raw should be 9984 got 2600.0` and passes with the change.

`./run_all` full suite green; `run_pre_commit` clean.
