### PR TITLE
fix(chat): don't fetch a model catalogue with no provider configured

### DIFF
--- a/apps/predbat/chat.py
+++ b/apps/predbat/chat.py
@@ -975,6 +975,12 @@ class ChatAgent(ComponentBase):
     # still reach.
     provider_name = "openrouter"
     provider = PROVIDERS["openrouter"]
+    # Same reasoning, for the two provider_ready() reads: list_models() now asks whether anything
+    # is configured before it will dial an endpoint, and an agent that never reached initialize()
+    # has configured nothing - so "no providers, none active" is both the truthful answer and the
+    # safe one.
+    providers = []
+    active_provider = None
 
     def initialize(self, config=None):
         """Store configuration and build the conversation store and event buffer.
@@ -1255,11 +1261,25 @@ class ChatAgent(ComponentBase):
         for it) - the Chat tab's footer uses it to show how full the context window is against the
         model actually in use, alongside the token count itself; see html_chat_models() and
         renderContextUsage() in web_chat.py.
+
+        An install with no usable provider fetches nothing at all and offers only whatever model
+        apps.yaml already names; see the guard below for why that is not merely an optimisation.
         """
         catalogue = None
         # Cleared per call: a cache hit never runs the fetch, so a reason left over from an
         # earlier failure would be reported against a catalogue that arrived perfectly well.
         self.catalogue_error = None
+        # Nothing usable is configured, so no endpoint's catalogue means anything here - and the
+        # fallback base_url is OpenRouter's, whose /models is served unauthenticated. The fetch
+        # therefore came back 200 rather than the 401 that would have stopped it, so an install
+        # with nothing set up made an outbound request on every view of the setup page and cached
+        # several hundred KB of a catalogue it cannot use. provider_ready() rather than "nothing
+        # is selected": an entry written down without its key is active but equally unusable, and
+        # it is the same predicate the turn path already refuses on. An endpoint the user is
+        # still typing into is probe_models()' job, which deliberately does not come through here.
+        if not self.provider_ready():
+            self.catalogue_error = NO_PROVIDER_MESSAGE
+            return await self._catalogue_to_models(None, self.provider, self.base_url, self.default_model)
         storage = self.storage
         try:
             if storage:

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -39,6 +39,7 @@ from chat import (
     max_attempts_for,
     MODEL_CACHE_MINUTES,
     MODEL_CACHE_VERSION,
+    NO_PROVIDER_MESSAGE,
     ollama_native_url,
     ollama_tags_to_catalogue,
     model_cache_name,
@@ -3779,6 +3780,133 @@ def test_a_working_catalogue_clears_the_previous_failure(my_predbat):
     return failed
 
 
+def _list_models_without_a_wire(my_predbat, providers):
+    """Run list_models() against a recording storage and a fetch that must not be called.
+
+    Returns (models, dialled, cache_names, catalogue_error). Both recorders matter and neither
+    substitutes for the other: dialled proves whether the endpoint was contacted, cache_names
+    proves whether the answer was written to storage - the two halves of what an unconfigured
+    install was doing every day.
+    """
+    dialled = []
+
+    async def fetch_should_not_run():
+        """Record the call and return a healthy catalogue, so a fetch that runs is not also empty."""
+        dialled.append(True)
+        return {"data": [{"id": "vendor/hosted", "supported_parameters": ["tools"]}]}
+
+    class RecordingStorage:
+        """Storage stand-in that records every fetch_cached name and otherwise behaves normally."""
+
+        def __init__(self):
+            """Start with nothing recorded."""
+            self.names = []
+
+        async def fetch_cached(self, module, filename, fetch_fn, fresh_minutes=30, stale_minutes=35, format="yaml"):
+            """Record the name asked for, then fetch as the real helper does on a cold cache."""
+            self.names.append(filename)
+            return await fetch_fn()
+
+    class StubComponents:
+        """Serves the recording storage to ComponentBase's read-only storage property."""
+
+        def __init__(self, storage):
+            """Hold the storage stand-in this registry should hand out."""
+            self.storage = storage
+
+        def get_component(self, name):
+            """Return the storage stand-in, and nothing else."""
+            return self.storage if name == "storage" else None
+
+    agent = _make_agent(my_predbat, providers=providers)
+    agent._fetch_model_catalogue = fetch_should_not_run
+    recorder = RecordingStorage()
+    # agent.storage is a read-only property reading base.components, so the registry is what has
+    # to be swapped - and put back, since my_predbat is shared with every other test.
+    previous_components = getattr(my_predbat, "components", None)
+    my_predbat.components = StubComponents(recorder)
+    try:
+        models = asyncio.run(agent.list_models())
+    finally:
+        my_predbat.components = previous_components
+    return models, dialled, recorder.names, agent.catalogue_error
+
+
+def test_the_catalogue_is_not_fetched_with_no_provider_configured(my_predbat):
+    """An install with nothing configured neither dials OpenRouter nor caches its catalogue.
+
+    The chat component is always started, even with nothing set up, because the Chat tab is what
+    configures it. With no provider, select_provider() falls back to OpenRouter's default URL with
+    no key - and OpenRouter serves /models unauthenticated, so the fetch came back 200 with the
+    whole several-hundred-model catalogue rather than the 401 that would have stopped it. Every
+    page view of the setup page therefore made an outbound request no user asked for, and cached
+    roughly 760KB of it for a day, for a catalogue that cannot be used until a provider exists.
+
+    The turn path already refuses here (see test_turn_refuses_with_no_provider_configured); this
+    is the same guard on the other path that reaches the wire.
+
+    Mutation check: dropping the provider_ready() guard from list_models() dials the endpoint and
+    writes the catalogue to storage.
+    """
+    failed = False
+    print("**** Testing that no provider configured means no catalogue fetch ****")
+
+    models, dialled, names, error = _list_models_without_a_wire(my_predbat, {})
+
+    if dialled:
+        print("ERROR: the catalogue endpoint was dialled with no provider configured")
+        failed = True
+    if names:
+        print("ERROR: the catalogue was written to storage with no provider configured: {}".format(names))
+        failed = True
+    if models:
+        print("ERROR: models were offered with no provider configured: {}".format(models))
+        failed = True
+    if error != NO_PROVIDER_MESSAGE:
+        print("ERROR: the picker was not told why there is no catalogue: {!r}".format(error))
+        failed = True
+    return failed
+
+
+def test_the_catalogue_is_not_fetched_for_a_provider_missing_its_key(my_predbat):
+    """A hosted provider written down without its key is not ready, so its catalogue is not fetched.
+
+    Half-configured is the commoner shape of the same bug: an entry exists, so select_provider()
+    makes it active and active_provider is not None, but it has no key and cannot answer a turn.
+    Guarding on "nothing is selected" would let this one straight through to the same
+    unauthenticated fetch, which is why the guard is provider_ready() - the predicate the turn
+    path already uses.
+
+    The picker still offers the model the entry names, because that is what it names; the guard is
+    about not reaching the wire, not about hiding what apps.yaml says.
+
+    Mutation check: guarding on active_provider is None instead of provider_ready() dials the
+    endpoint for this install.
+    """
+    failed = False
+    print("**** Testing that a provider missing its key does not fetch a catalogue ****")
+
+    providers = {"openrouter": {"type": "openrouter", "url": "https://openrouter.ai/api/v1"}}
+    models, dialled, names, error = _list_models_without_a_wire(my_predbat, providers)
+
+    if dialled:
+        print("ERROR: the catalogue endpoint was dialled for a provider with no key")
+        failed = True
+    if names:
+        print("ERROR: the catalogue was written to storage for a provider with no key: {}".format(names))
+        failed = True
+    # The model the entry names is still offered - _catalogue_to_models() always includes the
+    # configured one, which is what makes a custom endpoint serving no /models at all usable. What
+    # must not appear is anything that could only have come off the wire.
+    if "vendor/hosted" in [entry["id"] for entry in models]:
+        print("ERROR: a fetched catalogue was served for a provider with no key: {}".format(models))
+        failed = True
+    if error != NO_PROVIDER_MESSAGE:
+        print("ERROR: the picker was not told why there is no catalogue: {!r}".format(error))
+        failed = True
+    return failed
+
+
 def test_model_catalogue_is_cached_per_endpoint(my_predbat):
     """Each endpoint's model list is cached under its own name, not one shared "models".
 
@@ -4163,6 +4291,8 @@ def run_chat_tests(my_predbat):
     failed |= test_ollama_context_length_survives_a_server_that_cannot_answer(my_predbat)
     failed |= test_ollama_zero_context_length_is_treated_as_absent(my_predbat)
     failed |= test_a_working_catalogue_clears_the_previous_failure(my_predbat)
+    failed |= test_the_catalogue_is_not_fetched_with_no_provider_configured(my_predbat)
+    failed |= test_the_catalogue_is_not_fetched_for_a_provider_missing_its_key(my_predbat)
     failed |= test_local_models_are_free_however_little_pricing_they_publish(my_predbat)
     failed |= test_stop_reaches_a_turn_that_is_still_streaming(my_predbat)
     failed |= test_ollama_cloud_models_are_listed_but_not_free(my_predbat)

--- a/apps/predbat/tests/test_web_chat.py
+++ b/apps/predbat/tests/test_web_chat.py
@@ -1142,6 +1142,13 @@ def test_model_catalogue(my_predbat):
         return {"data": [{"id": "good/model", "name": "Good", "supported_parameters": ["tools", "temperature"], "context_length": 1000000}, {"id": "bad/model", "name": "Bad", "supported_parameters": ["temperature"]}]}
 
     agent._fetch_model_catalogue = fake_catalogue
+    # list_models() will not dial an endpoint no usable provider is configured for - see
+    # test_the_catalogue_is_not_fetched_with_no_provider_configured in test_chat.py - and this
+    # bare instance never reached initialize(), so it starts with none. Built by the real builder
+    # rather than hand-rolled, so the entry is the shape provider_ready() actually reads.
+    agent.providers = chat_module.build_providers({"openrouter": {"url": "https://openrouter.example/api/v1", "api_key": "test-key"}})
+    agent.active_provider = "openrouter"
+
     models = asyncio.run(agent.list_models())
     ids = [entry["id"] for entry in models]
     if "good/model" not in ids:


### PR DESCRIPTION
## The bug

Spotted in a log from an install with **no chat configuration at all**:

```
KeyDBStorage: Saved chat/models_v2_e0173a22bc8d97f0 (ttl=259200s, 760667 bytes)
```

That key is `md5("https://openrouter.ai/api/v1")[:16]` — the fallback base URL, not one anybody configured.

The chat component is [always started](https://github.com/springfall2008/batpred/blob/main/apps/predbat/components.py), deliberately, because the Chat tab is what configures it. With no provider, `select_provider(None)` falls back to `OPENROUTER_BASE_URL` with `api_key = None`. `model_catalogue_headers(None)` correctly sends no `Authorization` header — but OpenRouter's `/models` is **public**, so there was no 401 to bail out on: HTTP 200, ~760 KB, cached for a day.

The Chat tab still renders for an unconfigured install (it *is* the setup page) and `loadModels()` runs on page init and on every SSE reconnect, so every view made an outbound request nobody asked for. The half-configured case is the same bug and commoner: an entry written down without its API key is *active*, so `active_provider` is not `None`, and it dialled too.

## The fix

Guard `list_models()` on `provider_ready()` — the predicate the turn path already refuses on ([chat.py](../blob/main/apps/predbat/chat.py) `run_turn`), which covers both shapes — and set `catalogue_error` to the existing `NO_PROVIDER_MESSAGE` so the picker says what to add rather than "catalogue unavailable".

Deliberately unchanged: the model named in apps.yaml is still offered, because `_catalogue_to_models()` always includes the configured one — that is what makes a custom endpoint serving no `/models` usable at all. The guard is about not reaching the wire, not about hiding what apps.yaml says. An endpoint the user is still typing into is `probe_models()`, which deliberately does not come through here.

`provider_ready()` reads `self.providers` / `self.active_provider`, which only exist after `initialize()`, so both gain class-level defaults beside the ones already there for exactly this reason — `list_models()` is documented as reachable on a half-built agent.

## Tests

Two new tests in `test_chat.py`, both written first and watched fail:

- `test_the_catalogue_is_not_fetched_with_no_provider_configured` — nothing configured: no dial, no storage write, no models, the picker is told why. Against unfixed code it records the cache name `models_v2_e0173a22bc8d97f0`, the exact key from the reported log.
- `test_the_catalogue_is_not_fetched_for_a_provider_missing_its_key` — half-configured: same, and nothing that could only have come off the wire appears in the picker.

Mutation-checked: replacing `provider_ready()` with `active_provider is None` is caught by the second test; dropping the guard entirely is caught by both.

`test_web_chat.py::test_model_catalogue` builds a bare `ChatAgent.__new__` to exercise catalogue filtering; it now gives that instance a provider (via the real `build_providers`) to reach the fetch path.

## Verification

- `./run_all --quick` — all tests passed, 4 slow skipped
- `./run_pre_commit` — every hook passed, no rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)