### PR TITLE
fix(gecloud): stop deleting a manual inverter_mode override during automatic config (#5056)

### DIFF
--- a/apps/predbat/gecloud.py
+++ b/apps/predbat/gecloud.py
@@ -1326,7 +1326,7 @@ class GECloudDirect(ComponentBase):
 
         self.set_arg("inverter_type", ["GEC" for _ in range(num_inverters)])
         self.set_arg("num_inverters", num_inverters)
-        self.set_arg("inverter_mode", build_entities("switch", ["enable_eco_mode"]))
+        self.set_arg_auto("inverter_mode", build_entities("switch", ["enable_eco_mode"]), overwrite=False)
         if not self.get_arg("ge_cloud_load_today_ignore", default=False):
             self.set_arg("load_today", [f"sensor.{self.prefix}_gecloud_{device}_consumption_total" for device in batteries])
         self.set_arg("import_today", [f"sensor.{self.prefix}_gecloud_{device}_grid_import_total" for device in batteries])

--- a/apps/predbat/tests/test_ge_cloud.py
+++ b/apps/predbat/tests/test_ge_cloud.py
@@ -4451,6 +4451,20 @@ def _test_async_automatic_config(my_predbat):
         assert ge.config_args.get("charge_limit") == ["number.predbat_gecloud_battery001_ac_charge_upper_percent_limit"]
         assert ge.config_args.get("charge_limit_enable") is None, "charge_limit_enable should be None when enable register is absent"
 
+        # Test 10: a manually-configured inverter_mode in apps.yaml must survive auto-config when no
+        # eco-mode register exists to auto-discover (GH#5056). inverter_mode is bound via
+        # set_arg_auto(..., overwrite=False), the same precedent as export_limit (GH#4494/#4978), so a
+        # real apps.yaml value must win rather than being deleted by set_arg(None). Populating
+        # args_from_apps_yaml (not just config_args) is what actually exercises the overwrite=False
+        # branch - without it set_arg_auto sees no user-configured value and behaves like plain set_arg.
+        manual_inverter_mode = "switch.my_manual_inverter_mode"
+        ge.config_args = {"inverter_mode": manual_inverter_mode}
+        ge.base.args_from_apps_yaml = {"inverter_mode": manual_inverter_mode}
+        ge.settings = {"battery001": {}}
+        devices = {"ems": None, "gateway": None, "battery": ["battery001"]}
+        await ge.async_automatic_config(devices)
+        assert ge.config_args.get("inverter_mode") == manual_inverter_mode, "manually configured inverter_mode should survive auto-config when no eco toggle switch is discovered"
+
         return 0
 
     return run_async(test())


### PR DESCRIPTION

Fixes #5056

## Summary

On GE Cloud devices where the automatic register scan finds no matching entity for `inverter_mode` (no `enable_eco_mode` register on this hardware class), `async_automatic_config()` called `self.set_arg("inverter_mode", None)`. `set_arg()` treats `None` as "delete this key," so any value the user had explicitly set for `inverter_mode` in `apps.yaml` was deleted on every config refresh while `ge_cloud_automatic: true` — with no way to work around it from `apps.yaml`, since the key was gone again before `adjust_inverter_mode()` ever got a chance to read it.

This is exactly the class of problem `export_limit` already solves a few lines later in the same function: `set_arg_auto(..., overwrite=False)` (added for #4494 / PR #4500, and used again for site export limits in #4978) fills a key in when the user has set nothing, but leaves an explicit apps.yaml value alone rather than deleting it. `inverter_mode` had just never been switched over to it.

## Fix

```diff
- self.set_arg("inverter_mode", build_entities("switch", ["enable_eco_mode"]))
+ self.set_arg_auto("inverter_mode", build_entities("switch", ["enable_eco_mode"]), overwrite=False)
```

Scoped to `inverter_mode` only — the other `set_arg(key, build_entities(...))` call sites in this function (`charge_rate`, `discharge_rate`, `reserve`, `charge_limit`, `scheduled_charge_enable`, etc.) have the same delete-on-`None` behaviour but aren't part of this issue, per the reporter's own framing.

## Testing

A GitHub bot triage review of the issue flagged that the existing coverage at `test_ge_cloud.py:4164` (asserting `inverter_mode` is `None` when the eco toggle is absent) only passed because that assertion can't distinguish "key never set" from "key deleted" — it never actually populated `args_from_apps_yaml` with a manual value, so it never exercised `set_arg_auto`'s `overwrite=False` branch for this key at all. Added a new case to `_test_async_automatic_config` that seeds both `config_args["inverter_mode"]` and (critically) `base.args_from_apps_yaml["inverter_mode"]` with a manually-configured entity, then runs auto-config against a device with no eco-mode register, and asserts the manual value survives.

- `tools/triage_test.sh ge_cloud`: all passing, including the new case — verified red on the unfixed code and green on the fix. The new case is an added assertion inside the existing `automatic_config` test function rather than a separately-registered test, so the total stays at 94 either way (Predbat's suite counts registered test functions, not individual assertions); what changes is whether that function passes. Confirmed the wiring directly: reverting just the one-line `gecloud.py` change while keeping the new test flips `automatic_config` to failing (`EXCEPTION in automatic_config: manually configured inverter_mode should survive auto-config when no eco toggle switch is discovered`, 93 passed / 1 failed of 94); restoring the fix returns it to 94 passed, 0 failed.
- `run_pre_commit` (`pre-commit run --all-files` + `./run_all --quick`): passing aside from four pre-existing failures unrelated to gecloud — two Windows-specific environment issues (a `pathlib` crash in `tools/triage_daemon.py`, and a `ctypes`/glibc `LoadLibrary(None)` bug hit by two unrelated tests) and a missing compiled prediction kernel causing two golden-baseline tests to drift onto the slower Python fallback engine — all four reproducing identically on unmodified `main`. With those excluded, the remaining 306 quick tests pass.

## Related

- #1607 — 3-phase GivEnergy inverters generally lacking a controllable mode/eco register via GivTCP.
- #4909 — the underlying gap this lets users work around: no native `enable_eco_mode` register on some 3-phase GEC hardware, so `inverter_mode` can now be supplied manually and will actually stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
