### PR TITLE
Stop one failing issue blocking the whole triage daemon

### DIFF
--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -841,6 +841,103 @@ class OllamaContextWindowTests(unittest.TestCase):
         self.assertEqual(env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"], "1000000")
 
 
+class ProcessNewIssueTests(unittest.TestCase):
+    """The issue-triage orchestrator. Before it existed, triage() sat bare in the main loop
+    and a failure escaped the whole poll cycle - retrying the same issue forever while the
+    PR, review, cleanup and journal flows behind it never ran (#5004, 2026-09-08)."""
+
+    def setUp(self):
+        """Patch every collaborator process_new_issue() calls."""
+        self.patches = {}
+        for name in ["sync_repo", "reset_scratch", "triage", "mark_triage_failed", "save_state"]:
+            patcher = patch.object(triage_daemon, name)
+            self.patches[name] = patcher.start()
+            self.addCleanup(patcher.stop)
+        self.issue = {"number": 5004, "title": "Ghost EV load"}
+
+    def _fail(self):
+        self.patches["triage"].side_effect = subprocess.CalledProcessError(1, ["claude"])
+
+    def test_a_successful_triage_advances_the_watermark(self):
+        """The ordinary path has to keep working."""
+        state = {"last_processed": 5003}
+        self.assertTrue(triage_daemon.process_new_issue(self.issue, state))
+        self.assertEqual(state["last_processed"], 5004)
+        self.patches["mark_triage_failed"].assert_not_called()
+
+    def test_a_failure_does_not_escape_to_the_caller(self):
+        """The regression itself: the exception used to abandon the whole poll cycle, so the
+        cleanup, review and journal flows queued behind this issue never ran."""
+        self._fail()
+        state = {"last_processed": 5003}
+        try:
+            result = triage_daemon.process_new_issue(self.issue, state)
+        except subprocess.CalledProcessError:
+            self.fail("process_new_issue must not let a failed triage escape the poll cycle")
+        self.assertFalse(result)
+
+    def test_a_failure_below_the_limit_keeps_the_watermark_and_counts_the_attempt(self):
+        """Retrying is worth doing - #4899 and #5003 both passed on their third attempt - so
+        the issue stays at the head of the queue until its attempts are spent."""
+        self._fail()
+        state = {"last_processed": 5003}
+        self.assertFalse(triage_daemon.process_new_issue(self.issue, state))
+        self.assertEqual(state["last_processed"], 5003)
+        self.assertEqual(state["triage_attempts"]["5004"], 1)
+        self.patches["mark_triage_failed"].assert_not_called()
+
+    def test_the_last_attempt_marks_the_issue_and_moves_past_it(self):
+        """Unbounded retrying is what burned a full run every ten minutes."""
+        self._fail()
+        state = {"last_processed": 5003, "triage_attempts": {"5004": triage_daemon.TRIAGE_MAX_ATTEMPTS - 1}}
+        self.assertTrue(triage_daemon.process_new_issue(self.issue, state))
+        self.assertEqual(state["last_processed"], 5004)
+        self.patches["mark_triage_failed"].assert_called_once_with(5004, triage_daemon.TRIAGE_MAX_ATTEMPTS)
+        self.assertNotIn("5004", state["triage_attempts"])
+
+    def test_a_success_after_earlier_failures_clears_the_counter(self):
+        """Otherwise a later unrelated failure would inherit a nearly-spent budget."""
+        state = {"last_processed": 5003, "triage_attempts": {"5004": 2}}
+        self.assertTrue(triage_daemon.process_new_issue(self.issue, state))
+        self.assertNotIn("5004", state["triage_attempts"])
+        self.assertEqual(state["last_processed"], 5004)
+
+    def test_a_pending_retry_is_persisted(self):
+        """The count has to survive a daemon restart, or the limit never binds."""
+        self._fail()
+        state = {"last_processed": 5003}
+        triage_daemon.process_new_issue(self.issue, state)
+        self.patches["save_state"].assert_called_once_with(state)
+
+    def test_state_without_the_counter_still_works(self):
+        """Existing state.json files predate triage_attempts."""
+        self._fail()
+        state = {"last_processed": 5003}
+        triage_daemon.process_new_issue(self.issue, state)
+        self.assertEqual(state["triage_attempts"], {"5004": 1})
+
+
+class MarkTriageFailedTests(unittest.TestCase):
+    """What a maintainer sees when the bot gives up on an issue."""
+
+    def test_comments_and_labels_the_issue(self):
+        """Silently skipping would leave the issue looking untriaged with no explanation."""
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            triage_daemon.mark_triage_failed(5004, 3)
+            commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertTrue(any("comment" in c for c in commands))
+        label_cmd = next(c for c in commands if "edit" in c)
+        self.assertIn("BOT_FAILED", label_cmd)
+
+    def test_the_comment_says_how_to_retry(self):
+        """The watermark has moved past the issue, so nothing re-triages it on its own."""
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            triage_daemon.mark_triage_failed(5004, 3)
+            body = next(c for c in (call.args[0] for call in mock_run.call_args_list) if "comment" in c)[-1]
+        self.assertIn("BOT_REVIEW", body)
+        self.assertTrue(body.startswith("Automated "))
+
+
 class EffectiveOllamaModelTests(unittest.TestCase):
     """Tests for effective_ollama_model(), new - the priority logic behind --ollama
     (every claude invocation) vs --ollama_review (review-only invocations)."""

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -895,6 +895,20 @@ class ProcessNewIssueTests(unittest.TestCase):
         self.patches["mark_triage_failed"].assert_called_once_with(5004, triage_daemon.TRIAGE_MAX_ATTEMPTS)
         self.assertNotIn("5004", state["triage_attempts"])
 
+    def test_a_failing_mark_does_not_abort_the_cycle(self):
+        """mark_triage_failed() shells out to gh with check=True. If that raised here it would
+        escape to the main loop and abort the rest of the poll cycle with the watermark still
+        behind - reintroducing the exact bug at the one point we have decided to move on."""
+        self._fail()
+        self.patches["mark_triage_failed"].side_effect = subprocess.CalledProcessError(1, ["gh"])
+        state = {"last_processed": 5003, "triage_attempts": {"5004": triage_daemon.TRIAGE_MAX_ATTEMPTS - 1}}
+        try:
+            result = triage_daemon.process_new_issue(self.issue, state)
+        except subprocess.CalledProcessError:
+            self.fail("a failed mark_triage_failed() must not escape process_new_issue")
+        self.assertTrue(result)
+        self.assertEqual(state["last_processed"], 5004, "the watermark must advance even when labelling failed")
+
     def test_a_success_after_earlier_failures_clears_the_counter(self):
         """Otherwise a later unrelated failure would inherit a nearly-spent budget."""
         state = {"last_processed": 5003, "triage_attempts": {"5004": 2}}
@@ -936,6 +950,17 @@ class MarkTriageFailedTests(unittest.TestCase):
             body = next(c for c in (call.args[0] for call in mock_run.call_args_list) if "comment" in c)[-1]
         self.assertIn("BOT_REVIEW", body)
         self.assertTrue(body.startswith("Automated "))
+
+    def test_the_comment_says_to_remove_bot_failed_first(self):
+        """Nothing in this file ever removes BOT_FAILED, and a successful follow-up clears only
+        BOT_REVIEW - so a maintainer who adds BOT_REVIEW while BOT_FAILED is still on ends up
+        with a triaged issue permanently labelled as failed. Every other marker here says to
+        remove it first; this one has to as well."""
+        with patch("triage_daemon.subprocess.run") as mock_run:
+            triage_daemon.mark_triage_failed(5004, 3)
+            body = next(c for c in (call.args[0] for call in mock_run.call_args_list) if "comment" in c)[-1]
+        self.assertIn("Remove `BOT_FAILED`", body)
+        self.assertLess(body.index("BOT_FAILED"), body.index("BOT_REVIEW"), "the removal must be stated before the label to add")
 
 
 class EffectiveOllamaModelTests(unittest.TestCase):

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -620,6 +620,10 @@ def mark_triage_failed(issue_number, attempts):
 
     The watermark advances past the issue afterwards, so nothing re-triages it by itself.
     BOT_REVIEW is the documented way back in - that is the label the follow-up flow watches.
+    Unlike the other markers there is no label to swap out: a new issue carries no trigger
+    label, so BOT_FAILED is added rather than exchanged. That makes saying "remove BOT_FAILED
+    first" load-bearing - remove_review_label() clears only BOT_REVIEW on success, and nothing
+    in this file ever removes BOT_FAILED, so it would otherwise outlive the failure it records.
     """
     subprocess.run(
         [
@@ -631,7 +635,8 @@ def mark_triage_failed(issue_number, attempts):
             REPO,
             "--body",
             f"Automated triage did not complete for this issue after {attempts} attempts - see the triage bot's logs for details. "
-            "It has been skipped so that it does not hold up triage of later issues. Add the `BOT_REVIEW` label to have the bot look at it again.",
+            "It has been skipped so that it does not hold up triage of later issues. Remove `BOT_FAILED` and add `BOT_REVIEW` "
+            "to have the bot look at it again - nothing removes `BOT_FAILED` on its own, so leaving it on would outlive a later successful run.",
         ],
         check=True,
     )
@@ -1416,7 +1421,13 @@ def process_new_issue(issue, state):
             save_state(state)
             return False
         print(f"[triage] issue #{number}: failed {count} times - marking it and moving on", flush=True)
-        mark_triage_failed(number, count)
+        try:
+            mark_triage_failed(number, count)
+        except subprocess.CalledProcessError as mark_exc:
+            # Advancing matters more than the label. Letting this escape would abort the rest
+            # of the poll cycle and leave the watermark behind - the precise failure this
+            # function exists to prevent, at the one point we have already decided to move on.
+            print(f"[triage] issue #{number}: could not label the failed triage ({mark_exc}) - moving on anyway", flush=True)
     attempts.pop(str(number), None)
     state["last_processed"] = number
     save_state(state)

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -159,6 +159,11 @@ DICTIONARY_SCOPE = f"//{(CLONE_DIR / DICTIONARY_RELPATH).relative_to('/')}"
 JOURNAL_BRANCH_PREFIX = "bot/debug-journal-"
 # Branch prefixes the PR flow may create, matching issue-pr/SKILL.md.
 PR_BRANCH_PREFIXES = ("fix/", "feat/")
+# How many times one issue may fail triage before the daemon gives up and moves past it.
+# Retrying is worth doing - #4899 and #5003 each failed twice and succeeded on the third
+# attempt - but it has to be bounded: with no limit, #5004 burned a full 60-turn run every
+# ten minutes on 2026-09-08 and never advanced.
+TRIAGE_MAX_ATTEMPTS = 3
 # The clone's own refusal to update main, and the only layer that actually enforces it.
 # Permission rules are prefix globs over a command string: they cannot see what a ref
 # expression resolves to, so "git push origin HEAD:main" reads to them as an ordinary
@@ -610,6 +615,32 @@ def mark_pr_opened(issue_number):
         flag_pr_for_review(pr_number)
 
 
+def mark_triage_failed(issue_number, attempts):
+    """Note on an issue that triage never completed, label it, and let the queue move on.
+
+    The watermark advances past the issue afterwards, so nothing re-triages it by itself.
+    BOT_REVIEW is the documented way back in - that is the label the follow-up flow watches.
+    """
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            REPO,
+            "--body",
+            f"Automated triage did not complete for this issue after {attempts} attempts - see the triage bot's logs for details. "
+            "It has been skipped so that it does not hold up triage of later issues. Add the `BOT_REVIEW` label to have the bot look at it again.",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["gh", "issue", "edit", str(issue_number), "--repo", REPO, "--add-label", "BOT_FAILED"],
+        check=True,
+    )
+
+
 def mark_pr_failed(issue_number):
     """Swap BOT_PR for BOT_PR_FAILED so a failed run isn't retried every poll cycle."""
     subprocess.run(
@@ -882,8 +913,12 @@ def triage(issue_number):
             # directory in scope for Read/Grep as well as for the Bash rules above.
             "--add-dir",
             str(SCRATCH_DIR),
+            # Raised from 60 on 2026-09-08: triage had the smallest budget of any flow while
+            # doing the most open-ended work, and five separate issues have exhausted it
+            # (#4899, #4900, #4984, #5003, #5004). A long issue body plus a debug-file replay
+            # spends turns quickly.
             "--max-turns",
-            "60",
+            "100",
             # Client-side token-usage estimate, not a real spend cap under subscription
             # auth (see agent-sdk/cost-tracking) - just a circuit-breaker against a
             # runaway invocation, sized generously since one issue can need several
@@ -1352,6 +1387,42 @@ def cleanup_pr(pr_number):
     print(f"[cleanup-pr] PR #{pr_number}: exited {result.returncode}", flush=True)
 
 
+def process_new_issue(issue, state):
+    """Triage one new issue. Returns False when the caller should stop for this poll cycle.
+
+    Previously the triage call sat bare in the main loop, so a failure propagated out of the
+    whole `try` and took the rest of the cycle with it: the same issue was retried on every
+    poll forever, and the PR, review, cleanup and journal flows behind it never ran at all.
+    #5004 did exactly that on 2026-09-08 - ten consecutive 60-turn runs, watermark stuck.
+
+    Failures are counted instead. Below the limit we stop the issue loop and try again next
+    cycle, because retrying genuinely works (#4899 and #5003 both passed on their third go)
+    and because the watermark is a high-water mark - skipping ahead to a later issue would
+    strand this one permanently. Once the attempts are spent the issue is marked and the
+    watermark moves past it. Either way the rest of the poll cycle now runs.
+    """
+    number = issue["number"]
+    print(f'[triage] issue #{number}: "{issue["title"]}" - {issue_url(number)}', flush=True)
+    sync_repo()
+    reset_scratch()
+    attempts = state.setdefault("triage_attempts", {})
+    try:
+        triage(number)
+    except subprocess.CalledProcessError as exc:
+        count = attempts.get(str(number), 0) + 1
+        attempts[str(number)] = count
+        if count < TRIAGE_MAX_ATTEMPTS:
+            print(f"[triage] issue #{number}: failed ({exc}) - attempt {count} of {TRIAGE_MAX_ATTEMPTS}, retrying next cycle", flush=True)
+            save_state(state)
+            return False
+        print(f"[triage] issue #{number}: failed {count} times - marking it and moving on", flush=True)
+        mark_triage_failed(number, count)
+    attempts.pop(str(number), None)
+    state["last_processed"] = number
+    save_state(state)
+    return True
+
+
 def process_bot_cleanup_pr(pr):
     """Run the BOT_CLEANUP flow for one PR: address review feedback and CI failures,
     then remove the trigger label. A failed run swaps to BOT_FAILED instead, with an
@@ -1414,12 +1485,11 @@ def main():
     while True:
         try:
             for issue in fetch_new_issues(state["last_processed"]):
-                print(f'[triage] issue #{issue["number"]}: "{issue["title"]}" - {issue_url(issue["number"])}', flush=True)
-                sync_repo()
-                reset_scratch()
-                triage(issue["number"])
-                state["last_processed"] = issue["number"]
-                save_state(state)
+                if not process_new_issue(issue, state):
+                    # Retry pending on this issue. Stop the issue loop to keep the watermark
+                    # ordering intact, but fall through to the flows below rather than
+                    # abandoning the whole cycle.
+                    break
             for issue in fetch_bot_pr_issues():
                 process_bot_pr_issue(issue)
             for issue in fetch_bot_review_issues():


### PR DESCRIPTION
Issue #5004 has failed triage **ten times** since 19:52 today and would have carried on indefinitely. Two defects, and the second one is why the whole daemon went quiet.

## 1. The failure escaped the entire poll cycle

`triage()` sat bare in the main loop, inside the same `try` that wraps *every* flow:

```python
try:
    for issue in fetch_new_issues(state["last_processed"]):
        triage(issue["number"])          # ← raises
        state["last_processed"] = ...
    for issue in fetch_bot_pr_issues():  # ← never reached
    ...                                  # ← review, cleanup, journal: never reached
except subprocess.CalledProcessError:
```

So the daemon wasn't merely stuck on #5004 — it was doing **nothing else at all**, burning one full run every ten minutes. Nothing happened to be labelled `BOT_*` today, which is the only reason this didn't visibly stall PR work too.

## 2. Nothing bounded the retries

`last_processed` only advances after a *successful* triage, so a permanently failing issue is re-fetched on every poll forever.

Retrying is worth keeping, though — this is not a case for giving up on first failure:

| Issue | Outcome |
|---|---|
| #4899 | failed twice, **passed on the third attempt** |
| #5003 | failed twice, **passed on the third attempt** |
| #4900 | failed 7× |
| #5004 | failed 10× and counting |

So attempts are now counted in `state` and capped at `TRIAGE_MAX_ATTEMPTS = 3`. Below the cap, the issue stays at the head of the queue and the cycle **continues to the other flows**. At the cap it gets a comment explaining how to re-trigger it (add `BOT_REVIEW`, which the follow-up flow watches), a `BOT_FAILED` label, and the watermark moves past.

The issue loop `break`s rather than skipping ahead on a pending retry — `last_processed` is a high-water mark, so triaging a later issue first would strand this one permanently.

## Turn budget

Raised triage from **60 → 100**. It had the smallest allowance of any flow while doing the most open-ended work:

| flow | before | after |
|---|---|---|
| triage | 60 | **100** |
| triage_followup | 60 | 60 |
| flush_journal | 80 | 80 |
| review_pr | 100 | 100 |
| create_pr / cleanup_pr | 150 | 150 |

Five separate issues have exhausted 60 (#4899, #4900, #4984, #5003, #5004). #5004's body alone is 17KB before any debug replay. `triage_followup` is left at 60 — narrower job, has never hit the ceiling.

This is tuning, not a proven fix for #5004: it may simply be an issue that needs more than any reasonable budget. The bounded retry is what guarantees it stops costing anything either way.

## Tests

Nine new cases; **six fail with the fix reverted**, including the one that matters most — that a failed triage no longer escapes to the caller. Suite: 223 passing. `run_pre_commit`: clean.

## Note on #5000

The context-window fix is working — the `200k` auto-compact warning is gone from today's logs. It didn't help here because turns, not context, were the binding limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
