### PR TITLE
Teslemetry: an export window ending at midnight priced the whole of the next day at peak

### DIFF
--- a/apps/predbat/teslemetry.py
+++ b/apps/predbat/teslemetry.py
@@ -1061,6 +1061,12 @@ class TeslemetryAPI(ComponentBase, OAuthMixin):
         already finished today (end <= now) rolls to tomorrow; otherwise it stays today. A midnight-wrapped
         window splits across today and tomorrow, except when we are already inside its post-midnight tail
         (now < end), where only today's head [0, end) still needs the boost.
+
+        A window ending exactly at midnight has no tomorrow tail at all: [start, 1440) already is the
+        whole window. Emitting the empty [0, 0) tail anyway would carve a zero-length interval, which
+        _render_side encodes as fromHour/fromMinute/toHour/toMinute all zero - the same encoding it uses
+        for a period running to the end of the day - so tomorrow would be priced at the boost rate from
+        end to end.
         """
         start_min, end_min = window
         if start_min < end_min:
@@ -1068,6 +1074,8 @@ class TeslemetryAPI(ComponentBase, OAuthMixin):
             return [(offset, start_min, end_min)]
         if now_min < end_min:
             return [(0, 0, end_min)]
+        if end_min == 0:
+            return [(0, start_min, 1440)]
         return [(0, start_min, 1440), (1, 0, end_min)]
 
     @staticmethod

--- a/apps/predbat/tests/test_teslemetry.py
+++ b/apps/predbat/tests/test_teslemetry.py
@@ -667,6 +667,27 @@ def test_teslemetry_build_tariff_periods_partition_each_day():
             _assert_tou_periods_partition_day(day_periods)
 
 
+def test_teslemetry_build_tariff_export_window_ending_at_midnight_spares_tomorrow():
+    """An export window ending exactly at midnight must not price the whole of the next day at peak.
+
+    _boost_segments splits a midnight-wrapping window into a head on today and a tail on tomorrow. When
+    the window ends at 00:00 that tail is empty, and an empty [0, 0) segment renders as
+    fromHour/fromMinute/toHour/toMinute all zero - the same encoding _render_side uses for a period
+    running to the end of the day. Tomorrow would then carry a full-day ON_PEAK band, priced by
+    _boost_price at twice the highest real band, on top of its real bands."""
+    api = MockTeslemetryAPI()
+    api.base = _rate_base(import_p=28.0, export_p=15.0)
+    tariff = api.build_tariff((1380, 0), now_min=600)  # 23:00 -> 00:00, now 10:00
+    today_dow = api.base.now.weekday()
+    tomorrow_dow = (today_dow + 1) % 7
+    for tou_periods in (tariff["seasons"]["AllYear"]["tou_periods"], tariff["sell_tariff"]["seasons"]["AllYear"]["tou_periods"]):
+        boost_days = {day for day in range(7) for p in tou_periods.get("ON_PEAK", {"periods": []})["periods"] if p["fromDayOfWeek"] <= day <= p["toDayOfWeek"]}
+        assert boost_days == {today_dow}, "the boost belongs only to today's 23:00-24:00, not to tomorrow"
+        for day in range(7):
+            day_periods = {tier: {"periods": [p for p in block["periods"] if p["fromDayOfWeek"] <= day <= p["toDayOfWeek"]]} for tier, block in tou_periods.items()}
+            _assert_tou_periods_partition_day(day_periods)
+
+
 def test_teslemetry_build_tariff_consolidates_replicated_days():
     """Days sharing tomorrow's replicated pattern (issue #4346) collapse into ranged periods, not one
     per individual day - 6 near-identical days should render as at most 2 contiguous-day periods per
@@ -2283,6 +2304,7 @@ def test_teslemetry(my_predbat=None):
     test_teslemetry_build_tariff_fallback_flat_when_no_rates()
     test_teslemetry_build_tariff_boost_clamps_above_high_rates()
     test_teslemetry_build_tariff_periods_partition_each_day()
+    test_teslemetry_build_tariff_export_window_ending_at_midnight_spares_tomorrow()
     test_teslemetry_build_tariff_consolidates_replicated_days()
     test_teslemetry_saving_session_spike_keeps_daily_shape()
     test_teslemetry_quantise_in_range_excluded_price_no_keyerror()


### PR DESCRIPTION
An export window ending at exactly midnight makes Predbat tell Tesla that the whole of the **next day** is peak-priced.

This is on the current shipping path — the real-rate tariff every Teslemetry user is on today. Found while reviewing #4976, but it is independent of that feature and does not wait on it.

## The bug

`_boost_segments` splits a midnight-wrapping export window into a head on today and a tail on tomorrow. When the window ends at `00:00` that tail is empty, and it was emitted anyway as `[0, 0)`. A zero-length interval renders through `_render_side` as `fromHour`/`fromMinute`/`toHour`/`toMinute` all zero — which is the *same encoding* the function uses two lines above for a period running to the end of the day (the `to >= 1440` branch). So the empty tail is indistinguishable from "all day".

Reproduced against the shipped code, export window 23:00 → 00:00:

```
SUPER_OFF_PEAK   days 0 - 0   00:00 -> 23:00
SUPER_OFF_PEAK   days 1 - 1   00:00 -> 00:00     <- legitimate full day
SUPER_OFF_PEAK   days 2 - 6   00:00 -> 00:00
ON_PEAK          days 0 - 0   23:00 -> 00:00     <- correct, today's window
ON_PEAK          days 1 - 1   00:00 -> 00:00     <- spurious, the empty tail
```

Every minute of day 1 is covered twice, and the overlapping band is `ON_PEAK`, which `_boost_price` sets to at least twice the highest real band. With `optimization_strategy: economics` in force, Tesla's optimiser is told tomorrow is expensive from end to end, on both the buy and sell sides.

## The fix

A window ending at midnight has no tomorrow tail — `[start, 1440)` already is the whole window. One branch, before the general wrap case.

After the fix, the same window renders as it should, and the six untouched days now consolidate into a single ranged period:

```
SUPER_OFF_PEAK  days 0 - 0  00:00 -> 23:00
SUPER_OFF_PEAK  days 1 - 6  00:00 -> 00:00
ON_PEAK         days 0 - 0  23:00 -> 00:00
```

The two neighbouring cases are provably untouched — `(1380, 300)` at 10:00 still returns `[(0, 1380, 1440), (1, 0, 300)]`, and the same window at 01:00 (already inside the post-midnight tail) still returns `[(0, 0, 300)]`.

## Reachability

`INVERTER_DEF["TESLA"]` sets `can_span_midnight: False`, and `execute.py` clamps a *today* window ending at 1440 down to 23:59 — that covers the common case. It does not fire when `minutes_start >= 1440`, so a next-day export window ending at midnight still writes `"00:00:00"`. A non-zero `inverter_clock_skew_end` and a hand-edited `select.*_schedule_discharge_end_time` reach it too.

## Testing

`test_teslemetry_build_tariff_export_window_ending_at_midnight_spares_tomorrow` asserts both halves: that the `ON_PEAK` boost lands only on today's day-of-week, and that every day still partitions `[0, 1440)` exactly once via the module's existing `_assert_tou_periods_partition_day` helper. Written before the fix and confirmed failing on the assertion that the boost belongs only to today, then passing after. Full `teslemetry` module green.

Note the pre-existing `test_teslemetry_build_tariff_periods_partition_each_day` did not catch this: it uses a same-day window (`1020, 1080`), which never reaches the wrap branch at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
