### PR TITLE
Fix time-shifted car charging slots in the History view (#5004)

### DIFF
--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -3011,7 +3011,18 @@ class Output:
         )
         self.dashboard_item("binary_sensor." + self.prefix + "_demand", state="on" if isDemand else "off", attributes={"friendly_name": "Predbat is in demand mode", "icon": "mdi:battery-arrow-up"})
 
-    def yesterday_reconstruct_car_slots(self, end_record, yesterday_load_step):
+    def yesterday_reconstruct_car_slots(self, end_record, yesterday_load_step, minutes_now):
+        """
+        Rebuild yesterday's car charging slots and subtract their energy from yesterday's historical load
+
+        :param end_record: Length of the reconstructed day in minutes, i.e. the plan axis is 0 (yesterday midnight) to end_record
+        :param yesterday_load_step: Yesterday's per-step load, keyed on the same plan axis, modified in place
+        :param minutes_now: The real minutes_now of the live plan. calculate_yesterday() fakes self.minutes_now to 0 while it
+                            re-simulates yesterday, but self.car_charging_energy is still indexed in minutes before the real
+                            now - as is yesterday_load_step, which was built with base_offset = 24 * 60 + the real minutes_now.
+                            Reading the car energy with the faked self.minutes_now would time-shift every car slot by
+                            minutes_now against the load it is meant to cancel out (GH#5004).
+        """
         # Normalize to list for multi-car support
         entity_id_config = self.get_arg("octopus_intelligent_slot", indirect=False)
         if entity_id_config and not isinstance(entity_id_config, list):
@@ -3031,7 +3042,7 @@ class Output:
             for start_minute in range(0, end_record, self.plan_interval_minutes):
                 car_energy = 0
                 for minute in range(start_minute, start_minute + self.plan_interval_minutes):
-                    minute_previous = self.minutes_now + 24 * 60 - minute  # How far back in time are we looking
+                    minute_previous = minutes_now + 24 * 60 - minute  # How far back in time are we looking
                     car_energy += self.get_from_incrementing(self.car_charging_energy, minute_previous)
                 if car_energy > 0.1:
                     # Only add the slot if there isn't already one covering this time period
@@ -3287,7 +3298,8 @@ class Output:
         self.car_charging_soc = [0] * len(self.car_charging_soc)
 
         # re-construct car charging slots from non-octopus using the sensor
-        self.yesterday_reconstruct_car_slots(end_record, yesterday_load_step)
+        # Pass the real minutes_now saved above - self.minutes_now has just been faked to 0 but the car energy history is still indexed from the real now
+        self.yesterday_reconstruct_car_slots(end_record, yesterday_load_step, minutes_now)
 
         # Simulate yesterday
         self.prediction = Prediction(self, yesterday_pv_step, yesterday_pv_step, yesterday_load_step, yesterday_load_step, soc_kw=soc_yesterday)

--- a/apps/predbat/tests/test_calculate_yesterday.py
+++ b/apps/predbat/tests/test_calculate_yesterday.py
@@ -513,13 +513,18 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
 
     No octopus_intelligent_slot is configured and car_charging_slots starts empty.
     The car_charging_energy sensor records 1.5 kWh in the 30-minute window
-    starting at minute 60 of yesterday.  yesterday_reconstruct_car_slots should
-    synthesise a slot for that window and subtract the corresponding kWh from the
-    load step data before handing it to the Prediction.
+    starting at minute 600 (10:00) of yesterday.  yesterday_reconstruct_car_slots
+    should synthesise a slot for that window and subtract the corresponding kWh
+    from the load step data before handing it to the Prediction.
 
-    Slot: start=60, end=90, kwh=1.5 → load rate = 1.5/0.5h = 3.0 kW
-    Subtraction per 5-min step: 3.0 * 5/60 = 0.25 kWh > FLAT_LOAD_KWH (0.1)
-    Expected inside-slot value: max(0.1 - 0.25, 0) = 0.0
+    This is also the regression for GH#5004: calculate_yesterday fakes
+    self.minutes_now to 0 before reconstructing the car slots, while
+    car_charging_energy and yesterday_load_step are both still indexed from the
+    real now.  Reading the car energy off the faked minutes_now attributed the
+    energy recorded at yesterday clock time T to plan-axis minute T - minutes_now,
+    so the real session stayed in the load band and a ghost car slot appeared
+    minutes_now earlier.  With minutes_now=360 the shifted position of this
+    session is axis minute 240, which must stay untouched.
 
     Also verifies that car_charging_slots and car_charging_soc are fully
     restored to their pre-call values after calculate_yesterday returns.
@@ -543,21 +548,52 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
     my_predbat.octopus_slots = [[], [], [], []]
     my_predbat.octopus_intelligent_consider_full = False
 
-    # Inside calculate_yesterday, minutes_now is set to 0 before calling
-    # yesterday_reconstruct_car_slots, so the lookup formula becomes:
-    #   minute_previous = 0 + 1440 - minute
-    # For start_minute=60 the inner scan covers minutes 60..89.
-    # At minute=60: minute_previous = 1380.
-    # get_from_incrementing(data, 1380) = max(data[1380] - data[1381], 0).
-    # Correct representation of an incrementing kWh sensor: the sensor reads
-    # 1.5 kWh at minute 60 (index 1380) and all more-recent times (lower indices),
-    # and 0 at earlier times (indices > 1380).  The telescoping sum over the
-    # 30-minute window yields data[1351] - data[1381] = 1.5 - 0 = 1.5 kWh.
-    my_predbat.car_charging_energy = {k: 1.5 for k in range(0, 1381)}
+    # Keep the load cap deterministic regardless of the order the sub-tests run in
+    my_predbat.car_energy_reported_load = True
+    my_predbat.car_charging_loss = 1.0
+
+    # car_charging_energy is indexed in minutes before the REAL now, so the session
+    # at yesterday 10:00 (plan-axis minute 600) lives at index
+    #   minutes_now + 1440 - 600 = 360 + 1440 - 600 = 1200.
+    # An incrementing kWh sensor is monotonically non-decreasing forward in time
+    # (= decreasing index), so reading 1.5 kWh at index 1200 and every more-recent
+    # index, and 0 at earlier times (indices > 1200), represents a 1.5 kWh jump at
+    # yesterday 10:00.  get_from_incrementing(data, 1200) = 1.5 - 0 = 1.5 kWh.
+    car_session_minute = 600
+    shifted_minute = car_session_minute - 360  # where the GH#5004 bug painted it: 240
+    my_predbat.car_charging_energy = {k: 1.5 for k in range(0, 1201)}
 
     captured_load, original_run_pred = _apply_mocks(my_predbat, now_utc, cost_value=100.0, soc_value=5.0)
 
+    # Snapshot car_charging_slots as the (mocked) prediction sees them - calculate_yesterday
+    # restores the live slots before returning, so they can't be inspected afterwards
+    captured_slots = []
+    mocked_run_prediction = my_predbat.run_prediction
+
+    def _capture_car_slots(*args, **kwargs):
+        """Record the reconstructed car slots then defer to the standard run_prediction mock."""
+        captured_slots.append(copy.deepcopy(my_predbat.car_charging_slots))
+        return mocked_run_prediction(*args, **kwargs)
+
+    my_predbat.run_prediction = _capture_car_slots
+
     my_predbat.calculate_yesterday()
+
+    plan_iv = my_predbat.plan_interval_minutes  # 30 by default
+    slot_end = car_session_minute + plan_iv
+
+    # --- The synthesised slot must sit at the minute the energy was actually recorded ---
+    if not captured_slots:
+        print("ERROR: run_prediction was not called – cannot inspect car slots")
+        failed = True
+    else:
+        slots = captured_slots[0][0]
+        if len(slots) != 1:
+            print("ERROR: expected exactly 1 synthesised car slot, got {}".format(slots))
+            failed = True
+        elif slots[0].get("start") != car_session_minute or slots[0].get("end") != slot_end:
+            print("ERROR: car slot should span {}..{} (GH#5004 shifted it to {}), got {}".format(car_session_minute, slot_end, shifted_minute, slots[0]))
+            failed = True
 
     # --- Verify load subtraction via the captured load_minutes_step ---
     if len(captured_load) < 1:
@@ -565,18 +601,24 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
         failed = True
     else:
         load_step = captured_load[0]
-        plan_iv = my_predbat.plan_interval_minutes  # 30 by default
-        slot_end = 60 + plan_iv
 
-        # Inside-slot steps: max(0.1 - 3.0*5/60, 0) = max(0.1 - 0.25, 0) = 0.0
-        for inside_min in range(60, slot_end, PREDICT_STEP):
+        # Inside-slot steps: slot kwh is capped to load_reported (6 * 0.1 = 0.6 kWh),
+        # so the subtraction is 0.6/0.5h * 5/60 = 0.1 kWh/step → max(0.1 - 0.1, 0) = 0.0
+        for inside_min in range(car_session_minute, slot_end, PREDICT_STEP):
             val = load_step.get(inside_min, -1)
             if abs(val) > 1e-9:
                 print("ERROR: step {} (inside energy-sensor slot) should be 0.0 but got {}".format(inside_min, val))
                 failed = True
 
+        # The position the GH#5004 shift used to paint must be left alone entirely
+        for ghost_min in range(shifted_minute, shifted_minute + plan_iv, PREDICT_STEP):
+            val = load_step.get(ghost_min, -1)
+            if abs(val - FLAT_LOAD_KWH) > 1e-9:
+                print("ERROR: step {} is minutes_now before the real session and must be untouched at {}, got {}".format(ghost_min, FLAT_LOAD_KWH, val))
+                failed = True
+
         # Outside-slot steps should be unchanged at FLAT_LOAD_KWH.
-        for outside_min in [0, 5, 55, slot_end, slot_end + 5, 300]:
+        for outside_min in [0, 5, 55, car_session_minute - 5, slot_end, slot_end + 5, 300]:
             val = load_step.get(outside_min, -1)
             if abs(val - FLAT_LOAD_KWH) > 1e-9:
                 print("ERROR: step {} (outside energy-sensor slot) should be {} but got {}".format(outside_min, FLAT_LOAD_KWH, val))
@@ -676,7 +718,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     end_record = 24 * 60  # 1440 minutes
     yesterday_load_step = {m: FLAT_LOAD_KWH for m in range(0, end_record, PREDICT_STEP)}
 
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step, 0)
 
     # Exactly one slot should have been added
     slots = my_predbat.car_charging_slots[0]
@@ -734,7 +776,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.car_charging_energy = {k: 1.2 for k in range(0, 1381)}  # same energy as 5a
 
     yesterday_load_step = {m: FLAT_LOAD_KWH for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step, 0)
 
     if len(my_predbat.car_charging_slots[0]) != 1:
         print("ERROR 5b: expected 1 slot (no duplicate), got {}".format(len(my_predbat.car_charging_slots[0])))
@@ -771,7 +813,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.load_octopus_slots = _mock_load_octopus_slots
 
     yesterday_load_step = {m: FLAT_LOAD_KWH for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step, 0)
 
     my_predbat.load_octopus_slots = original_load_octopus_slots
 
@@ -819,7 +861,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.car_charging_slots = [[cancelled_slot], [], [], []]
 
     yesterday_load_step_5d = {m: TINY_LOAD for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5d)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5d, 0)
 
     # The slot kwh should have been zeroed out.
     if cancelled_slot.get("kwh") != 0:
@@ -857,7 +899,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.car_charging_slots = [[adjusted_slot], [], [], []]
 
     yesterday_load_step_5e = {m: MEDIUM_LOAD for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5e)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5e, 0)
 
     expected_adj_kwh = (plan_iv // PREDICT_STEP) * MEDIUM_LOAD * my_predbat.car_charging_loss  # 6 * 0.2 * 1.0 = 1.2
     if abs(adjusted_slot.get("kwh", -1) - expected_adj_kwh) > 1e-9:
@@ -905,7 +947,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.car_charging_slots = [[slot_car0], [slot_car1], [], []]
 
     yesterday_load_step_5f = {m: TWO_CAR_LOAD for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5f)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5f, 0)
 
     # Car 0 should be unchanged (load was sufficient).
     if abs(slot_car0.get("kwh", -1) - 0.6) > 1e-9:
@@ -930,6 +972,52 @@ def _test_reconstruct_car_slots(my_predbat, failed):
         val = yesterday_load_step_5f.get(m, -1)
         if abs(val - TWO_CAR_LOAD) > 1e-9:
             print("ERROR 5f: step {} outside slot should be {}, got {}".format(m, TWO_CAR_LOAD, val))
+            failed = True
+
+    # -----------------------------------------------------------------------
+    # 5g - the passed minutes_now indexes the energy sensor, not self.minutes_now (GH#5004)
+    # -----------------------------------------------------------------------
+    print("calculate_yesterday: Test 5g - car energy is indexed off the passed minutes_now, not the faked one (#5004)")
+
+    # self.minutes_now is 0 here exactly as calculate_yesterday fakes it, while the
+    # real plan is at 06:00 - so the energy sensor is still indexed from 06:00 today.
+    _setup_base(my_predbat, minutes_now=0)
+    real_minutes_now = 360
+    my_predbat.num_cars = 1
+    my_predbat.car_charging_slots = [[] for _ in range(4)]
+    my_predbat.car_energy_reported_load = True
+    my_predbat.car_charging_loss = 1.0
+    my_predbat.octopus_intelligent_consider_full = False
+    my_predbat.octopus_slots = [[], [], [], []]
+    my_predbat.args["octopus_intelligent_slot"] = None
+
+    # 1.2 kWh recorded at yesterday 10:00 = plan-axis minute 600, which is
+    # real_minutes_now + 1440 - 600 = 1200 minutes before the real now.
+    session_minute_5g = 600
+    shifted_minute_5g = session_minute_5g - real_minutes_now  # 240, where the bug painted it
+    my_predbat.car_charging_energy = {k: 1.2 for k in range(0, real_minutes_now + 24 * 60 - session_minute_5g + 1)}
+
+    yesterday_load_step_5g = {m: FLAT_LOAD_KWH for m in range(0, end_record, PREDICT_STEP)}
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5g, real_minutes_now)
+
+    slots_5g = my_predbat.car_charging_slots[0]
+    if len(slots_5g) != 1:
+        print("ERROR 5g: expected 1 synthesised slot, got {}".format(slots_5g))
+        failed = True
+    elif slots_5g[0].get("start") != session_minute_5g:
+        print("ERROR 5g: slot start should be {} (the bug placed it at {}), got {}".format(session_minute_5g, shifted_minute_5g, slots_5g[0].get("start")))
+        failed = True
+
+    # Load is cancelled at the real session minutes and left alone at the shifted ones
+    for m in range(session_minute_5g, session_minute_5g + plan_iv, PREDICT_STEP):
+        val = yesterday_load_step_5g.get(m, -1)
+        if abs(val) > 1e-9:
+            print("ERROR 5g: step {} inside the real session should be 0.0, got {}".format(m, val))
+            failed = True
+    for m in range(shifted_minute_5g, shifted_minute_5g + plan_iv, PREDICT_STEP):
+        val = yesterday_load_step_5g.get(m, -1)
+        if abs(val - FLAT_LOAD_KWH) > 1e-9:
+            print("ERROR 5g: step {} is the shifted position and should be untouched at {}, got {}".format(m, FLAT_LOAD_KWH, val))
             failed = True
 
     # Restore


### PR DESCRIPTION
This is an automated draft PR generated from issue #5004 — a maintainer should review it before merging.

Fixes #5004

## Summary

`calculate_yesterday()` fakes `self.minutes_now` to 0 before it re-simulates yesterday, then calls `yesterday_reconstruct_car_slots()` (`output.py:3301`). That function reads the car-charging energy history with `minute_previous = self.minutes_now + 24 * 60 - minute` (`output.py:3045`), which therefore evaluated as `1440 - minute`. But `yesterday_load_step` is built *before* the fake, with `base_offset = 24 * 60 + <real minutes_now>` (`output.py:3128`), and `self.car_charging_energy` is likewise still indexed in minutes before the real now.

So car energy recorded at yesterday clock time *T* was attributed to plan-axis minute *T − minutes_now*. That produces both reported symptoms:

1. The real charging session stays in the **load kWh** band, because the subtraction is applied at the wrong minutes.
2. **Ghost car kWh** appears where nothing was charging, `minutes_now` earlier than the real session.

Because `calculate_yesterday()` re-runs hourly, the offset changed on every recalculation, so the misalignment moved around between refreshes.

The fix passes the real `minutes_now` (already saved into a local at `output.py:3253` before the fake) into `yesterday_reconstruct_car_slots()` rather than reading the faked `self.minutes_now`. The live plan is unaffected — this is the History/savings view only.

## Testing

- `tools/triage_test.sh calculate_yesterday` — PASSED.
- `coverage/run_pre_commit` — all hooks Passed, and the quick suite it runs finished `All tests passed (4 slow tests skipped, total time: 82.42s)`, exit 0.
- Negative check: with only the one-line fix reverted (tests unchanged), the suite fails with exactly the reported symptoms — `car slot should span 600..630 (GH#5004 shifted it to 240), got {'start': 240, 'end': 270, ...}`, the real session left at `0.1` kWh/step in the load band, and the shifted position zeroed. So the new assertions are not vacuous.

Test changes in `apps/predbat/tests/test_calculate_yesterday.py`:

- `_test_car_slot_from_energy_sensor` (end-to-end through `calculate_yesterday()` with `minutes_now=360`) now records the session at yesterday 10:00 using the correct sensor index, asserts the synthesised slot lands at plan-axis 600, and asserts plan-axis 240 — where the bug painted it — is left untouched. Its previous fixture encoded the buggy `1440 - minute` formula as expected behaviour, which is why the existing suite passed.
- New sub-case 5g pins the invariant directly: with `self.minutes_now` faked to 0 and `minutes_now=360` passed in, the slot must follow the passed value.
- The six existing direct call sites pass `0` explicitly, matching the `minutes_now=0` they already set up.

## Notes

The debug journal already records that `calculate_yesterday()` zeroes `minutes_now` on the shared instance (`tools/debug-journal.md:56`); this is a second consumer that read the faked value where it needed the real one.

One related gap is **left unfixed** as out of scope here: the reconstruction loop only covers plan-axis `0..end_record` (yesterday), while the History view renders `end_record + minutes_now` (through to now). Car charging that happened *today* is therefore still shown in the load band rather than the car band. Extending it needs care — the inner scan would run past `now` into negative offsets, which `get_from_incrementing()` silently wraps by +1440 — so it is better handled separately.

Also noted but not changed: reconstructed slots are always appended to `car_charging_slots[0]` (`output.py:3050`), so with `num_cars: 2` all reconstructed energy folds into car 1's graph. `car_charging_energy` is a single summed series across the configured sensors, so there is no per-car split available at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)