### PR TITLE
fix(gecloud): drive enable_force_charge as the scheduled charge control (#5040)

### DIFF
--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -1118,7 +1118,11 @@ class GECloudDirect(ComponentBase):
                             changed = True
                         else:
                             self.log("GECloud: Warn: Failed to set {} for {}".format(ha_name, device))
-            if ha_name == "enable_ac_charge" and has_force_charge:
+            # Matched by substring as GE spells this family inconsistently across firmware, but the
+            # AC charge *upper limit* switch shares the prefix under at least three names
+            # (enable_ac_charge_upper_percent_limit, enable_ac_charge_1_upper_soc_percent_limit and
+            # enable_ac_charge_upper_limit) and is a different control, so limit registers are excluded.
+            if ("enable_ac_charge" in ha_name) and ("limit" not in ha_name) and has_force_charge:
                 if value:
                     changed = True
                     continue
@@ -1285,7 +1289,7 @@ class GECloudDirect(ComponentBase):
                     has_discharge_target_soc = True
                 if "pause_battery" in ha_name:
                     has_pause_battery = True
-                if ha_name == "enable_force_charge":
+                if "enable_force_charge" in ha_name:
                     has_force_charge = True
 
         def register_names(device):

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -1124,7 +1124,7 @@ class GECloudDirect(ComponentBase):
             # enable_ac_charge_upper_limit) and is a different control, so limit registers are excluded.
             if ("enable_ac_charge" in ha_name) and ("limit" not in ha_name) and has_force_charge:
                 if value:
-                    changed = True
+                    # Already on, so nothing was written and there is no change to report.
                     continue
                 self.log("GECloud: Enabling AC charge for {} as enable_force_charge is the scheduled charge control, current value is {}".format(device, value))
                 result = await self.async_write_inverter_setting(device, key, True)

--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -1016,6 +1016,10 @@ class GECloudDirect(ComponentBase):
         device_ha_names = {regname_to_ha(registers[key].get("name", "")) for key in registers}
         has_charge_power = "battery_charge_power" in device_ha_names
         has_discharge_power = "battery_discharge_power" in device_ha_names
+        # When this device exposes both charge switches, async_automatic_config binds
+        # enable_force_charge as scheduled_charge_enable, so enable_ac_charge is a second gate that
+        # must be held on or the timed grid charge silently imports nothing (GH#5040).
+        has_force_charge = "enable_force_charge" in device_ha_names
         # Predbat drives the export target register itself (discharge_target_soc, the DC discharge
         # lower SoC limit) and tracks the minimum reserve SoC there, so leave that one alone rather
         # than resetting it and fighting adjust_force_export.
@@ -1114,6 +1118,19 @@ class GECloudDirect(ComponentBase):
                             changed = True
                         else:
                             self.log("GECloud: Warn: Failed to set {} for {}".format(ha_name, device))
+            if ha_name == "enable_ac_charge" and has_force_charge:
+                if value:
+                    changed = True
+                    continue
+                self.log("GECloud: Enabling AC charge for {} as enable_force_charge is the scheduled charge control, current value is {}".format(device, value))
+                result = await self.async_write_inverter_setting(device, key, True)
+                if result and ("value" in result):
+                    registers[key]["value"] = result["value"]
+                    await self.publish_registers(device, self.settings[device], select_key=key)
+                    changed = True
+                else:
+                    self.log("GECloud: Warn: Failed to enable AC charge for {}".format(device))
+                continue
             if "real_time_control" in ha_name:
                 if self.ems_device:
                     # RTC is on the EMS, not the individual inverters — skip
@@ -1248,6 +1265,7 @@ class GECloudDirect(ComponentBase):
         has_pause_start_time = False
         has_discharge_target_soc = False
         has_pause_battery = False
+        has_force_charge = False
         for device in batteries:
             registers = self.settings.get(device, {})
             for key in registers:
@@ -1267,6 +1285,8 @@ class GECloudDirect(ComponentBase):
                     has_discharge_target_soc = True
                 if "pause_battery" in ha_name:
                     has_pause_battery = True
+                if ha_name == "enable_force_charge":
+                    has_force_charge = True
 
         def register_names(device):
             """Return HA-format register names for a specific device."""
@@ -1295,8 +1315,8 @@ class GECloudDirect(ComponentBase):
 
         self.log("GECloud: Auto-configuring Predbat and not using apps.yaml entries for control")
         self.log(
-            "GECloud: detected features - charge rate: {}, discharge rate: {}, charge power percent: {}, discharge power percent: {}, pause battery: {}, pause start time: {}, discharge target soc: {}".format(
-                has_charge_rate, has_discharge_rate, has_charge_power_percent, has_discharge_power_percent, has_pause_battery, has_pause_start_time, has_discharge_target_soc
+            "GECloud: detected features - charge rate: {}, discharge rate: {}, charge power percent: {}, discharge power percent: {}, pause battery: {}, pause start time: {}, discharge target soc: {}, force charge: {}".format(
+                has_charge_rate, has_discharge_rate, has_charge_power_percent, has_discharge_power_percent, has_pause_battery, has_pause_start_time, has_discharge_target_soc, has_force_charge
             )
         )
 
@@ -1323,7 +1343,11 @@ class GECloudDirect(ComponentBase):
         self.set_arg("charge_limit_enable", build_entities("switch", ["enable_ac_charge_upper_percent_limit", "enable_ac_charge_1_upper_soc_percent_limit"]))
         self.set_arg("discharge_start_time", [f"select.{self.prefix}_gecloud_{device}_dc_discharge_1_start_time" for device in batteries])
         self.set_arg("discharge_end_time", [f"select.{self.prefix}_gecloud_{device}_dc_discharge_1_end_time" for device in batteries])
-        self.set_arg("scheduled_charge_enable", build_entities("switch", ["ac_charge_enable", "enable_ac_charge"]))
+        # On devices that expose both charge switches ("Enable AC Charge" and "Enable Force Charge")
+        # it is Force Charge that gates the timed grid charge, so bind that as the per-slot control and
+        # let enable_default_options hold AC Charge on as a static enable. Devices without a
+        # enable_force_charge register keep their existing AC-charge binding (GH#5040).
+        self.set_arg("scheduled_charge_enable", build_entities("switch", ["enable_force_charge", "ac_charge_enable", "enable_ac_charge"]))
         self.set_arg("scheduled_discharge_enable", build_entities("switch", ["enable_dc_discharge", "enable_force_discharge"]))
         self.set_arg("battery_temperature", [f"sensor.{self.prefix}_gecloud_{device}_battery_temperature" for device in batteries])
         self.set_arg("battery_scaling", [f"sensor.{self.prefix}_gecloud_{device}_battery_dod_soh" for device in batteries])

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -300,6 +300,7 @@ def test_ge_cloud(my_predbat=None):
         ("hybrid_detection", _test_hybrid_detection, "Hybrid inverter detection"),
         ("enable_defaults", _test_enable_default_options, "Enable default options"),
         ("enable_defaults_skip_target", _test_enable_default_options_skips_discharge_target, "Enable defaults skips the discharge target register"),
+        ("force_charge_control", _test_force_charge_control, "Force charge is the scheduled charge control when both charge switches exist"),
         ("enable_defaults_read_only", _test_run_read_only_skips_reset, "Enable defaults skipped in read-only mode"),
         ("enable_defaults_after_read_only", _test_run_enables_reset_after_read_only, "Enable defaults on first non-read-only run"),
         ("enable_defaults_24h", _test_run_enables_reset_after_24h, "Enable defaults re-runs after 24 hours"),
@@ -4744,6 +4745,168 @@ def _test_hybrid_detection(my_predbat):
         return 0
 
     return run_async(test())
+
+
+def _test_force_charge_control(my_predbat):
+    """GH#5040: on devices exposing both charge switches, Force Charge is the scheduled charge control and AC Charge is held on"""
+
+    async def test():
+        # --- Part A: async_automatic_config binds the right switch as scheduled_charge_enable ---
+
+        ge = MockGECloudDirect()
+
+        # A device exposing both charge switches (the 3-phase GEC register family) must bind
+        # enable_force_charge, as that is the switch that actually gates the timed grid charge.
+        ge.config_args = {}
+        ge.settings = {"battery001": {"reg1": {"name": "Enable_AC_Charge"}, "reg2": {"name": "Enable_Force_Charge"}, "reg3": {"name": "Enable_Force_Discharge"}}}
+        await ge.async_automatic_config({"ems": None, "gateway": None, "battery": ["battery001"]})
+
+        expect = ["switch.predbat_gecloud_battery001_enable_force_charge"]
+        if ge.config_args.get("scheduled_charge_enable") != expect:
+            print("ERROR: Both switches present should bind enable_force_charge, got {}".format(ge.config_args.get("scheduled_charge_enable")))
+            return 1
+        if not any("force charge: True" in message for message in ge.log_messages):
+            print("ERROR: Expected the detected-features log to report force charge: True")
+            return 1
+
+        # A standard device with only enable_ac_charge is unchanged by the new precedence.
+        ge.config_args = {}
+        ge.settings = {"battery002": {"reg1": {"name": "Enable_AC_Charge"}}}
+        await ge.async_automatic_config({"ems": None, "gateway": None, "battery": ["battery002"]})
+
+        expect = ["switch.predbat_gecloud_battery002_enable_ac_charge"]
+        if ge.config_args.get("scheduled_charge_enable") != expect:
+            print("ERROR: enable_ac_charge alone should still bind enable_ac_charge, got {}".format(ge.config_args.get("scheduled_charge_enable")))
+            return 1
+
+        # ac_charge_enable still wins over enable_ac_charge when there is no force charge register.
+        ge.config_args = {}
+        ge.settings = {"battery003": {"reg1": {"name": "AC_Charge_Enable"}, "reg2": {"name": "Enable_AC_Charge"}}}
+        await ge.async_automatic_config({"ems": None, "gateway": None, "battery": ["battery003"]})
+
+        expect = ["switch.predbat_gecloud_battery003_ac_charge_enable"]
+        if ge.config_args.get("scheduled_charge_enable") != expect:
+            print("ERROR: ac_charge_enable should still take precedence over enable_ac_charge, got {}".format(ge.config_args.get("scheduled_charge_enable")))
+            return 1
+
+        # Register sets can differ between inverters on one site, so the choice is made per device.
+        ge.config_args = {}
+        ge.settings = {
+            "battery001": {"reg1": {"name": "Enable_AC_Charge"}, "reg2": {"name": "Enable_Force_Charge"}},
+            "battery002": {"reg1": {"name": "Enable_AC_Charge"}},
+        }
+        await ge.async_automatic_config({"ems": None, "gateway": None, "battery": ["battery001", "battery002"]})
+
+        expect = ["switch.predbat_gecloud_battery001_enable_force_charge", "switch.predbat_gecloud_battery002_enable_ac_charge"]
+        if ge.config_args.get("scheduled_charge_enable") != expect:
+            print("ERROR: Mixed register sets should bind per device, got {}".format(ge.config_args.get("scheduled_charge_enable")))
+            return 1
+
+        # --- Part B: enable_default_options holds enable_ac_charge on as the static enable ---
+
+        ge_cloud = MockGECloudDirect()
+        ge_cloud.settings = {"test123": {}}
+
+        write_calls = []
+
+        async def mock_write(device, key, value):
+            write_calls.append({"device": device, "key": key, "value": value})
+            return {"value": value}
+
+        async def mock_publish(*args, **kwargs):
+            pass
+
+        ge_cloud.async_write_inverter_setting = mock_write
+        ge_cloud.publish_registers = mock_publish
+
+        # Force charge present and AC charge off — AC charge must be turned on and left on.
+        registers = {
+            200: {"name": "Enable_AC_Charge", "value": False, "validation_rules": []},
+            201: {"name": "Enable_Force_Charge", "value": False, "validation_rules": []},
+        }
+        result = await ge_cloud.enable_default_options("test123", registers)
+
+        if len(write_calls) != 1 or write_calls[0]["key"] != 200 or write_calls[0]["value"] is not True:
+            print("ERROR: Expected a single write enabling Enable_AC_Charge, got {}".format(write_calls))
+            return 1
+        if not result:
+            print("ERROR: enable_default_options should report a change when enabling AC charge")
+            return 1
+        if registers[200]["value"] is not True:
+            print("ERROR: Enable_AC_Charge register should be updated to True, got {}".format(registers[200]["value"]))
+            return 1
+        # The scheduled charge control itself is Predbat's to drive per slot, so it is never written here.
+        if registers[201]["value"] is not False:
+            print("ERROR: Enable_Force_Charge must be left for Predbat to drive, got {}".format(registers[201]["value"]))
+            return 1
+
+        # Already on — nothing to write.
+        write_calls.clear()
+        registers = {
+            200: {"name": "Enable_AC_Charge", "value": True, "validation_rules": []},
+            201: {"name": "Enable_Force_Charge", "value": True, "validation_rules": []},
+        }
+        result = await ge_cloud.enable_default_options("test123", registers)
+
+        if write_calls:
+            print("ERROR: Should not write when Enable_AC_Charge is already on, got {}".format(write_calls))
+            return 1
+
+        # No force charge register — enable_ac_charge is itself the scheduled charge control on this
+        # device, so Predbat must not force it on.
+        write_calls.clear()
+        registers = {200: {"name": "Enable_AC_Charge", "value": False, "validation_rules": []}}
+        result = await ge_cloud.enable_default_options("test123", registers)
+
+        if write_calls:
+            print("ERROR: Should not touch Enable_AC_Charge without a force charge register, got {}".format(write_calls))
+            return 1
+        if result:
+            print("ERROR: enable_default_options should report no change on a standard device")
+            return 1
+        if registers[200]["value"] is not False:
+            print("ERROR: Enable_AC_Charge should be untouched on a standard device, got {}".format(registers[200]["value"]))
+            return 1
+
+        # The match is exact: the charge-limit enable register must not be mistaken for it.
+        write_calls.clear()
+        registers = {
+            202: {"name": "Enable_AC_Charge_Upper_Percent_Limit", "value": False, "validation_rules": []},
+            201: {"name": "Enable_Force_Charge", "value": False, "validation_rules": []},
+        }
+        result = await ge_cloud.enable_default_options("test123", registers)
+
+        if write_calls:
+            print("ERROR: Enable_AC_Charge_Upper_Percent_Limit should not be force-enabled, got {}".format(write_calls))
+            return 1
+
+        # A rejected write is reported and does not count as a change.
+        async def mock_write_fail(device, key, value):
+            write_calls.append({"device": device, "key": key, "value": value})
+            return None
+
+        write_calls.clear()
+        ge_cloud.log_messages = []
+        ge_cloud.async_write_inverter_setting = mock_write_fail
+        registers = {
+            200: {"name": "Enable_AC_Charge", "value": False, "validation_rules": []},
+            201: {"name": "Enable_Force_Charge", "value": False, "validation_rules": []},
+        }
+        result = await ge_cloud.enable_default_options("test123", registers)
+
+        if len(write_calls) != 1:
+            print("ERROR: Expected one attempted write on the failure path, got {}".format(write_calls))
+            return 1
+        if result:
+            print("ERROR: A failed write should not report a change")
+            return 1
+        if not any("Failed to enable AC charge" in message for message in ge_cloud.log_messages):
+            print("ERROR: Expected a warning when the AC charge write fails, got {}".format(ge_cloud.log_messages))
+            return 1
+
+        return 0
+
+    return asyncio.run(test())
 
 
 def _test_enable_default_options_skips_discharge_target(my_predbat):

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -4769,6 +4769,16 @@ def _test_force_charge_control(my_predbat):
             print("ERROR: Expected the detected-features log to report force charge: True")
             return 1
 
+        # The detected-features flag is a substring match, so a suffixed spelling still reports it.
+        ge.config_args = {}
+        ge.log_messages = []
+        ge.settings = {"battery001": {"reg1": {"name": "Enable_AC_Charge"}, "reg2": {"name": "Enable_Force_Charge_2"}}}
+        await ge.async_automatic_config({"ems": None, "gateway": None, "battery": ["battery001"]})
+
+        if not any("force charge: True" in message for message in ge.log_messages):
+            print("ERROR: A suffixed force charge register should still report force charge: True")
+            return 1
+
         # A standard device with only enable_ac_charge is unchanged by the new precedence.
         ge.config_args = {}
         ge.settings = {"battery002": {"reg1": {"name": "Enable_AC_Charge"}}}
@@ -4868,16 +4878,35 @@ def _test_force_charge_control(my_predbat):
             print("ERROR: Enable_AC_Charge should be untouched on a standard device, got {}".format(registers[200]["value"]))
             return 1
 
-        # The match is exact: the charge-limit enable register must not be mistaken for it.
+        # The AC charge upper limit switch shares the enable_ac_charge prefix and is a different
+        # control, so none of its known spellings may be force-enabled. Enable_AC_Charge_Upper_Limit
+        # is the one the pre-existing "enable_" guard above does not catch, so it pins the exclusion.
+        for limit_name in ("Enable_AC_Charge_Upper_Percent_Limit", "Enable_AC_Charge_1_Upper_SOC_Percent_Limit", "Enable_AC_Charge_Upper_Limit"):
+            write_calls.clear()
+            registers = {
+                202: {"name": limit_name, "value": False, "validation_rules": []},
+                201: {"name": "Enable_Force_Charge", "value": False, "validation_rules": []},
+            }
+            result = await ge_cloud.enable_default_options("test123", registers)
+
+            if write_calls:
+                print("ERROR: {} should not be force-enabled, got {}".format(limit_name, write_calls))
+                return 1
+            if registers[202]["value"] is not False:
+                print("ERROR: {} should be left untouched, got {}".format(limit_name, registers[202]["value"]))
+                return 1
+
+        # A firmware that names the switch with a suffix is still matched, as the register family is
+        # spelled inconsistently across GE devices.
         write_calls.clear()
         registers = {
-            202: {"name": "Enable_AC_Charge_Upper_Percent_Limit", "value": False, "validation_rules": []},
+            203: {"name": "Enable_AC_Charge_2", "value": False, "validation_rules": []},
             201: {"name": "Enable_Force_Charge", "value": False, "validation_rules": []},
         }
         result = await ge_cloud.enable_default_options("test123", registers)
 
-        if write_calls:
-            print("ERROR: Enable_AC_Charge_Upper_Percent_Limit should not be force-enabled, got {}".format(write_calls))
+        if len(write_calls) != 1 or write_calls[0]["key"] != 203 or write_calls[0]["value"] is not True:
+            print("ERROR: A suffixed Enable_AC_Charge register should still be enabled, got {}".format(write_calls))
             return 1
 
         # A rejected write is reported and does not count as a change.

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -4861,6 +4861,9 @@ def _test_force_charge_control(my_predbat):
         if write_calls:
             print("ERROR: Should not write when Enable_AC_Charge is already on, got {}".format(write_calls))
             return 1
+        if result:
+            print("ERROR: enable_default_options should report no change when Enable_AC_Charge is already on")
+            return 1
 
         # No force charge register — enable_ac_charge is itself the scheduled charge control on this
         # device, so Predbat must not force it on.
@@ -4895,6 +4898,9 @@ def _test_force_charge_control(my_predbat):
             if registers[202]["value"] is not False:
                 print("ERROR: {} should be left untouched, got {}".format(limit_name, registers[202]["value"]))
                 return 1
+            if result:
+                print("ERROR: enable_default_options should report no change for {}".format(limit_name))
+                return 1
 
         # A firmware that names the switch with a suffix is still matched, as the register family is
         # spelled inconsistently across GE devices.
@@ -4907,6 +4913,9 @@ def _test_force_charge_control(my_predbat):
 
         if len(write_calls) != 1 or write_calls[0]["key"] != 203 or write_calls[0]["value"] is not True:
             print("ERROR: A suffixed Enable_AC_Charge register should still be enabled, got {}".format(write_calls))
+            return 1
+        if not result:
+            print("ERROR: enable_default_options should report a change when a suffixed register is enabled")
             return 1
 
         # A rejected write is reported and does not count as a change.


### PR DESCRIPTION
This is an automated draft PR generated from issue #5040 — a maintainer should review it before merging.

Fixes #5040

## Summary

On GE Cloud devices whose register set exposes **both** `Enable AC Charge` and `Enable Force Charge`, both switches gate grid import, but Predbat only ever drove `enable_ac_charge` — `enable_force_charge` appeared nowhere in the codebase. A planned charge window therefore entered the charge state, set the AC charge slot, logged `Charging target …%`, and imported nothing.

Two changes, both gated on the **device's own** registers so a standard GivEnergy device is unaffected:

- `async_automatic_config()` now binds `scheduled_charge_enable` from candidates `["enable_force_charge", "ac_charge_enable", "enable_ac_charge"]`. Where the force-charge register exists it becomes the per-slot control, so the existing `write_and_poll_switch("scheduled_charge_enable", …)` calls in `inverter.py` (enable at `:3230`, disable at `:2814`/`:1590`) land on the switch that actually gates the timed charge. Devices without that register keep their current binding, and `ac_charge_enable` still wins over `enable_ac_charge` as before.
- `enable_default_options()` now holds `enable_ac_charge` **on** when — and only when — that same device also exposes `enable_force_charge`, so it stops being a second gate Predbat has to think about. This mirrors the static-enable pattern `real_time_control` already uses in that function. The register check is built from the per-device `registers` dict passed in, so mixed multi-inverter sites are handled per device (the flag-vs-per-device wrinkle raised in triage and previously hit on #4909).

That leaves one switch as the per-slot control and one as a static enable, matching how the export side (`enable_dc_discharge` / `enable_force_discharge`) already behaves. It also avoids the failure mode the reporter hit when holding Force Charge on by hand: `enable_force_charge` is now cleared at the end of the window like any other scheduled-charge toggle, so the inverter stops acting on a stale `ac_charge_1` slot.

The detected-features log line now also reports `force charge: <bool>`, so this register family is visible in a bug report without needing a full register dump.

## Testing

- New `force_charge_control` test in `apps/predbat/tests/test_ge_cloud.py` (registered in the `test_ge_cloud` sub-registry) covering both halves: the binding for a both-switches device, a standard `enable_ac_charge`-only device, `ac_charge_enable` precedence, a mixed two-inverter site, and for `enable_default_options` — the write when AC charge is off, no write when already on, **no** write at all without a force-charge register, the exact-match guard against `Enable_AC_Charge_Upper_Percent_Limit`, and the rejected-write path.
- Verified the test genuinely catches the bug: with the `gecloud.py` change reverted it fails (`Both switches present should bind enable_force_charge, got ['switch.predbat_gecloud_battery001_enable_ac_charge']`), and with only the `enable_default_options` half reverted it fails on the missing write.
- `tools/triage_test.sh ge_cloud` — **94 passed, 0 failed**.
- `coverage/run_pre_commit` — all hooks passed and `./run_all --quick` passed (4 slow tests skipped, 83s).

## Notes

`.claude/skills/issue-triage/references/debug-journal.md` records this class of GE Cloud auto-config gap on non-standard register sets (the `GE Cloud (gecloud.py)` row, alongside #4908). Worth adding this register family to that entry once the approach is confirmed on hardware.

**Cannot be verified from code and needs maintainer/hardware confirmation:** that both switches must be on for grid import on this hardware, and that clearing `enable_force_charge` alone is sufficient to stop a charge. Both rest on the reporter's observations.