### PR TITLE
Fix GE Cloud force charge scheduling

### DIFF
--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -1016,6 +1016,7 @@ class GECloudDirect(ComponentBase):
         device_ha_names = {regname_to_ha(registers[key].get("name", "")) for key in registers}
         has_charge_power = "battery_charge_power" in device_ha_names
         has_discharge_power = "battery_discharge_power" in device_ha_names
+        has_force_charge = "enable_force_charge" in device_ha_names
         # Predbat drives the export target register itself (discharge_target_soc, the DC discharge
         # lower SoC limit) and tracks the minimum reserve SoC there, so leave that one alone rather
         # than resetting it and fighting adjust_force_export.
@@ -1131,6 +1132,15 @@ class GECloudDirect(ComponentBase):
                     changed = True
                 else:
                     self.log("GECloud: Warn: Failed to enable real-time control for {}".format(device))
+            if has_force_charge and ha_name == "enable_ac_charge" and not value:
+                self.log("GECloud: Enabling AC charge for {} because force charge is available".format(device))
+                result = await self.async_write_inverter_setting(device, key, True)
+                if result and ("value" in result):
+                    registers[key]["value"] = result["value"]
+                    await self.publish_registers(device, self.settings[device], select_key=key)
+                    changed = True
+                else:
+                    self.log("GECloud: Warn: Failed to enable AC charge for {}".format(device))
         return changed
 
     async def publish_registers(self, device, registers, select_key=None):
@@ -1323,7 +1333,7 @@ class GECloudDirect(ComponentBase):
         self.set_arg("charge_limit_enable", build_entities("switch", ["enable_ac_charge_upper_percent_limit", "enable_ac_charge_1_upper_soc_percent_limit"]))
         self.set_arg("discharge_start_time", [f"select.{self.prefix}_gecloud_{device}_dc_discharge_1_start_time" for device in batteries])
         self.set_arg("discharge_end_time", [f"select.{self.prefix}_gecloud_{device}_dc_discharge_1_end_time" for device in batteries])
-        self.set_arg("scheduled_charge_enable", build_entities("switch", ["ac_charge_enable", "enable_ac_charge"]))
+        self.set_arg("scheduled_charge_enable", build_entities("switch", ["enable_force_charge", "ac_charge_enable", "enable_ac_charge"]))
         self.set_arg("scheduled_discharge_enable", build_entities("switch", ["enable_dc_discharge", "enable_force_discharge"]))
         self.set_arg("battery_temperature", [f"sensor.{self.prefix}_gecloud_{device}_battery_temperature" for device in batteries])
         self.set_arg("battery_scaling", [f"sensor.{self.prefix}_gecloud_{device}_battery_dod_soh" for device in batteries])

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -4450,6 +4450,18 @@ def _test_async_automatic_config(my_predbat):
         assert ge.config_args.get("charge_limit") == ["number.predbat_gecloud_battery001_ac_charge_upper_percent_limit"]
         assert ge.config_args.get("charge_limit_enable") is None, "charge_limit_enable should be None when enable register is absent"
 
+        # Test 10: Force charge is the schedule switch when both charge switches are available
+        ge.config_args = {}
+        ge.settings = {
+            "battery003": {
+                "reg1": {"name": "Enable_AC_Charge"},
+                "reg2": {"name": "Enable_Force_Charge"},
+            }
+        }
+        devices = {"ems": None, "gateway": None, "battery": ["battery003"]}
+        await ge.async_automatic_config(devices)
+        assert ge.config_args.get("scheduled_charge_enable") == ["switch.predbat_gecloud_battery003_enable_force_charge"]
+
         return 0
 
     return run_async(test())
@@ -5229,6 +5241,28 @@ def _test_enable_default_options(my_predbat):
 
         if len(write_calls) != 0:
             print("ERROR: Expected 0 write calls when percentage already 100, got {}".format(len(write_calls)))
+            return 1
+
+        # Test 29: Keep AC charge enabled when force charge is the schedule switch
+        write_calls = []
+        registers = {
+            310: {"name": "Enable_Force_Charge", "value": False, "validation_rules": []},
+            311: {"name": "Enable_AC_Charge", "value": False, "validation_rules": []},
+        }
+
+        result = await ge_cloud.enable_default_options("test123", registers)
+
+        if not result or len(write_calls) != 1 or write_calls[0]["key"] != 311 or write_calls[0]["value"] is not True:
+            print("ERROR: Expected AC charge to be enabled when force charge is available, got {}".format(write_calls))
+            return 1
+
+        # Devices without force charge retain their existing AC charge state.
+        write_calls = []
+        registers = {312: {"name": "Enable_AC_Charge", "value": False, "validation_rules": []}}
+        result = await ge_cloud.enable_default_options("test123", registers)
+
+        if result or write_calls:
+            print("ERROR: AC charge should not be changed without force charge, got {}".format(write_calls))
             return 1
 
         return 0


### PR DESCRIPTION
Fixes #5040

## Summary
- Prefer the enable_force_charge register as the GE Cloud scheduled-charge gate when a device exposes it.
- Keep enable_ac_charge enabled for devices with both switches so timed grid charging works in both directions.
- Add regression coverage for the force-charge device shape and the legacy fallback.

## Testing
- cd coverage && ./run_all --test ge_cloud (93 passed)
- cd coverage && ./run_pre_commit (all hooks and quick tests passed)
- git diff --check

AI-assisted: OpenAI Codex.