### PR TITLE
Let an apps.yaml energy sensor win over GivTCP auto-configuration

### DIFF
--- a/apps/predbat/component_base.py
+++ b/apps/predbat/component_base.py
@@ -93,20 +93,38 @@ class ComponentBase(ABC):
         """
         return self.base.set_arg(arg, value)
 
-    def set_arg_auto(self, arg, value):
+    def set_arg_auto(self, arg, value, overwrite=True):
         """
         Like set_arg(), but for auto-discovery code (typically automatic_config()) binding an
-        apps.yaml key to an auto-discovered entity/value. Auto-discovery still always wins - this
-        does not change that - but if the user had already set this key explicitly in apps.yaml,
-        silently discarding it left no way to notice (issue #4494 follow-up discussion, PR #4500).
-        Logs a one-time note per key when that happens, then behaves exactly like set_arg().
+        apps.yaml key to an auto-discovered entity/value.
+
+        With overwrite=True (the default) auto-discovery wins and replaces whatever the user set,
+        which is what every caller did before this option existed. Silently discarding an explicit
+        apps.yaml entry left no way to notice (issue #4494 follow-up discussion, PR #4500), so a
+        one-time note per key is logged when that happens.
+
+        With overwrite=False the user's own apps.yaml entry wins and is left exactly as written;
+        auto-discovery still fills the key in when the user set nothing. Callers use this for keys
+        whose recorder HISTORY Predbat reads rather than just their current state - repointing one
+        of those at a sensor Predbat has only just created throws that history away, which for the
+        daily energy totals the load model is built from means planning against no history at all
+        until the days build back up.
+
+        Either way the decision is per key, and neither message repeats for the same key.
         """
         raw_args = getattr(self.base, "args_from_apps_yaml", None) or {}
         raw_value = raw_args.get(arg)
+        user_configured = raw_value is not None and raw_value != value
         warned = getattr(self.base, "apps_yaml_override_warned", None)
-        if raw_value is not None and raw_value != value and warned is not None and arg not in warned:
+        if user_configured and warned is not None and arg not in warned:
             warned.add(arg)
-            self.log(f"Note: apps.yaml sets '{arg}: {raw_value}' but auto-discovery is using '{value}' instead - auto-discovery always wins currently; remove the apps.yaml entry to avoid this message")
+            if overwrite:
+                self.log(f"Note: apps.yaml sets '{arg}: {raw_value}' but auto-discovery is using '{value}' instead - auto-discovery wins for this setting; remove the apps.yaml entry to avoid this message")
+            else:
+                self.log(f"Info: apps.yaml sets '{arg}: {raw_value}' - keeping your apps.yaml setting rather than auto-discovering '{value}'")
+        if user_configured and not overwrite:
+            # Deliberately not calling set_arg() at all - the user's own value is already in self.args
+            return None
         return self.set_arg(arg, value)
 
     def get_arg(self, arg, default=None, indirect=True, combine=False, attribute=None, index=None, domain=None, can_override=True, required_unit=None):

--- a/apps/predbat/givtcp.py
+++ b/apps/predbat/givtcp.py
@@ -246,6 +246,20 @@ GIVTCP_ENERGY_TODAY_FIELDS = {
     "pv_today": "PV_Energy_Today_kWh",
 }
 
+# The keys automatic_config() will NOT overwrite when the user named a sensor of their own in
+# apps.yaml - they are passed to set_arg_auto(overwrite=False).
+#
+# These four are the only keys claimed here whose recorder HISTORY Predbat reads:
+# minute_data_load()/minute_data_import_export() go back max_days_previous days. A user who was
+# already naming the GivTCP HA integration's own sensors has months of that history behind them,
+# and repointing the key at a sensor this component only just created throws it away - Predbat then
+# plans with no load model at all until the days build back up. Everything else claimed here
+# (soc_max, the controls, the power figures) is read as a current value, where a repoint costs
+# nothing, so those keep overwriting as before.
+#
+# Applied per key, so naming one of the four by hand does not opt the other three out.
+GIVTCP_AUTO_CONFIG_USER_WINS_KEYS = tuple(GIVTCP_ENERGY_TODAY_FIELDS)
+
 # Everything else the Energy block carries, as key -> (section, field). From the same snapshot at no
 # extra cost, and published but NOT auto-configured: Predbat has no apps.yaml key that consumes a
 # battery flow or a lifetime counter, so there is nothing to point at them.
@@ -806,7 +820,11 @@ class GivTCPComponent(ComponentBase):
                 continue
             # Indexed by REST endpoint, not by position: _parse_entity feeds self.rest[n] on every
             # write, so renumbering would route the surviving inverter's writes at a dead client.
-            self.set_arg_auto(key, [self._entity_id(domain, n, key) for n in discovered])
+            #
+            # overwrite=False on the history-bearing energy totals leaves a sensor the user named
+            # themselves in place, so its recorded history survives - set_arg_auto still fills the
+            # key in when they named nothing.
+            self.set_arg_auto(key, [self._entity_id(domain, n, key) for n in discovered], overwrite=key not in GIVTCP_AUTO_CONFIG_USER_WINS_KEYS)
 
     def _parse_entity(self, entity_id):
         """entity_id -> (inverter index, control name), or (None, None) if it doesn't match."""

--- a/apps/predbat/tests/test_component_base.py
+++ b/apps/predbat/tests/test_component_base.py
@@ -406,6 +406,58 @@ def test_component_base_set_arg_auto(my_predbat):
     return False
 
 
+def test_component_base_set_arg_auto_keeps_user_setting(my_predbat):
+    """
+    Test ComponentBase.set_arg_auto(overwrite=False): leaves a key the user set in apps.yaml alone.
+
+    Repointing an entity key at a freshly published sensor throws away that sensor's recorder
+    history. For the keys Predbat reads history from - the daily energy totals its load model is
+    built out of - that means planning against no history at all until days accumulate, so those
+    callers opt out of overwriting. The default stays overwrite=True, which is what keeps every
+    existing caller's behaviour unchanged.
+    """
+    print("\n*** Test: ComponentBase.set_arg_auto(overwrite=False) keeps the user's apps.yaml setting ***")
+
+    base = MockBase()
+    base.args_from_apps_yaml = {"load_today": ["sensor.my_own_load_today"]}
+    base.apps_yaml_override_warned = set()
+    set_calls = {}
+    base.set_arg = lambda arg, value: set_calls.__setitem__(arg, value)
+
+    component = TestComponent(base)
+
+    # The user configured this key, so overwrite=False must not touch it at all
+    component.set_arg_auto("load_today", ["sensor.predbat_givtcp_0_load_today"], overwrite=False)
+    assert "load_today" not in set_calls, f"User's apps.yaml setting should not be overwritten, got {set_calls.get('load_today')}"
+    assert any("load_today" in msg and "keeping your apps.yaml setting" in msg for msg in base.log_messages), "Should say the user's setting was kept"
+
+    # Said once when it happens, not on every automatic_config pass for the life of the process
+    component.set_arg_auto("load_today", ["sensor.predbat_givtcp_0_load_today"], overwrite=False)
+    kept_count = sum(1 for msg in base.log_messages if "load_today" in msg and "keeping your apps.yaml setting" in msg)
+    assert kept_count == 1, f"Kept message should not repeat, got {kept_count}"
+
+    # A key the user never configured is still auto-discovered - overwrite=False protects the
+    # user's own value, it does not stop auto-discovery filling in a key that has none
+    component.set_arg_auto("pv_today", ["sensor.predbat_givtcp_0_pv_today"], overwrite=False)
+    assert set_calls.get("pv_today") == ["sensor.predbat_givtcp_0_pv_today"], "An unconfigured key should still be auto-configured"
+
+    # The default is unchanged: auto-discovery still wins when overwrite is not passed
+    component.set_arg_auto("load_today", ["sensor.predbat_givtcp_0_load_today"])
+    assert set_calls.get("load_today") == ["sensor.predbat_givtcp_0_load_today"], "Default overwrite=True should still apply the auto-discovered value"
+
+    # Keeping the user's value must not depend on the warned-set bookkeeping being present -
+    # a component built outside PredBat.initialize() has neither snapshot attribute
+    bare_base = MockBase()
+    bare_base.args_from_apps_yaml = {"load_today": ["sensor.my_own_load_today"]}
+    bare_set_calls = {}
+    bare_base.set_arg = lambda arg, value: bare_set_calls.__setitem__(arg, value)
+    bare_component = TestComponent(bare_base)
+    bare_component.set_arg_auto("load_today", ["sensor.predbat_givtcp_0_load_today"], overwrite=False)
+    assert "load_today" not in bare_set_calls, "User's setting should be kept even without an apps_yaml_override_warned set"
+
+    print("PASS: set_arg_auto(overwrite=False) keeps an explicit apps.yaml setting and still fills in unset keys")
+
+
 def test_component_base_set_state_external(my_predbat):
     """
     Test ComponentBase.set_state_external() forwards to the HA interface with the attributes intact.
@@ -450,6 +502,7 @@ def test_component_base_all(my_predbat):
         ("run_timeout", test_component_base_run_timeout, "Hung run() triggers timeout, stack trace, and error count"),
         ("first_cleared_preset", test_component_base_first_cleared_when_run_presets_api_started, "first flag clears even when run() pre-sets api_started"),
         ("set_arg_auto", test_component_base_set_arg_auto, "set_arg_auto warns once on an apps.yaml override, silent otherwise"),
+        ("set_arg_auto_keep", test_component_base_set_arg_auto_keeps_user_setting, "set_arg_auto(overwrite=False) keeps an explicit apps.yaml setting"),
         ("set_state_external", test_component_base_set_state_external, "set_state_external forwards to the HA interface"),
     ]
 

--- a/apps/predbat/tests/test_givtcp_component.py
+++ b/apps/predbat/tests/test_givtcp_component.py
@@ -2078,6 +2078,58 @@ def test_automatic_config_can_be_turned_off(my_predbat=None):
     return 1 if failed else 0
 
 
+def test_energy_today_keys_keep_the_users_own_sensors(my_predbat=None):
+    """
+    An apps.yaml entry for one of the day's energy totals wins over auto-configuration.
+
+    These four are the only keys automatic_config() claims whose recorder HISTORY Predbat reads -
+    minute_data_load()/minute_data_import_export() go back max_days_previous days. A user who was
+    already naming the GivTCP HA integration's own sensors has months of that history; repointing
+    them at a sensor this component only just created discards it, and Predbat plans against no
+    load model until the days build back up. Everything else auto-config claims is read as a
+    current value, so it keeps overwriting as before.
+
+    Claimed per key, so naming one of the four by hand does not opt the other three out.
+    """
+    failed = False
+    base, component = _rest_from_fixture("cases/rest_v3.json")
+    _mark_discovered(component)
+    # The user named their own load sensor in apps.yaml; the rest were left to Predbat
+    base.args_from_apps_yaml = {"load_today": ["sensor.givtcp_load_energy_today_kwh"]}
+    base.apps_yaml_override_warned = set()
+    base.args["load_today"] = ["sensor.givtcp_load_energy_today_kwh"]
+
+    run_async(component.publish_data())
+    run_async(component.automatic_config())
+
+    if base.args.get("load_today") != ["sensor.givtcp_load_energy_today_kwh"]:
+        print("ERROR: the user's own load_today sensor was replaced by {}".format(base.args.get("load_today")))
+        failed = True
+
+    # The entity is still published either way - only the apps.yaml pointing changes
+    if "sensor.predbat_givtcp_0_load_today" not in base.entities:
+        print("ERROR: load_today entity was not published when the user's own sensor was kept")
+        failed = True
+
+    # Per key: the three the user did not name are still auto-configured
+    for key in ("import_today", "export_today", "pv_today"):
+        if base.args.get(key) != ["sensor.predbat_givtcp_0_" + key]:
+            print("ERROR: {} should still be auto-configured, got {}".format(key, base.args.get(key)))
+            failed = True
+
+    # Keys read as a current value rather than as history still overwrite as before
+    if base.args.get("charge_rate") != ["number.predbat_givtcp_0_charge_rate"]:
+        print("ERROR: charge_rate should still be auto-configured, got {}".format(base.args.get("charge_rate")))
+        failed = True
+    if base.args.get("soc_kw") != ["sensor.predbat_givtcp_0_soc_kw"]:
+        print("ERROR: soc_kw should still be auto-configured, got {}".format(base.args.get("soc_kw")))
+        failed = True
+
+    if not failed:
+        print("PASS: an explicit apps.yaml energy sensor is kept, per key, while everything else auto-configures")
+    return 1 if failed else 0
+
+
 def test_extra_energy_figures_are_published_but_not_claimed(my_predbat=None):
     """
     The battery flows and the lifetime counters are published, and deliberately not auto-configured.
@@ -2224,6 +2276,7 @@ def test_givtcp_component(my_predbat=None):
         ("friendly_names_complete", test_every_control_and_sensor_has_a_friendly_name_defined, "friendly name table covers every entity"),
         ("energy_today_publish", test_energy_today_sensors_are_published_and_claimed, "day energy totals published and claimed"),
         ("energy_today_absent", test_energy_today_keys_not_claimed_when_unreported, "energy totals unclaimed when unreported"),
+        ("energy_today_user_wins", test_energy_today_keys_keep_the_users_own_sensors, "an apps.yaml energy sensor wins over auto-config"),
         ("energy_extra", test_extra_energy_figures_are_published_but_not_claimed, "battery flows and lifetime totals published, not claimed"),
         ("automatic_off", test_automatic_config_can_be_turned_off, "givtcp_automatic can be turned off"),
     ]

--- a/docs/apps-yaml.md
+++ b/docs/apps-yaml.md
@@ -1559,8 +1559,15 @@ If you get a bunch of inverter information back then it's working!
 With **givtcp_rest** set, Predbat reads the GivTCP REST API itself and publishes what it finds as its own
 entities (`sensor.predbat_givtcp_0_*` and friends), then points its own settings at them - including
 **inverter_type**, **num_inverters**, the control entities, and the daily energy totals **load_today**,
-**import_today**, **export_today** and **pv_today**. You do not need to configure any of those by hand,
-and anything you do set for them is overridden.
+**import_today**, **export_today** and **pv_today**. You do not need to configure any of those by hand.
+
+The four daily energy totals are the one exception to auto-configuration winning: if you name a sensor
+of your own for **load_today**, **import_today**, **export_today** or **pv_today** in `apps.yaml`,
+Predbat keeps yours. It reads days of recorded history back from these to build its load model, and
+repointing them at a sensor it has only just created would throw that history away and leave it
+planning with no load model until the days build back up. This applies per setting, so naming one of
+the four by hand leaves the other three auto-configured. Everything else Predbat auto-configures here
+is read as a current value rather than as history, and anything you set for those is still overridden.
 
 Predbat also publishes the battery flows and the lifetime counters -
 `sensor.predbat_givtcp_<n>_battery_{charge,discharge}_today` and


### PR DESCRIPTION
## Problem

GivTCP auto-config claims `load_today`, `import_today`, `export_today` and `pv_today` alongside everything else it discovers, and overrides whatever the user set.

Those four are the only keys it claims whose recorder **history** Predbat reads — `minute_data_load()` / `minute_data_import_export()` go back `max_days_previous` days ([fetch.py:984-1025](https://github.com/springfall2008/batpred/blob/main/apps/predbat/fetch.py#L984-L1025)). A user who was already naming the GivTCP HA integration's own sensors had months of that history silently swapped for `sensor.predbat_givtcp_0_*` entities Predbat had only just created, leaving it planning with no load model until the days built back up.

## Change

`ComponentBase.set_arg_auto()` grows an `overwrite=` option:

| | behaviour | log, once per key |
|---|---|---|
| `overwrite=True` (default) | auto value wins, as today | existing "auto-discovery is using ... instead" note |
| `overwrite=False` | user's apps.yaml value kept, `set_arg()` not called | "keeping your apps.yaml setting" |

The default is byte-for-byte what every existing caller already did, so myenergi, solis, sunsynk, alphaess, gecloud and ohme are unchanged — that's what makes this safe to add to a symbol with 17 upstream callers across 6 components. Auto-discovery still fills a key in when the user named nothing, and the decision is per key.

GivTCP passes `overwrite=False` for those four energy totals only, via a new `GIVTCP_AUTO_CONFIG_USER_WINS_KEYS`. Everything else it claims — `soc_max`, the controls, the power figures — is read as a current value where a repoint costs nothing, so those keep overwriting as before. The entities are published either way; only the apps.yaml pointing changes.

## Tests

Written first, both watched failing for the right reason before the implementation went in:

- `test_component_base_set_arg_auto_keeps_user_setting` — `overwrite=False` keeps an explicit value and does not call `set_arg`; the message is said once, not every pass; an unconfigured key is still auto-configured; the default still overwrites; and keeping the user's value does not depend on the `apps_yaml_override_warned` bookkeeping existing.
- `test_energy_today_keys_keep_the_users_own_sensors` — against the real `cases/rest_v3.json` capture: a user-named `load_today` survives, the entity is still published, the other three energy keys are still auto-configured (per key), and `charge_rate` / `soc_kw` still overwrite.

Verified locally: `component_base`, `components`, `givtcp_component`, `givtcp_rest`, `myenergi`, `ohme`, `alphaess_*`, `sunsynk_*` and the `inverter*` suites all pass, and `run_pre_commit` is clean. The full `--quick` suite is left to CI.

## Docs

`docs/apps-yaml.md` said "anything you do set for them is overridden" — now carves out the four daily totals and explains why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
