### PR TITLE
docs(car-charging): document car_charging_battery_size as a list (#2172)

### DIFF
--- a/apps/predbat/tests/test_validate_config.py
+++ b/apps/predbat/tests/test_validate_config.py
@@ -393,6 +393,43 @@ def test_validate_config(my_predbat):
         print(f"  [transient_ok] {name} pointing at an entity that does not exist still fails")
         _run(my_predbat, {name: "sensor.test_charger_typo"}, expect_errors=[name])
 
+    # ==========================================================================
+    # car_charging_battery_size  (#2172)
+    #
+    # A fixed battery size is written as a list with one entry per car, the form
+    # every apps.yaml template uses. A bare number on the same line as the key
+    # is not accepted: the sensor branch wraps a scalar into a list only when it
+    # is a string (predbat.py), so a numeric scalar never reaches the "fixed
+    # float values are allowed" check. The car-charging docs used to describe
+    # that failing form ("must be entered with one decimal place, e.g. 50.0"),
+    # which is what #2172 reported.
+    # ==========================================================================
+    print("  [sensor float] car_charging_battery_size as a one-entry list passes")
+    _run(my_predbat, {"car_charging_battery_size": [77.4], "num_cars": 1}, expect_clean=["car_charging_battery_size"])
+
+    print("  [sensor float] car_charging_battery_size as a whole number in a list passes (templates use '- 75')")
+    _run(my_predbat, {"car_charging_battery_size": [75], "num_cars": 1}, expect_clean=["car_charging_battery_size"])
+
+    print("  [sensor float] car_charging_battery_size written inline as a number fails (#2172)")
+    _run(my_predbat, {"car_charging_battery_size": 77.4, "num_cars": 1}, expect_errors=["car_charging_battery_size"])
+
+    # A string scalar IS wrapped into a list, so it validates - the docs must not
+    # claim a list is the only accepted form, only that an inline number fails.
+    print("  [sensor float] car_charging_battery_size as an entity name still passes (scalar strings are wrapped)")
+    _run(
+        my_predbat,
+        {"car_charging_battery_size": "sensor.test_car_battery_size", "num_cars": 1},
+        extra_states={"sensor.test_car_battery_size": 77.4},
+        expect_clean=["car_charging_battery_size"],
+    )
+
+    # entries is "num_cars", so the list must have one entry per car. With two
+    # cars an inline number fails earlier, as the wrong type rather than the
+    # wrong sensor, so the reported error differs from the one-car case above.
+    print("  [sensor float] car_charging_battery_size needs one entry per car")
+    _run(my_predbat, {"car_charging_battery_size": [77.4, 64.0], "num_cars": 2}, expect_clean=["car_charging_battery_size"])
+    _run(my_predbat, {"car_charging_battery_size": 77.4, "num_cars": 2}, expect_errors=["car_charging_battery_size"])
+
     print("**** test_validate_config PASSED ****")
     return False
 

--- a/docs/car-charging.md
+++ b/docs/car-charging.md
@@ -219,7 +219,15 @@ To make Predbat-led car charging more accurate, additionally you can configure t
   #  - 're:sensor.tsunami_battery'
 ```
 
-- **car_charging_battery_size** - Set this value in `apps.yaml` to the car's battery size in kWh which *must* be entered with one decimal place, e.g. 50.0.
+- **car_charging_battery_size** - Set this value in `apps.yaml` to the car's battery size in kWh, as a list with one entry per car:
+
+```yaml
+  car_charging_battery_size:
+    - 75
+```
+
+Writing the number on the same line as the key (`car_charging_battery_size: 75`) fails Predbat's `apps.yaml` validation
+with *"is not of type 'sensor'"*, so use the list form above. A whole number is fine - a decimal place is not required.
 If not set, Predbat defaults to 100.0kWh. This will be used to predict when Predbat will stop car charging.
 
 - **car_charging_limit** - You should configure this to point to a sensor that specifies the % limit the car is set to charge to.


### PR DESCRIPTION
_(Claude wrote this PR, posted under my account.)_

Fixes #2172. Replaces the automated draft #5019, which is closed.

## The problem

The car-charging docs told users to write `car_charging_battery_size` as a plain value — *"must be entered with one decimal place, e.g. 50.0"* — but that form fails validation on every run:

```
Warn: Validation of apps.yaml found configuration item 'car_charging_battery_size'
is not of type 'sensor' value was 77.4
```

`validate_config()`'s `sensor` branch wraps a scalar into a list only when it is a **string**, so a numeric scalar never reaches the "fixed float values are allowed" check and falls through to the generic type error. The docs described exactly the form that breaks.

Per @chalfontchubby's direction on the issue, this fixes the **documentation** rather than the validator: allowing scalars for any `sensor`-typed item would invite worse configs for keys like `pv_forecast_today` and `car_charging_soc`, where a fixed value is rarely what the user wants.

## The change

The bullet now carries its own uncommented example:

```yaml
  car_charging_battery_size:
    - 75
```

Previously the prose pointed at the example block further up the page, which is entirely commented out — a user who uncommented just the key line would leave `#  - 75` commented, get YAML `null`, and hit the same error. The decimal-place claim is dropped as well: the templates use `- 75` and `fetch.py` reads the value through `float()`.

The prose says an inline **number** fails, not that a list is mandatory — a string scalar *is* wrapped, so `car_charging_battery_size: sensor.my_car_kwh` validates fine, and overstating the rule would be a new inaccuracy.

Six subtests pin the validator's real behaviour rather than the doc text:

- a one-entry list passes
- a whole number in a list passes (`- 75`, as templates use)
- a bare number fails — the #2172 error, reproduced verbatim
- a string scalar still passes, because strings are wrapped
- with `num_cars: 2`, a two-entry list passes and an inline number fails as the **wrong type** (`is not a list, but requires 2 entries based on num_cars`) — a different code path and message from the one-car case

No code path changes. Car charging itself was never affected; the impact was the `config_valid` sensor and the "found N configuration errors" log line.

## Known follow-ups, deliberately not in this PR

Found while reviewing this area. All pre-existing, none belong in a documentation fix:

- **`car_charging_battery_size: [0]` validates clean** despite the schema's `zero: False`, and `plan.py` then divides by it (`fetch.py` guards, `plan.py` does not). The most substantive of the three — happy to file it.
- **`test_infra.py` ships the failing form** — `num_cars: 2` with an inline `car_charging_battery_size: 100.0`, so this key sits in the shared fixture's `arg_errors` baseline on every `validate_config()` call in the module.
- **`_run()` does not snapshot `manual_api`**, which this key routes through via `CONFIG_API_OVERRIDE`. A helper-level isolation gap affecting every subtest in the module.

## Testing

- `./run_all --test validate_config` — passes; log shows both distinct error messages
- `coverage/run_pre_commit` (12 hooks + `./run_all --quick`) — all passed, 4 slow skipped, 78.02s
