### PR TITLE
Fix the test that fails for one hour a day, every night the journal flush runs

### DIFF
--- a/apps/predbat/tests/test_energydataservice.py
+++ b/apps/predbat/tests/test_energydataservice.py
@@ -19,8 +19,14 @@ def test_energydataservice(my_predbat):
     failed = 0
 
     print("Test energy data service")
-    today = datetime.now().strftime("%Y-%m-%d")
-    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    # Anchor the fixture to Predbat's own day, not the host's. midnight_utc is local midnight
+    # in the configured timezone (Europe/London in the harness); datetime.now() is the machine's
+    # clock. Between 23:00 and 00:00 UTC under BST those land on different dates, the published
+    # rates are then a day out from the day the code is modelling, and rates[1440] does not
+    # exist - failing this test for the one hour a day CI happens to run in that window. Same
+    # trap, same fix as PR #4998 for the multi-car IOG tests.
+    today = my_predbat.midnight_utc.strftime("%Y-%m-%d")
+    tomorrow = (my_predbat.midnight_utc + timedelta(days=1)).strftime("%Y-%m-%d")
     tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(my_predbat.midnight_utc).total_seconds() / 3600)
     tz_offset = f"{tz_offset:02d}"
 


### PR DESCRIPTION
`test_energydataservice` fails for one hour a day, and the nightly journal flush is scheduled inside that hour.

## The bug

```python
today    = datetime.now().strftime("%Y-%m-%d")                    # ← the machine's clock
tomorrow = (datetime.now() + timedelta(days=1)).strftime(...)     # ← the machine's clock
tz_offset = int(my_predbat.midnight_utc.tzinfo.utcoffset(...))    # ← Predbat's clock
```

The fixture dates come from the host, the offset from Predbat (Europe/London in the harness). When those disagree on the date, the published rates are a day out from the day the code is modelling and `rates[1440]` doesn't exist — `KeyError: 1440`.

On a UTC runner during BST they disagree between **23:00 and 00:00 UTC**.

## Why it matters now

This isn't intermittent flakiness. The nightly `/journal-update` flush fires at local midnight, which during BST *is* 23:0x UTC — so it lands in the failing hour **every night**. #5011 is a docs-only change (one markdown file) that failed CI at 23:12 UTC for exactly this reason. Until BST ends in late October, every nightly journal PR fails the same way.

## The fix

Anchor the fixture to `my_predbat.midnight_utc` — the same clock the next line already reads. Identical trap and identical fix to **#4998** for the multi-car IOG tests last week, and the trap already has a bullet in the debug journal ("Build test dates from Predbat's clock, not the machine's").

## Verification

Reproduced with `TZ=Pacific/Pitcairn`, which puts the host a calendar day behind Europe/London:

| | before | after |
|---|---|---|
| `--test energydataservice`, shifted TZ | `KeyError: 1440` | passes |
| `--test energydataservice`, normal TZ | passes | passes |
| `--quick`, shifted TZ | aborts | **all passed**, 82.98s |

The suite aborts on the first uncaught exception, so this was masking anything later in the run. With it fixed, nothing else in the quick suite fails in that window.

## Worth considering separately

Nineteen other test files call `datetime.now()`. None is currently affected — I checked by running the whole suite in the window — but the pattern is latent, and this is the second instance in a week. A scheduled CI run in a shifted timezone would catch the next one before a maintainer does. I haven't added one here since it's a workflow change with its own cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
