### PR TITLE
fix(tests): pin the prediction_batch fixture clock instead of inheriting the wall clock

### DIFF
--- a/apps/predbat/tests/test_infra.py
+++ b/apps/predbat/tests/test_infra.py
@@ -609,6 +609,13 @@ def update_rates_export(my_predbat, export_window_best):
     my_predbat.rate_scan_export(my_predbat.rate_export, print=False)
 
 
+# The fixture's clock: noon. create_predbat() pins minutes_now/now_utc from it so a standalone run
+# behaves like the suite, reset_inverter re-asserts the same value after its scenarios, and modules
+# that want to check their own clock import it rather than restating the literal - so the three can
+# never silently diverge (#5026).
+FIXTURE_MINUTES_NOW = 12 * 60
+
+
 def reset_inverter(my_predbat):
     my_predbat.inverter_limit = 1 / 60.0
     my_predbat.num_inverters = 1
@@ -656,7 +663,7 @@ def reset_inverter(my_predbat):
     my_predbat.iboost_smart = False
     my_predbat.iboost_on_export = False
     my_predbat.iboost_prevent_discharge = False
-    my_predbat.minutes_now = 12 * 60
+    my_predbat.minutes_now = FIXTURE_MINUTES_NOW
     my_predbat.best_soc_keep = 0.0
     my_predbat.carbon_enable = 0
     my_predbat.inverter_soc_reset = True

--- a/apps/predbat/tests/test_kernel_parity.py
+++ b/apps/predbat/tests/test_kernel_parity.py
@@ -57,9 +57,12 @@ RESULT_NAMES = [
     "final_carbon_g",
 ]
 
-# Attributes mutated by the parity scenarios, or by a module pinning the clock before them, that
-# reset_inverter/reset_rates do not restore; snapshotted before the tests and restored afterwards
-# so later tests see a clean predbat
+# Attributes mutated by the parity scenarios that reset_inverter/reset_rates do not restore;
+# snapshotted before the tests and restored afterwards so later tests see a clean predbat.
+# One exception: the parity scenarios only ever read minutes_now - its entry exists for
+# run_prediction_batch_tests, which pins the fixture clock while it runs and hands the caller's
+# back through the snapshot mechanism this list drives (#5026). Dropping the entry would leave
+# that module passing and only its own hand-back check failing, so it is documented here.
 SCENARIO_STATE_ATTRS = [
     "minutes_now",
     "soc_max",

--- a/apps/predbat/tests/test_kernel_parity.py
+++ b/apps/predbat/tests/test_kernel_parity.py
@@ -57,9 +57,11 @@ RESULT_NAMES = [
     "final_carbon_g",
 ]
 
-# Attributes mutated by the parity scenarios that reset_inverter/reset_rates do not restore;
-# snapshotted before the tests and restored afterwards so later tests see a clean predbat
+# Attributes mutated by the parity scenarios, or by a module pinning the clock before them, that
+# reset_inverter/reset_rates do not restore; snapshotted before the tests and restored afterwards
+# so later tests see a clean predbat
 SCENARIO_STATE_ATTRS = [
+    "minutes_now",
     "soc_max",
     "soc_kw",
     "reserve",

--- a/apps/predbat/tests/test_prediction_batch.py
+++ b/apps/predbat/tests/test_prediction_batch.py
@@ -34,6 +34,14 @@ from prediction_kernel import create_kernel_context
 from tests.test_kernel_parity import apply_random_scenario, kernel_available, make_step_data, make_windows, restore_scenario_state, snapshot_scenario_state
 
 
+# create_predbat() takes minutes_now from the wall clock, and only part of the day leaves the seed-5
+# routing scenario's ten trial costs distinct - an evening run collapses the three highest onto one
+# value and trips that test's precondition. Run after another module the value is whatever residue
+# that module left (reset_inverter's noon), so standalone runs failed while the full suite passed;
+# the module pins the same noon for itself rather than inheriting either (#5026).
+BATCH_TEST_MINUTES_NOW = 12 * 60
+
+
 def make_export_windows(minutes_now):
     """Build a small deterministic export window layout for the trial-input tests"""
     return [
@@ -605,20 +613,57 @@ def test_batch_thread_count_resolution():
     return failed
 
 
+def test_minutes_now_is_pinned_and_restored(my_predbat):
+    """The module must run on its own pinned clock and hand the caller's back, returns True on failure.
+
+    These tests used to inherit whatever minutes_now the fixture arrived with, which is the wall clock
+    standalone and reset_inverter's noon after another module has run. The routing test's precondition
+    - ten trial SoCs with ten distinct costs - only holds for part of the day, so the module failed
+    when run on its own in the evening and passed in the full suite purely on leftover state (#5026).
+
+    Pinning is only half of it: the pin must not follow the module out, or it would hand the next test
+    a clock the caller never set. That is what the scenario snapshot is for, so this checks the round
+    trip carries minutes_now rather than trusting the attribute list by eye.
+    """
+    print("**** Running pinned clock tests ****")
+    failed = False
+
+    if my_predbat.minutes_now != BATCH_TEST_MINUTES_NOW:
+        print("ERROR: the batch tests are running at minutes_now {}, expected the pinned {}".format(my_predbat.minutes_now, BATCH_TEST_MINUTES_NOW))
+        failed = True
+
+    # A value no fixture would set by chance, so a restore that misses it cannot pass by luck
+    state = snapshot_scenario_state(my_predbat)
+    my_predbat.minutes_now = BATCH_TEST_MINUTES_NOW + 137
+    restore_scenario_state(my_predbat, state)
+    if my_predbat.minutes_now != BATCH_TEST_MINUTES_NOW:
+        print("ERROR: the scenario snapshot does not restore minutes_now, left {} not {}".format(my_predbat.minutes_now, BATCH_TEST_MINUTES_NOW))
+        my_predbat.minutes_now = BATCH_TEST_MINUTES_NOW
+        failed = True
+
+    if not failed:
+        print("Pinned clock tests passed")
+    return failed
+
+
 def run_prediction_batch_tests(my_predbat):
     """Run every batched prediction test, returns True on failure"""
-    failed = test_export_trial_does_not_mutate_caller_window(my_predbat)
-    failed |= test_batch_thread_count_resolution()
-    failed |= test_available_cpu_count_respects_a_cgroup_quota()
-    failed |= test_batch_state_exists_without_a_base(my_predbat)
-
-    available, required_failure = kernel_available()
-    if not available:
-        print("WARNING: kernel not available - batch tests that need it are SKIPPED")
-        return failed or required_failure
-
+    # Snapshotted before anything is pinned so the caller's clock and scenario both go back untouched
     state = snapshot_scenario_state(my_predbat)
     try:
+        my_predbat.minutes_now = BATCH_TEST_MINUTES_NOW
+
+        failed = test_minutes_now_is_pinned_and_restored(my_predbat)
+        failed |= test_export_trial_does_not_mutate_caller_window(my_predbat)
+        failed |= test_batch_thread_count_resolution()
+        failed |= test_available_cpu_count_respects_a_cgroup_quota()
+        failed |= test_batch_state_exists_without_a_base(my_predbat)
+
+        available, required_failure = kernel_available()
+        if not available:
+            print("WARNING: kernel not available - batch tests that need it are SKIPPED")
+            return failed or required_failure
+
         failed |= test_queued_matches_direct(my_predbat)
         failed |= test_queued_range_window_in_the_past(my_predbat)
         failed |= test_batch_is_lazy(my_predbat)

--- a/apps/predbat/tests/test_prediction_batch.py
+++ b/apps/predbat/tests/test_prediction_batch.py
@@ -31,15 +31,8 @@ from const import PREDICT_STEP, PV_SCENARIO_NOMINAL, PV_SCENARIO_PV10
 from plan import resolve_batch_threads
 from prediction import Prediction
 from prediction_kernel import create_kernel_context
+from tests.test_infra import FIXTURE_MINUTES_NOW
 from tests.test_kernel_parity import apply_random_scenario, kernel_available, make_step_data, make_windows, restore_scenario_state, snapshot_scenario_state
-
-
-# create_predbat() takes minutes_now from the wall clock, and only part of the day leaves the seed-5
-# routing scenario's ten trial costs distinct - an evening run collapses the three highest onto one
-# value and trips that test's precondition. Run after another module the value is whatever residue
-# that module left (reset_inverter's noon), so standalone runs failed while the full suite passed;
-# the module pins the same noon for itself rather than inheriting either (#5026).
-BATCH_TEST_MINUTES_NOW = 12 * 60
 
 
 def make_export_windows(minutes_now):
@@ -613,47 +606,21 @@ def test_batch_thread_count_resolution():
     return failed
 
 
-def test_minutes_now_is_pinned_and_restored(my_predbat):
-    """The module must run on its own pinned clock and hand the caller's back, returns True on failure.
-
-    These tests used to inherit whatever minutes_now the fixture arrived with, which is the wall clock
-    standalone and reset_inverter's noon after another module has run. The routing test's precondition
-    - ten trial SoCs with ten distinct costs - only holds for part of the day, so the module failed
-    when run on its own in the evening and passed in the full suite purely on leftover state (#5026).
-
-    Pinning is only half of it: the pin must not follow the module out, or it would hand the next test
-    a clock the caller never set. That is what the scenario snapshot is for, so this checks the round
-    trip carries minutes_now rather than trusting the attribute list by eye.
-    """
-    print("**** Running pinned clock tests ****")
-    failed = False
-
-    if my_predbat.minutes_now != BATCH_TEST_MINUTES_NOW:
-        print("ERROR: the batch tests are running at minutes_now {}, expected the pinned {}".format(my_predbat.minutes_now, BATCH_TEST_MINUTES_NOW))
-        failed = True
-
-    # A value no fixture would set by chance, so a restore that misses it cannot pass by luck
-    state = snapshot_scenario_state(my_predbat)
-    my_predbat.minutes_now = BATCH_TEST_MINUTES_NOW + 137
-    restore_scenario_state(my_predbat, state)
-    if my_predbat.minutes_now != BATCH_TEST_MINUTES_NOW:
-        print("ERROR: the scenario snapshot does not restore minutes_now, left {} not {}".format(my_predbat.minutes_now, BATCH_TEST_MINUTES_NOW))
-        my_predbat.minutes_now = BATCH_TEST_MINUTES_NOW
-        failed = True
-
-    if not failed:
-        print("Pinned clock tests passed")
-    return failed
-
-
 def run_prediction_batch_tests(my_predbat):
     """Run every batched prediction test, returns True on failure"""
-    # Snapshotted before anything is pinned so the caller's clock and scenario both go back untouched
+    # The module pins the fixture clock (create_predbat already does, so this is belt and braces
+    # against the fixture ever drifting) and hands the caller's clock and scenario back through the
+    # snapshot. entry_minutes_now records the clock as the caller left it so the finally can prove
+    # the hand-back rather than trusting that the attribute list still carries minutes_now (#5026
+    # review): a dropped list entry or a snapshot taken after the pin leaves the pin's value behind
+    # and fails here.
+    entry_minutes_now = my_predbat.minutes_now
     state = snapshot_scenario_state(my_predbat)
+    clock_handed_back = False
+    failed = False
     try:
-        my_predbat.minutes_now = BATCH_TEST_MINUTES_NOW
+        my_predbat.minutes_now = FIXTURE_MINUTES_NOW
 
-        failed = test_minutes_now_is_pinned_and_restored(my_predbat)
         failed |= test_export_trial_does_not_mutate_caller_window(my_predbat)
         failed |= test_batch_thread_count_resolution()
         failed |= test_available_cpu_count_respects_a_cgroup_quota()
@@ -662,18 +629,27 @@ def run_prediction_batch_tests(my_predbat):
         available, required_failure = kernel_available()
         if not available:
             print("WARNING: kernel not available - batch tests that need it are SKIPPED")
-            return failed or required_failure
-
-        failed |= test_queued_matches_direct(my_predbat)
-        failed |= test_queued_range_window_in_the_past(my_predbat)
-        failed |= test_batch_is_lazy(my_predbat)
-        failed |= test_batch_cache_and_dedup(my_predbat)
-        failed |= test_batch_fallbacks(my_predbat)
-        failed |= test_save_run_drains_pending_batch(my_predbat)
-        failed |= test_batch_results_match_their_own_job(my_predbat)
+            failed |= required_failure
+        else:
+            # Reset the kernel flag only when the kernel tests actually ran - the skip path must not
+            # touch shared fixture state the caller never saw change before (#5026 review)
+            try:
+                failed |= test_queued_matches_direct(my_predbat)
+                failed |= test_queued_range_window_in_the_past(my_predbat)
+                failed |= test_batch_is_lazy(my_predbat)
+                failed |= test_batch_cache_and_dedup(my_predbat)
+                failed |= test_batch_fallbacks(my_predbat)
+                failed |= test_save_run_drains_pending_batch(my_predbat)
+                failed |= test_batch_results_match_their_own_job(my_predbat)
+            finally:
+                my_predbat.prediction_kernel_enable = False
     finally:
         restore_scenario_state(my_predbat, state)
-        my_predbat.prediction_kernel_enable = False
+        clock_handed_back = my_predbat.minutes_now == entry_minutes_now
+
+    if not clock_handed_back:
+        print("ERROR: the batch tests handed back minutes_now {} instead of the caller's {}".format(my_predbat.minutes_now, entry_minutes_now))
+        failed = True
 
     if failed:
         print("**** Prediction batch tests FAILED ****")

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -13,6 +13,7 @@ import time
 import sys
 import glob
 import argparse
+from datetime import timedelta
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -20,7 +21,7 @@ if hasattr(sys.stderr, "reconfigure"):
     sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 from predbat import PredBat
-from tests.test_infra import TestHAInterface, set_plot_enabled
+from tests.test_infra import FIXTURE_MINUTES_NOW, TestHAInterface, set_plot_enabled
 from tests.test_compute_metric import run_compute_metric_tests
 from tests.test_pv90 import run_pv90_tests
 from tests.test_performance_tweaks import run_performance_tweaks_tests
@@ -388,6 +389,15 @@ def create_predbat():
     my_predbat.states = {}
     my_predbat.reset()
     my_predbat.update_time()
+    # update_time() takes the clock from the host, so the same module used to behave differently
+    # standalone and in the suite - a suite run sat at reset_inverter's noon residue while a
+    # standalone run inherited the wall clock, and a time-of-day-dependent test could pass one way
+    # and fail the other (#5026). Pin the fixture clock here instead, now_utc from midnight_utc so
+    # the two stay consistent, the same way the scenario loader pins a scenario's own clock
+    # (test_random_scenarios.py apply_random_scenario). Modules that want more still pin and hand
+    # their clock back themselves, but nothing inherits the wall clock any more.
+    my_predbat.minutes_now = FIXTURE_MINUTES_NOW
+    my_predbat.now_utc = my_predbat.midnight_utc + timedelta(minutes=FIXTURE_MINUTES_NOW)
     my_predbat.ha_interface = TestHAInterface()
     my_predbat.ha_interface.base = my_predbat
     my_predbat.ha_interface.history_enable = False

--- a/apps/predbat/unit_test.py
+++ b/apps/predbat/unit_test.py
@@ -394,8 +394,10 @@ def create_predbat():
     # standalone run inherited the wall clock, and a time-of-day-dependent test could pass one way
     # and fail the other (#5026). Pin the fixture clock here instead, now_utc from midnight_utc so
     # the two stay consistent, the same way the scenario loader pins a scenario's own clock
-    # (test_random_scenarios.py apply_random_scenario). Modules that want more still pin and hand
-    # their clock back themselves, but nothing inherits the wall clock any more.
+    # (test_random_scenarios.py apply_random_scenario). Only minutes_now and now_utc are pinned
+    # here - update_time() has already taken midnight_utc and now_utc_real from the host clock
+    # and they are left alone. Modules that want more still pin and hand their clock back
+    # themselves, but no module inherits the wall clock into those two fields any more.
     my_predbat.minutes_now = FIXTURE_MINUTES_NOW
     my_predbat.now_utc = my_predbat.midnight_utc + timedelta(minutes=FIXTURE_MINUTES_NOW)
     my_predbat.ha_interface = TestHAInterface()

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -1151,6 +1151,8 @@ class CleanupModelTests(unittest.TestCase):
                 start = source.index(flow)
                 block = source[start : source.index("\ndef ", start + 10)]
                 self.assertIn("review_only=True", block)
+
+
 class JournalPrBodyTests(DaemonPathsTestCase):
     """The flush cannot pass a PR body on a command line - permission rules match a command
     string and a multi-line command matches nothing - so it edits a file and the daemon opens


### PR DESCRIPTION
This is an automated draft PR generated from issue #5026 — a maintainer should review it before merging.

Fixes #5026

## Summary

`run_prediction_batch_tests` took `minutes_now` from whatever `create_predbat()` left on the fixture — the host's wall clock standalone, `reset_inverter`'s noon once another module has run. The routing test's precondition (ten trial SoCs giving ten distinct costs) only holds for part of the day: at ~20:15 BST the three highest SoCs collapse onto one cost, so the distinctness guard trips before any routing is compared. That is why the module failed standalone in the evening and passed inside the full suite, on leftover state rather than on merit.

After review the fix pins the fixture clock at its source rather than per module: `FIXTURE_MINUTES_NOW = 12 * 60` (noon) now lives in `tests/test_infra.py`, and `create_predbat()` sets `minutes_now`/`now_utc` from it immediately after `update_time()`, the same way `apply_random_scenario` pins a scenario's own clock. `reset_inverter` re-asserts the same constant instead of restating the literal, so the pins cannot silently diverge and no module inherits the wall clock into those two fields. Only those two fields are pinned — `midnight_utc`/`now_utc_real` still come from the host clock.

`run_prediction_batch_tests` keeps a pin of its own as belt and braces against the fixture ever drifting: it records the caller's clock on entry, snapshots the scenario state, pins, and restores in a `finally`. `minutes_now` was added to `SCENARIO_STATE_ATTRS` so the pin is handed back rather than leaking to the next module, and the runner then fails if the restored clock is not the caller's — which pins the snapshot-before-pin ordering as well as the round trip. The kernel-unavailable early return no longer resets `prediction_kernel_enable`; that reset now runs only when the kernel tests actually ran, so the skip path writes no shared fixture state. Nothing in the batch code itself changed; the failing check was on the test's own oracle, so no result was ever actually misrouted.

Coverage for the clock hand-back is that runner-level check rather than a separate named test. An earlier revision of this PR added a standalone `test_minutes_now_is_pinned_and_restored`; review found it deep-copied the whole ~70-attribute scenario state to assert one int and carried a dead repair line, so it was replaced by the in-runner check, which exercises the same `snapshot_scenario_state` → pin → `restore_scenario_state` path with the caller's real entry value on every invocation, including the kernel-skip path.

## Testing

- Reproduced first on main (d48cb223) at 20:28 BST: `tools/triage_test.sh prediction_batch` failed with costs `[..., 2590.8878, 2590.8878, 2590.8878]`.
- After the change, the same standalone command passes at the same time of day (exit 0, all subtests including the routing test).
- A temporary registered probe test confirmed a fresh `create_predbat()` carries `minutes_now = 720` and `now_utc = midnight + 720` (probe removed before commit).
- `coverage/run_pre_commit` passes: every hook Passed, and the quick suite it runs is green — `kernel_parity` included, since it shares `SCENARIO_STATE_ATTRS`.

## Notes

Same family as the trap the debug journal already records under "Build test dates from Predbat's clock, not the machine's" (and PR #5013 / #4998): a fixture inheriting the host's clock instead of a pinned one. This variant is about `minutes_now` rather than the calendar date.
