### PR TITLE
Let low power charging apply during daylight, behind a switch (#4975)

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -1087,6 +1087,14 @@ CONFIG_ITEMS = [
         "default": 150,
     },
     {
+        "name": "set_charge_low_power_solar_full_rate",
+        "friendly_name": "Low power mode full rate in solar",
+        "type": "switch",
+        "icon": "mdi:solar-power",
+        "enable": "set_charge_low_power",
+        "default": True,
+    },
+    {
         "name": "set_reserve_enable",
         "friendly_name": "Set Reserve Enable",
         "type": "switch",

--- a/apps/predbat/execute.py
+++ b/apps/predbat/execute.py
@@ -274,6 +274,7 @@ class Execute:
                             current_charge_rate=current_charge_rate / MINUTE_WATT,
                             pv_window_kwh=pv_window_kwh,
                             low_power_pv_threshold_w=self.low_power_pv_threshold_w,
+                            solar_full_rate=self.set_charge_low_power_solar_full_rate,
                         )
                         new_charge_rate = int(new_charge_rate * MINUTE_WATT)
 

--- a/apps/predbat/fetch.py
+++ b/apps/predbat/fetch.py
@@ -3126,6 +3126,7 @@ class Fetch:
         self.set_export_low_power = self.get_arg("set_export_low_power")
         self.charge_low_power_margin = self.get_arg("charge_low_power_margin")
         self.low_power_pv_threshold_w = self.get_arg("low_power_pv_threshold_w")
+        self.set_charge_low_power_solar_full_rate = self.get_arg("set_charge_low_power_solar_full_rate")
         self.calculate_export_first = True
 
         self.set_status_notify = self.get_arg("set_status_notify")

--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -1083,6 +1083,7 @@ class Output:
             self.battery_temperature_charge_curve,
             pv_window_kwh=pv_window_kwh,
             low_power_pv_threshold_w=self.low_power_pv_threshold_w,
+            solar_full_rate=self.set_charge_low_power_solar_full_rate,
         )
         return dp2(charge_rate_now_curve * MINUTE_WATT / 1000.0)
 

--- a/apps/predbat/prediction.py
+++ b/apps/predbat/prediction.py
@@ -106,6 +106,7 @@ class Prediction(PredictionBatch):
             self.calculate_export_on_pv = base.calculate_export_on_pv
             self.charge_low_power_margin = base.charge_low_power_margin
             self.low_power_pv_threshold_w = base.low_power_pv_threshold_w
+            self.set_charge_low_power_solar_full_rate = base.set_charge_low_power_solar_full_rate
             self.car_charging_slots = base.car_charging_slots
             # Model-facing car charge limit (#4967): fetch raises this above the real limit for cars
             # following an Octopus Intelligent dispatch plan with consider_full off, making the fill
@@ -1045,6 +1046,7 @@ class Prediction(PredictionBatch):
                     self.battery_temperature_charge_curve,
                     pv_window_kwh=pv_window_kwh,
                     low_power_pv_threshold_w=self.low_power_pv_threshold_w,
+                    solar_full_rate=self.set_charge_low_power_solar_full_rate,
                 )
                 charge_rate_now_curve_step = charge_rate_now_curve * step
 

--- a/apps/predbat/tests/test_find_charge_rate.py
+++ b/apps/predbat/tests/test_find_charge_rate.py
@@ -74,6 +74,10 @@ def test_find_charge_rate_pv_overlap(my_predbat):
 
     Throttling the charge rate while the sun is shining stops PV going into the battery, the surplus
     is exported cheaply and the target is then made up with grid import, which increases the plan cost.
+
+    set_charge_low_power_solar_full_rate turns that bypass off for a window where the trade does not
+    hold - a free or very cheap import period, where the spilled PV costs nothing to buy back and the
+    throttled rate is wanted anyway (#4975).
     """
     failed = 0
 
@@ -125,6 +129,23 @@ def test_find_charge_rate_pv_overlap(my_predbat):
     print("With PV - Best_rate {} Best_rate_real {}".format(sun_rate * MINUTE_WATT, sun_rate_real * MINUTE_WATT))
     if sun_rate * MINUTE_WATT != max_rate:
         print("**** ERROR: PV production in the window should force the max rate {}W, got {}W ****".format(max_rate, sun_rate * MINUTE_WATT))
+        failed = 1
+
+    # With the full rate in solar switch off, the same PV must not force the max rate any more - the
+    # window is throttled on its own charge_left / minutes_left just as a dark one would be (#4975)
+    kwargs_no_full_rate = dict(kwargs)
+    kwargs_no_full_rate["solar_full_rate"] = False
+    opt_out_rate, opt_out_rate_real = find_charge_rate(*args, pv_window_kwh=2.0, **kwargs_no_full_rate)
+    print("With PV, full rate in solar off - Best_rate {} Best_rate_real {}".format(opt_out_rate * MINUTE_WATT, opt_out_rate_real * MINUTE_WATT))
+    if opt_out_rate != dark_rate:
+        print("**** ERROR: with solar_full_rate off the PV should not change the rate, expected {}W got {}W ****".format(dark_rate * MINUTE_WATT, opt_out_rate * MINUTE_WATT))
+        failed = 1
+
+    # The switch only has meaning when there is PV to abandon low power for - with no PV in the window
+    # it must make no difference either way
+    no_pv_opt_out_rate, _ = find_charge_rate(*args, **kwargs_no_full_rate)
+    if no_pv_opt_out_rate != dark_rate:
+        print("**** ERROR: with no PV solar_full_rate should not change the rate, expected {}W got {}W ****".format(dark_rate * MINUTE_WATT, no_pv_opt_out_rate * MINUTE_WATT))
         failed = 1
 
     return failed

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -1697,6 +1697,7 @@ def find_charge_rate(
     current_charge_rate=None,
     pv_window_kwh=0.0,
     low_power_pv_threshold_w=0.0,
+    solar_full_rate=True,
 ):
     """
     Find the lowest charge rate that fits the charge slow
@@ -1708,6 +1709,12 @@ def find_charge_rate(
     pv_window_kwh directly against a fixed energy figure keeps the decision independent of how long the
     remaining window happens to be - a long window at a low constant trickle should not accumulate its
     way past a threshold sized for "is this bright enough to matter" (#4699 follow-up).
+
+    solar_full_rate turns that abandon off (#4975). Whether spilling PV to hold a throttled rate is
+    worth it depends on what import costs in this particular window, which is not something the PV
+    forecast can answer - a user charging in a free or very cheap daytime window loses nothing by
+    throttling, while on a normal tariff the exported surplus has to be bought back later. Defaults to
+    True, the behaviour of #4373.
     """
     if battery_temperature_curve is None:
         battery_temperature_curve = {}
@@ -1731,9 +1738,11 @@ def find_charge_rate(
 
         # If the charge window's own average PV power over its remainder is above the threshold, charge
         # at max rate instead - a throttled rate would cap the PV going into the battery, exporting the
-        # surplus and importing to make the target up later
+        # surplus and importing to make the target up later. Turned off by
+        # set_charge_low_power_solar_full_rate for a window where that trade does not apply, e.g. a
+        # free import period, where the throttled rate is wanted even though PV will spill (#4975)
         low_power_pv_threshold_kwh = (low_power_pv_threshold_w / MINUTE_WATT) * max(abs_minutes_left, 0)
-        if pv_window_kwh > 0 and pv_window_kwh >= low_power_pv_threshold_kwh:
+        if solar_full_rate and pv_window_kwh > 0 and pv_window_kwh >= low_power_pv_threshold_kwh:
             if log_to:
                 log_to("Low power mode: PV forecast in window {}kWh > {}kWh ({}W over {} minutes), default to max rate".format(dp2(pv_window_kwh), dp2(low_power_pv_threshold_kwh), low_power_pv_threshold_w, abs_minutes_left))
             return max_rate, max_rate_real

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -460,6 +460,7 @@ Low-power charging is skipped for any charge window whose forecast solar product
 the full charge rate is used instead. Throttling the charge rate while the sun is shining would cap how much solar reaches the battery, the surplus
 would be exported at the export rate and the charge target then made up from grid import later, which costs more than the full rate charge Predbat
 planned for. A long charge window is also split at dawn so its dark, PV-free portion stays on low power even if the window continues on into daylight.
+This skipping can be turned off with **switch.predbat_set_charge_low_power_solar_full_rate** if it does not suit your tariff.
 
 The YouTube video [low power charging and charging curve](https://youtu.be/L2vY_Vj6pQg?si=0ZiIVrDLHkeDCx7h)
 explains how the low-power charging works and shows how Predbat automatically creates it.
@@ -472,6 +473,12 @@ above which a charge window (or the daylight portion of one split at dawn) is co
 figure rather than a percentage of your system's forecast peak, since a heavily overcast day's own peak is much lower than a clear day's - a percentage would
 make the threshold effectively different day to day. Defaults to 150W; increase it if low-power charging is being abandoned on days with only a trickle of solar,
 decrease it if a genuinely sunny window is still being throttled.
+
+**switch.predbat_set_charge_low_power_solar_full_rate** (requires **switch.predbat_set_charge_low_power** to be turned On) When turned On (the default) a charge
+window with solar forecast above the threshold above charges at the full rate rather than a throttled one, so the solar goes into the battery instead of being
+exported and bought back later. Turn it Off if you want low-power charging to apply during daylight anyway - worthwhile when the import in that window is free or
+very cheap, since the solar the throttled rate spills then costs nothing to replace. Be aware that on a sunny day this can export or clip a significant amount of
+solar, so leave it On unless you specifically want the slow charge.
 
 **switch.predbat_set_reserve_enable** (_expert_mode_) When turned On (the default) the battery reserve setting is used to hold the battery charge level
 once it has been reached or to protect against discharging beyond the set limit.


### PR DESCRIPTION
Addresses #4975. **Based on #4726** — please merge that first; this PR targets its branch, so the diff shown here is only the switch.

## The problem

Low power charging is abandoned for any charge window whose forecast solar averages above `low_power_pv_threshold_w`, using the full rate instead. That is deliberate (#4373): throttling while the sun is up caps how much solar reaches the battery, and the surplus is exported cheaply then bought back later.

Whether that trade is worth it depends on **what import costs in that particular window** — something the PV forecast cannot tell you. The reporter on #4975 has a free import period from 11:00–14:00 every day, sitting entirely in daylight. For him the spilled solar was being exported anyway and the grid fill is free, so throttling costs nothing — but low power can never engage for that window however the thresholds are tuned, because the guard fires on every recompute.

His ask is the exact opposite of #4373's, and nothing in the solar data separates the two cases. So this adds a switch rather than changing the behaviour.

## The change

New `set_charge_low_power_solar_full_rate`, "Low power mode full rate in solar", **default On**, requires `set_charge_low_power`. On is today's behaviour, so no existing plan changes on upgrade. Turned Off, a solar-overlapping window is throttled on its own `charge_left / minutes_left`, exactly as a dark window is.

The guard itself gains one condition:

```python
if solar_full_rate and pv_window_kwh > 0 and pv_window_kwh >= low_power_pv_threshold_kwh:
```

The rest is plumbing the flag from config through `fetch` to the three `find_charge_rate()` call sites, plus docs.

The dawn split is untouched and still does what it was added for — the dark part of a sunrise-spanning window is a separate window regardless of this switch.

## Caveat, documented for users

With the switch Off, a low power window overlapping **peaky** solar will spill: solar above the throttled rate exports or clips. For the reporter that is free-for-free, but it is not free in general, which is why On is the default. The docs say so explicitly.

The genuinely clean fix — throttle only the grid portion and let solar flow in on top — needs a grid import power limit separate from battery charge rate, which most supported inverters do not expose. Out of scope here.

## Testing

- `test_find_charge_rate_pv_overlap` extended: with PV present, On → 3000 W (max), Off → 900 W (identical to the no-PV result); and with no PV the switch changes nothing either way. #4373's original assertion is left intact.
- Quick suite passes; `run_pre_commit` clean.
- Kernel unaffected: `kernel_supported()` requires `not save`, low power only runs when `save` is set, so the C++ path never reaches this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)