### PR TITLE
docs(car-charging): document car_charging_battery_size as a list, matching the validator

### DIFF
--- a/apps/predbat/tests/test_validate_config.py
+++ b/apps/predbat/tests/test_validate_config.py
@@ -393,6 +393,43 @@ def test_validate_config(my_predbat):
         print(f"  [transient_ok] {name} pointing at an entity that does not exist still fails")
         _run(my_predbat, {name: "sensor.test_charger_typo"}, expect_errors=[name])
 
+    # ==========================================================================
+    # car_charging_battery_size  (#2172)
+    #
+    # A fixed battery size is written as a list with one entry per car, the form
+    # every apps.yaml template uses. A bare number on the same line as the key
+    # is not accepted: the sensor branch wraps a scalar into a list only when it
+    # is a string (predbat.py), so a numeric scalar never reaches the "fixed
+    # float values are allowed" check. The car-charging docs used to describe
+    # that failing form ("must be entered with one decimal place, e.g. 50.0"),
+    # which is what #2172 reported.
+    # ==========================================================================
+    print("  [sensor float] car_charging_battery_size as a one-entry list passes")
+    _run(my_predbat, {"car_charging_battery_size": [77.4], "num_cars": 1}, expect_clean=["car_charging_battery_size"])
+
+    print("  [sensor float] car_charging_battery_size as a whole number in a list passes (templates use '- 75')")
+    _run(my_predbat, {"car_charging_battery_size": [75], "num_cars": 1}, expect_clean=["car_charging_battery_size"])
+
+    print("  [sensor float] car_charging_battery_size written inline as a number fails (#2172)")
+    _run(my_predbat, {"car_charging_battery_size": 77.4, "num_cars": 1}, expect_errors=["car_charging_battery_size"])
+
+    # A string scalar IS wrapped into a list, so it validates - the docs must not
+    # claim a list is the only accepted form, only that an inline number fails.
+    print("  [sensor float] car_charging_battery_size as an entity name still passes (scalar strings are wrapped)")
+    _run(
+        my_predbat,
+        {"car_charging_battery_size": "sensor.test_car_battery_size", "num_cars": 1},
+        extra_states={"sensor.test_car_battery_size": 77.4},
+        expect_clean=["car_charging_battery_size"],
+    )
+
+    # entries is "num_cars", so the list must have one entry per car. With two
+    # cars an inline number fails earlier, as the wrong type rather than the
+    # wrong sensor, so the reported error differs from the one-car case above.
+    print("  [sensor float] car_charging_battery_size needs one entry per car")
+    _run(my_predbat, {"car_charging_battery_size": [77.4, 64.0], "num_cars": 2}, expect_clean=["car_charging_battery_size"])
+    _run(my_predbat, {"car_charging_battery_size": 77.4, "num_cars": 2}, expect_errors=["car_charging_battery_size"])
+
     print("**** test_validate_config PASSED ****")
     return False
 

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -219,7 +219,15 @@ To make Predbat-led car charging more accurate, additionally you can configure t
   #  - 're:sensor.tsunami_battery'
 ```
 
-- **car_charging_battery_size** - Set this value in `apps.yaml` to the car's battery size in kWh which *must* be entered with one decimal place, e.g. 50.0.
+- **car_charging_battery_size** - Set this value in `apps.yaml` to the car's battery size in kWh, as a list with one entry per car:
+
+```yaml
+  car_charging_battery_size:
+    - 75
+```
+
+Writing the number on the same line as the key (`car_charging_battery_size: 75`) fails Predbat's `apps.yaml` validation
+with *"is not of type 'sensor'"*, so use the list form above. A whole number is fine - a decimal place is not required.
 If not set, Predbat defaults to 100.0kWh. This will be used to predict when Predbat will stop car charging.
 
 - **car_charging_limit** - You should configure this to point to a sensor that specifies the % limit the car is set to charge to.


### PR DESCRIPTION
This is an automated draft PR generated from issue #2172 — a maintainer should review it before merging.

Fixes #2172

_(Rewritten from scratch and force-pushed by Claude after the review on the first attempt — see the note at the bottom.)_

## Summary

The car-charging docs told users to write `car_charging_battery_size` as a plain value ("must be entered with one decimal place, e.g. 50.0"), but `validate_config()` only wraps a *string* scalar into a list for `sensor`-typed items, so a bare number never reaches the "fixed float values are allowed" check and is reported as `'car_charging_battery_size' is not of type 'sensor'` on every run.

Per the direction on the issue — allowing scalars for any `sensor` item would invite worse configs for keys like `pv_forecast_today` and `car_charging_soc` — this fixes the documentation rather than the validator.

The bullet now shows the list form inline:

```yaml
  car_charging_battery_size:
    - 75
```

rather than pointing at the example block further up the page, which is entirely commented out — a user who uncommented only the key line would leave `#  - 75` commented, producing YAML `null` and the same validation error. The decimal-place claim is dropped too: the templates use `- 75` and `fetch.py` reads the value through `float()`.

Six subtests pin the validator's actual behaviour: a one-entry list passes, a whole number in a list passes, a bare number fails as #2172 reported, **a string scalar still passes** (strings are wrapped, so a list is not the only accepted form), and with `num_cars: 2` a two-entry list passes while an inline number fails as the *wrong type* rather than the wrong sensor — a different error message from the one-car case.

No code path changes; car charging itself was never affected, only the `config_valid` sensor and the "found N configuration errors" log line.

## What changed from the first attempt

The review found the first version's doc prose overstated the rule, and that its 49-line `templates/` + `docs/` filesystem scan was wrong in both directions — it missed the dominant key-then-next-line YAML form (which is what actually fails) while flagging the valid `[77.4]` flow list and any key line carrying a trailing comment. Both confirmed by running the regex against `yaml.safe_load`.

Rather than patch the regex, the scan is gone. It was guarding a doc example against drift, but the invariant it claimed to enforce cannot be checked by matching line starts, and a YAML-parsing version would still have missed `apps/predbat/config/apps.yaml` — the template users actually copy — and mis-flagged the many templates that ship this key commented out. The validator subtests are the real regression guard; the doc is a doc.

Two review points are deliberately **not** addressed here, as pre-existing and out of scope for a docs fix:

- `test_infra.py` sets `num_cars: 2` with `car_charging_battery_size: 100.0` (an inline scalar), so that key sits in the shared fixture's `arg_errors` baseline on every `validate_config()` call in this module.
- `car_charging_battery_size: [0]` validates clean despite the spec's `zero: False`, and `plan.py` then divides by it (`fetch.py` guards, `plan.py` does not).

Both are worth fixing; neither belongs in a two-line documentation change. Happy to file them.

## Testing

- `./run_all --test validate_config` — passes; the log shows both distinct error messages (`not of type 'sensor'` at `num_cars: 1`, `is not a list, but requires 2 entries` at `num_cars: 2`).
- `coverage/run_pre_commit` (12 hooks + `./run_all --quick`) — all passed, 4 slow tests skipped, 78.02s.
