### PR TITLE
fix(inverter): model the reserve floor the register will accept, not just set_reserve_min

### DIFF
--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -17,6 +17,7 @@ target SoC setting, and reserve management via both REST API and Home
 Assistant entity writes with polling validation.
 """
 
+import math
 import os
 import time
 import pytz
@@ -1735,8 +1736,11 @@ class Inverter:
         model's known floor instead (GivTCP does this with GE's 4%), so a user who has configured
         battery_min_soc lower has that reflected in what is published.
 
-        The rounding is the caller's contract as much as this one's - a floor rounds up and a ceiling
-        rounds down, so the value returned is always one the register accepts. Both the write
+        The rounding is the caller's contract as much as this one's: reserve is written as a whole
+        percent, so a floor takes the ceiling and a ceiling takes the floor and the value returned is
+        always one the register accepts. Rounding to nearest instead would turn a published floor of
+        4.2 into 4 - under the bound, so the write is clamped-and-confirmed to something else and
+        retries forever, which is the GH#4826 failure this is meant to prevent. Both the write
         (GH#4826) and the modelled reserve (GH#4953) go through here so the two cannot disagree about
         what the battery will hold.
         """
@@ -1745,10 +1749,10 @@ class Inverter:
             return None, None
 
         bounds = []
-        for attribute, round_up in (("min", True), ("max", False)):
+        for attribute, round_towards_accepted in (("min", math.ceil), ("max", math.floor)):
             value = self.base.get_state_wrapper(reserve_entity, attribute=attribute, default=None)
             try:
-                bounds.append(int(float(value) + 0.5) if round_up else int(float(value)))
+                bounds.append(round_towards_accepted(float(value)))
             except (ValueError, TypeError):
                 # Absent, empty or unparseable - no bound to honour rather than a bound of zero
                 bounds.append(None)

--- a/apps/predbat/inverter.py
+++ b/apps/predbat/inverter.py
@@ -444,11 +444,26 @@ class Inverter:
             self.base.expose_config("set_reserve_min" + reserve_min_postfix, battery_min_soc)
             self.reserve_min = battery_min_soc
 
-        self.base.log("Inverter {} Reserve min: {}%, battery_min: {}%".format(self.id, self.reserve_min, dp0(battery_min_soc)))
+        device_min, device_max = self.reserve_device_bounds()
+        if device_min is None and device_max is None:
+            register_bounds = ""
+        else:
+            register_bounds = ", register accepts {} to {}".format("{}%".format(device_min) if device_min is not None else "any", "{}%".format(device_max) if device_max is not None else "any")
+        self.base.log("Inverter {} Reserve min: {}%, battery_min: {}%{}".format(self.id, self.reserve_min, dp0(battery_min_soc), register_bounds))
         if (self.base.set_reserve_enable and self.inv_has_reserve_soc) or not self.inv_has_reserve_soc:
             self.reserve_percent = self.reserve_min
         else:
             self.reserve_percent = self.reserve_percent_current
+
+        # adjust_reserve() already clamps what it writes to these same bounds (GH#4826), so they are
+        # what the inverter is actually holding. Model that floor too, rather than planning against a
+        # bottom of the battery the write path will never ask for and the battery will never release
+        # (GH#4953). Applies whichever branch above chose reserve_percent: the limit is the device's,
+        # not a policy, so set_reserve_enable does not change it.
+        if device_min is not None:
+            self.reserve_percent = max(self.reserve_percent, device_min)
+        if device_max is not None:
+            self.reserve_percent = min(self.reserve_percent, device_max)
         self.reserve = dp3(self.soc_max * self.reserve_percent / 100.0)
 
         # Max inverter rate override
@@ -1710,6 +1725,35 @@ class Inverter:
                     f"Inverter {self.id} Current SoC {self.soc_percent}% is less than Target SoC {current_charge_limit}. Grid charging enabled with charge current set to {self.base.get_arg('timed_charge_current', index=self.id, default=65):0.2f}"
                 )
 
+    def reserve_device_bounds(self):
+        """
+        Return the (min, max) reserve percentages the inverter will accept, as whole percent, or
+        None for either bound the component does not publish.
+
+        Components publish the bounds onto the reserve entity's min/max attributes. They are not
+        always discovered from the device: where an API reports no bound the component publishes the
+        model's known floor instead (GivTCP does this with GE's 4%), so a user who has configured
+        battery_min_soc lower has that reflected in what is published.
+
+        The rounding is the caller's contract as much as this one's - a floor rounds up and a ceiling
+        rounds down, so the value returned is always one the register accepts. Both the write
+        (GH#4826) and the modelled reserve (GH#4953) go through here so the two cannot disagree about
+        what the battery will hold.
+        """
+        reserve_entity = self.base.get_arg("reserve", indirect=False, index=self.id, required_unit="%")
+        if not reserve_entity:
+            return None, None
+
+        bounds = []
+        for attribute, round_up in (("min", True), ("max", False)):
+            value = self.base.get_state_wrapper(reserve_entity, attribute=attribute, default=None)
+            try:
+                bounds.append(int(float(value) + 0.5) if round_up else int(float(value)))
+            except (ValueError, TypeError):
+                # Absent, empty or unparseable - no bound to honour rather than a bound of zero
+                bounds.append(None)
+        return bounds[0], bounds[1]
+
     def adjust_reserve(self, reserve):
         """
         Adjust the output reserve target %
@@ -1739,27 +1783,11 @@ class Inverter:
         reserve = min(reserve, self.reserve_max)
 
         reserve_entity = self.base.get_arg("reserve", indirect=False, index=self.id, required_unit="%")
-        if reserve_entity:
-            # Components publish the bounds the inverter will accept onto the entity's min/max
-            # attributes; respect them so we never ask for a value the device will silently clamp and
-            # confirm - otherwise write_and_poll_value's poll-back never matches the un-clamped target
-            # and the same failing write retries forever (GH#4826).
-            #
-            # Not always discovered from the device: where an API reports no bound the component
-            # publishes the model's known floor instead (GivTCP does this with GE's 4%), so a user
-            # who has configured battery_min_soc lower has that reflected in what is published.
-            device_min = self.base.get_state_wrapper(reserve_entity, attribute="min", default=None)
-            device_max = self.base.get_state_wrapper(reserve_entity, attribute="max", default=None)
-            if device_min not in (None, ""):
-                try:
-                    reserve = max(reserve, int(float(device_min) + 0.5))
-                except (ValueError, TypeError):
-                    pass
-            if device_max not in (None, ""):
-                try:
-                    reserve = min(reserve, int(float(device_max)))
-                except (ValueError, TypeError):
-                    pass
+        device_min, device_max = self.reserve_device_bounds()
+        if device_min is not None:
+            reserve = max(reserve, device_min)
+        if device_max is not None:
+            reserve = min(reserve, device_max)
 
         if current_reserve != reserve:
             self.base.log("Inverter {} Current Reserve is {}% and new target is {}%".format(self.id, dp0(current_reserve), dp0(reserve)))

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -3132,6 +3132,9 @@ def run_inverter_tests(my_predbat_dummy):
     failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_min2", ha, inv, 3, 4, device_min=5, device_max=100, expect_reserve=5)
     failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_max1", ha, inv, 10, 80, device_min=4, device_max=50, expect_reserve=50)
     failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_no_bounds", ha, inv, 4, 10, device_min=None, device_max=None, expect_reserve=10)
+    # A fractional floor must not round down to a value under it, or the write is clamped and
+    # confirmed to something else and never converges
+    failed |= test_adjust_reserve_device_bounds("adjust_reserve_device_min_fractional", ha, inv, 4, 4, device_min=4.2, device_max=100, expect_reserve=5)
     if failed:
         return failed
 
@@ -3148,7 +3151,10 @@ def run_inverter_tests(my_predbat_dummy):
     # GH#4953: the plan must be built to the same floor the write is clamped to, or it counts on
     # capacity the inverter will never release
     failed |= test_reserve_model_device_bounds("reserve_model_device_min", my_predbat, ha, set_reserve_min=4, device_min=5, device_max=100, expect_reserve_percent=5)
-    failed |= test_reserve_model_device_bounds("reserve_model_device_min_fractional", my_predbat, ha, set_reserve_min=4, device_min=4.2, device_max=100, expect_reserve_percent=4)
+    # A fractional bound rounds towards the value the register accepts, not to nearest: 4.2 must
+    # become 5, since modelling or writing 4 is under the device's floor
+    failed |= test_reserve_model_device_bounds("reserve_model_device_min_fractional", my_predbat, ha, set_reserve_min=4, device_min=4.2, device_max=100, expect_reserve_percent=5)
+    failed |= test_reserve_model_device_bounds("reserve_model_device_max_fractional", my_predbat, ha, set_reserve_min=100, device_min=5, device_max=99.7, expect_reserve_percent=99)
     failed |= test_reserve_model_device_bounds("reserve_model_device_min_below_config", my_predbat, ha, set_reserve_min=10, device_min=5, device_max=100, expect_reserve_percent=10)
     failed |= test_reserve_model_device_bounds("reserve_model_device_max", my_predbat, ha, set_reserve_min=60, device_min=5, device_max=50, expect_reserve_percent=50)
     failed |= test_reserve_model_device_bounds("reserve_model_no_bounds", my_predbat, ha, set_reserve_min=4, device_min=None, device_max=None, expect_reserve_percent=4)

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -344,6 +344,43 @@ def test_battery_rate_max_source(test_name, my_predbat, ha, inverter_type, charg
     return failed
 
 
+def test_reserve_model_device_bounds(test_name, my_predbat, ha, set_reserve_min, device_min, device_max, expect_reserve_percent, set_reserve_enable=True):
+    """
+    Test
+       Inverter.__init__ models the reserve floor the component publishes for the register, not just
+       set_reserve_min.
+
+    adjust_reserve() already clamps the write to these bounds (GH#4826), so a plan built to a lower
+    floor expects to use capacity the battery never releases (GH#4953).
+    """
+    failed = False
+    print("Test: {}".format(test_name))
+
+    saved_reserve_min = my_predbat.get_arg("set_reserve_min")
+    saved_reserve_enable = my_predbat.set_reserve_enable
+    saved_reserve_item = ha.dummy_items["number.reserve"]
+    try:
+        my_predbat.expose_config("set_reserve_min", set_reserve_min)
+        my_predbat.set_reserve_enable = set_reserve_enable
+        ha.dummy_items["number.reserve"] = {"state": 4.0, "min": device_min, "max": device_max}
+
+        inv = Inverter(my_predbat, 0)
+        if inv.reserve_percent != expect_reserve_percent:
+            print("ERROR: reserve_percent should be {} got {}".format(expect_reserve_percent, inv.reserve_percent))
+            failed = True
+        # reserve is what the plan actually treats as the bottom of the battery
+        expect_reserve_kwh = round(inv.soc_max * expect_reserve_percent / 100.0, 3)
+        if inv.reserve != expect_reserve_kwh:
+            print("ERROR: reserve should be {}kWh got {}kWh".format(expect_reserve_kwh, inv.reserve))
+            failed = True
+    finally:
+        my_predbat.expose_config("set_reserve_min", saved_reserve_min)
+        my_predbat.set_reserve_enable = saved_reserve_enable
+        ha.dummy_items["number.reserve"] = saved_reserve_item
+
+    return failed
+
+
 def test_adjust_force_export(test_name, ha, inv, dummy_rest, prev_start, prev_end, prev_force_export, prev_discharge_target, new_start, new_end, new_force_export, has_inv_time_button_press=False, expect_inv_time_button_press=False):
     """
     Test
@@ -3105,6 +3142,18 @@ def run_inverter_tests(my_predbat_dummy):
     failed |= test_battery_rate_max_source("battery_rate_max_percent_only", my_predbat, ha, "GEC", None, charge_rate_max=None, battery_rate_max_arg="sensor.battery_rate_max", expect_rate_raw=9984)
     failed |= test_battery_rate_max_source("battery_rate_max_percent_only_ge", my_predbat, ha, "GE", None, charge_rate_max=None, battery_rate_max_arg="sensor.battery_rate_max", expect_rate_raw=9984)
     failed |= test_battery_rate_max_source("battery_rate_max_no_source", my_predbat, ha, "GEC", None, charge_rate_max=None, battery_rate_max_arg=None, expect_rate_raw=2600)
+    if failed:
+        return failed
+
+    # GH#4953: the plan must be built to the same floor the write is clamped to, or it counts on
+    # capacity the inverter will never release
+    failed |= test_reserve_model_device_bounds("reserve_model_device_min", my_predbat, ha, set_reserve_min=4, device_min=5, device_max=100, expect_reserve_percent=5)
+    failed |= test_reserve_model_device_bounds("reserve_model_device_min_fractional", my_predbat, ha, set_reserve_min=4, device_min=4.2, device_max=100, expect_reserve_percent=4)
+    failed |= test_reserve_model_device_bounds("reserve_model_device_min_below_config", my_predbat, ha, set_reserve_min=10, device_min=5, device_max=100, expect_reserve_percent=10)
+    failed |= test_reserve_model_device_bounds("reserve_model_device_max", my_predbat, ha, set_reserve_min=60, device_min=5, device_max=50, expect_reserve_percent=50)
+    failed |= test_reserve_model_device_bounds("reserve_model_no_bounds", my_predbat, ha, set_reserve_min=4, device_min=None, device_max=None, expect_reserve_percent=4)
+    # The floor is the device's, not a policy, so it applies with set_reserve_enable off too
+    failed |= test_reserve_model_device_bounds("reserve_model_device_min_no_set_reserve", my_predbat, ha, set_reserve_min=4, device_min=5, device_max=100, expect_reserve_percent=5, set_reserve_enable=False)
     if failed:
         return failed
 


### PR DESCRIPTION
Fixes #4953.

### What was wrong

#4828 stopped the retry storm in #4826 by clamping the reserve *write* to the bounds a component publishes on the reserve entity. The reserve Predbat *models* was left alone — `reserve_percent` and so `self.reserve` still came from `set_reserve_min` / `battery_min_soc` with no reference to the register's `min`.

So on an inverter whose register floors above the configured value, the plan is built to a bottom of the battery the write path never asks for and the battery never releases, and `adjust_battery_target` floors every target SoC one step low. Because #4828 makes the write land on the device's floor, the two stay divergent rather than converging — nothing ever tells the model the device said no.

A GivEnergy 3-phase site: `number.<serial>_battery_reserve_percent` publishes `min: 5`, `set_reserve_min` was the default 4, and `sensor.<prefix>_inverter_config` showed `reserve: 0.679` — 4.0% of a 16.974 kWh battery — while the inverter held 5%. About 0.17 kWh the plan expected to use and never got.

### The change

`reserve_device_bounds()` holds the bounds read that was inline in `adjust_reserve()`, and both the write and the modelled reserve go through it, so they cannot disagree about what the battery will hold. The rounding convention moves into it too — a floor rounds up, a ceiling rounds down — so the value returned is always one the register accepts.

The clamp applies to whichever branch chose `reserve_percent`. The limit is the device's rather than a policy, so `set_reserve_enable` does not change it.

The bounds are reported through the existing per-cycle `Reserve min:` log rather than a new line, since inverters are reconstructed every cycle by `fetch_inverter_data()` and a second line would be pure repetition:

```
Inverter 0 Reserve min: 4%, battery_min: 4%, register accepts 5% to 100%
```

### Behaviour change worth a look

This changes the modelled floor for anyone whose component publishes a `min` above their `set_reserve_min`, not only GE Cloud 3-phase.

The group to think about is GivTCP, where the published `min` is GE's assumed 4% floor rather than something read from the device (`givtcp.py`, `GIVTCP_CONTROLS`), lowered by `battery_min_soc` where the user has set one. Since `set_reserve_min` defaults to 4, most users are unaffected; those who explicitly lowered it below 4 without setting `battery_min_soc` will see the modelled floor rise to 4%.

I think that is right rather than a regression, and the reason is #4828 rather than anything about provenance: the write is *already* clamped to that same 4, so the inverter is already holding 4% for those users. The model agreeing with the write is a correction whether the bound was discovered or assumed — and where a user does want to go lower, `battery_min_soc` already lowers the published bound, so it lowers both together. Worth your judgement though, since it moves plans for existing installs.

### Verification

Six new cases in `test_reserve_model_device_bounds`: floor above config, fractional floor rounding, floor below config (config wins), ceiling, no bounds published (unchanged), and the floor applying with `set_reserve_enable` off. Confirmed three of them fail on the unpatched tree — `reserve_percent should be 5 got 4` / `reserve should be 0.5kWh got 0.4kWh` and the ceiling equivalent — while the three control cases pass either way.

Existing `test_adjust_reserve_device_bounds` cases from #4828 still pass unchanged against the extracted helper. `./run_all` full suite green; `run_pre_commit` clean with no reformatting.
