### PR TITLE
Make the PR flow prove its test can fail

### DIFF
--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -43,23 +43,21 @@ Both of these must pass before you continue to step 5. `run_pre_commit` must run
 cd coverage
 ./run_pre_commit
 cd ..
-tools/triage_test.sh <name> <scratch>/test.log
-```
-
-Use the test module named in the triage comment, or the one `TEST_REGISTRY` maps to the area you changed. If there's no clean single-module mapping, run `./run_all --quick` instead (from `coverage/`, same as above) rather than guessing at a module name.
-
-If either fails, stop here — do not commit, push, or open a PR. Go to step 7 and report what failed.
-
-### Prove your test can fail
-
-A test that passes with and without your change is not coverage, it is decoration — and it is easy to write one by accident. Before the gate counts as passed, check the new test actually fails without the fix:
-
-```bash
-git stash push -- <the source files you changed, NOT the test file>
+git stash push -u -- <the source files you changed, NOT the test file>
 tools/triage_test.sh <name> <scratch>/test-red.log     # expect FAILURE
 git stash pop
 tools/triage_test.sh <name> <scratch>/test.log         # expect PASS
 ```
+
+Use the test module named in the triage comment, or the one `TEST_REGISTRY` maps to the area you changed. If there's no clean single-module mapping, run `./run_all --quick` instead (from `coverage/`, same as above) rather than guessing at a module name.
+
+If `run_pre_commit` fails, or the second run does not pass, stop here — do not commit, push, or open a PR. Go to step 7 and report what failed.
+
+### Why the module runs twice
+
+A test that passes with and without your change is not coverage, it is decoration — and it is easy to write one by accident. The first run is the proof that the test can fail; the second is the gate. **A red run that passes is a failure of the check**, not a pass: stop and work out why before going further.
+
+`-u` is not optional. Without it, `git stash push` **fails outright** on a fix that adds a new source file — it refuses with "Did you forget to 'git add'?" and stashes *nothing*, so the red run contains your entire fix, passes, and tells you the opposite of the truth. Check the stash actually happened before trusting a red run: the source file should be back to its committed content, and any new file gone.
 
 Stash only the source change. If you stash the test too, both runs pass and you have proved nothing.
 

--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -50,6 +50,25 @@ Use the test module named in the triage comment, or the one `TEST_REGISTRY` maps
 
 If either fails, stop here — do not commit, push, or open a PR. Go to step 7 and report what failed.
 
+### Prove your test can fail
+
+A test that passes with and without your change is not coverage, it is decoration — and it is easy to write one by accident. Before the gate counts as passed, check the new test actually fails without the fix:
+
+```bash
+git stash push -- <the source files you changed, NOT the test file>
+tools/triage_test.sh <name> <scratch>/test-red.log     # expect FAILURE
+git stash pop
+tools/triage_test.sh <name> <scratch>/test.log         # expect PASS
+```
+
+Stash only the source change. If you stash the test too, both runs pass and you have proved nothing.
+
+Report both outcomes in the PR body's Testing section — "fails without the fix, passes with it" is the sentence a reviewer is looking for.
+
+If `git stash pop` reports a conflict, **stop and go to step 7**. Do not improvise another way to restore the change; say the fix is stashed and needs recovering by hand.
+
+Some fixes genuinely cannot be made to fail on this harness, and that is a real finding rather than an excuse. The GH#4965 guard is the worked example: deleting the attribute it protects does not reproduce the crash, because the mock inverter never reaches the read. When that happens, say which and why in the PR body, and make the test assert the guard is present rather than dressing up a reproduction that would pass either way.
+
 ## 5. Branch, commit, push
 
 Branch name: `fix/<slug>-<issue-number>` for a `bug` classification, `feat/<slug>-<issue-number>` for `enhancement` — matching this repo's existing convention (e.g. `fix/solis-tou-bit-refused-4707`). `<slug>` is a short kebab-case description of the change.
@@ -81,7 +100,7 @@ Fixes #<issue-number>
 
 ## Testing
 
-<what you ran in step 4 and its result>
+<what you ran in step 4 and its result, including whether the new test fails without the fix>
 
 ## Notes
 


### PR DESCRIPTION
The PR flow already writes a test and runs it — every run in the archive shows a real `triage_test.sh` invocation, and the gate blocks committing if it fails. What nothing checked is whether the new test would **fail without the fix**.

That gap matters because a test which passes either way looks identical to real coverage.

## It isn't hypothetical

Two bot-authored tests reviewed this week could not fail:

- one asserted that the permission strings equalled what the code had just built — true, and useless; it could never have caught the `.claude/` write block that stalled the journal for days
- one wrote into a directory that always existed, because a derived path constant was never patched in the test base class. It was silently writing into the operator's live bot directory.

Both looked fine in review.

## The change

Step 4 now asks for a red/green check:

```bash
git stash push -- <source files, NOT the test>
tools/triage_test.sh <name> <scratch>/test-red.log     # expect FAILURE
git stash pop
tools/triage_test.sh <name> <scratch>/test.log         # expect PASS
```

and asks for both outcomes in the PR body's Testing section — *"fails without the fix, passes with it"* is the sentence a reviewer wants. It's cheap, since the flow is already running that module. Verified the grants cover it: `git stash push -- <file>`, `git stash pop` and `triage_test.sh` are all already permitted to this flow.

## Two failure modes spelled out

**Stashing the test too.** Then both runs pass and nothing is proved. The instruction names it, because it's the obvious way to get a green result by accident.

**Fixes that genuinely cannot fail on this harness.** This is real, not an excuse, so the skill gives the worked example: the GH#4965 guard: deleting the attribute it protects doesn't reproduce the crash, because the mock inverter never reaches the read. When that happens the flow should say which and why, and assert the guard is *present* — rather than dressing up a reproduction that would pass either way. Without this carve-out a run would be pushed toward faking the red.

A failed `git stash pop` routes to step 7 rather than being worked around — the same rule the cleanup skill learned the hard way when improvising around a refused push put an unreviewed commit on `main`.

Documentation only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
