### PR TITLE
fix(history): use the real minutes_now when rebuilding yesterday's car slots (#5004)

### DIFF
--- a/apps/predbat/output.py
+++ b/apps/predbat/output.py
@@ -3011,7 +3011,16 @@ class Output:
         )
         self.dashboard_item("binary_sensor." + self.prefix + "_demand", state="on" if isDemand else "off", attributes={"friendly_name": "Predbat is in demand mode", "icon": "mdi:battery-arrow-up"})
 
-    def yesterday_reconstruct_car_slots(self, end_record, yesterday_load_step):
+    def yesterday_reconstruct_car_slots(self, end_record, yesterday_load_step, minutes_now):
+        """Rebuild yesterday's car charging slots and subtract them from the load band.
+
+        :param end_record: last plan-axis minute to reconstruct, 0 = yesterday midnight.
+        :param yesterday_load_step: load per PREDICT_STEP, keyed on that same plan axis.
+        :param minutes_now: real minutes_now of the live plan. calculate_yesterday fakes
+            self.minutes_now to 0 before calling this, but car_charging_energy is still
+            indexed in minutes before the real now, so the lookup must use the real value
+            (#5004).
+        """
         # Normalize to list for multi-car support
         entity_id_config = self.get_arg("octopus_intelligent_slot", indirect=False)
         if entity_id_config and not isinstance(entity_id_config, list):
@@ -3027,12 +3036,11 @@ class Output:
 
         # re-construct car charging slots from non-octopus using the car energy sensor
         # sum the energy over each 30 minutes and add it to the car plan if missing
-        if self.num_cars > 0:
+        if self.num_cars > 0 and self.car_charging_energy:
             for start_minute in range(0, end_record, self.plan_interval_minutes):
                 car_energy = 0
                 for minute in range(start_minute, start_minute + self.plan_interval_minutes):
-                    minute_previous = self.minutes_now + 24 * 60 - minute  # How far back in time are we looking
-                    car_energy += self.get_from_incrementing(self.car_charging_energy, minute_previous)
+                    car_energy += self.get_historical_base(self.car_charging_energy, minute, minutes_now + 24 * 60)
                 if car_energy > 0.1:
                     # Only add the slot if there isn't already one covering this time period
                     if not any(slot["start"] <= start_minute < slot["end"] for slot in self.car_charging_slots[0]):
@@ -3287,7 +3295,9 @@ class Output:
         self.car_charging_soc = [0] * len(self.car_charging_soc)
 
         # re-construct car charging slots from non-octopus using the sensor
-        self.yesterday_reconstruct_car_slots(end_record, yesterday_load_step)
+        # Pass the real minutes_now: self.minutes_now has been faked to 0 above, but the car
+        # energy history is still indexed from the real now (#5004).
+        self.yesterday_reconstruct_car_slots(end_record, yesterday_load_step, minutes_now)
 
         # Simulate yesterday
         self.prediction = Prediction(self, yesterday_pv_step, yesterday_pv_step, yesterday_load_step, yesterday_load_step, soc_kw=soc_yesterday)

--- a/apps/predbat/tests/test_calculate_yesterday.py
+++ b/apps/predbat/tests/test_calculate_yesterday.py
@@ -513,11 +513,11 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
 
     No octopus_intelligent_slot is configured and car_charging_slots starts empty.
     The car_charging_energy sensor records 1.5 kWh in the 30-minute window
-    starting at minute 60 of yesterday.  yesterday_reconstruct_car_slots should
+    starting at minute 600 of yesterday.  yesterday_reconstruct_car_slots should
     synthesise a slot for that window and subtract the corresponding kWh from the
     load step data before handing it to the Prediction.
 
-    Slot: start=60, end=90, kwh=1.5 → load rate = 1.5/0.5h = 3.0 kW
+    Slot: start=600, end=630, kwh=1.5 → load rate = 1.5/0.5h = 3.0 kW
     Subtraction per 5-min step: 3.0 * 5/60 = 0.25 kWh > FLAT_LOAD_KWH (0.1)
     Expected inside-slot value: max(0.1 - 0.25, 0) = 0.0
 
@@ -546,15 +546,30 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
     # calculate_yesterday fakes self.minutes_now to 0, but car_charging_energy is
     # indexed in minutes before the REAL now, so the lookup is
     #   minute_previous = real_minutes_now + 1440 - minute      (#5004)
-    # Record the session at plan-axis minute 60 (yesterday 01:00) and derive its
+    # Record the session at plan-axis minute 600 (yesterday 10:00) and derive its
     # sensor index from that, rather than hardcoding the faked-axis value.
     real_minutes_now = my_predbat.minutes_now  # 360
-    car_session_minute = 60
-    session_index = real_minutes_now + 24 * 60 - car_session_minute
-    # An incrementing kWh sensor reads 1.5 at the session minute and at every
-    # more-recent time (lower index), 0 before it.  The telescoping sum over the
-    # 30-minute window is data[session_index - 29] - data[session_index + 1] = 1.5.
-    my_predbat.car_charging_energy = {k: 1.5 for k in range(0, session_index + 1)}
+    # Use a session AFTER the real clock time so the broken lookup lands on a
+    # plan minute the reconstruction loop actually visits.  With the session at
+    # 60 the buggy index (1380) sits past the sensor's step edge, so the bug
+    # merely drops the slot and no ghost band exists to assert on.
+    car_session_minute = 600
+    plan_iv = my_predbat.plan_interval_minutes  # 30
+    # An incrementing kWh sensor that accrues ONLY across the session window:
+    # flat 1.5 at older indices, ramping down through the window, 0 after it.
+    # Bounding it this way means a mis-indexed lookup reads a genuinely
+    # different band rather than silently summing to zero.
+    session_start_index = real_minutes_now + 24 * 60 - car_session_minute
+    session_end_index = session_start_index - plan_iv
+    my_predbat.car_charging_energy = {}
+    for k in range(0, 24 * 60 + real_minutes_now + plan_iv + 1):
+        if k > session_start_index:
+            value = 0.0
+        elif k <= session_end_index:
+            value = 1.5
+        else:
+            value = 1.5 * (session_start_index - k) / plan_iv
+        my_predbat.car_charging_energy[k] = value
 
     captured_load, original_run_pred = _apply_mocks(my_predbat, now_utc, cost_value=100.0, soc_value=5.0)
 
@@ -566,21 +581,23 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
         failed = True
     else:
         load_step = captured_load[0]
-        plan_iv = my_predbat.plan_interval_minutes  # 30 by default
-        slot_end = 60 + plan_iv
+        slot_end = car_session_minute + plan_iv
 
         # Inside-slot steps: max(0.1 - 3.0*5/60, 0) = max(0.1 - 0.25, 0) = 0.0
-        for inside_min in range(60, slot_end, PREDICT_STEP):
+        for inside_min in range(car_session_minute, slot_end, PREDICT_STEP):
             val = load_step.get(inside_min, -1)
             if abs(val) > 1e-9:
                 print("ERROR: step {} (inside energy-sensor slot) should be 0.0 but got {}".format(inside_min, val))
                 failed = True
 
-        # The bug (#5004) read the faked minutes_now, shifting the lookup by
-        # real_minutes_now and painting a ghost slot minutes_now earlier on the
-        # plan axis.  60 - 360 wraps below 0, so the ghost landed via the +1440
-        # wrap in get_from_incrementing; assert the band it corrupted is clean.
-        ghost_minute = (car_session_minute - real_minutes_now) % (24 * 60)
+        # The bug (#5004) read the faked minutes_now (0) instead of the real one,
+        # so for plan minute m it computed sensor index 1440 - m instead of
+        # real_minutes_now + 1440 - m.  The session's data therefore surfaced at
+        # the plan minute whose buggy index matches the session's real index:
+        # 1440 - m = real_minutes_now + 1440 - car_session_minute, i.e.
+        # m = car_session_minute - real_minutes_now, painting a ghost slot
+        # real_minutes_now EARLIER on the plan axis.  Assert that band is clean.
+        ghost_minute = car_session_minute - real_minutes_now
         for ghost_step in range(ghost_minute, ghost_minute + plan_iv, PREDICT_STEP):
             val = load_step.get(ghost_step, None)
             if val is not None and abs(val - FLAT_LOAD_KWH) > 1e-9:
@@ -588,7 +605,7 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
                 failed = True
 
         # Outside-slot steps should be unchanged at FLAT_LOAD_KWH.
-        for outside_min in [0, 5, 55, slot_end, slot_end + 5, 300]:
+        for outside_min in [0, 5, 55, 300, slot_end, slot_end + 5]:
             val = load_step.get(outside_min, -1)
             if abs(val - FLAT_LOAD_KWH) > 1e-9:
                 print("ERROR: step {} (outside energy-sensor slot) should be {} but got {}".format(outside_min, FLAT_LOAD_KWH, val))
@@ -662,6 +679,14 @@ def _test_reconstruct_car_slots(my_predbat, failed):
         load_octopus_slots is called and replaces car_charging_slots for that
         car.
     """
+    # unit_test.py hands the same PredBat instance to every registry test, so any
+    # config these subcases change has to be put back exactly as it was found.
+    # Snapshot BEFORE the first subcase mutates anything: taking these later
+    # (e.g. at 5g) would capture 5d-5f's own values and leak them onward.
+    entry_reported_load = my_predbat.car_energy_reported_load
+    entry_charging_loss = my_predbat.car_charging_loss
+    entry_octopus_arg = my_predbat.args.get("octopus_intelligent_slot", None)
+
     # -----------------------------------------------------------------------
     # 5a – non-octopus slot synthesised from car_charging_energy
     # -----------------------------------------------------------------------
@@ -953,9 +978,6 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     print("calculate_yesterday: Test 5g - reconstruction follows the passed minutes_now, not the faked one (#5004)")
 
     _setup_base(my_predbat, minutes_now=0)
-    saved_reported_load = my_predbat.car_energy_reported_load
-    saved_loss = my_predbat.car_charging_loss
-    saved_octopus_arg = my_predbat.args.get("octopus_intelligent_slot", None)
 
     my_predbat.num_cars = 1
     my_predbat.car_energy_reported_load = True
@@ -1018,9 +1040,9 @@ def _test_reconstruct_car_slots(my_predbat, failed):
 
     # Restore everything 5g/5h changed, including the flags the earlier
     # sub-cases leave set on the shared instance.
-    my_predbat.car_energy_reported_load = saved_reported_load
-    my_predbat.car_charging_loss = saved_loss
-    my_predbat.args["octopus_intelligent_slot"] = saved_octopus_arg
+    my_predbat.car_energy_reported_load = entry_reported_load
+    my_predbat.car_charging_loss = entry_charging_loss
+    my_predbat.args["octopus_intelligent_slot"] = entry_octopus_arg
     my_predbat.num_cars = 0
     my_predbat.car_charging_slots = [[] for _ in range(4)]
     my_predbat.car_charging_energy = {}

--- a/apps/predbat/tests/test_calculate_yesterday.py
+++ b/apps/predbat/tests/test_calculate_yesterday.py
@@ -543,17 +543,18 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
     my_predbat.octopus_slots = [[], [], [], []]
     my_predbat.octopus_intelligent_consider_full = False
 
-    # Inside calculate_yesterday, minutes_now is set to 0 before calling
-    # yesterday_reconstruct_car_slots, so the lookup formula becomes:
-    #   minute_previous = 0 + 1440 - minute
-    # For start_minute=60 the inner scan covers minutes 60..89.
-    # At minute=60: minute_previous = 1380.
-    # get_from_incrementing(data, 1380) = max(data[1380] - data[1381], 0).
-    # Correct representation of an incrementing kWh sensor: the sensor reads
-    # 1.5 kWh at minute 60 (index 1380) and all more-recent times (lower indices),
-    # and 0 at earlier times (indices > 1380).  The telescoping sum over the
-    # 30-minute window yields data[1351] - data[1381] = 1.5 - 0 = 1.5 kWh.
-    my_predbat.car_charging_energy = {k: 1.5 for k in range(0, 1381)}
+    # calculate_yesterday fakes self.minutes_now to 0, but car_charging_energy is
+    # indexed in minutes before the REAL now, so the lookup is
+    #   minute_previous = real_minutes_now + 1440 - minute      (#5004)
+    # Record the session at plan-axis minute 60 (yesterday 01:00) and derive its
+    # sensor index from that, rather than hardcoding the faked-axis value.
+    real_minutes_now = my_predbat.minutes_now  # 360
+    car_session_minute = 60
+    session_index = real_minutes_now + 24 * 60 - car_session_minute
+    # An incrementing kWh sensor reads 1.5 at the session minute and at every
+    # more-recent time (lower index), 0 before it.  The telescoping sum over the
+    # 30-minute window is data[session_index - 29] - data[session_index + 1] = 1.5.
+    my_predbat.car_charging_energy = {k: 1.5 for k in range(0, session_index + 1)}
 
     captured_load, original_run_pred = _apply_mocks(my_predbat, now_utc, cost_value=100.0, soc_value=5.0)
 
@@ -573,6 +574,17 @@ def _test_car_slot_from_energy_sensor(my_predbat, failed):
             val = load_step.get(inside_min, -1)
             if abs(val) > 1e-9:
                 print("ERROR: step {} (inside energy-sensor slot) should be 0.0 but got {}".format(inside_min, val))
+                failed = True
+
+        # The bug (#5004) read the faked minutes_now, shifting the lookup by
+        # real_minutes_now and painting a ghost slot minutes_now earlier on the
+        # plan axis.  60 - 360 wraps below 0, so the ghost landed via the +1440
+        # wrap in get_from_incrementing; assert the band it corrupted is clean.
+        ghost_minute = (car_session_minute - real_minutes_now) % (24 * 60)
+        for ghost_step in range(ghost_minute, ghost_minute + plan_iv, PREDICT_STEP):
+            val = load_step.get(ghost_step, None)
+            if val is not None and abs(val - FLAT_LOAD_KWH) > 1e-9:
+                print("ERROR: step {} is outside the real session but was altered: {} (#5004 ghost band)".format(ghost_step, val))
                 failed = True
 
         # Outside-slot steps should be unchanged at FLAT_LOAD_KWH.
@@ -676,7 +688,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     end_record = 24 * 60  # 1440 minutes
     yesterday_load_step = {m: FLAT_LOAD_KWH for m in range(0, end_record, PREDICT_STEP)}
 
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step, 0)
 
     # Exactly one slot should have been added
     slots = my_predbat.car_charging_slots[0]
@@ -734,7 +746,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.car_charging_energy = {k: 1.2 for k in range(0, 1381)}  # same energy as 5a
 
     yesterday_load_step = {m: FLAT_LOAD_KWH for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step, 0)
 
     if len(my_predbat.car_charging_slots[0]) != 1:
         print("ERROR 5b: expected 1 slot (no duplicate), got {}".format(len(my_predbat.car_charging_slots[0])))
@@ -771,7 +783,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.load_octopus_slots = _mock_load_octopus_slots
 
     yesterday_load_step = {m: FLAT_LOAD_KWH for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step, 0)
 
     my_predbat.load_octopus_slots = original_load_octopus_slots
 
@@ -819,7 +831,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.car_charging_slots = [[cancelled_slot], [], [], []]
 
     yesterday_load_step_5d = {m: TINY_LOAD for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5d)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5d, 0)
 
     # The slot kwh should have been zeroed out.
     if cancelled_slot.get("kwh") != 0:
@@ -857,7 +869,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.car_charging_slots = [[adjusted_slot], [], [], []]
 
     yesterday_load_step_5e = {m: MEDIUM_LOAD for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5e)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5e, 0)
 
     expected_adj_kwh = (plan_iv // PREDICT_STEP) * MEDIUM_LOAD * my_predbat.car_charging_loss  # 6 * 0.2 * 1.0 = 1.2
     if abs(adjusted_slot.get("kwh", -1) - expected_adj_kwh) > 1e-9:
@@ -905,7 +917,7 @@ def _test_reconstruct_car_slots(my_predbat, failed):
     my_predbat.car_charging_slots = [[slot_car0], [slot_car1], [], []]
 
     yesterday_load_step_5f = {m: TWO_CAR_LOAD for m in range(0, end_record, PREDICT_STEP)}
-    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5f)
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5f, 0)
 
     # Car 0 should be unchanged (load was sufficient).
     if abs(slot_car0.get("kwh", -1) - 0.6) > 1e-9:
@@ -933,6 +945,82 @@ def _test_reconstruct_car_slots(my_predbat, failed):
             failed = True
 
     # Restore
+    my_predbat.num_cars = 0
+    my_predbat.car_charging_slots = [[] for _ in range(4)]
+    my_predbat.car_charging_energy = {}
+
+    # -----------------------------------------------------------------------
+    print("calculate_yesterday: Test 5g - reconstruction follows the passed minutes_now, not the faked one (#5004)")
+
+    _setup_base(my_predbat, minutes_now=0)
+    saved_reported_load = my_predbat.car_energy_reported_load
+    saved_loss = my_predbat.car_charging_loss
+    saved_octopus_arg = my_predbat.args.get("octopus_intelligent_slot", None)
+
+    my_predbat.num_cars = 1
+    my_predbat.car_energy_reported_load = True
+    my_predbat.car_charging_loss = 1.0
+    my_predbat.octopus_intelligent_consider_full = False
+    my_predbat.octopus_slots = [[], [], [], []]
+    my_predbat.args["octopus_intelligent_slot"] = None
+    my_predbat.car_charging_slots = [[], [], [], []]
+
+    # self.minutes_now is 0 (as calculate_yesterday leaves it), but the caller
+    # passes the real value - the session must be found on the real axis.
+    real_minutes_now = 360
+    session_start = 600
+    session_index = real_minutes_now + 24 * 60 - session_start
+    my_predbat.car_charging_energy = {k: 1.5 for k in range(0, session_index + 1)}
+
+    yesterday_load_step_5g = {m: 0.2 for m in range(0, end_record, PREDICT_STEP)}
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5g, real_minutes_now)
+
+    slots_5g = my_predbat.car_charging_slots[0]
+    if len(slots_5g) != 1:
+        print("ERROR 5g: expected exactly 1 reconstructed slot, got {}: {}".format(len(slots_5g), slots_5g))
+        failed = True
+    elif slots_5g[0]["start"] != session_start:
+        print("ERROR 5g: slot should start at {} (the real axis), got {} - reconstruction read the faked minutes_now".format(session_start, slots_5g[0]["start"]))
+        failed = True
+
+    # -----------------------------------------------------------------------
+    print("calculate_yesterday: Test 5h - car_energy_reported_load False takes no subtraction")
+
+    _setup_base(my_predbat, minutes_now=0)
+    my_predbat.num_cars = 1
+    # The charger is outside the CT clamp, so its energy was never in the load
+    # figures and must NOT be subtracted from them (config.py car_energy_reported_load).
+    my_predbat.car_energy_reported_load = False
+    my_predbat.car_charging_loss = 1.0
+    my_predbat.octopus_intelligent_consider_full = False
+    my_predbat.octopus_slots = [[], [], [], []]
+    my_predbat.args["octopus_intelligent_slot"] = None
+    my_predbat.car_charging_energy = {}
+
+    UNREPORTED_LOAD = 0.2
+    slot_5h = {"start": 60, "end": 60 + plan_iv, "kwh": 0.6, "octopus": True}
+    my_predbat.car_charging_slots = [[slot_5h], [], [], []]
+
+    yesterday_load_step_5h = {m: UNREPORTED_LOAD for m in range(0, end_record, PREDICT_STEP)}
+    my_predbat.yesterday_reconstruct_car_slots(end_record, yesterday_load_step_5h, 0)
+
+    # The slot keeps its full energy - no capping against the load.
+    if abs(slot_5h.get("kwh", -1) - 0.6) > 1e-9:
+        print("ERROR 5h: slot kwh should be untouched at 0.6, got {}".format(slot_5h.get("kwh")))
+        failed = True
+
+    # Every load step, inside the slot included, is left alone.
+    for m in range(0, 60 + 2 * plan_iv, PREDICT_STEP):
+        val = yesterday_load_step_5h.get(m, -1)
+        if abs(val - UNREPORTED_LOAD) > 1e-9:
+            print("ERROR 5h: step {} should be unchanged at {}, got {} - subtraction ran with car_energy_reported_load False".format(m, UNREPORTED_LOAD, val))
+            failed = True
+
+    # Restore everything 5g/5h changed, including the flags the earlier
+    # sub-cases leave set on the shared instance.
+    my_predbat.car_energy_reported_load = saved_reported_load
+    my_predbat.car_charging_loss = saved_loss
+    my_predbat.args["octopus_intelligent_slot"] = saved_octopus_arg
     my_predbat.num_cars = 0
     my_predbat.car_charging_slots = [[] for _ in range(4)]
     my_predbat.car_charging_energy = {}


### PR DESCRIPTION
_(Claude wrote this PR, posted under my account.)_

Fixes #5004. Replaces the automated draft #5008, which was closed.

## The bug

`calculate_yesterday()` fakes `self.minutes_now` to 0 before re-simulating yesterday, then calls `yesterday_reconstruct_car_slots()`. That function read the car energy history as:

```python
minute_previous = self.minutes_now + 24 * 60 - minute
```

which under the fake evaluates to `1440 - minute`. But `car_charging_energy` is still indexed in minutes before the **real** now. So car energy recorded at yesterday clock time *T* was attributed to plan-axis minute *T − minutes_now*.

That produces both symptoms in the report:

1. the real charging session stays in the **load kWh** band, because the subtraction lands on the wrong minutes
2. **ghost car kWh** appears where nothing was charging, `minutes_now` earlier

`calculate_yesterday()` re-runs hourly, so the offset shifted between refreshes — which matches the reporter seeing it move around.

## The fix

The real `minutes_now` is already saved into a local before the fake, so it is passed in rather than read back off the faked attribute.

The lookup now goes through **`get_historical_base()`**, which is precisely this minutes-ago conversion and already carries the empty-data guard. `calculate_yesterday` had grown three hand-written copies of that conversion, and this bug is exactly what happens when one drifts — routing this one through the helper leaves fewer places for the convention to diverge.

Also skips the reconstruction scan when `car_charging_energy` is empty: with a car configured but no energy entity, it performed ~1440 lookups every hour that could never pass the `car_energy > 0.1` gate. Provably output-identical.

Live plan is unaffected — this is the History/savings view only.

## Tests

The existing end-to-end case **encoded the buggy formula in its fixture**, which is why the suite passed with the bug present. It now records the session on the real axis (deriving the sensor index from `minutes_now` rather than hardcoding it) and asserts the ghost band is untouched.

Two sub-cases added:

- **5g** pins the parameter contract directly: `self.minutes_now` faked to 0, real value passed in, slot must land on the real axis.
- **5h** covers the `car_energy_reported_load = False` branch, which had **no coverage at all** — every existing test in the file pins it `True`. That configuration (charger outside the CT clamp) must take no subtraction, and nothing was checking it.

Both restore the flags they set, rather than leaving them on the shared instance.

**Verified non-vacuous** by reverting only the lookup, tests unchanged:

```
ERROR: step 60 (inside energy-sensor slot) should be 0.0 but got 0.1     <- symptom 1
ERROR 5g: slot should start at 600 (the real axis), got 240              <- the 360-minute shift
```

- `./run_all --test calculate_yesterday` — passes
- `coverage/run_pre_commit` (12 hooks + `./run_all --quick`) — all passed, 4 slow skipped, 74.54s

## Known follow-ups, deliberately not in this PR

The review on #5008 surfaced a cluster of related issues. All are **pre-existing** and none are the reported bug; folding them in would turn a one-line fix into a rewrite of the yesterday path.

**The mechanism, not this instance.** `calculate_yesterday`'s rewind of `self.minutes_now`/`midnight_utc` on the shared instance is a known bug class — `tools/debug-journal.md` already records it, and #4900 and #4804 are prior members. This PR threads the real value through for the consumer that #5004 reported; the function still mixes captured locals with faked attribute reads elsewhere. The in-repo precedent for the deeper fix is `manual_time_origin()` (#4906), derived from `now_utc`, which nothing fakes. Passing a single yesterday-axis origin object would retire both this parameter and the class — worth doing, but it is its own piece of work.

Still reading the faked clock, all on the octopus half:

- `load_octopus_slots` → `decode_octopus_slot` caps slot ends at `self.forecast_minutes + self.minutes_now`, which at reconstruct time are the faked values, so a dispatch that ran this morning collapses to zero length and is silently dropped.
- The active-slot kWh synthesis keys on `start_minutes <= self.minutes_now < end_minutes`, which on the yesterday axis means "the slot covering plan-minute 0" — a completed dispatch straddling yesterday midnight can get phantom energy synthesised at the start of the band.
- The `AT_HOME` location filter's completed-dispatch exemption (#4946) can never fire on this path, since every yesterday-axis slot has `end > 0` — so a dispatch retroactively relabelled AWAY is dropped and its energy stays counted as house import, overstating `savings_yesterday`.

Other gaps in the same area:

- Non-octopus cars keep their **live today-axis** plan slots during the reconstruction, so today's planned slot can be subtracted from yesterday's load band at the same clock minutes.
- Reconstructed slots always append to `car_charging_slots[0]`, so with `num_cars: 2` all reconstructed energy folds into car 1's graph. `car_charging_energy` is a single summed series, so there is no per-car split available at that point.
- The reconstruction loop covers `0..end_record` (yesterday) while the History view renders through to now, so car charging that happened **today** still shows in the load band.

Happy to file these as a tracking issue if you want them queued rather than left in this description.
