### PR TITLE
fix(tests): pin midnight_utc in the multi-car IOG tests so they don't fail for an hour a day

### DIFF
--- a/apps/predbat/tests/test_multi_car_iog.py
+++ b/apps/predbat/tests/test_multi_car_iog.py
@@ -16,6 +16,30 @@ from prediction import Prediction
 from tests.test_infra import reset_rates
 
 
+def pin_test_clock(my_predbat):
+    """
+    Pin the clock to noon UTC today, returning the previous (now_utc, midnight_utc, minutes_now).
+
+    midnight_utc has to be pinned alongside now_utc: update_time() derives it from
+    datetime.now(Europe/London), so between 23:00 and 00:00 UTC under BST it lands on the
+    following UTC date. Slot times built from the pinned now_utc are then before it, so
+    decode_octopus_slot() clamps them to 0 and drops them - failing these tests for the one
+    hour a day CI happens to run in that window. minutes_now=0 keeps slots out of the past.
+    """
+    saved = (my_predbat.now_utc, my_predbat.midnight_utc, my_predbat.minutes_now)
+    my_predbat.now_utc = datetime.now(tz=timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+    my_predbat.midnight_utc = my_predbat.now_utc.replace(hour=0)
+    my_predbat.minutes_now = 0
+    return saved
+
+
+def restore_test_clock(my_predbat, saved):
+    """
+    Restore the clock attributes saved by pin_test_clock() so they don't leak into later tests
+    """
+    my_predbat.now_utc, my_predbat.midnight_utc, my_predbat.minutes_now = saved
+
+
 def process_octopus_intelligent_slots(my_predbat):
     """
     Helper function to simulate the octopus intelligent slot processing from fetch_sensor_data
@@ -198,12 +222,9 @@ def run_multi_car_iog_load_slots_test(testname, my_predbat):
     my_predbat.octopus_intelligent_consider_full = False
     # octopus_slots must be pre-initialised per production code in fetch_sensor_data
     my_predbat.octopus_slots = [[] for _ in range(my_predbat.num_cars)]
-    # Pin now_utc to noon today so slot times (now+1h..now+3h) don't cross
-    # midnight regardless of when the test runs. Also set minutes_now=0 so
-    # slots are not filtered as past events (dynamic_load_car default is 720).
-    now = datetime.now(tz=timezone.utc)
-    my_predbat.now_utc = now.replace(hour=12, minute=0, second=0, microsecond=0)
-    my_predbat.minutes_now = 0
+    # Pin the clock so slot times (now+1h..now+3h) sit at a fixed offset from midnight
+    # regardless of when the test runs
+    saved_clock = pin_test_clock(my_predbat)
 
     # apps.yaml config args needed by fetch_sensor_data_cars
     my_predbat.args["car_charging_loss"] = 0.0  # loss = 1 - 0.0 = 1.0
@@ -263,6 +284,8 @@ def run_multi_car_iog_load_slots_test(testname, my_predbat):
         if len(my_predbat.car_charging_soc) != 2:
             print("ERROR: Expected car_charging_soc to have 2 entries, got {}".format(len(my_predbat.car_charging_soc)))
             failed = True
+
+    restore_test_clock(my_predbat, saved_clock)
 
     if failed:
         print("Test: {} FAILED".format(testname))
@@ -460,9 +483,7 @@ def run_multi_car_iog_adhoc_dispatch_test(testname, my_predbat):
     my_predbat.octopus_intelligent_consider_full = False
     my_predbat.octopus_slots = [[]]
 
-    now = datetime.now(tz=timezone.utc)
-    my_predbat.now_utc = now.replace(hour=12, minute=0, second=0, microsecond=0)
-    my_predbat.minutes_now = 0
+    saved_clock = pin_test_clock(my_predbat)
 
     my_predbat.args["car_charging_loss"] = 0.0
     my_predbat.args["car_charging_soc"] = [50.0]
@@ -490,6 +511,8 @@ def run_multi_car_iog_adhoc_dispatch_test(testname, my_predbat):
         failed = True
     else:
         print("OK: car_charging_slots[0] populated from car_charging_now alone: {}".format(my_predbat.car_charging_slots[0]))
+
+    restore_test_clock(my_predbat, saved_clock)
 
     if failed:
         print("Test: {} FAILED".format(testname))
@@ -535,6 +558,7 @@ def run_iog_model_limit_fetch_test(testname, my_predbat):
         "octopus_intelligent_consider_full",
         "octopus_slots",
         "now_utc",
+        "midnight_utc",
         "minutes_now",
     ]
     saved = {attr: copy.deepcopy(getattr(my_predbat, attr)) for attr in snapshot_attrs if hasattr(my_predbat, attr)}
@@ -558,9 +582,7 @@ def run_iog_model_limit_fetch_test(testname, my_predbat):
     my_predbat.octopus_intelligent_consider_full = False
     my_predbat.octopus_slots = [[], []]
 
-    now = datetime.now(tz=timezone.utc)
-    my_predbat.now_utc = now.replace(hour=12, minute=0, second=0, microsecond=0)
-    my_predbat.minutes_now = 0
+    pin_test_clock(my_predbat)
 
     my_predbat.args["car_charging_loss"] = 0.0
     my_predbat.args["car_charging_soc"] = [50.0, 50.0]


### PR DESCRIPTION
Two `multi_car_iog` tests fail for roughly one hour a day. They took down CI on #4995 — a **docs-only** PR (`tools/debug-journal.md` + one cspell word) whose test step happened to run at **23:11:37 UTC**:

```
ERROR: Expected car 0 to have charging slots from IOG, got none
ERROR: Expected car 1 to have charging slots from IOG, got none
Test: multi_car_iog_load_slots_regression FAILED
ERROR: car 0 should have IOG slots, got none
ERROR: car_charging_limit_model should be set with consider_full off and IOG slots present, got None
Test: multi_car_iog_model_limit_fetch_4967 FAILED
```

## Cause

`run_multi_car_iog_load_slots_test` and `run_iog_model_limit_fetch_test` pin `now_utc` to noon on the current **UTC** date, but leave `midnight_utc` on the real clock. `update_time()` derives `midnight_utc` from `datetime.now(Europe/London)` — London-local midnight, independent of the runner's TZ.

Between 23:00 and 00:00 UTC under BST the London date is already the next day, so `midnight_utc` lands on the *following* UTC date, **after** the pinned `now_utc`. On #4995 that was `midnight_utc` = 7 Sept 23:00 UTC against a pinned `now_utc` of 7 Sept 12:00 UTC — eleven hours earlier.

Every IOG dispatch built as `now+1h..now+3h` therefore decodes to negative minutes relative to `midnight_utc`, and `decode_octopus_slot()` clamps them away:

```python
start_minutes = max(start_minutes, 0)
end_minutes = max(min(end_minutes, self.forecast_minutes + self.minutes_now), start_minutes)
if start_minutes == end_minutes:
    return 0, 0, 0, source, location
```

`kwh > 0` never holds, no slots load, and the assertions fail. Outside that hour the London date matches the UTC date, `midnight_utc` is at or before the pinned noon, and the slots land at +780/+840 minutes. Under GMT there is no offset, so the window is BST-only.

## Fix

- Shared `pin_test_clock()` / `restore_test_clock()` helpers. The pin sets `midnight_utc = now_utc.replace(hour=0)` alongside `now_utc`/`minutes_now`, so slot offsets are a fixed 780/840/900 minutes whatever the wall clock says.
- `run_multi_car_iog_adhoc_dispatch_test` uses the helper too — it had the same latent hazard. In the failing window its IOG slot was silently clipped away and the test passed only on the `car_charging_now` fallback slot, which is not what it means to assert.
- The clock is restored on the way out instead of left pinned: `restore_test_clock()` in the two tests without a snapshot harness, and `midnight_utc` added to `snapshot_attrs` in `run_iog_model_limit_fetch_test`. Previously `now_utc` leaked out pinned while `midnight_utc` stayed real.

No production code is touched.

## Verification

Ran the module under the real clock and under a faithful emulation of the CI instant (00:11 Europe/London on the day after the current UTC date = 23:11 UTC), before and after the change:

| | real clock | simulated 23:11 UTC |
|---|---|---|
| before | 8/8 pass | **2 fail** (identical error text to the CI log) |
| after | 8/8 pass | 8/8 pass |

Full quick suite: `All tests passed (4 slow tests skipped, total time: 83.03s)`. Pre-commit hooks on the changed file all pass.

#4995 needs only a CI re-run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)