### PR TITLE
perf(tests): cut the unit test suite from 123s to 78s

### DIFF
--- a/.cspell/custom-dictionary-workspace.txt
+++ b/.cspell/custom-dictionary-workspace.txt
@@ -327,6 +327,7 @@ ladybugdb
 larr
 libbi
 libc
+libyaml
 LIFEPO
 linebreak
 linestyle

--- a/apps/predbat/component_base.py
+++ b/apps/predbat/component_base.py
@@ -24,6 +24,13 @@ import asyncio
 import time
 import traceback
 
+# Components typically come up in milliseconds, so the previous 1s poll spent nearly all of a
+# start-up wait asleep after the component was already live. Polling ten times a second makes
+# start-up feel immediate for no meaningful cost - one cheap flag check per tick. The wait is
+# bounded by a monotonic deadline rather than by counting ticks, so `timeout` stays honest in
+# seconds however often the flag is checked.
+API_START_POLL_SECONDS = 0.1
+
 
 class ComponentBase(ABC):
     """
@@ -355,10 +362,9 @@ class ComponentBase(ABC):
             bool: True if component started successfully, False if timeout
         """
         self.log(f"{self.__class__.__name__}: Waiting for API to start")
-        count = 0
-        while not self.api_started and count < timeout:
-            time.sleep(1)
-            count += 1
+        deadline = time.monotonic() + timeout
+        while not self.api_started and time.monotonic() < deadline:
+            time.sleep(API_START_POLL_SECONDS)
         if not self.api_started:
             self.log(f"Warn: {self.__class__.__name__}: Failed to start")
             return False

--- a/apps/predbat/tests/test_alphaess_api.py
+++ b/apps/predbat/tests/test_alphaess_api.py
@@ -12,7 +12,7 @@ import predbat  # noqa: F401  (import first - avoids circular import: config.py 
 import hashlib
 import pytz
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from alphaess import AlphaESSAPI
 from tests.test_infra import run_async as run_async_local, create_aiohttp_mock_response, create_aiohttp_mock_session
 
@@ -32,12 +32,18 @@ class MockAlphaESS(AlphaESSAPI):
         self.state = {}
         self.published = {}
         self.external_state = {}
+        # 0 rather than initialize()'s real 2s default: api_delay is a courtesy pause between
+        # consecutive calls to AlphaESS's rate-limited cloud, and nothing here talks to the real
+        # cloud - every request is a scripted mock. Left at 2 it was several real seconds of
+        # dead wall-clock per test that reads more than one endpoint. A test that wants to
+        # exercise the pacing can still set client.api_delay itself.
         self.initialize(
             app_id=app_id,
             app_secret=app_secret,
             inverter_sn=inverter_sn,
             automatic=automatic,
             control_enable=control_enable,
+            api_delay=0,
         )
 
     def log(self, message):
@@ -213,7 +219,10 @@ def test_alphaess_transport_failure_returns_minus_one():
     failed = False
     client = MockAlphaESS()
     session = create_aiohttp_mock_session(exception=Exception("connection reset"))
-    with patch("alphaess.aiohttp.ClientSession", return_value=session):
+    # _request backs off between its retries with asyncio.sleep(1 + attempt) - 3 real seconds
+    # before it gives up. What is asserted here is the verdict it lands on, not the pacing it
+    # keeps on the way there, so the wait is skipped.
+    with patch("alphaess.aiohttp.ClientSession", return_value=session), patch("alphaess.asyncio.sleep", new_callable=AsyncMock):
         code, data = run_async_local(client._get("ess_list"))
     if code != -1:
         print(f"ERROR: transport failure code {code} should be -1")

--- a/apps/predbat/tests/test_chat.py
+++ b/apps/predbat/tests/test_chat.py
@@ -14,6 +14,7 @@ loop, the tool dispatch and the confirmation gate are all exercised without a ne
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import shutil
@@ -1710,6 +1711,25 @@ def _write_call_response(entity_id="input_number.predbat_best_soc_keep", value="
     return _tool_call_response("set_config", {"entity_id": entity_id, "value": value}, call_id="call_write")
 
 
+@contextlib.contextmanager
+def _fast_confirm_poll():
+    """Shorten await_confirmation's poll interval for tests whose answer arrives at once.
+
+    await_confirmation re-checks the pending confirmation every CONFIRM_POLL_SECONDS (0.2s). That
+    is the right cadence against a person at a browser, but a test whose background thread answers
+    in microseconds still sits out a whole tick, and these tests assert that the answer is
+    honoured - not how often the waiter looks for it. Shortened rather than removed so the polling
+    loop is still genuinely exercised. Same trick test_write_confirmation_timeout uses on
+    CONFIRM_TIMEOUT_SECONDS.
+    """
+    original = chat.CONFIRM_POLL_SECONDS
+    chat.CONFIRM_POLL_SECONDS = 0.002
+    try:
+        yield
+    finally:
+        chat.CONFIRM_POLL_SECONDS = original
+
+
 def _confirm_soon(agent, approved):
     """Answer the next pending confirmation from a background thread, as a browser would."""
 
@@ -1738,7 +1758,8 @@ def test_write_confirmation_approved(my_predbat):
     cid = asyncio.run(agent.store.create())
 
     _confirm_soon(agent, True)
-    asyncio.run(agent.run_turn(cid, "raise best soc keep"))
+    with _fast_confirm_poll():
+        asyncio.run(agent.run_turn(cid, "raise best soc keep"))
 
     kinds = [event["type"] for event in agent.events_since(0, cid)[0]]
     for required in ("confirm", "confirm_result", "tool_start", "tool_end"):
@@ -1763,7 +1784,8 @@ def test_write_confirmation_rejected(my_predbat):
     cid = asyncio.run(agent.store.create())
 
     _confirm_soon(agent, False)
-    asyncio.run(agent.run_turn(cid, "raise best soc keep"))
+    with _fast_confirm_poll():
+        asyncio.run(agent.run_turn(cid, "raise best soc keep"))
 
     results = [message for message in asyncio.run(agent.store.get_messages(cid)) if message["role"] == "tool"]
     if not results or "declined" not in str(results[0].get("content")).lower():
@@ -1853,7 +1875,8 @@ def test_set_apps_config_confirmation_gate_and_card(my_predbat):
         cid = asyncio.run(agent.store.create())
 
         _confirm_soon(agent, False)
-        asyncio.run(agent.run_turn(cid, "change the HA url"))
+        with _fast_confirm_poll():
+            asyncio.run(agent.run_turn(cid, "change the HA url"))
 
         events, _, _ = agent.events_since(0, cid)
         kinds = [event["type"] for event in events]
@@ -1913,7 +1936,8 @@ def test_set_apps_config_approved_writes_apps_yaml(my_predbat):
         cid = asyncio.run(agent.store.create())
 
         _confirm_soon(agent, True)
-        asyncio.run(agent.run_turn(cid, "change num_inverters"))
+        with _fast_confirm_poll():
+            asyncio.run(agent.run_turn(cid, "change num_inverters"))
 
         with open(os.path.join(temp_dir, "apps.yaml"), "r", encoding="utf-8") as handle:
             written = handle.read()
@@ -3138,7 +3162,8 @@ def test_stop_reaches_a_turn_parked_on_a_confirmation(my_predbat):
         approved = await agent.await_confirmation("call_x")
         return approved, time.monotonic() - started
 
-    approved, elapsed = asyncio.run(drive())
+    with _fast_confirm_poll():
+        approved, elapsed = asyncio.run(drive())
 
     if approved:
         print("ERROR: a stopped confirmation was treated as approved")

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -3209,7 +3209,12 @@ def _test_async_get_inverter_settings_success(my_predbat):
 
         ge_cloud.async_read_inverter_setting = mock_read_setting
 
-        result = await ge_cloud.async_get_inverter_settings("test123")
+        # async_get_inverter_settings paces itself with a 0.2s sleep per setting so a large
+        # register list does not burst the GE Cloud rate limit. The reads here are local mocks
+        # with no rate limit to respect, so the pacing is skipped - as the retry/backoff tests
+        # in this file already do.
+        with patch("gecloud.asyncio.sleep", new_callable=AsyncMock):
+            result = await ge_cloud.async_get_inverter_settings("test123")
 
         # Result structure: {sid: {"name": ..., "value": ..., "validation_rules": ..., "validation": ...}}
         if 1 not in result or result[1]["value"] != "75":
@@ -3246,7 +3251,9 @@ def _test_async_get_inverter_settings_partial_failure(my_predbat):
 
         # Provide previous data - previous dict structure matches result structure
         previous = {2: {"name": "charge_power", "value": "2500", "validation": {}, "validation_rules": {}}}
-        result = await ge_cloud.async_get_inverter_settings("test123", previous=previous)
+        # Local mocks, so skip the rate-limit pacing - see the success case above.
+        with patch("gecloud.asyncio.sleep", new_callable=AsyncMock):
+            result = await ge_cloud.async_get_inverter_settings("test123", previous=previous)
 
         if result[1]["value"] != "75":
             print("ERROR: Expected setting 1 value='75', got {}".format(result.get(1)))

--- a/apps/predbat/tests/test_givtcp_component.py
+++ b/apps/predbat/tests/test_givtcp_component.py
@@ -66,8 +66,23 @@ def _rest_data_blob(
 
 
 def _make_component(rest_urls="http://givtcp:6345", automatic=True):
+    """
+    A GivTCPComponent whose REST clients count their retry waits rather than taking them.
+
+    GivTCPRest paces its retry ladders with InverterRestState.sleep(), a blocking time.sleep():
+    2s between each of the five write-verification attempts, and 20s then 40s between read
+    attempts. Those are the right delays against a real inverter that may still be booting, but
+    in a test they are dead wall-clock - a single write that never verifies costs the whole
+    5 x 2s ladder, which was most of this module's runtime.
+
+    Recorded into inverter.slept rather than discarded, so a test that does want to assert on the
+    pacing still can. This mirrors test_givtcp_rest.py's own _client helper.
+    """
     base = MockBase()
     component = GivTCPComponent(base, rest_urls=rest_urls, automatic=automatic)
+    for rest in component.rest:
+        rest.inverter.slept = []
+        rest.inverter.sleep = rest.inverter.slept.append
     return base, component
 
 

--- a/apps/predbat/tests/test_ohme.py
+++ b/apps/predbat/tests/test_ohme.py
@@ -1319,7 +1319,11 @@ def _test_ohme_client_async_get_charge_session_retry(my_predbat=None):
 
     client._make_request = mock_make_request_with_retry
 
-    run_async(client.async_get_charge_session())
+    # async_get_charge_session waits a real second between attempts to give the charger time to
+    # leave CALCULATING. What is under test is that it retries at all, not how long it pauses
+    # first, so the wait is skipped rather than served.
+    with patch("ohme.asyncio.sleep", new_callable=AsyncMock):
+        run_async(client.async_get_charge_session())
 
     # Should have retried at least once
     assert call_count[0] >= 2, f"Expected at least 2 calls, got {call_count[0]}"

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -749,7 +749,10 @@ def main():
     parser.add_argument("--test", "-t", action="append", help="Run specific test(s) by name (can be used multiple times, use --list to see available tests)")
     parser.add_argument("--keyword", "-k", action="store", help="Run tests matching keyword pattern (e.g., -k carbon_ runs all carbon tests)")
     parser.add_argument("--list", "-l", action="store_true", help="List all available tests")
-    parser.add_argument("--quick", "-q", action="store_true", help="Skip slow tests (optimise_levels, optimise_windows, debug_cases)")
+    # Named from the registry rather than hard-coded: the previous literal list had drifted to
+    # name three tests that are not marked slow at all, while the four that are went unmentioned.
+    slow_test_names = ", ".join(name for name, _func, _desc, slow in TEST_REGISTRY if slow) or "none currently marked slow"
+    parser.add_argument("--quick", "-q", action="store_true", help=f"Skip slow tests ({slow_test_names})")
     parser.add_argument("--plot", action="store_true", help="Display failure plots on screen (blocks until closed); the PNG is written either way")
     parser.add_argument("--random-generate", action="store_true", help="Generate random benchmark scenarios and write to a YAML file")
     parser.add_argument("--random-count", type=int, default=100, metavar="N", help="Number of random scenarios to generate (default: 100)")
@@ -867,26 +870,30 @@ def main():
             skipped_count += 1
             continue
 
-        # Show descriptive message for keyword/specific tests, simple for full suite
-        print(f"**** Running: {name} - {desc} ****")
+        # Show descriptive message for keyword/specific tests, simple for full suite.
+        # The wall-clock stamps bracket each test so a run that stalls can be read straight
+        # from the log: the elapsed figure below only appears once a test returns, so a test
+        # still running (or one that hung) is identified by its unmatched start stamp.
+        print(f"**** Running: {name} - {desc} (start {time.strftime('%H:%M:%S')}) ****")
 
         start_time = time.time()
         test_failed = func(my_predbat)
         elapsed = time.time() - start_time
         total_time += elapsed
+        end_stamp = time.strftime("%H:%M:%S")
 
         if test_failed:
             if args.keyword or args.test:
-                print(f"**** ERROR: Test {name} FAILED in {elapsed:.2f}s ****")
+                print(f"**** ERROR: Test {name} FAILED in {elapsed:.2f}s (end {end_stamp}) ****")
             else:
-                print(f"**** {name}: FAILED in {elapsed:.2f}s ****")
+                print(f"**** {name}: FAILED in {elapsed:.2f}s (end {end_stamp}) ****")
             failed = True
             break
         else:
             if args.keyword or args.test:
-                print(f"**** Test {name} PASSED in {elapsed:.2f}s ****")
+                print(f"**** Test {name} PASSED in {elapsed:.2f}s (end {end_stamp}) ****")
             else:
-                print(f"**** {name}: PASSED in {elapsed:.2f}s ****")
+                print(f"**** {name}: PASSED in {elapsed:.2f}s (end {end_stamp}) ****")
 
     # Report results
     if failed:

--- a/apps/predbat/userinterface.py
+++ b/apps/predbat/userinterface.py
@@ -37,6 +37,13 @@ from const import (
 from config import APPS_SCHEMA, CONFIG_API_OVERRIDE
 from predbat import THIS_VERSION, THIS_VERSION_DISPLAY
 
+# A debug dump is several megabytes of deeply nested YAML and PyYAML's pure-Python parser spends
+# most of a replay's wall-clock on it - about 6s for a 5MB dump. CLoader pairs libyaml's C parser
+# with the very same (unsafe) Constructor that yaml.unsafe_load uses, so the Python-object tags
+# these dumps carry still load and the result is identical, roughly 6x faster. PyYAML is not
+# always built with libyaml, so fall back to the pure-Python loader when the C one is absent.
+DEBUG_YAML_LOADER = getattr(yaml, "CLoader", yaml.UnsafeLoader)
+
 
 class DebugYamlDumper(yaml.Dumper):
     """
@@ -765,7 +772,7 @@ class UserInterface:
         debug = {}
         if os.path.exists(filename):
             with open(filename, "r") as file:
-                debug = yaml.unsafe_load(file)
+                debug = yaml.load(file, Loader=DEBUG_YAML_LOADER)
         else:
             self.log("Warn: Debug file {} not found".format(filename))
             return


### PR DESCRIPTION
## What

`./run_all --quick` went from **122.9s to 78s** (−37%), and the full suite from 155s to ~110s. Two production changes carry most of it; the rest are tests that were waiting on real delays no assertion depended on.

## How this was found

Profiled the suite by wrapping `time.sleep`/`asyncio.sleep` and attributing real seconds to each call site: **38.2s of the 123s was spent literally asleep**. Profiling the remaining hot spots with cProfile turned up one avoidable cost dominating the rest — parsing multi-megabyte debug dumps with PyYAML's pure-Python parser.

## Production changes

**`read_debug_yaml()` now loads through libyaml's `CLoader`.** `CLoader` pairs the C parser with the very same (unsafe) `Constructor` that `yaml.unsafe_load` uses, so the Python-object tags these dumps carry still load and the result is identical:

```
pure-Python unsafe_load: 6.55s
libyaml CLoader        : 1.14s   (5.8x faster)
identical result       : True
```

It falls back to the pure-Python loader when PyYAML was not built with libyaml. **This speeds up real `--debug_file` replays for users too, not just tests** — every path that reads a dump was paying it.

**`ComponentBase.wait_api_started()` polls every 0.1s instead of every 1s.** Components come up in milliseconds, so the old cadence spent nearly the whole wait asleep after the component was already live. The loop is now bounded by a monotonic deadline rather than by counting ticks, so `timeout` stays honest in seconds however often the flag is checked.

## Test changes

Each of these waited on a real delay nothing asserted on:

- **`test_givtcp_component`** — `_make_component()` records the REST retry waits instead of taking them, mirroring `test_givtcp_rest.py`'s `_client`. One test asserting a write *never* verifies was walking the whole 5 × 2s ladder.
- **`test_alphaess_api`** — `MockAlphaESS` was inheriting `initialize()`'s real 2s `api_delay`; only 11 of 50 tests overrode it by hand. The transport-failure test also served the full 3s retry backoff.
- **`test_ohme` / `test_ge_cloud`** — skip the retry wait and the rate-limit pacing, as neighbouring tests in those same files already do.
- **`test_chat`** — `_fast_confirm_poll()` shortens (rather than removes, so the loop is still exercised) `await_confirmation`'s 0.2s poll for tests whose background thread answers immediately. Same idiom the file already uses for `CONFIRM_TIMEOUT_SECONDS`.

## Tooling

- `--quick`'s help named `optimise_levels`, `optimise_windows` and `debug_cases` — none of which are marked slow — while the four that are went unmentioned. It is now derived from `TEST_REGISTRY` so it cannot drift again.
- Each test logs a wall-clock start/end stamp, so a run that stalls is identifiable from its unmatched start stamp rather than needing a re-run.

## Results

| test | before | after |
|---|---:|---:|
| `debug_cases` | 22.56s | 12.01s |
| `random` | 27.94s | 22.44s |
| `givtcp_component` | 10.04s | 0.03s |
| `alphaess_api` | 7.05s | 0.04s |
| `window_cache` | 7.47s | 2.09s |
| `web_if` | 3.37s | 1.57s |
| `chat` | 3.50s | 2.52s |
| `debug_yaml_scope` | 2.04s | 0.19s |
| `ge_cloud` | 1.67s | 1.04s |
| `ohme` | 1.01s | 0.01s |

`window_cache` is representative: 93% of it was parsing a 5.3MB dump, not exercising the cache.

## What was deliberately left alone

Roughly 19s of sleep remains and most of it should. The `test_chat`, `test_agent_tools` and `test_db_manager` sleeps *are* the assertion — they prove the event loop is not blocked, and mocking them would delete what the test checks. `annual_job` spawns real subprocesses. The `web.py` server heartbeat and `test_component_base`'s already-scaled `fast_sleep` run concurrently with real work rather than adding wall-clock.

## Testing

`./run_pre_commit` green on the rebased branch — all hooks pass, all 306 tests pass. No test behaviour was weakened: every stubbed sleep is a delay the surrounding assertions never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
