### PR TITLE
feat(fox): load CLI credentials from an apps.yaml file with --config

### DIFF
--- a/apps/predbat/fox.py
+++ b/apps/predbat/fox.py
@@ -17,6 +17,7 @@ Feedin), real-time monitoring, and device settings via the Fox ESS Cloud API.
 import asyncio
 from datetime import datetime, timedelta, timezone
 import os
+import yaml
 import time
 import hashlib
 from predbat_metrics import record_api_call
@@ -27,7 +28,7 @@ import random
 from component_base import ComponentBase
 from mock_base import MockBase
 from oauth_mixin import OAuthMixin
-from utils import dp2
+from utils import dp2, load_apps_yaml
 
 # Define TIME_FORMAT_HA locally to avoid dependency issues
 TIME_FORMAT_HA = "%Y-%m-%dT%H:%M:%S%z"
@@ -2482,6 +2483,75 @@ async def test_fox_api(sn, api_key, token_hash, token_expires, supabase_url, sup
     print("Run completed successfully")
 
 
+# Fox credentials as they appear in apps.yaml, mapped to the command line fields they stand in
+# for, so --config can supply them instead. Written out by hand rather than read from
+# COMPONENT_LIST: components.py pulls predbat in behind it, and fox.py is imported by components
+# itself. test_fox_cli_credential_keys_match_component keeps this in step with what the component
+# actually declares.
+FOX_CLI_CREDENTIAL_KEYS = {
+    "api_key": "fox_key",
+    "token_hash": "fox_token_hash",
+    "token_expires": "fox_token_expires_at",
+    "serial": "fox_inverter_sn",
+}
+
+# The OAuth refresh settings, which are not Fox component args: oauth_mixin reads
+# SUPABASE_URL/SUPABASE_KEY from the environment and user_id from base.args. Without them an
+# OAuth run cannot refresh its token and every request comes back 401, so --config reads them
+# too rather than making the caller export environment variables alongside the file.
+FOX_CLI_OAUTH_KEYS = {
+    "user_id": "user_id",
+    "supabase_url": "supabase_url",
+    "supabase_key": "supabase_key",
+}
+
+
+def merge_fox_credentials(cli, config, report=False):
+    """
+    Fill in any Fox credential not given on the command line from an apps.yaml-format config
+
+    An explicit command line value always wins, so a one-off run against a different key or
+    inverter does not mean editing apps.yaml.
+
+    A config carrying both an API key and an OAuth token hash is ambiguous, so fox_auth_method
+    decides - the same field the component itself uses to pick between them. With neither
+    declared, whatever is present is used, preferring the key (the component's own default).
+
+    With report=True, returns (merged, used) where used lists the config keys actually taken, so
+    the caller can show them - a key the CLI does not look for otherwise fails silently, with a
+    401 several lines later as its only symptom.
+    """
+    merged = dict(cli)
+    used = []
+
+    auth_method = config.get("fox_auth_method")
+    skip = set()
+    if auth_method == "oauth":
+        skip.add("api_key")
+    elif auth_method == "api_key":
+        skip.add("token_hash")
+        skip.add("token_expires")
+    elif config.get("fox_key") and config.get("fox_token_hash"):
+        skip.add("token_hash")
+        skip.add("token_expires")
+
+    for mapping in (FOX_CLI_CREDENTIAL_KEYS, FOX_CLI_OAUTH_KEYS):
+        for cli_name, config_key in mapping.items():
+            if merged.get(cli_name) or cli_name in skip:
+                continue
+            value = config.get(config_key)
+            # fox_inverter_sn is "string|string_list" in APPS_SCHEMA, but the CLI drives one device
+            if isinstance(value, list):
+                value = value[0] if value else None
+            if value:
+                merged[cli_name] = value
+                used.append(config_key)
+
+    if report:
+        return merged, used
+    return merged
+
+
 async def _await_schedule(fox_api, serial, expected, timeout=90, interval=5):  # pragma: no cover
     """
     Read the scheduler back until it agrees with expected, or the timeout runs out
@@ -2708,9 +2778,14 @@ def main():  # pragma: no cover
     """
     parser = argparse.ArgumentParser(description="Test Fox API")
     parser.add_argument("--serial", action="store", default=None, help="Fox API serial number")
-    auth_group = parser.add_mutually_exclusive_group(required=True)
+    auth_group = parser.add_mutually_exclusive_group()
     auth_group.add_argument("--api-key", help="Fox API key")
     auth_group.add_argument("--token-hash", action="store", help="Fox API OAuth token hash")
+    parser.add_argument(
+        "--config",
+        action="store",
+        help="Load credentials from an apps.yaml-format file instead of passing them here, resolving !secret as Predbat does. Reads fox_key, fox_auth_method, fox_token_hash, fox_token_expires_at, fox_inverter_sn, and for an OAuth refresh supabase_url, supabase_key and user_id. Anything also given on the command line wins",
+    )
     parser.add_argument("--token-expires", action="store", help="Fox API OAuth token expiry timestamp")
     parser.add_argument("--supabase-url", action="store", help="Supabase URL for OAuth token refresh")
     parser.add_argument("--supabase-key", action="store", help="Supabase anon key for OAuth token refresh")
@@ -2728,6 +2803,29 @@ def main():  # pragma: no cover
     supabase_url = args.supabase_url
     supabase_key = args.supabase_key
     user_id = args.user_id
+
+    if args.config:
+        try:
+            config, _ = load_apps_yaml(args.config)
+        except (yaml.YAMLError, KeyError, OSError) as exc:
+            parser.error(f"could not read Fox credentials from {args.config}: {exc}")
+        cli_values = {"api_key": api_key, "token_hash": token_hash, "token_expires": token_expires, "serial": serial, "user_id": user_id, "supabase_url": supabase_url, "supabase_key": supabase_key}
+        credentials, used = merge_fox_credentials(cli_values, config, report=True)
+        api_key = credentials["api_key"]
+        token_hash = credentials["token_hash"]
+        token_expires = credentials["token_expires"]
+        serial = credentials["serial"]
+        user_id = credentials["user_id"]
+        supabase_url = credentials["supabase_url"]
+        supabase_key = credentials["supabase_key"]
+        # Name what was taken: a key the CLI does not look for leaves its credential unset, and
+        # the only other symptom is a 401 much further down
+        print("Read from {}: {}".format(args.config, ", ".join(used) if used else "nothing - no keys the CLI looks for"))
+        if token_hash and not (supabase_url and supabase_key):
+            print("Warning: an OAuth token cannot be refreshed without supabase_url and supabase_key - expect 401s once it expires")
+
+    if not api_key and not token_hash:
+        parser.error("no Fox credentials: pass --api-key or --token-hash, or --config pointing at an apps.yaml holding fox_key or fox_token_hash")
 
     # Run the test
     if args.write_schedule:

--- a/apps/predbat/hass.py
+++ b/apps/predbat/hass.py
@@ -6,7 +6,6 @@ rotation, scheduled callback execution, and file change detection for
 development hot-reload.
 """
 
-import io
 import yaml
 import sys
 import asyncio
@@ -37,6 +36,7 @@ def write_git_version_marker():
 write_git_version_marker()
 
 import predbat
+from utils import load_apps_yaml
 import time
 from datetime import datetime, timedelta
 from multiprocessing import set_start_method
@@ -246,56 +246,6 @@ class Hass:
             t.join(5 * 60)
         self.logfile.close()
 
-    def load_secrets(self):
-        """
-        Load secrets from secrets.yaml file
-        Priority: PREDBAT_SECRETS_FILE env var, ./secrets.yaml, /config/secrets.yaml
-        """
-        secrets = {}
-        secrets_file = None
-
-        # Try loading from different locations in priority order
-        possible_locations = [
-            os.getenv("PREDBAT_SECRETS_FILE"),
-            "secrets.yaml",
-            "/homeassistant/secrets.yaml",
-            "/conf/secrets.yaml",
-            "/config/secrets.yaml",
-        ]
-
-        for location in possible_locations:
-            if location and os.path.isfile(location):
-                secrets_file = location
-                break
-
-        if secrets_file:
-            self.log(f"Loading secrets from {secrets_file}", quiet=False)
-            try:
-                with io.open(secrets_file, "r") as stream:
-                    secrets = yaml.safe_load(stream) or {}
-                    # Check for debug logging option
-                    if secrets.get("logger") == "debug":
-                        self.log(f"Info: Secrets loaded from {secrets_file}", quiet=False)
-            except yaml.YAMLError as exc:
-                self.log(f"Error: Failed to load secrets from {secrets_file}: {exc}", quiet=False)
-            except Exception as exc:
-                self.log(f"Error: Failed to open secrets file {secrets_file}: {exc}", quiet=False)
-        else:
-            self.log("Info: No secrets.yaml file found", quiet=False)
-
-        return secrets
-
-    def secret_constructor(self, loader, node):
-        """
-        YAML constructor for !secret tag
-        """
-        secret_key = loader.construct_scalar(node)
-        if secret_key in self.secrets:
-            return self.secrets[secret_key]
-        else:
-            self.log(f"Warn: Secret '{secret_key}' not found in secrets.yaml")
-            return None
-
     def __init__(self):
         """
         Start Predbat
@@ -308,22 +258,12 @@ class Hass:
 
         self.logfile = open("predbat.log", "a")
 
-        # Load secrets first
-        self.secrets = self.load_secrets()
-
-        # Register custom YAML constructor for !secret tag
-        yaml.add_constructor("!secret", self.secret_constructor, Loader=yaml.SafeLoader)
-
-        # Open YAML file apps.yaml and read it
-        apps_file = os.getenv("PREDBAT_APPS_FILE", "apps.yaml")
-        self.log(f"Loading {apps_file}", quiet=False)
-        with io.open(apps_file, "r") as stream:
-            try:
-                config = yaml.safe_load(stream)
-                self.args = config["pred_bat"]
-            except yaml.YAMLError as exc:
-                print(exc)
-                sys.exit(1)
+        # Load apps.yaml (resolving !secret) through the shared loader
+        try:
+            self.args, self.secrets = load_apps_yaml(log=self.log)
+        except yaml.YAMLError as exc:
+            print(exc)
+            sys.exit(1)
 
     def run_every(self, callback, next_time, run_every, **kwargs):
         """

--- a/apps/predbat/tests/test_fox_api.py
+++ b/apps/predbat/tests/test_fox_api.py
@@ -25,6 +25,9 @@ from fox import (
     OPTIONS_WORK_MODE,
     FOX_SETTINGS_CACHE_VERSION,
     SCHEDULER_READ_STALE_SECONDS,
+    merge_fox_credentials,
+    FOX_CLI_CREDENTIAL_KEYS,
+    FOX_CLI_OAUTH_KEYS,
 )
 from tests.test_infra import run_async, create_aiohttp_mock_response, create_aiohttp_mock_session
 
@@ -7258,6 +7261,159 @@ def test_scheduler_read_is_trusted_once_the_write_window_has_passed(my_predbat):
     return False
 
 
+def test_merge_fox_credentials_from_config(my_predbat):
+    """
+    Test fox credentials are taken from an apps.yaml-format config when not given on the command line
+    """
+    print("  - test_merge_fox_credentials_from_config")
+
+    config = {"fox_key": "config-key", "fox_inverter_sn": "SN123456", "fox_automatic": True}
+    merged = merge_fox_credentials({"api_key": None, "token_hash": None, "token_expires": None, "serial": None}, config)
+
+    assert merged["api_key"] == "config-key", f"Expected the config key, got {merged['api_key']}"
+    assert merged["serial"] == "SN123456", f"Expected the config serial, got {merged['serial']}"
+    assert merged["token_hash"] is None
+
+    return False
+
+
+def test_merge_fox_credentials_command_line_wins(my_predbat):
+    """
+    Test an explicit command line value overrides the config file
+
+    The config is the fallback, so a one-off run against a different key or inverter does not mean
+    editing apps.yaml.
+    """
+    print("  - test_merge_fox_credentials_command_line_wins")
+
+    config = {"fox_key": "config-key", "fox_inverter_sn": "SN123456"}
+    merged = merge_fox_credentials({"api_key": "cli-key", "token_hash": None, "token_expires": None, "serial": "SN999999"}, config)
+
+    assert merged["api_key"] == "cli-key", f"Expected the CLI key to win, got {merged['api_key']}"
+    assert merged["serial"] == "SN999999", f"Expected the CLI serial to win, got {merged['serial']}"
+
+    return False
+
+
+def test_merge_fox_credentials_inverter_sn_list(my_predbat):
+    """
+    Test a list-valued fox_inverter_sn yields the first serial
+
+    fox_inverter_sn is "string|string_list" in APPS_SCHEMA, but the CLI drives one device at a time.
+    """
+    print("  - test_merge_fox_credentials_inverter_sn_list")
+
+    merged = merge_fox_credentials({"api_key": None, "token_hash": None, "token_expires": None, "serial": None}, {"fox_inverter_sn": ["SN111111", "SN222222"]})
+
+    assert merged["serial"] == "SN111111", f"Expected the first serial, got {merged['serial']}"
+
+    return False
+
+
+def test_merge_fox_credentials_oauth(my_predbat):
+    """
+    Test an OAuth config supplies the token hash and expiry, and that auth_method breaks a tie
+
+    A config carrying both a key and a token hash is ambiguous, so fox_auth_method decides - the
+    same field the component itself uses to pick between them.
+    """
+    print("  - test_merge_fox_credentials_oauth")
+
+    oauth = {"fox_auth_method": "oauth", "fox_token_hash": "hash-abc", "fox_token_expires_at": "2026-09-11T09:53:12.236+00:00"}
+    merged = merge_fox_credentials({"api_key": None, "token_hash": None, "token_expires": None, "serial": None}, oauth)
+    assert merged["token_hash"] == "hash-abc", f"Expected the token hash, got {merged['token_hash']}"
+    assert merged["token_expires"] == "2026-09-11T09:53:12.236+00:00"
+
+    # Both present, OAuth declared - the key must not be used
+    both_oauth = dict(oauth, fox_key="config-key")
+    merged = merge_fox_credentials({"api_key": None, "token_hash": None, "token_expires": None, "serial": None}, both_oauth)
+    assert merged["api_key"] is None, f"Expected the key to be ignored under oauth, got {merged['api_key']}"
+    assert merged["token_hash"] == "hash-abc"
+
+    # Both present, api_key declared - the token hash must not be used
+    both_api = {"fox_auth_method": "api_key", "fox_key": "config-key", "fox_token_hash": "hash-abc"}
+    merged = merge_fox_credentials({"api_key": None, "token_hash": None, "token_expires": None, "serial": None}, both_api)
+    assert merged["api_key"] == "config-key"
+    assert merged["token_hash"] is None, f"Expected the token hash to be ignored under api_key, got {merged['token_hash']}"
+
+    return False
+
+
+def test_fox_cli_credential_keys_match_component(my_predbat):
+    """
+    Test the CLI's apps.yaml key names are the ones the Fox component actually declares
+
+    The CLI maps its own argument names onto apps.yaml keys by hand, because importing
+    components.py into fox.py would pull predbat in behind it. This is what keeps that copy honest
+    if a config key is ever renamed in COMPONENT_LIST.
+    """
+    print("  - test_fox_cli_credential_keys_match_component")
+
+    from components import COMPONENT_LIST
+
+    declared = {spec.get("config") for spec in COMPONENT_LIST["fox"]["args"].values() if spec.get("config")}
+    for cli_name, config_key in FOX_CLI_CREDENTIAL_KEYS.items():
+        assert config_key in declared, f"{cli_name} maps to {config_key}, which the fox component does not declare: {sorted(declared)}"
+    assert "fox_auth_method" in declared, "fox_auth_method is used to break the key/token tie but is not declared"
+
+    return False
+
+
+def test_merge_fox_credentials_supabase(my_predbat):
+    """
+    Test the OAuth refresh settings are picked up from the config too
+
+    An OAuth run is useless without them: oauth_mixin reads SUPABASE_URL/SUPABASE_KEY from the
+    environment and user_id from base.args, so a --config run carrying only a token hash refused
+    to refresh with "OAuth refresh skipped - SUPABASE_URL or SUPABASE_KEY not set" and every
+    request came back 401.
+
+    These are not Fox component args - supabase_url/supabase_key are environment variables in
+    production and user_id is a base arg - so they sit in their own mapping, away from the
+    fox_-prefixed keys the component declares.
+    """
+    print("  - test_merge_fox_credentials_supabase")
+
+    config = {
+        "fox_auth_method": "oauth",
+        "fox_token_hash": "hash-abc",
+        "supabase_url": "https://project.supabase.co",
+        "supabase_key": "anon-key-123",
+        "user_id": "user-uuid-456",
+    }
+    blank = {key: None for key in list(FOX_CLI_CREDENTIAL_KEYS) + list(FOX_CLI_OAUTH_KEYS)}
+    merged = merge_fox_credentials(blank, config)
+
+    assert merged["supabase_url"] == "https://project.supabase.co", f"Expected the supabase url, got {merged['supabase_url']}"
+    assert merged["supabase_key"] == "anon-key-123", f"Expected the supabase key, got {merged['supabase_key']}"
+    assert merged["user_id"] == "user-uuid-456", f"Expected the user id, got {merged['user_id']}"
+    assert merged["token_hash"] == "hash-abc"
+
+    # An explicit command line value still wins
+    merged = merge_fox_credentials(dict(blank, supabase_url="https://cli.supabase.co"), config)
+    assert merged["supabase_url"] == "https://cli.supabase.co", f"Expected the CLI url to win, got {merged['supabase_url']}"
+
+    return False
+
+
+def test_merge_fox_credentials_reports_what_it_used(my_predbat):
+    """
+    Test the merge reports which config keys it took, so a mis-named key is visible
+
+    The failure mode this guards against is silent: a key the CLI does not look for simply leaves
+    the credential unset, and the only symptom is a 401 several lines later.
+    """
+    print("  - test_merge_fox_credentials_reports_what_it_used")
+
+    blank = {key: None for key in list(FOX_CLI_CREDENTIAL_KEYS) + list(FOX_CLI_OAUTH_KEYS)}
+    merged, used = merge_fox_credentials(blank, {"fox_key": "k", "user_id": "u"}, report=True)
+
+    assert set(used) == {"fox_key", "user_id"}, f"Expected the keys actually used, got {used}"
+    assert merged["api_key"] == "k"
+
+    return False
+
+
 def run_fox_api_tests(my_predbat):
     """
     Run all Fox API tests
@@ -7477,6 +7633,15 @@ def run_fox_api_tests(my_predbat):
         failed |= test_stale_scheduler_read_does_not_overwrite_a_recent_write(my_predbat)
         failed |= test_stale_scheduler_read_does_not_skip_the_write_that_ends_a_freeze(my_predbat)
         failed |= test_scheduler_read_is_trusted_once_the_write_window_has_passed(my_predbat)
+
+        # --config credential loading tests
+        failed |= test_merge_fox_credentials_from_config(my_predbat)
+        failed |= test_merge_fox_credentials_command_line_wins(my_predbat)
+        failed |= test_merge_fox_credentials_inverter_sn_list(my_predbat)
+        failed |= test_merge_fox_credentials_oauth(my_predbat)
+        failed |= test_fox_cli_credential_keys_match_component(my_predbat)
+        failed |= test_merge_fox_credentials_supabase(my_predbat)
+        failed |= test_merge_fox_credentials_reports_what_it_used(my_predbat)
 
         # compute_schedule charge-rate power fix tests (issue #3610)
         failed |= test_compute_schedule_charge_power_reads_slot_fdpwr(my_predbat)

--- a/apps/predbat/tests/test_secrets.py
+++ b/apps/predbat/tests/test_secrets.py
@@ -12,6 +12,7 @@ import os
 import yaml
 import tempfile
 from hass import Hass
+from utils import load_apps_yaml
 
 
 def test_secrets_loading():
@@ -172,4 +173,49 @@ def run_secrets_tests(my_predbat=None):
     """
     failed = test_secrets_loading()
     failed |= test_mask_secret_yaml_text()
+    failed |= test_load_apps_yaml_resolves_secrets()
+    return failed
+
+
+def test_load_apps_yaml_resolves_secrets():
+    """
+    Test load_apps_yaml reads a given apps.yaml and resolves its !secret references
+
+    fox.py's --config option loads credentials through this rather than carrying its own parser,
+    so !secret keeps working for a standalone CLI run exactly as it does for Predbat itself.
+    """
+    print("**** Running test_load_apps_yaml_resolves_secrets ****")
+    failed = False
+
+    saved_secrets_env = os.environ.get("PREDBAT_SECRETS_FILE")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        secrets_path = os.path.join(tmpdir, "secrets.yaml")
+        with open(secrets_path, "w") as handle:
+            yaml.dump({"fox_api_key": "secret-fox-key"}, handle)
+
+        apps_path = os.path.join(tmpdir, "apps.yaml")
+        with open(apps_path, "w") as handle:
+            handle.write("pred_bat:\n  fox_key: !secret fox_api_key\n  fox_automatic: True\n  num_inverters: 1\n")
+
+        os.environ["PREDBAT_SECRETS_FILE"] = secrets_path
+        try:
+            args, secrets = load_apps_yaml(apps_path)
+        finally:
+            if saved_secrets_env is None:
+                os.environ.pop("PREDBAT_SECRETS_FILE", None)
+            else:
+                os.environ["PREDBAT_SECRETS_FILE"] = saved_secrets_env
+
+    if args.get("fox_key") != "secret-fox-key":
+        print("ERROR: expected the !secret reference to resolve, got {}".format(args.get("fox_key")))
+        failed = True
+    if args.get("fox_automatic") is not True:
+        print("ERROR: expected fox_automatic True, got {}".format(args.get("fox_automatic")))
+        failed = True
+    if secrets.get("fox_api_key") != "secret-fox-key":
+        print("ERROR: expected the secrets dict to be returned, got {}".format(secrets))
+        failed = True
+
+    if not failed:
+        print("**** test_load_apps_yaml_resolves_secrets PASSED ****")
     return failed

--- a/apps/predbat/utils.py
+++ b/apps/predbat/utils.py
@@ -211,6 +211,82 @@ def _mask_secrets_in_place(value):
             _mask_secrets_in_place(entry)
 
 
+def load_secrets(log=None):
+    """
+    Load secrets from secrets.yaml file
+    Priority: PREDBAT_SECRETS_FILE env var, ./secrets.yaml, /config/secrets.yaml
+    """
+    import yaml
+
+    log = log or (lambda message, **kwargs: print(message))
+    secrets = {}
+    secrets_file = None
+
+    # Try loading from different locations in priority order
+    possible_locations = [
+        os.getenv("PREDBAT_SECRETS_FILE"),
+        "secrets.yaml",
+        "/homeassistant/secrets.yaml",
+        "/conf/secrets.yaml",
+        "/config/secrets.yaml",
+    ]
+
+    for location in possible_locations:
+        if location and os.path.isfile(location):
+            secrets_file = location
+            break
+
+    if secrets_file:
+        log(f"Loading secrets from {secrets_file}", quiet=False)
+        try:
+            with open(secrets_file, "r") as stream:
+                secrets = yaml.safe_load(stream) or {}
+                # Check for debug logging option
+                if secrets.get("logger") == "debug":
+                    log(f"Info: Secrets loaded from {secrets_file}", quiet=False)
+        except yaml.YAMLError as exc:
+            log(f"Error: Failed to load secrets from {secrets_file}: {exc}", quiet=False)
+        except Exception as exc:
+            log(f"Error: Failed to open secrets file {secrets_file}: {exc}", quiet=False)
+    else:
+        log("Info: No secrets.yaml file found", quiet=False)
+
+    return secrets
+
+
+def load_apps_yaml(apps_file=None, log=None):
+    """
+    Load an apps.yaml-format file and return its pred_bat section, with !secret references resolved
+
+    Shared so anything reading Predbat's configuration reads it the same way - Predbat's own
+    startup below, and fox.py's --config option for a standalone CLI run. Raises yaml.YAMLError
+    for a malformed file and KeyError when the pred_bat section is missing, leaving the caller to
+    decide whether that is fatal.
+
+    Returns (args, secrets).
+    """
+    import yaml
+
+    log = log or (lambda message, **kwargs: print(message))
+    secrets = load_secrets(log=log)
+
+    def secret_constructor(loader, node):
+        """YAML constructor for the !secret tag, resolving against the secrets just loaded."""
+        secret_key = loader.construct_scalar(node)
+        if secret_key in secrets:
+            return secrets[secret_key]
+        log(f"Warn: Secret '{secret_key}' not found in secrets.yaml")
+        return None
+
+    yaml.add_constructor("!secret", secret_constructor, Loader=yaml.SafeLoader)
+
+    apps_file = apps_file or os.getenv("PREDBAT_APPS_FILE", "apps.yaml")
+    log(f"Loading {apps_file}", quiet=False)
+    with open(apps_file, "r") as stream:
+        config = yaml.safe_load(stream)
+    return config["pred_bat"], secrets
+
+
 def mask_secret_args(args):
     """
     Return a deep copy of an apps.yaml-style args dict with credential-like keys redacted.


### PR DESCRIPTION
Follow-up to #5038. Running `fox.py` meant pasting an API key or OAuth token hash onto the command line every time, where it lands in shell history.

```
python3 apps/predbat/fox.py --config fox_test_key.yaml --feedin-schedule --hold-seconds 60
```

## Uses Predbat's own loader, moved to where it can be shared

The apps.yaml loader was inline in `Hass.__init__`, so it moves to `utils.py` as `load_apps_yaml()` / `load_secrets()` and both callers use it from there. `!secret` resolution therefore works for a CLI run exactly as it does for Predbat.

It could not live in `hass.py` and be imported by `fox.py`: `hass.py` imports `predbat`, `predbat` subclasses `hass.Hass` at import time, and `fox.py` is itself imported by `components.py` — so a top-level import is circular, and a function-local one would still drag `predbat` in. I tried the `hass.py` version first and the end-to-end CLI run failed with `partially initialized module 'hass' has no attribute 'Hass'`. `utils.py` is stdlib-only and `fox.py` already imports from it.

(That circularity is pre-existing and unchanged — `import hass` as the first import fails identically on `main`. Verified against a stashed tree, and `Hass()` still constructs in the normal ordering.)

## Keys read

`fox_key`, `fox_auth_method`, `fox_token_hash`, `fox_token_expires_at`, `fox_inverter_sn` — the config keys `COMPONENT_LIST["fox"]["args"]` declares.

Plus `supabase_url`, `supabase_key`, `user_id`. **These are the ones that made the first cut of this unusable:** `oauth_mixin` takes `SUPABASE_URL`/`SUPABASE_KEY` from the environment and `user_id` from `base.args`, so a `--config` run carrying only a token hash could not refresh it:

```
Warn: OAuth refresh skipped — SUPABASE_URL or SUPABASE_KEY not set
Warn: Fox: Authentication error with status code 401
```

They are not Fox component args, so they sit in their own mapping (`FOX_CLI_OAUTH_KEYS`) rather than being mixed in with the `fox_`-prefixed ones.

## Precedence and ambiguity

Anything also given on the command line wins, so a one-off run against a different key or inverter does not mean editing the file. A config carrying both an API key and a token hash is ambiguous, so `fox_auth_method` decides — the same field the component itself uses. `fox_inverter_sn` may be a list (it is `string|string_list` in `APPS_SCHEMA`); the CLI takes the first, since it drives one device.

## Both silent failures now say something

A mis-named key used to leave its credential unset, with a 401 much later as the only symptom. So the run names what it took:

```
Read from full_oauth.yaml: fox_token_hash, fox_token_expires_at, fox_inverter_sn, user_id, supabase_url, supabase_key
Read from typo.yaml: nothing - no keys the CLI looks for
Warning: an OAuth token cannot be refreshed without supabase_url and supabase_key - expect 401s once it expires
```

## Testing

8 new tests, each watched failing first: the loader resolving `!secret` from a given path; credentials from config; command line winning; list-valued serial; the `fox_auth_method` tie-break both ways; supabase/user_id pickup; and the report of which keys were used. One guard test asserts the CLI's hand-written key names are the ones `COMPONENT_LIST["fox"]["args"]` actually declares, since that mapping is a deliberate copy.

Verified end to end against real files, not just unit tests: `!secret` resolution (reaching a genuine 401 from a fake key), the OAuth path now actually attempting a refresh instead of skipping it, command line override, and clean `parser.error` messages for a missing file, malformed YAML, a missing `pred_bat` section, and no credentials at all.

`./run_all` green (130s, no skips), `./run_pre_commit` clean, `detect_changes` LOW risk with no affected processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)