### PR TITLE
fix(octopus): honour octopus_intelligent_consider_full in the prediction

### DIFF
--- a/apps/predbat/annual.py
+++ b/apps/predbat/annual.py
@@ -807,6 +807,9 @@ def reset_sample_state(predbat):
     # function BEFORE that leg sets them, never after.
     predbat.car_charging_planned = [False]
     predbat.car_charging_limit = [0.0]
+    # Annual plans cars on the plan_car_charging path where the real fill clamp must hold, so make
+    # sure no model-facing limit override leaks in from a live IOG fetch (#4967)
+    predbat.car_charging_limit_model = None
     predbat.car_charging_soc = [0.0]
     predbat.car_charging_rate = [DEFAULT_CAR_RATE_KW]
     predbat.car_charging_battery_size = [50.0]

--- a/apps/predbat/compare.py
+++ b/apps/predbat/compare.py
@@ -517,6 +517,9 @@ class Compare:
         my_predbat = self.pb
 
         my_predbat.car_charging_slots = [[] for car_n in range(my_predbat.num_cars)]
+        # Compare re-plans car charging on the rate-based path (plan_car_charging), where the real
+        # fill clamp must hold - drop any model-facing limit override left by the live IOG fetch (#4967)
+        my_predbat.car_charging_limit_model = None
 
         for car_n in range(my_predbat.num_cars):
             total_car_kwh = 0
@@ -574,6 +577,7 @@ class Compare:
         save_octopus_intelligent_charging = my_predbat.octopus_intelligent_charging
         save_car_charging_plan_smart = copy.deepcopy(my_predbat.car_charging_plan_smart)
         save_car_charging_limit = copy.deepcopy(my_predbat.car_charging_limit)
+        save_car_charging_limit_model = copy.deepcopy(my_predbat.car_charging_limit_model)
         save_car_charging_soc = copy.deepcopy(my_predbat.car_charging_soc)
         save_car_charging_battery_size = copy.deepcopy(my_predbat.car_charging_battery_size)
         save_car_charging_slots = copy.deepcopy(my_predbat.car_charging_slots)
@@ -681,6 +685,7 @@ class Compare:
             my_predbat.export_today_now = save_export_today_now
             my_predbat.octopus_intelligent_charging = save_octopus_intelligent_charging
             my_predbat.car_charging_limit = save_car_charging_limit
+            my_predbat.car_charging_limit_model = save_car_charging_limit_model
             my_predbat.car_charging_soc = save_car_charging_soc
             my_predbat.car_charging_battery_size = save_car_charging_battery_size
             my_predbat.car_charging_slots = save_car_charging_slots

--- a/apps/predbat/const.py
+++ b/apps/predbat/const.py
@@ -63,6 +63,7 @@ INVERTER_MAX_RETRY_REST = 5  # Maximum number of retries for inverter REST comma
 INVERTER_REST_TIMEOUT = 10  # Seconds to wait for a REST response before giving up (local network call, should be fast)
 INVERTER_QUICK_UPDATE_SECONDS = 120  # Minimum seconds between quick inverter data updates
 PREDBAT_MAX_CARS = 8  # Matches PK_MAX_CARS in prediction_kernel.cpp and the car_charging_rate/_1../_7 config items - the hard ceiling on num_cars
+CAR_CHARGING_LIMIT_UNCAPPED = 9999.0  # Model-facing car charge limit (kWh) that makes predict()'s fill clamp inert - larger than any real car battery (#4967)
 DEBUG_ENABLE_MAX_HOURS = 2  # Auto-disable switch.predbat_debug_enable after this long left on, to bound the raw per-cycle debug.yaml disk writes it triggers (and the C++ kernel bypass it forces) if left on by accident - the rotating debug-history buffer covers longer-term history at a coarser interval instead
 # How far ahead a manual override may be placed. The two horizons differ on purpose: a manual
 # charge/export/freeze/demand slot is bounded by the plan, since Predbat can only act on a slot the

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -31,6 +31,7 @@ from const import (
     PREDBAT_MODE_MONITOR,
     LOAD_FORECAST_HISTORY_MAX_DAYS,
     PREDBAT_MAX_CARS,
+    CAR_CHARGING_LIMIT_UNCAPPED,
     LOW_POWER_PV_LIGHT_FRACTION,
     CLOUD_WINDOW_MINUTES,
     CLOUD_ARRAY_MARGIN,
@@ -1393,6 +1394,10 @@ class Fetch:
         else:
             entity_id_list = []
 
+        # Cars whose charging plan came from Octopus Intelligent dispatch slots this cycle - used
+        # below to decide which cars get a model-facing charge limit override (#4967)
+        iog_slot_cars = []
+
         if entity_id_list:
             # Process each car's intelligent slot configuration
             for car_n in range(min(len(entity_id_list), self.num_cars)):
@@ -1494,6 +1499,7 @@ class Fetch:
                     if not self.octopus_intelligent_ignore_unplugged or self.car_charging_planned[car_n] or self.car_charging_now[car_n]:
                         self.car_charging_slots[car_n] = self.load_octopus_slots(car_n, self.octopus_slots[car_n], self.octopus_intelligent_consider_full)
                         if self.car_charging_slots[car_n]:
+                            iog_slot_cars.append(car_n)
                             self.log(
                                 "Car {} using Octopus Intelligent, charging planned - charging limit {}, ready time {} - battery size {}".format(
                                     car_n, self.car_charging_limit[car_n], self.car_charging_plan_time[car_n], self.car_charging_battery_size[car_n]
@@ -1509,6 +1515,19 @@ class Fetch:
         else:
             # Disable octopus charging if we don't have the slot sensor
             self.octopus_intelligent_charging = False
+
+        # Model-facing car charge limit (#4967). With octopus_intelligent_consider_full off (the
+        # default) the prediction must trust the Octopus dispatch plan rather than modelling the car
+        # filling up, so cars carrying IOG slots get an uncapped limit for predict()'s fill clamp
+        # (which also releases the battery discharge hold once the modelled car "fills"). The real
+        # car_charging_limit is left untouched - execute.py's "car is full" decision, the
+        # plan_car_charging path and load_octopus_slots all still need it. None means no override.
+        if iog_slot_cars and not self.octopus_intelligent_consider_full:
+            self.car_charging_limit_model = self.car_charging_limit[:]
+            for car_n in iog_slot_cars:
+                self.car_charging_limit_model[car_n] = CAR_CHARGING_LIMIT_UNCAPPED
+        else:
+            self.car_charging_limit_model = None
 
         # Log final car SoC (initialised before the IOG loop, updated per-car after Octopus battery_size is read)
         if self.num_cars:

--- a/apps/predbat/predbat.py
+++ b/apps/predbat/predbat.py
@@ -464,6 +464,9 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
         self.charge_window_best = []
         self.car_charging_battery_size = [100]
         self.car_charging_limit = [100]
+        # Per-car charge limit as the prediction model should see it, or None to use car_charging_limit.
+        # Set by fetch_sensor_data_cars() for cars on Octopus Intelligent dispatch slots (#4967).
+        self.car_charging_limit_model = None
         self.car_charging_soc = [0]
         self.car_charging_soc_next = [None]
         self.car_charging_rate = [7.4]
@@ -958,6 +961,23 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
                 extra=status_extra,
             )
 
+    def update_car_manual_soc(self):
+        """
+        Write the predicted next car SoC back to the manual car SoC tracker for cars using car_charging_manual_soc
+        """
+        for car_n in range(self.num_cars):
+            if car_n < len(self.car_charging_manual_soc) and self.car_charging_manual_soc[car_n]:
+                car_postfix = "" if car_n == 0 else "_" + str(car_n)
+                self.log("Car {} charging Manual SoC current is {} next is {}".format(car_n, self.car_charging_soc[car_n], self.car_charging_soc_next[car_n]))
+                if self.car_charging_soc_next[car_n] is not None:
+                    soc_next = self.car_charging_soc_next[car_n]
+                    # The modelled car SoC can run past the real charge limit when the prediction's fill
+                    # clamp is inert (octopus_intelligent_consider_full off, #4967) - the tracked manual
+                    # SoC stands in for a measurement, so keep it within the real per-car limit
+                    if car_n < len(self.car_charging_limit):
+                        soc_next = min(soc_next, self.car_charging_limit[car_n])
+                    self.expose_config("car_charging_manual_soc_kwh" + car_postfix, dp3(soc_next))
+
     def update_pred(self, scheduled=True):
         """
         Update the prediction state, everything is called from here right now
@@ -1292,12 +1312,7 @@ class PredBat(hass.Hass, Octopus, Energidataservice, Stromligning, Fetch, Plan, 
 
         # Car SoC increment
         if scheduled:
-            for car_n in range(self.num_cars):
-                if car_n < len(self.car_charging_manual_soc) and self.car_charging_manual_soc[car_n]:
-                    car_postfix = "" if car_n == 0 else "_" + str(car_n)
-                    self.log("Car {} charging Manual SoC current is {} next is {}".format(car_n, self.car_charging_soc[car_n], self.car_charging_soc_next[car_n]))
-                    if self.car_charging_soc_next[car_n] is not None:
-                        self.expose_config("car_charging_manual_soc_kwh" + car_postfix, dp3(self.car_charging_soc_next[car_n]))
+            self.update_car_manual_soc()
 
         # Holiday days left countdown, subtract a day at midnight every day
         if scheduled and self.holiday_days_left > 0 and self.minutes_now < RUN_EVERY:

--- a/apps/predbat/prediction.py
+++ b/apps/predbat/prediction.py
@@ -111,8 +111,7 @@ class Prediction(PredictionBatch):
             # clamp in predict() (and in the C++ kernel, whose context is built from this attribute)
             # inert for them without predict() knowing anything about the tariff. None - including a
             # replayed debug dump from before this attribute existed - means use the real limits.
-            car_charging_limit_model = getattr(base, "car_charging_limit_model", None)
-            self.car_charging_limit = car_charging_limit_model if car_charging_limit_model is not None else base.car_charging_limit
+            self.car_charging_limit = base.car_charging_limit_model if base.car_charging_limit_model is not None else base.car_charging_limit
             self.car_charging_from_battery = base.car_charging_from_battery
             self.iboost_enable = base.iboost_enable
             self.iboost_on_export = base.iboost_on_export

--- a/apps/predbat/prediction.py
+++ b/apps/predbat/prediction.py
@@ -106,7 +106,13 @@ class Prediction(PredictionBatch):
             self.calculate_export_on_pv = base.calculate_export_on_pv
             self.charge_low_power_margin = base.charge_low_power_margin
             self.car_charging_slots = base.car_charging_slots
-            self.car_charging_limit = base.car_charging_limit
+            # Model-facing car charge limit (#4967): fetch raises this above the real limit for cars
+            # following an Octopus Intelligent dispatch plan with consider_full off, making the fill
+            # clamp in predict() (and in the C++ kernel, whose context is built from this attribute)
+            # inert for them without predict() knowing anything about the tariff. None - including a
+            # replayed debug dump from before this attribute existed - means use the real limits.
+            car_charging_limit_model = getattr(base, "car_charging_limit_model", None)
+            self.car_charging_limit = car_charging_limit_model if car_charging_limit_model is not None else base.car_charging_limit
             self.car_charging_from_battery = base.car_charging_from_battery
             self.iboost_enable = base.iboost_enable
             self.iboost_on_export = base.iboost_on_export

--- a/apps/predbat/tests/test_multi_car_iog.py
+++ b/apps/predbat/tests/test_multi_car_iog.py
@@ -8,7 +8,12 @@
 # pylint: disable=line-too-long
 # pylint: disable=attribute-defined-outside-init
 
+import copy
 from datetime import datetime, timedelta, timezone
+
+from const import CAR_CHARGING_LIMIT_UNCAPPED
+from prediction import Prediction
+from tests.test_infra import reset_rates
 
 
 def process_octopus_intelligent_slots(my_predbat):
@@ -494,6 +499,317 @@ def run_multi_car_iog_adhoc_dispatch_test(testname, my_predbat):
     return failed
 
 
+def run_iog_model_limit_fetch_test(testname, my_predbat):
+    """
+    Issue #4967: with octopus_intelligent_consider_full off (the default), fetch_sensor_data_cars()
+    must publish a model-facing car charge limit (car_charging_limit_model) that is uncapped for
+    cars carrying IOG dispatch slots - so predict()'s fill clamp is inert and the prediction trusts
+    the Octopus dispatch plan - while leaving the real car_charging_limit untouched and keeping the
+    real limit for cars with no IOG slots. With the switch on the override must be absent (None).
+    """
+    failed = False
+    print("**** Running Test: multi_car_iog {} ****".format(testname))
+
+    my_predbat.num_cars = 2
+    my_predbat.car_charging_planned = [True, False]
+    my_predbat.car_charging_now = [False, False]
+    my_predbat.car_charging_plan_smart = [False, False]
+    my_predbat.car_charging_plan_max_price = [0, 0]
+    my_predbat.car_charging_plan_time = ["07:00:00", "07:00:00"]
+    my_predbat.car_charging_battery_size = [100.0, 80.0]
+    my_predbat.car_charging_limit = [80.0, 64.0]
+    my_predbat.car_charging_rate = [7.4, 7.4]
+    my_predbat.car_charging_slots = [[], []]
+    my_predbat.car_charging_exclusive = [False, False]
+    my_predbat.car_charging_manual_soc = [False, False]
+    my_predbat.octopus_intelligent_charging = True
+    my_predbat.octopus_intelligent_ignore_unplugged = True  # car 1 is unplugged, so it must get no IOG slots
+    my_predbat.octopus_intelligent_consider_full = False
+    my_predbat.octopus_slots = [[], []]
+
+    now = datetime.now(tz=timezone.utc)
+    my_predbat.now_utc = now.replace(hour=12, minute=0, second=0, microsecond=0)
+    my_predbat.minutes_now = 0
+
+    my_predbat.args["car_charging_loss"] = 0.0
+    my_predbat.args["car_charging_soc"] = [50.0, 50.0]
+    my_predbat.args["car_charging_limit"] = [80.0, 80.0]
+    my_predbat.args["octopus_intelligent_slot"] = ["binary_sensor.octopus_energy_intelligent_dispatching_car_a", "binary_sensor.octopus_energy_intelligent_dispatching_car_b"]
+
+    slot_start = (my_predbat.now_utc + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S%z")
+    slot_end = (my_predbat.now_utc + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S%z")
+    my_predbat.ha_interface.set_state(
+        "binary_sensor.octopus_energy_intelligent_dispatching_car_a",
+        "on",
+        attributes={
+            "completed_dispatches": [],
+            "planned_dispatches": [{"start": slot_start, "end": slot_end, "charge_in_kwh": 3.0, "source": "smart-charge", "location": "AT_HOME"}],
+            "vehicle_battery_size_in_kwh": 100.0,
+            "charge_point_power_in_kw": 7.4,
+        },
+    )
+    my_predbat.ha_interface.set_state(
+        "binary_sensor.octopus_energy_intelligent_dispatching_car_b",
+        "off",
+        attributes={
+            "completed_dispatches": [],
+            "planned_dispatches": [],
+            "vehicle_battery_size_in_kwh": 80.0,
+            "charge_point_power_in_kw": 7.4,
+        },
+    )
+
+    my_predbat.fetch_sensor_data_cars()
+
+    if not my_predbat.car_charging_slots[0]:
+        print("ERROR: car 0 should have IOG slots, got none")
+        failed = True
+    if my_predbat.car_charging_slots[1]:
+        print("ERROR: car 1 should have no IOG slots (unplugged), got {}".format(my_predbat.car_charging_slots[1]))
+        failed = True
+
+    model = my_predbat.car_charging_limit_model
+    if model is None:
+        print("ERROR: car_charging_limit_model should be set with consider_full off and IOG slots present, got None")
+        failed = True
+    else:
+        if model[0] != CAR_CHARGING_LIMIT_UNCAPPED:
+            print("ERROR: car 0 model limit should be uncapped ({}), got {}".format(CAR_CHARGING_LIMIT_UNCAPPED, model[0]))
+            failed = True
+        if abs(model[1] - my_predbat.car_charging_limit[1]) > 0.01:
+            print("ERROR: car 1 model limit should equal its real limit {}, got {}".format(my_predbat.car_charging_limit[1], model[1]))
+            failed = True
+
+    # The real limits must not have been raised - execute.py's car-full decision and the
+    # plan_car_charging path still rely on them (80% of the Octopus-reported battery sizes)
+    if abs(my_predbat.car_charging_limit[0] - 80.0) > 0.01 or abs(my_predbat.car_charging_limit[1] - 64.0) > 0.01:
+        print("ERROR: real car_charging_limit changed unexpectedly: {}".format(my_predbat.car_charging_limit))
+        failed = True
+
+    # With consider_full on, load_octopus_slots() itself clamps the plan and predict() must keep
+    # the real fill clamp - no model override
+    my_predbat.octopus_intelligent_consider_full = True
+    my_predbat.car_charging_slots = [[], []]
+    my_predbat.octopus_slots = [[], []]  # fetch_sensor_data_cars appends to octopus_slots; the real caller resets it each cycle
+    my_predbat.fetch_sensor_data_cars()
+    if my_predbat.car_charging_limit_model is not None:
+        print("ERROR: car_charging_limit_model should be None with consider_full on, got {}".format(my_predbat.car_charging_limit_model))
+        failed = True
+    if not my_predbat.car_charging_slots[0]:
+        print("ERROR: car 0 should still have IOG slots with consider_full on (limit not yet reached), got none")
+        failed = True
+
+    if failed:
+        print("Test: {} FAILED".format(testname))
+    else:
+        print("Test: {} PASSED".format(testname))
+
+    return failed
+
+
+def run_iog_consider_full_predict_test(testname, my_predbat):
+    """
+    Issue #4967: predict() clamps car load at Prediction.car_charging_limit and releases the battery
+    discharge hold once the modelled car "fills". With the model-facing limit uncapped (IOG car,
+    consider_full off) the full slot energy must be delivered and the hold kept for the whole slot;
+    with no override (consider_full on, or a non-IOG car) the old clamped behaviour must remain.
+
+    Scenario: one car, 10kWh of dispatch across a 2h slot at 5kW, real limit 5kWh from empty; flat
+    1kW house load; battery full at 10kWh with charging disabled. Clamped: the car takes 5kWh (1h),
+    the hold then releases and the battery serves the second hour of house load - import 6kWh, final
+    SoC 9kWh. Uncapped: all 10kWh delivered, hold kept for both hours - import 12kWh, final SoC 10kWh.
+    """
+    failed = False
+    print("**** Running Test: multi_car_iog {} ****".format(testname))
+
+    snapshot_attrs = [
+        "num_cars",
+        "car_charging_slots",
+        "car_charging_soc",
+        "car_charging_soc_next",
+        "car_charging_limit",
+        "car_charging_limit_model",
+        "car_charging_battery_size",
+        "car_charging_loss",
+        "car_energy_reported_load",
+        "car_charging_from_battery",
+        "set_charge_window",
+        "set_export_window",
+        "soc_kw",
+        "soc_max",
+        "reserve",
+        "battery_loss",
+        "battery_loss_discharge",
+        "inverter_loss",
+        "inverter_hybrid",
+        "battery_rate_max_charge",
+        "battery_rate_max_charge_dc",
+        "battery_rate_max_discharge",
+        "battery_rate_max_export",
+        "battery_rate_min",
+        "charge_rate_now",
+        "discharge_rate_now",
+        "inverter_limit",
+        "export_limit",
+        "pv_ac_limit",
+        "import_today_now",
+        "export_today_now",
+        "load_minutes_now",
+        "pv_today_now",
+        "cost_today_sofar",
+        "carbon_today_sofar",
+        "iboost_today",
+        "iboost_enable",
+        "carbon_enable",
+        "io_adjusted",
+        "rate_import",
+        "rate_export",
+        "rate_min",
+        "rate_max",
+        "rate_min_base",
+        "rate_max_base",
+        "rate_export_min",
+        "minutes_now",
+        "combine_charge_slots",
+        "best_soc_keep",
+    ]
+    saved = {attr: copy.deepcopy(getattr(my_predbat, attr)) for attr in snapshot_attrs if hasattr(my_predbat, attr)}
+
+    try:
+        my_predbat.minutes_now = 0
+        my_predbat.num_cars = 1
+        my_predbat.car_charging_slots = [[{"start": 0, "end": 120, "kwh": 10.0, "average": 7.5, "cost": 75.0, "soc": 10.0, "octopus": True}]]
+        my_predbat.car_charging_soc = [0.0]
+        my_predbat.car_charging_soc_next = [None]
+        my_predbat.car_charging_limit = [5.0]
+        my_predbat.car_charging_battery_size = [50.0]
+        my_predbat.car_charging_loss = 1.0
+        my_predbat.car_energy_reported_load = True  # count the car behind the CT so it shows up in import
+        my_predbat.car_charging_from_battery = False
+        my_predbat.set_charge_window = True  # required for the car discharge hold in predict()
+        my_predbat.set_export_window = False
+        my_predbat.soc_kw = 10.0
+        my_predbat.soc_max = 10.0
+        my_predbat.reserve = 0.0
+        my_predbat.battery_loss = 1.0
+        my_predbat.battery_loss_discharge = 1.0
+        my_predbat.inverter_loss = 1.0
+        my_predbat.inverter_hybrid = False
+        my_predbat.battery_rate_max_charge = 1 / 60.0
+        my_predbat.battery_rate_max_charge_dc = 1 / 60.0
+        my_predbat.battery_rate_max_discharge = 1 / 60.0
+        my_predbat.battery_rate_max_export = 1 / 60.0
+        my_predbat.battery_rate_min = 0
+        my_predbat.charge_rate_now = 1 / 60.0
+        my_predbat.discharge_rate_now = 1 / 60.0
+        my_predbat.inverter_limit = 2 / 60.0
+        my_predbat.export_limit = 10 / 60.0
+        my_predbat.pv_ac_limit = 0
+        my_predbat.import_today_now = 0.0
+        my_predbat.export_today_now = 0.0
+        my_predbat.load_minutes_now = 0.0
+        my_predbat.pv_today_now = 0.0
+        my_predbat.cost_today_sofar = 0.0
+        my_predbat.carbon_today_sofar = 0.0
+        my_predbat.iboost_today = 0.0
+        my_predbat.iboost_enable = False
+        my_predbat.carbon_enable = False
+        my_predbat.io_adjusted = {}
+        my_predbat.best_soc_keep = 0.0
+        reset_rates(my_predbat, 10.0, 0.0)
+
+        pv_step = {minute: 0.0 for minute in range(0, my_predbat.forecast_minutes, 5)}
+        load_step = {minute: 1.0 / 12.0 for minute in range(0, my_predbat.forecast_minutes, 5)}  # flat 1kW house load
+        end_record = 120
+
+        results = {}
+        for scenario, model_limit in [("clamped", None), ("uncapped", [CAR_CHARGING_LIMIT_UNCAPPED])]:
+            my_predbat.car_charging_limit_model = model_limit
+            pred = Prediction(my_predbat, pv_step, pv_step, load_step, load_step)
+            (metric, import_kwh_battery, import_kwh_house, export_kwh, soc_min, final_soc, soc_min_minute, battery_cycle, metric_keep, final_iboost, final_carbon_g, predict_soc, car_soc_next, iboost_next, ib_run, ib_solar, ib_full) = pred.run_prediction(
+                [], [], [], [], False, end_record
+            )
+            results[scenario] = {"import": import_kwh_battery + import_kwh_house, "soc": final_soc}
+            print("  scenario {}: import {}kWh final soc {}kWh".format(scenario, results[scenario]["import"], results[scenario]["soc"]))
+
+        # Clamped: 5kWh of car (fills after 1h) + 1kWh house from grid while the hold is active,
+        # then the hold releases and the battery serves the second hour of house load
+        if abs(results["clamped"]["import"] - 6.0) > 0.25:
+            print("ERROR: clamped import should be ~6.0kWh, got {}".format(results["clamped"]["import"]))
+            failed = True
+        if abs(results["clamped"]["soc"] - 9.0) > 0.25:
+            print("ERROR: clamped final soc should be ~9.0kWh (hold released after the modelled fill), got {}".format(results["clamped"]["soc"]))
+            failed = True
+
+        # Uncapped: the full 10kWh of dispatch is delivered and the hold survives the whole slot
+        if abs(results["uncapped"]["import"] - 12.0) > 0.25:
+            print("ERROR: uncapped import should be ~12.0kWh (full slot energy + house load), got {}".format(results["uncapped"]["import"]))
+            failed = True
+        if abs(results["uncapped"]["soc"] - 10.0) > 0.25:
+            print("ERROR: uncapped final soc should be ~10.0kWh (discharge hold kept all slot), got {}".format(results["uncapped"]["soc"]))
+            failed = True
+
+    finally:
+        for attr, value in saved.items():
+            setattr(my_predbat, attr, value)
+
+    if failed:
+        print("Test: {} FAILED".format(testname))
+    else:
+        print("Test: {} PASSED".format(testname))
+
+    return failed
+
+
+def run_update_car_manual_soc_cap_test(testname, my_predbat):
+    """
+    Issue #4967: with the prediction's fill clamp inert the modelled car SoC can run past the real
+    charge limit, so update_car_manual_soc() must cap the value it writes back to the manual car
+    SoC tracker at the real per-car limit (a value below the limit passes through unchanged).
+    """
+    failed = False
+    print("**** Running Test: multi_car_iog {} ****".format(testname))
+
+    saved = {attr: copy.deepcopy(getattr(my_predbat, attr)) for attr in ["num_cars", "car_charging_manual_soc", "car_charging_soc", "car_charging_soc_next", "car_charging_limit"]}
+    saved_manual_soc_switch = my_predbat.get_arg("car_charging_manual_soc", default=False)
+    saved_soc_kwh = my_predbat.get_arg("car_charging_manual_soc_kwh", 0.0)
+
+    try:
+        my_predbat.num_cars = 1
+        my_predbat.car_charging_manual_soc = [True]
+        # The car_charging_manual_soc_kwh config item is enable-gated on the car_charging_manual_soc
+        # switch - turn it on so expose_config()/get_arg() actually store and return the value
+        my_predbat.expose_config("car_charging_manual_soc", True)
+        my_predbat.car_charging_soc = [4.0]
+        my_predbat.car_charging_limit = [5.0]
+
+        my_predbat.car_charging_soc_next = [12.0]  # model overshot the real limit
+        my_predbat.update_car_manual_soc()
+        written = my_predbat.get_arg("car_charging_manual_soc_kwh", 0.0)
+        if abs(written - 5.0) > 0.001:
+            print("ERROR: manual SoC write-back should be capped at the real limit 5.0, got {}".format(written))
+            failed = True
+
+        my_predbat.car_charging_soc_next = [3.0]  # below the limit passes through
+        my_predbat.update_car_manual_soc()
+        written = my_predbat.get_arg("car_charging_manual_soc_kwh", 0.0)
+        if abs(written - 3.0) > 0.001:
+            print("ERROR: manual SoC write-back below the limit should be unchanged at 3.0, got {}".format(written))
+            failed = True
+    finally:
+        my_predbat.expose_config("car_charging_manual_soc_kwh", saved_soc_kwh)
+        my_predbat.expose_config("car_charging_manual_soc", saved_manual_soc_switch)
+        for attr, value in saved.items():
+            setattr(my_predbat, attr, value)
+
+    if failed:
+        print("Test: {} FAILED".format(testname))
+    else:
+        print("Test: {} PASSED".format(testname))
+
+    return failed
+
+
 def run_multi_car_iog_tests(my_predbat):
     """
     Run all multi-car IOG tests
@@ -504,4 +820,7 @@ def run_multi_car_iog_tests(my_predbat):
     failed |= run_multi_car_iog_unplugged_car_test("multi_car_iog_unplugged_car_3592", my_predbat)
     failed |= run_multi_car_shared_charger_exclusive_test("multi_car_shared_charger_exclusive_4305", my_predbat)
     failed |= run_multi_car_iog_adhoc_dispatch_test("multi_car_iog_adhoc_dispatch_car_charging_now", my_predbat)
+    failed |= run_iog_model_limit_fetch_test("multi_car_iog_model_limit_fetch_4967", my_predbat)
+    failed |= run_iog_consider_full_predict_test("multi_car_iog_consider_full_predict_4967", my_predbat)
+    failed |= run_update_car_manual_soc_cap_test("multi_car_iog_manual_soc_cap_4967", my_predbat)
     return failed

--- a/apps/predbat/tests/test_multi_car_iog.py
+++ b/apps/predbat/tests/test_multi_car_iog.py
@@ -510,6 +510,37 @@ def run_iog_model_limit_fetch_test(testname, my_predbat):
     failed = False
     print("**** Running Test: multi_car_iog {} ****".format(testname))
 
+    # fetch_sensor_data_cars() rewrites a lot of shared fixture state (including car_charging_loss,
+    # which it reads from the config item, not args) - snapshot and restore everything this test
+    # touches so a module that runs after this one is not polluted (the shared-fixture trap)
+    snapshot_attrs = [
+        "num_cars",
+        "car_charging_planned",
+        "car_charging_now",
+        "car_charging_plan_smart",
+        "car_charging_plan_max_price",
+        "car_charging_plan_time",
+        "car_charging_battery_size",
+        "car_charging_limit",
+        "car_charging_limit_model",
+        "car_charging_rate",
+        "car_charging_slots",
+        "car_charging_exclusive",
+        "car_charging_manual_soc",
+        "car_charging_soc",
+        "car_charging_soc_next",
+        "car_charging_loss",
+        "octopus_intelligent_charging",
+        "octopus_intelligent_ignore_unplugged",
+        "octopus_intelligent_consider_full",
+        "octopus_slots",
+        "now_utc",
+        "minutes_now",
+    ]
+    saved = {attr: copy.deepcopy(getattr(my_predbat, attr)) for attr in snapshot_attrs if hasattr(my_predbat, attr)}
+    arg_keys = ["car_charging_loss", "car_charging_soc", "car_charging_limit", "octopus_intelligent_slot"]
+    saved_args = {key: copy.deepcopy(my_predbat.args[key]) for key in arg_keys if key in my_predbat.args}
+
     my_predbat.num_cars = 2
     my_predbat.car_charging_planned = [True, False]
     my_predbat.car_charging_now = [False, False]
@@ -598,6 +629,15 @@ def run_iog_model_limit_fetch_test(testname, my_predbat):
     if not my_predbat.car_charging_slots[0]:
         print("ERROR: car 0 should still have IOG slots with consider_full on (limit not yet reached), got none")
         failed = True
+
+    # Restore the shared fixture state captured above
+    for key in arg_keys:
+        if key in saved_args:
+            my_predbat.args[key] = saved_args[key]
+        else:
+            my_predbat.args.pop(key, None)
+    for attr, value in saved.items():
+        setattr(my_predbat, attr, value)
 
     if failed:
         print("Test: {} FAILED".format(testname))


### PR DESCRIPTION
This is an automated draft PR generated from issue #4967 — a maintainer should review it before merging.

Fixes #4967

## Summary

`predict()` clamped car load at `car_charging_limit - car_soc` unconditionally (`prediction.py:799`, mirrored in `prediction_kernel.cpp:827`), so the car was always modelled as filling and ceasing to draw load — and the battery discharge hold at `prediction.py:814` released for the rest of the window once the modelled car "filled" — regardless of `switch.predbat_octopus_intelligent_consider_full`, whose documented Off default is *not* to predict the car filling.

Following the approach suggested in the issue and affirmed in triage:

- **`fetch_sensor_data_cars()`** now publishes a model-facing limit list, `car_charging_limit_model`: for cars actually carrying IOG dispatch slots with `consider_full` off, the per-car entry is `CAR_CHARGING_LIMIT_UNCAPPED` (9999 kWh) so the fill clamp is inert; every other car keeps its real limit. `None` means no override.
- **`Prediction.__init__`** assigns the model-facing list (falling back to the real limits when it is `None` — which also covers replaying a debug dump from before this attribute existed). `predict()` itself is untouched and knows nothing about the tariff; the **C++ kernel** context is built from the same `pred.car_charging_limit` attribute (`prediction_kernel.py:684`), so both engines get the identical treatment with no kernel rebuild and parity preserved by construction.
- The real `car_charging_limit` is never mutated — `execute.py:571`'s car-full decision, `plan.py`'s `plan_car_charging` path and `octopus.py`'s `load_octopus_slots` still see the real per-car limits.
- **`compare.py`** (`recompute_car_charging` + save/restore in `run_all`) and **`annual.py`** (`prepare_sample`) explicitly clear the override, since both re-plan cars on the rate-based path where the real clamp must hold.
- **Manual car SoC guard**: with the clamp inert the modelled car SoC can overshoot the real limit, and `update_pred()` writes the modelled next SoC back into `car_charging_manual_soc_kwh`. The write-back (extracted to `update_car_manual_soc()`) is now capped at the real per-car limit, so manual SoC tracking cannot ratchet past the car's configured limit (e.g. through an Octopus zero-kWh active slot re-synthesised at full rate).

## Testing

- Three new tests in `test_multi_car_iog.py` (all pass):
  - `multi_car_iog_model_limit_fetch_4967` — real `fetch_sensor_data_cars()`: IOG car gets the uncapped model limit with the switch off, non-IOG car keeps its real limit, real limits unchanged, override absent with the switch on.
  - `multi_car_iog_consider_full_predict_4967` — runs `Prediction.run_prediction()` both ways on a 10 kWh dispatch against a 5 kWh limit: clamped run imports ~6 kWh and the released hold drains the battery (~9 kWh final); uncapped run delivers the full 10 kWh and keeps the hold all slot (~12 kWh import, battery untouched).
  - `multi_car_iog_manual_soc_cap_4967` — the manual SoC write-back caps at the real limit and passes values below it through unchanged.
- `cd coverage && ./run_pre_commit` — all hooks pass, and its embedded quick suite is green (308 module passes including `kernel_parity`, `model`, `compare`, `annual_*`, `octopus_*` and the `debug_cases` golden replays, which exercise the `None`-fallback for pre-change dumps).
- `tools/triage_test.sh multi_car_iog` — exit 0.
- GitNexus impact analysis flagged `fetch_sensor_data_cars` as HIGH blast radius (it heads the `update_pred` flow); the fetch change is additive (a new parallel attribute), and `detect_changes()` confirms only the intended symbols changed.

## Fix-order dependency (from the issue — maintainer decision)

The unconditional clamp was accidentally bounding the **#4952** Ohme slot-energy overestimate. #4952 is still open with no PR: merging this alone lets that inflated energy inflate the modelled car load *total* as well as its shape. Per the issue, the `slot_list()` energy fix in #4952 should land first or together with this — please hold this until then. #4888 (display-vs-model Car kWh disagreement) is the same root clamp and should be re-checked after this lands.

## Notes

`.claude/skills/issue-triage/references/debug-journal.md`'s car-charging row documents the clamp pair (`prediction.py:799` / `prediction_kernel.cpp:827`) and the manual-SoC write-back behaviour (GH#4889) that informed the guard here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)