### PR TITLE
fix(fox): don't model Feed-in First on FoxCloud, which never selects it (#5015)

### DIFF
--- a/apps/predbat/config.py
+++ b/apps/predbat/config.py
@@ -2176,8 +2176,12 @@ INVERTER_DEF = {
         "write_and_poll_sleep": 2,
         "has_time_window": False,
         "support_charge_freeze": True,
-        # See FoxESS's entry above - same hardware, correctly modelled rather than disabled (#4207).
-        "support_feedin_first": True,
+        # Unlike FoxESS above, the Cloud path never actually selects Feed-in First (#5015). It drives
+        # the inverter through the API scheduler, which only ever emits ForceCharge/ForceDischarge
+        # groups, and adjust_inverter_mode pins the work mode to SelfUse - so a freeze export slot
+        # leaves the inverter in Self Use and PV charges the battery instead of being exported.
+        # Modelling recapture here made the planner pick freeze export slots that do nothing.
+        "support_feedin_first": False,
         "support_discharge_freeze": True,
         "has_idle_time": False,
         "can_span_midnight": False,

--- a/apps/predbat/tests/test_inverter.py
+++ b/apps/predbat/tests/test_inverter.py
@@ -24,11 +24,13 @@ from const import MINUTE_WATT
 
 def test_foxess_support_discharge_freeze_matches_foxcloud():
     """
-    FoxESS (modbus) and FoxCloud are the same hardware via two different connection methods - "feed-in
-    first"/freeze export does not hold SoC flat on either, PV above the export limit still charges the
-    battery instead of being clipped (#4207). Both are now True: that spillover-charges-the-battery
-    behaviour is correctly modelled (prediction.py's freeze branch, gated on support_feedin_first)
-    rather than being a reason to disable freeze outright for this hardware - see
+    FoxESS (modbus) and FoxCloud are the same hardware via two different connection methods, so both
+    support freeze export rather than having it disabled outright for this hardware (#4207) - this
+    pins support_discharge_freeze only.
+
+    support_feedin_first deliberately does NOT match across the two: whether the freeze is a real
+    Feed-in First mode depends on the control path rather than the silicon, and only the modbus side
+    selects that mode (#5015). See test_support_feedin_first_is_opt_in, and
     test_freeze_export_recapture_beyond_limit in test_optimise_solar.py for the modelling itself.
     """
     failed = False
@@ -45,14 +47,19 @@ def test_support_feedin_first_is_opt_in():
     """
     support_feedin_first says the inverter's Freeze Export really is a "Feed-in First" mode (load,
     then export, then battery), so PV past the export limit charges the battery instead of being
-    clipped. Only types whose component actually selects such a mode may opt in - the Fox hardware,
-    plus the four clouds that switch work mode for the freeze: SolisCloud ("Feed-in priority",
-    solis.py), SolaxCloud ("feedin", solax.py), SunsynkCloud and DeyeCloud (Selling First,
-    sunsynk.py/deye.py). Every other type must default off, because modelling recapture on an
-    inverter that merely disables charging invents energy that never reaches the battery.
+    clipped. Only types whose component actually selects such a mode may opt in - FoxESS (modbus, via
+    the discharge_freeze_service in templates/fox.yaml), plus the four clouds that switch work mode
+    for the freeze: SolisCloud ("Feed-in priority", solis.py), SolaxCloud ("feedin", solax.py),
+    SunsynkCloud and DeyeCloud (Selling First, sunsynk.py/deye.py). Every other type must default
+    off, because modelling recapture on an inverter that merely disables charging invents energy
+    that never reaches the battery.
+
+    FoxCloud is deliberately excluded despite being the same hardware as FoxESS: its control path is
+    the API scheduler, which never emits a Feedin group, and adjust_inverter_mode pins the work mode
+    to SelfUse (#5015). Same silicon, different control surface - so the capability differs.
     """
     failed = False
-    expect_feedin_first = {"FoxESS", "FoxCloud", "SolisCloud", "SolaxCloud", "SunsynkCloud", "DeyeCloud"}
+    expect_feedin_first = {"FoxESS", "SolisCloud", "SolaxCloud", "SunsynkCloud", "DeyeCloud"}
 
     for inverter_type in expect_feedin_first:
         if INVERTER_DEF[inverter_type].get("support_feedin_first", False) is not True:


### PR DESCRIPTION
_(Claude wrote this PR, posted under my account.)_

Fixes #5015.

## The bug

FoxCloud declares `support_feedin_first: True`, justified in `config.py` by a comment saying it is the *same hardware* as FoxESS. That flag tells the planner the inverter's freeze export is a real "Feed-in First" mode — load, then export, then battery — so PV past the export limit is recaptured into the battery rather than clipped (`prediction.py:1146`).

The Cloud path never selects that mode:

- it drives the inverter through the Fox API scheduler, and `apply_battery_schedule` only ever emits `ForceCharge` / `ForceDischarge` groups — `Feedin` appears in `fox.py` only in enum lists, never in a written schedule
- `adjust_inverter_mode` hardcodes `new_inverter_mode = "SelfUse"` for any `has_fox_inverter_mode` inverter (`inverter.py:2443`)
- `fox_cloud.yaml` has no `discharge_freeze_service` (no `*_service` stanzas at all), so the freeze hook finds nothing configured and no-ops

So the inverter sits in Self Use for the whole slot: PV covers house load, then charges the battery, and exports only once the battery is full — exactly the Demand behaviour the reporter observes.

Same silicon, different control surface. FoxESS (modbus) reaches the mode through `select.foxess_work_mode`, wired up by the `discharge_freeze_service` stanza in `templates/fox.yaml`.

## Why now

Two commits that are individually fine but mutually inconsistent:

- the SelfUse hardcode is from **#2659, Sept 2025** — a year old
- `support_feedin_first: True` on FoxCloud came from **3ed9151e, 24 Aug 2026**

The old hardcode was harmless until the recent planner change started relying on the mode it blocks. That matches the reporter's "until a few weeks ago freeze export slots were never planned".

Worth noting #4864 (GivTCP) is **not** implicated despite also shipping in v9.0.1 — it touched no Fox files, and the hardcode predates it by a year.

## The change

One flag, plus the two tests that asserted the old value.

`support_discharge_freeze` stays `True` — freeze export is still attempted, it is only the Feed-in First *recapture modelling* that was wrong.

The shared opt-in test's docstring claimed all five other types genuinely select the mode, so I checked before shrinking the set: they do (`solax.py:833` calls `set_default_work_mode(mode="feedin")`, sunsynk/deye have dedicated Selling First freeze handling, solis.py has the feed-in priority bit). FoxCloud was the only false member.

## Effect for users

Freeze export slots on FoxCloud go back to being Demand slots, as they were before 24 Aug. That is the correct plan for what the inverter actually does, but it will look like a regression if unexplained — the plan stops promising something the hardware was never being told to do.

Adding the mode properly to the Cloud path is tracked in #5022, which records the implementation route I verified (the Cloud component *does* publish a writable work-mode select whose enum includes `Feedin`; the blocker is that `adjust_inverter_mode` would revert it).

## Testing

- `./run_all --test inverter` passes
- full `./run_all --quick` suite green (1015 passed, exit 0)
- all 12 pre-commit hooks pass

## Known follow-up, deliberately not in this PR

`support_feedin_first` is a *type-level* constant asserting something that is really *user config* — `call_service_template` resolves `discharge_freeze_service` from `self.base.args` with no inverter-type gate anywhere. A **modbus** user who trimmed that stanza from their `apps.yaml` has this same silent mismatch today.

Gating the flag on the service actually being configured would fix that, but it changes behaviour for all five remaining opt-in types on a path nobody has reported a problem with, and it needs a design call on when the gate is evaluated (apps.yaml changes at runtime; the kernel context carries the flag). Kept out of a targeted bug fix — happy to file it separately if you want it tracked.
