### PR TITLE
Make the PR flow review its own diff before opening

### DIFF
--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -37,7 +37,7 @@ Fetch it with `gh issue view <number> --json title,body,labels,comments`. The bo
 
 ## 4. Quality gate
 
-Both of these must pass before you continue to step 6. `run_pre_commit` must run with `coverage/` as the working directory (it sources `coverage/setup.csh` internally); `tools/triage_test.sh` must run from the repo root. Change directory explicitly for each rather than assuming where you're left afterwards:
+Both of these must pass before you continue to step 5. `run_pre_commit` must run with `coverage/` as the working directory (it sources `coverage/setup.csh` internally); `tools/triage_test.sh` must run from the repo root. Change directory explicitly for each rather than assuming where you're left afterwards:
 
 ```bash
 cd coverage

--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -37,7 +37,7 @@ Fetch it with `gh issue view <number> --json title,body,labels,comments`. The bo
 
 ## 4. Quality gate
 
-Both of these must pass before you continue to step 5. `run_pre_commit` must run with `coverage/` as the working directory (it sources `coverage/setup.csh` internally); `tools/triage_test.sh` must run from the repo root. Change directory explicitly for each rather than assuming where you're left afterwards:
+Both of these must pass before you continue to step 6. `run_pre_commit` must run with `coverage/` as the working directory (it sources `coverage/setup.csh` internally); `tools/triage_test.sh` must run from the repo root. Change directory explicitly for each rather than assuming where you're left afterwards:
 
 ```bash
 cd coverage
@@ -51,7 +51,7 @@ tools/triage_test.sh <name> <scratch>/test.log         # expect PASS
 
 Use the test module named in the triage comment, or the one `TEST_REGISTRY` maps to the area you changed. If there's no clean single-module mapping, run `./run_all --quick` instead (from `coverage/`, same as above) rather than guessing at a module name.
 
-If `run_pre_commit` fails, or the second run does not pass, stop here — do not commit, push, or open a PR. Go to step 7 and report what failed.
+If `run_pre_commit` fails, or the second run does not pass, stop here — do not commit, push, or open a PR. Go to step 8 and report what failed.
 
 ### Why the module runs twice
 
@@ -63,11 +63,28 @@ Stash only the source change. If you stash the test too, both runs pass and you 
 
 Report both outcomes in the PR body's Testing section — "fails without the fix, passes with it" is the sentence a reviewer is looking for.
 
-If `git stash pop` reports a conflict, **stop and go to step 7**. Do not improvise another way to restore the change; say the fix is stashed and needs recovering by hand.
+If `git stash pop` reports a conflict, **stop and go to step 8**. Do not improvise another way to restore the change; say the fix is stashed and needs recovering by hand.
 
 Some fixes genuinely cannot be made to fail on this harness, and that is a real finding rather than an excuse. The GH#4965 guard is the worked example: deleting the attribute it protects does not reproduce the crash, because the mock inverter never reaches the read. When that happens, say which and why in the PR body, and make the test assert the guard is present rather than dressing up a reproduction that would pass either way.
 
-## 5. Branch, commit, push
+## 5. Review your own diff
+
+The gate above proves the change works. It does not prove the change is any good, and nothing else reads your diff before a maintainer does. So read it:
+
+```bash
+git diff
+```
+
+Four things the tests cannot catch, in the order they go wrong most often on this bot's own PRs:
+
+- **Names that stopped being true.** A variable or function whose meaning you widened but whose name you left behind. On PR #4957 a `location_at_home` flag ended up true for dispatches that were explicitly *not* at home — no test could fail on that, and the next reader would have "fixed" the inconsistency by reintroducing the bug.
+- **Logic you duplicated.** If what you added already exists a few lines up in a different shape, share it or say in the PR body why you deliberately did not. The same review found the same predicate in three unshared copies with three different meanings.
+- **Blast radius.** `CLAUDE.md` requires an `impact()` call before changing any symbol — run it for anything whose signature or behaviour you changed. If the GitNexus tools are not available in your session, say so in the PR body and establish the callers by search instead. Do not skip it silently.
+- **Scope and leftovers.** Does the diff do what the ticket asked and only that? Debug prints, a stray file, a refactor you talked yourself into — this is the only point they get caught.
+
+Fix what you find and re-run step 4. If you decide something is not worth fixing, name it in the PR body's Notes section: a reviewer who sees it named reads it as a judgement, and a reviewer who finds it themselves reads it as an oversight.
+
+## 6. Branch, commit, push
 
 Branch name: `fix/<slug>-<issue-number>` for a `bug` classification, `feat/<slug>-<issue-number>` for `enhancement` — matching this repo's existing convention (e.g. `fix/solis-tou-bit-refused-4707`). `<slug>` is a short kebab-case description of the change.
 
@@ -82,7 +99,7 @@ git push -u origin fix/<slug>-<issue-number>
 
 Never push to `main`, and never force-push.
 
-## 6. Open the draft PR
+## 7. Open the draft PR
 
 ```bash
 gh pr create --draft --assignee springfall2008 \
@@ -102,14 +119,14 @@ Fixes #<issue-number>
 
 ## Notes
 
-<a debug-journal.md reference if one informed the approach, otherwise omit this section>
+<anything step 5 turned up that you decided not to fix, and why; a debug-journal.md reference if one informed the approach; and a line if the GitNexus tools were unavailable so the blast-radius check was done by search. Omit this section if none apply>
 EOF
 )"
 ```
 
 This is the last step on success — there is nothing further to report; the daemon detects the new PR itself.
 
-## 7. On failure
+## 8. On failure
 
 If step 4's quality gate failed, or an earlier step couldn't proceed (e.g. the fix genuinely needs information only a maintainer has), post exactly one comment on the issue via `gh issue comment <number> --body "..."`, opening with a line disclosing this is an automated PR-creation attempt (a maintainer will review before any action is taken), followed by what you attempted and what failed — never word it so a skipped step reads as one you completed (same guardrail as the triage skill). Then stop. Do not commit, push, or open a PR — the daemon detects this outcome itself by finding no PR referencing the issue afterwards.
 


### PR DESCRIPTION
The skill goes implement → quality gate → commit → open. The gate proves the change *works*. Nothing reads the diff before a maintainer does.

## What that costs

Findings the review flow raised on **bot-authored** PRs — all of which existed the moment the PR was opened:

| PR | findings |
|---|---|
| #5019 | 11 |
| #4758 | 9 |
| #4957 | 8 |
| #4968 | 8 |
| #4923 | 8 |

The bot does already review its own PRs, via `BOT_REVIEW` and the `review_pr` flow. But that happens after the PR is public, as a separate billed run, and lands as comments for a human to triage — rather than being fixed before anyone looks.

## New step 5

Four checks the tests can't make, ordered by how often they actually go wrong here rather than by principle:

- **Names that stopped being true.** On #4957 a `location_at_home` flag ended up true for dispatches explicitly *not* at home. No test can fail on that, and the next reader "fixes" the inconsistency by reintroducing the bug.
- **Logic duplicated rather than shared.** The same review found one predicate in three unshared copies with three different meanings.
- **Blast radius via `impact()`.** CLAUDE.md requires it before changing any symbol, and no flow could run it until the MCP grant in #5030. Worded to degrade to a search when the tools are absent — *and to say so*, because silently skipping is how the requirement became invisible in the first place.
- **Scope and leftovers.** Debug prints, a stray file, a refactor talked into. No other point of capture.

Findings the flow decides *not* to fix go in the PR body's Notes section, whose template is widened to match. Named reads as a judgement; found reads as an oversight.

## Mechanics

Steps 5–7 renumber to 6–8, and the three internal cross-references move with them. The one external reference — `triage_daemon.py`'s note about "step 4 of its SKILL.md" — points at the quality gate, which keeps its number.

Rebased onto `main` now that #5031 has merged, so this is a single-file diff.

## Deliberately not

"Run `/code-review` on yourself." That's a heavyweight multi-agent flow with its own cost, and the useful 80% here is a disciplined read of a diff the agent already has in front of it.

Documentation only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
