### PR TITLE
Unbreak black on main, and remove the last stale claims

### DIFF
--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -1151,10 +1151,14 @@ class CleanupModelTests(unittest.TestCase):
                 start = source.index(flow)
                 block = source[start : source.index("\ndef ", start + 10)]
                 self.assertIn("review_only=True", block)
+
+
 class JournalPrBodyTests(DaemonPathsTestCase):
-    """The flush cannot pass a PR body on a command line - permission rules match a command
-    string and a multi-line command matches nothing - so it edits a file and the daemon opens
-    the PR. PR #5011 shipped a one-line body promising a list that never arrived."""
+    """The flush writes its PR body to a file and the daemon opens the PR. A body is many
+    lines of markdown, and assembling one in the shell means getting the quoting right on top
+    of the permission matcher - --body-file needs a file the flush has no grant to create, and
+    a --body heredoc puts the whole body through shell quoting. PR #5011 shipped a one-line
+    body promising a per-candidate list that never arrived."""
 
     def test_the_placeholder_is_written_before_the_run(self):
         """Edit needs an existing file, and a Write grant is not an option here."""

--- a/tools/test_triage_daemon.py
+++ b/tools/test_triage_daemon.py
@@ -1155,10 +1155,9 @@ class CleanupModelTests(unittest.TestCase):
 
 class JournalPrBodyTests(DaemonPathsTestCase):
     """The flush writes its PR body to a file and the daemon opens the PR. A body is many
-    lines of markdown, and assembling one in the shell means getting the quoting right on top
-    of the permission matcher - --body-file needs a file the flush has no grant to create, and
-    a --body heredoc puts the whole body through shell quoting. PR #5011 shipped a one-line
-    body promising a per-candidate list that never arrived."""
+    lines of markdown, and building one inline for --body is brittle (shell quoting + permission
+    matching), while --body-file needs an existing file path the flush has no grant to create.
+    PR #5011 shipped a one-line body promising a per-candidate list that never arrived."""
 
     def test_the_placeholder_is_written_before_the_run(self):
         """Edit needs an existing file, and a Write grant is not an option here."""

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -985,10 +985,11 @@ def journal_pr_body():
 def open_journal_pr(today):
     """Open the draft PR for a journal branch the flush pushed, if it did not already exist.
 
-    Done here rather than inside the flush because a pull request body does not fit on a
-    command line: permission rules match a command string, a multi-line command matches
-    nothing, and a real per-candidate list is many lines. Opening it from the daemon also
-    means the one flow that can push no longer needs a `gh pr create` grant at all.
+    Done here rather than inside the flush because the body is written to a file: the flush
+    has no grant that would let it create one for --body-file, and building a real
+    per-candidate list into a --body argument means getting shell quoting right over many
+    lines of markdown. Opening it from the daemon also means the one flow that can push no
+    longer needs a `gh pr create` grant at all.
 
     A flush that deliberately landed nothing pushes no branch, so there is nothing to open.
     """

--- a/tools/triage_daemon.py
+++ b/tools/triage_daemon.py
@@ -985,9 +985,9 @@ def journal_pr_body():
 def open_journal_pr(today):
     """Open the draft PR for a journal branch the flush pushed, if it did not already exist.
 
-    Done here rather than inside the flush because the body is written to a file: the flush
-    has no grant that would let it create one for --body-file, and building a real
-    per-candidate list into a --body argument means getting shell quoting right over many
+    Done here rather than inside the flush because the body is written to a pre-created file: the flush
+    can edit it but has no grant to create it for --body-file. Building a real
+    per-candidate list into a --body argument would also require careful shell quoting over many
     lines of markdown. Opening it from the daemon also means the one flow that can push no
     longer needs a `gh pr create` grant at all.
 


### PR DESCRIPTION
**`main` is currently failing pre-commit on `black`.** This restores it.

## What happened

My fault, and worth stating plainly. Resolving the #5014 rebase conflict meant splicing two test-class blocks together, and I stripped one blank line too many. I then force-pushed the resolved branch **without re-running the quality gate on the resolved tree** — I had run it before the rebase, not after. The PR merged with black failing.

The irony isn't lost on me: this is the exact failure mode #5032 adds a step to catch — re-read your own diff before it goes anywhere.

Two blank lines restored, taken verbatim from black's own fix.

## Also: the last of a correction

Two docstrings still claimed a multi-line command "matches nothing". That's false, and I'd already corrected it elsewhere — multi-line commands work; **shell redirection to a file** is what's refused, which is why `--body-file` was out of reach and `--body` never was.

The earlier correction caught the skill text and one comment but missed `open_journal_pr`'s docstring and `JournalPrBodyTests`'. Neither copy remains.

## Verification

`run_pre_commit`: clean. Suite: 256 passing. Both run against **this** tree — which is the whole point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)